### PR TITLE
test(docs): two gates said every documented env var was real, and both were right about a name that warns at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+- **The egress matrix named the deprecated variable for the vision slot, one row above the current one for
+  speech-to-text.** `02-hosting.md`'s table gave `OLLAMA_URL` for vision and `STT_BASE_URL` for STT — two
+  spellings of the same 2.1 decision, one table apart. An operator reading it to find which variable controls
+  vision egress got the name that warns at startup.
+  - Swept for the rest rather than fixing the reported one: three more in the media-embedding guide's setup list
+    (already fixed), and the rename note's own example now names both spellings.
+  - **Our own deployment artifacts are clean** — `docker-compose.yml` and the Kubernetes manifests mention the
+    legacy names only in comments explaining why they are deliberately *not* set. Checked rather than assumed;
+    a `git grep -l` matched both files and the hits turned out to be those comments.
+
+### Added
+- **A gate: a renamed env var may appear in the docs, but never on its own.** A legacy name is only allowed on a
+  line that also names its replacement.
+  - **Two existing gates were right and still missed this.** `egress-matrix` asserts every documented env var is
+    *real*, and `OLLAMA_URL` is entirely real — the loader reads it on purpose. `env-var-docs-coverage` asserts
+    the docs name every variable the code reads, and the code does read it. Neither asks *which of two working
+    names a reader should be told to use*, which is a claim about behaviour rather than about existence.
+  - The rule needs no exemption list: every legitimate mention — the rename note, the "Legacy alias" column, the
+    upgrade table — already names both, and that pairing is exactly what a reader needs in order to migrate.
+  - The pairs are parsed from `RENAMED_ENV_VARS` in the config loader rather than copied, because the next rename
+    is precisely when a hand-kept second list would be wrong.
+
 - **The media-embedding guide told you to set the deprecated env vars, and then told you they were deprecated
   eighty lines later.** Its "required services" list used `OLLAMA_URL`, `WHISPER_URL` and `WHISPER_MODEL`, so a
   reader following the setup instructions got a startup deprecation warning for doing exactly what the document

--- a/docs/integration-guide/02-hosting.md
+++ b/docs/integration-guide/02-hosting.md
@@ -420,7 +420,7 @@ broken, and nothing compared the two.
 | Slot | Slot key | Env | Sends | Guard | Acknowledgement |
 |---|---|---|---|---|---|
 | Embedding | `embedding` | `EMBEDDING_URL` | record + query text | yes, when the provider is `external` | — |
-| Vision (captions) | `vision` | `OLLAMA_URL` | uploaded images | yes, when the provider is `external` | — |
+| Vision (captions) | `vision` | `VISION_BASE_URL` | uploaded images | yes, when the provider is `external` | — |
 | Speech-to-text | `stt` | `STT_BASE_URL` | uploaded audio | yes, when the provider is `external` | — |
 | Reranker | `rerank` | `RERANK_URL` | the query **and** the passages it matched | yes, unless the URL is local | — |
 | Contradiction judge | `nli` | `NLI_URL` | pairs of stored records | yes, unless the URL is local | — |

--- a/docs/integration-guide/05b-media-embedding.md
+++ b/docs/integration-guide/05b-media-embedding.md
@@ -27,7 +27,7 @@ Required services (bundled by default; override only when you point at external 
 - **Ollama** (image captioning): `VISION_BASE_URL=http://ollama:11434` — deploy any vision-capable model, set via `VISION_MODEL` (default: `moondream`).
 - **faster-whisper-server** (audio/video STT): `STT_BASE_URL=http://whisper:8000` — set model via `STT_MODEL` (default: `base`).
 
-> The legacy names `OLLAMA_URL`, `WHISPER_URL` and `WHISPER_MODEL` still work and warn once at startup — see the rename note below.
+> The legacy names still work and warn once at startup: `OLLAMA_URL` → `VISION_BASE_URL`, `WHISPER_URL` → `STT_BASE_URL`, `WHISPER_MODEL` → `STT_MODEL`. The reasoning is in the rename note below.
 
 Kubernetes manifests are provided in `kubernetes/manifests/ollama-deploy.yaml` and `kubernetes/manifests/whisper-deploy.yaml`. Dual `NetworkPolicy` + `CiliumNetworkPolicy` resources are in `media-netpol.yaml` and `media-cilium-netpol.yaml`.
 
@@ -112,7 +112,7 @@ The worker-tuning fields — `workerConcurrency`, `workerPollIntervalMs`, `worke
 > **Renamed in 2.1: `OLLAMA_URL` → `VISION_BASE_URL`, `WHISPER_URL` → `STT_BASE_URL`, `WHISPER_MODEL` → `STT_MODEL`.**
 >
 > The old names described the implementation that happened to be first, not the field they configure.
-> `OLLAMA_URL` is the sharpest case: it sets `vision.baseUrl`, which is used **even when
+> `OLLAMA_URL` (now `VISION_BASE_URL`) is the sharpest case: it sets `vision.baseUrl`, which is used **even when
 > `visionProvider` is `external`** — so an operator running vLLM or llama.cpp had to set a variable named
 > after a product they were not running, assuming they found it at all. This is the same distinction the
 > provider switch already gets right: **the setting names a wire protocol, not a product.**

--- a/testing/standalone/docs-name-current-env-vars.test.js
+++ b/testing/standalone/docs-name-current-env-vars.test.js
@@ -1,0 +1,105 @@
+/**
+ * A renamed env var may appear in the docs, but never on its own.
+ *
+ * ## The failure
+ *
+ * `VISION_BASE_URL`, `STT_BASE_URL` and `STT_MODEL` replaced `OLLAMA_URL`, `WHISPER_URL` and
+ * `WHISPER_MODEL` in 2.1, because the old names described the implementation that happened to be first
+ * rather than the field they configure. The old names keep working **and warn once at startup** — a
+ * deliberate choice: breaking a documented env var to improve its spelling is not a trade worth making,
+ * but an alias nobody is told about is one nobody migrates off.
+ *
+ * The documentation then went on recommending the old ones. `05b-media-embedding.md` opened its "required
+ * services" list with all three, so an operator following the setup instructions earned a deprecation
+ * warning for doing exactly what the document said — while the same file, eighty lines down, carried the
+ * rename note. And `02-hosting.md`'s egress matrix named `OLLAMA_URL` for the vision slot on the row above
+ * `STT_BASE_URL` for speech-to-text: two spellings of the same decision, one table apart.
+ *
+ * ## Why no existing gate saw it
+ *
+ * `egress-matrix` asserts *every documented env var is real*, and `OLLAMA_URL` is entirely real — the
+ * loader reads it, on purpose. `env-var-docs-coverage` asserts the docs name every variable the code
+ * reads, and the code does read it. Both are right. Neither asks which of two working names a reader
+ * should be told to use, and that is a claim about behaviour, which is the class of documentation defect
+ * a name-existence check cannot reach.
+ *
+ * ## The rule
+ *
+ * A legacy name may appear only on a line that also names its replacement. That covers every legitimate
+ * use — the rename note, the "Legacy alias: X" column, the upgrade table — and nothing else, so there is
+ * no exemption list to grow. It is also the shape a reader needs: seeing the old name without the new one
+ * beside it is precisely what leaves them on the deprecated spelling.
+ *
+ * ## The pairs come from the code
+ *
+ * `RENAMED_ENV_VARS` in the config loader is the ground truth, parsed rather than copied. A hand-kept
+ * second list would be one more thing to remember on the next rename — and the next rename is exactly
+ * when this check needs to already be right.
+ *
+ * Run: node --test testing/standalone/docs-name-current-env-vars.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+const LOADER = 'server/src/config/loader.ts';
+
+/** The `{ current, legacy }` pairs, read out of the loader's own table. */
+function renamedPairs() {
+  const src = readFileSync(LOADER, 'utf8');
+  const table = src.slice(src.indexOf('const RENAMED_ENV_VARS'));
+  const body = table.slice(0, table.indexOf('];'));
+  return [...body.matchAll(/current:\s*'([A-Z0-9_]+)',\s*legacy:\s*'([A-Z0-9_]+)'/g)]
+    .map((m) => ({ current: m[1], legacy: m[2] }));
+}
+
+function docLines() {
+  const files = execFileSync('git', ['ls-files', 'docs/*.md', 'docs/*/*.md'], { encoding: 'utf8' })
+    .split('\n').filter(Boolean);
+  return files.flatMap((f) => readFileSync(f, 'utf8').split(/\r?\n/).map((text, i) => ({ file: f, line: i + 1, text })));
+}
+
+describe('the check itself works before it is trusted', () => {
+  it('reads the rename table out of the loader', () => {
+    // If the table is renamed or restructured this finds nothing, and a gate that checks nothing passes.
+    const pairs = renamedPairs();
+    assert.ok(pairs.length >= 3, `parsed ${pairs.length} renamed env vars out of ${LOADER} — expected at least 3`);
+    assert.ok(pairs.some((p) => p.legacy === 'OLLAMA_URL' && p.current === 'VISION_BASE_URL'),
+      'the OLLAMA_URL -> VISION_BASE_URL pair is missing; the parse is wrong or the rename was undone');
+  });
+
+  it('sees the docs', () => {
+    const lines = docLines();
+    assert.ok(lines.length > 2000, `only read ${lines.length} lines of documentation`);
+  });
+
+  it('FLAGS a legacy name that stands alone, and allows one paired with its replacement', () => {
+    // Mutation-check on the predicate. A rule that cannot fire looks exactly like a clean repository.
+    const pairs = [{ current: 'NEW_NAME', legacy: 'OLD_NAME' }];
+    const check = (text) => offenders([{ file: 'x.md', line: 1, text }], pairs);
+    assert.equal(check('set `OLD_NAME` to the endpoint').length, 1, 'a lone legacy name must be flagged');
+    assert.equal(check('`OLD_NAME` is now `NEW_NAME`').length, 0, 'a paired mention must be allowed');
+  });
+});
+
+/** Doc lines naming a legacy env var without its replacement. Exported shape kept simple for the test above. */
+function offenders(lines, pairs) {
+  const out = [];
+  for (const { file, line, text } of lines) {
+    for (const { current, legacy } of pairs) {
+      if (text.includes(legacy) && !text.includes(current)) out.push(`${file}:${line} names ${legacy} without ${current}`);
+    }
+  }
+  return out;
+}
+
+describe('the docs recommend the current env var names', () => {
+  it('never names a renamed variable without its replacement on the same line', () => {
+    const found = offenders(docLines(), renamedPairs());
+    assert.deepEqual(found, [],
+      'These lines send a reader to a deprecated env var:\n  ' + `${found.join('\n  ')}\n\n`
+      + 'The old names keep working and warn once at startup, so following the documentation earns a\n'
+      + 'deprecation warning. Use the current name; if the line is genuinely about the rename, name both.');
+  });
+});


### PR DESCRIPTION
`02-hosting.md`'s egress matrix gave `OLLAMA_URL` for the vision slot and `STT_BASE_URL` for speech-to-text — two spellings of the same 2.1 decision, one row apart. An operator reading that table to find which variable controls vision egress got the name that logs a deprecation warning.

## Why nothing caught it

- **`egress-matrix`** asserts *every documented env var is real*. `OLLAMA_URL` is entirely real: the loader reads it, deliberately, and will keep reading it.
- **`env-var-docs-coverage`** asserts the docs name every variable the code reads. The code does read it.

Both gates are right. Neither asks **which of two working names a reader should be told to use** — a claim about *behaviour* rather than about existence, which is the class of documentation defect a name-existence check cannot reach.

## The rule

**A legacy name may appear only on a line that also names its replacement.**

That covers every legitimate mention — the rename note, the "Legacy alias" column, the upgrade table — and nothing else, so there is **no exemption list to grow**. It is also the shape a reader needs: seeing the old name *without* the new one beside it is exactly what leaves them on the deprecated spelling.

The pairs are parsed out of `RENAMED_ENV_VARS` in the config loader rather than copied into the test, because the next rename is precisely when a hand-kept second list would be wrong. There is a guard for that too: the check fails if it parses fewer than three pairs, or if the `OLLAMA_URL → VISION_BASE_URL` pair is missing, so a restructured table cannot silently turn this into a gate that checks nothing.

## It reproduced #801's finding independently

Before the rebase, this gate flagged exactly the three lines in `05b-media-embedding.md` that #801 fixed by reading. A gate that independently rediscovers a defect found by hand is the confirmation worth having.

It then flagged **one more that #801 introduced**: the deprecation note added there listed all three legacy names without their replacements. Rewritten to name each pair, which is better for the reader anyway — and it is the rule applying to its own author, which is the point of writing it down.

## Swept, not fixed where reported

Three more instances in the media-embedding guide's setup list, and the rename note's own worked example (`OLLAMA_URL` is the sharpest case…) now names both spellings.

**Our own deployment artefacts are clean.** `docker-compose.yml` and the Kubernetes manifests mention the legacy names only in comments explaining why they are deliberately *not* set. Checked rather than assumed — a `git grep -l` matched both files, and the hits turned out to be exactly those comments.

## Verified

- `npm run preflight` — PASSED, rebased onto merged #801
- the predicate is mutation-checked both ways: a lone legacy name is flagged, a paired mention is allowed
- `egress-matrix`, `env-var-docs-coverage`, `docs-name-real-identifiers` — all still green
