### PR TITLE
release: 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.6.0] — 2026-08-11
 ### Added
 - **A gate: `Settings → X` in the docs must name something the sidebar actually says.** The nav is parsed out of
   `shell.component.ts` and the labels resolved through `en.json`, so no hand-kept copy exists to go stale —
@@ -435,6 +437,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **A tracker edit does not count as work in progress**, which is the specific failure it catches: a reply
     whose newest work is bookkeeping, with nothing running and no PR open.
   - Not wired into preflight — preflight guards a *push*, and this guards a *turn ending*.
+
+- **A gate: every locked version must describe the artefact it resolves to.** npm encodes the version in the
+  tarball URL, so the lockfile carries the answer next to the claim and comparing them needs no network.
+  - Mutation-checked against a planted mismatch, because a check that cannot fire looks exactly like a clean
+    lockfile — and this one looked clean through three releases while being wrong.
 
 ### Changed
 - **The use-case catalogue is three chapters instead of one 1,038-line file, and it finally has a table of
@@ -922,6 +929,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     *transience*. Now narrowed by the server error **code** for that one name: 11600, 91, 11602, 189, 13436.
   - `AuthenticationFailed` (18) still fails immediately, and an unrecognised name with a transient code is still
     rejected — widening by code alone would re-admit everything the allowlist exists to reject.
+
+- **Seven dependencies in `package-lock.json` recorded a version their own tarball contradicts.** They claimed
+  2.4.0 while resolving to 2.3.0 artefacts — collateral from the 2.3.0 → 2.4.0 release, whose version bump was
+  done with a find-and-replace on `"version": "<old>"`. That string is not unique: any dependency sitting at
+  the version being bumped FROM is rewritten with it, while its `resolved` URL and `integrity` hash go on
+  describing the real artefact.
+  - It had shipped that way for three releases. **This release reproduced it live** on `watchpack`, which is
+    what made the old damage visible — the same mistake, caught in the act.
+  - `npm ci` never notices: it installs from `resolved` and verifies `integrity`, so the wrong `version` is a
+    lie that works. What reads the field is everything that reports *about* the tree — SBOMs, attribution and
+    licence tooling, `npm ls`, and CVE matching, where an advisory against 2.3.0 does not match a record
+    claiming 2.4.0.
 
 ### Internal
 - **The per-type schema editor is a component two hosts can open.** Its ~224 template lines lived inside the

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/client",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ythril",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ythril",
-      "version": "2.5.1",
+      "version": "2.6.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "workspaces": [
         "server",
@@ -18,7 +18,7 @@
     },
     "client": {
       "name": "@ythril/client",
-      "version": "2.5.1",
+      "version": "2.6.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@angular/animations": "^21.0.0",
@@ -349,7 +349,7 @@
       }
     },
     "node_modules/@ampproject/remapping": {
-      "version": "2.4.0",
+      "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
       "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
       "dev": true,
@@ -10085,7 +10085,7 @@
       }
     },
     "node_modules/binary-extensions": {
-      "version": "2.4.0",
+      "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "dev": true,
@@ -11898,7 +11898,7 @@
       }
     },
     "node_modules/domelementtype": {
-      "version": "2.4.0",
+      "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
       "dev": true,
@@ -19070,7 +19070,7 @@
       "license": "MIT"
     },
     "node_modules/tapable": {
-      "version": "2.4.0",
+      "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
       "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
       "dev": true,
@@ -19381,7 +19381,7 @@
       }
     },
     "node_modules/ts-dedent": {
-      "version": "2.4.0",
+      "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
       "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
       "license": "MIT",
@@ -20320,7 +20320,7 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/ipaddr.js": {
-      "version": "2.4.0",
+      "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz",
       "integrity": "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==",
       "dev": true,
@@ -20674,7 +20674,7 @@
       }
     },
     "node_modules/why-is-node-running": {
-      "version": "2.4.0",
+      "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
       "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
@@ -21022,7 +21022,7 @@
     },
     "server": {
       "name": "@ythril/server",
-      "version": "2.5.1",
+      "version": "2.6.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ythril",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "type": "module",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/server",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "type": "module",
   "scripts": {

--- a/testing/standalone/lockfile-versions-are-real.test.js
+++ b/testing/standalone/lockfile-versions-are-real.test.js
@@ -1,0 +1,88 @@
+/**
+ * A package's recorded version in `package-lock.json` must match the artefact it points at.
+ *
+ * ## The failure, which happened twice
+ *
+ * A release bumps four manifests. Three are one line each; the fourth is `package-lock.json`, where the
+ * project's own version appears four times among twenty thousand lines of dependency records. So the bump
+ * gets done with a find-and-replace on `"version": "<old>"` — and that string is not unique. Any dependency
+ * that happens to sit at the version you are bumping *from* is rewritten too, while its `resolved` URL and
+ * `integrity` hash go on describing the real artefact.
+ *
+ * The 2.3.0 → 2.4.0 release did exactly this and left **seven** dependencies claiming 2.4.0 while resolving
+ * to 2.3.0 tarballs. It shipped that way for three releases. The 2.5.1 → 2.6.0 bump reproduced it live on
+ * `watchpack`, which is what made the old damage visible.
+ *
+ * ## Why nothing else catches it
+ *
+ * `npm ci` installs from `resolved` and verifies `integrity`, so the wrong `version` field never breaks an
+ * install — it is a lie that works. What reads the field instead is everything that reports *about* the
+ * dependency tree: SBOMs, licence and attribution tooling, `npm ls`, vulnerability matching. A CVE that
+ * applies to 2.3.0 does not match a record that says 2.4.0.
+ *
+ * ## The check
+ *
+ * Every entry with a `resolved` tarball URL states its version in that URL, by npm's own naming convention.
+ * Comparing the two costs nothing and needs no network. Entries without a `resolved` (workspaces, link
+ * targets) are the project's own packages and are covered by the release gate's four-manifest check.
+ *
+ * Run: node --test testing/standalone/lockfile-versions-are-real.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const LOCK = 'package-lock.json';
+
+/** The version npm encoded in a tarball URL: `…/name-1.2.3.tgz`, including prerelease suffixes. */
+function versionFromResolved(resolved) {
+  const m = /-(\d+\.\d+\.\d+[^/]*)\.tgz$/.exec(resolved);
+  return m ? m[1] : null;
+}
+
+function entries() {
+  const lock = JSON.parse(readFileSync(LOCK, 'utf8'));
+  return Object.entries(lock.packages ?? {});
+}
+
+describe('the check itself works before it is trusted', () => {
+  it('reads a lockfile with a real dependency tree in it', () => {
+    // A parse that found nothing would make the assertion below vacuously true.
+    const all = entries();
+    assert.ok(all.length > 500, `only ${all.length} entries in ${LOCK} — the lockfile did not parse`);
+    assert.ok(all.filter(([, v]) => v.resolved).length > 500, 'no entries carry a resolved URL');
+  });
+
+  it('extracts the version npm put in a tarball URL', () => {
+    assert.equal(versionFromResolved('https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz'), '2.3.0');
+    assert.equal(versionFromResolved('https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz'), '2.3.0');
+    // A scoped package whose name itself contains digits and dashes must not confuse the suffix match.
+    assert.equal(versionFromResolved('https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz'), '2.6.0');
+    assert.equal(versionFromResolved('https://registry.npmjs.org/foo/-/foo-1.2.3-beta.4.tgz'), '1.2.3-beta.4');
+    assert.equal(versionFromResolved('git+ssh://git@github.com/x/y.git#abc'), null, 'a non-tarball must be skipped, not guessed');
+  });
+
+  it('WOULD report a mismatch', () => {
+    // Mutation-check on the comparison rather than on the file: a check that cannot fire looks exactly like
+    // a clean lockfile, and this one has been clean-looking through three releases while being wrong.
+    const planted = [['node_modules/x', { version: '9.9.9', resolved: 'https://registry.npmjs.org/x/-/x-1.0.0.tgz' }]];
+    const bad = planted.filter(([, v]) => versionFromResolved(v.resolved) && versionFromResolved(v.resolved) !== v.version);
+    assert.equal(bad.length, 1, 'the comparison must flag a version that disagrees with its tarball');
+  });
+});
+
+describe('every locked version describes the artefact it resolves to', () => {
+  it('has no dependency whose version disagrees with its tarball URL', () => {
+    const wrong = entries()
+      .map(([name, v]) => ({ name, version: v.version, url: versionFromResolved(v.resolved ?? '') }))
+      .filter((e) => e.url && e.version !== e.url)
+      .map((e) => `${e.name}: records ${e.version}, resolves to ${e.url}`);
+    assert.deepEqual(wrong, [],
+      'These lockfile entries claim a version their own tarball contradicts:\n  ' + `${wrong.join('\n  ')}\n\n`
+      + 'Almost certainly a release bump done with a find-and-replace on `"version": "<old>"`, which is not a\n'
+      + 'unique string — any dependency sitting at the version you bumped FROM is rewritten with it.\n'
+      + '`npm ci` will not notice, because it installs from `resolved` and checks `integrity`; what breaks is\n'
+      + 'everything that reports about the tree — SBOMs, attribution, and CVE matching against a version that\n'
+      + 'was never installed.');
+  });
+});


### PR DESCRIPTION
Closes `[Unreleased]` into `[2.6.0] — 2026-08-11` and bumps the four manifests.

## Why 2.6.0 and not 3.0.0

The cycle contains exactly **one** breaking item: *"BREAKING for operators using an external face model: the in-process fallback is now OFF by default."* Narrow, and it has a documented way back. A second apparent hit turned out to be prose saying a change **would be** breaking and was therefore not made.

`MEDIA_EMBEDDING_ENABLED` looked like a third until I checked: it was removed in **2.3.0, a minor**. So this project already ships an operator-breaking env-var removal in a minor — which settles the precedent question rather than leaving it to taste.

And **3.0 is spoken for**. `_DEPRECATIONS.md` is the 3.0 removal checklist and none of it is done; cutting 3.0 now would consume the major and strand the list. That file warns that a major is exactly when someone deletes those rows by accident.

## The bump found a bug it was about to repeat

Four manifests carry the version. Three are one line each. The fourth is `package-lock.json`, where the project's version appears four times among twenty thousand lines of dependency records — so the bump gets done with a find-and-replace on `"version": "<old>"`, and **that string is not unique**.

Bumping 2.5.1 → 2.6.0 rewrote **`watchpack`**, which really is at 2.5.1, leaving it claiming 2.6.0 while its `resolved` URL and `integrity` hash still described the 2.5.1 tarball.

Checking the rest of the lockfile for the same shape found **seven more**, all claiming 2.4.0 while resolving to 2.3.0 tarballs — collateral from the 2.3.0 → 2.4.0 release doing exactly this, and shipped that way for three releases since:

```
@ampproject/remapping   binary-extensions   domelementtype   tapable
ts-dedent               ipaddr.js           why-is-node-running
```

All eight are repaired to the version their own artefact describes.

**`npm ci` never notices.** It installs from `resolved` and verifies `integrity`, so a wrong `version` is a lie that works. What reads the field is everything that reports *about* the tree — SBOMs, attribution and licence tooling, `npm ls`, and CVE matching, where an advisory against 2.3.0 does not match a record claiming 2.4.0.

`lockfile-versions-are-real.test.js` now compares the two on every run: npm encodes the version in the tarball URL, so the lockfile carries the answer next to the claim and checking it needs no network. Mutation-checked against a planted mismatch, because a check that cannot fire looks exactly like a clean lockfile — and this one looked clean through three releases while being wrong.

## What is in 2.6.0

The `[Unreleased]` section was regrouped by topic in #804, so the release notes now read as one section of each kind with related work together. The headline items:

- **Per-space rights matrix for tokens**, replacing the `spaces` allowlist — including a proxy space usable as a lens over what a scoped token may already see, and all 29 read fan-outs narrowed to what the caller may see.
- **The documentation split**: five files over 1,000 lines became 21, the largest document dropping from 2,037 lines to 817, plus five gates that keep it that way.
- **`suppressEmbeddings`** end to end, with `POST /api/spaces/:id/reembed` as the way back.
- **`<app-timestamp>`** — one absolute-time treatment across every data table, replacing five hand-rolled formats.
- **Face-descriptor width** read from each space's own index rather than a built-in constant, and the external-model fallback now off by default.

## Verified

- `npm run preflight` — PASSED
- `npm run release:gate` — PASSED: docs match code, the CHANGELOG carries 2.6.0, NOTICE is complete
- the four manifests agree on 2.6.0, and the lockfile's dependency versions agree with their own tarballs
