### PR TITLE
fix(audit): a documented privacy window was swept against a collection nothing has ever written to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- **The audit log's record-change retention swept the wrong collection, so a documented privacy window was
+  never enforced — for fourteen releases.** `change-retention.ts` declared its own
+  `const COLLECTION = '_audit_log'` when it was introduced in 2.0.0. The audit log has been `audit_log` since
+  the feature existed. So the sweep ran every six hours against a collection **nothing has ever written to**
+  and redacted nothing.
+  - The `changes` payload on a brain record edit is allowlisted **user content** — the old text of a memory,
+    the previous description of an entity — held in a store with different access rules, since any admin can
+    read the audit log including for spaces their token could not otherwise reach. That is exactly why it has
+    a shorter window than the entry around it. It kept its content for the full `retentionDays` instead.
+  - **Every check was green.** `doc-cited-constants` verified the docs quote `recordChangeRetentionDays: 14`
+    faithfully; they do. The documentation described the sweep correctly. The constant, the prose and the gate
+    all agreed with each other about behaviour that never ran.
+  - **Why it was silent rather than broken-looking:** `updateMany` against a collection that does not exist
+    *succeeds* with `modifiedCount: 0`, and the sweep logged only when the count was above zero. Zero redacted
+    is also what a healthy instance with nothing aged out reports. There was no failure to notice.
+  - Fixed by **exporting** the name from `audit.ts` and importing it, so there is one copy rather than two
+    that agree. The gate asserts that shape: it fails on a second collection literal in the pruner **even when
+    spelled correctly**, because the second copy is the defect and the typo was only its symptom.
+  - **The sweep now reports its first pass of each process even when it redacts nothing**, naming the
+    collection and how many record-edit entries it can see. That is the line that would have exposed this on
+    day one; a housekeeping sweep that speaks only on success cannot be told apart from one pointed at
+    nothing.
+  - **Upgrade note:** the first sweep after upgrading redacts the whole accumulated backlog in one pass and
+    logs the count. A large number there is the backlog, not a fault.
 
 ## [2.6.0] — 2026-08-11
 ### Added
@@ -1823,7 +1848,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   memories and edges all leave, and bypassed the property validation the same space applies on create. Now
   `PATCH`, like the other three types. Both verbs reach the same writer, so records are unaffected.
 
-
 ### Fixed
 
 - **The duplicate check could not see the batch you were writing** (reported by two integrators
@@ -1863,7 +1887,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reach an excluded record even deliberately, while `query`, `list`, `traverse` and reads by id return it
   unchanged. An audit that must include retired records has to be a structured read.
 
-
 ### Fixed
 
 - **`excludeFromVectorSearch` was not settable over REST.** It was wired into the four update functions
@@ -1874,7 +1897,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     the writer beneath them is invisible from where the request is parsed.
   - It may be the **only** field in a request: retiring a record from vector search is a complete edit in
     itself, not a modifier on some other change.
-
 
 ### Fixed
 
@@ -1891,7 +1913,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `cross-encoder/nli-deberta-v3-base` is `0=contradiction, 1=entailment, 2=neutral`, so an
     index-emitting server is misread as agreeing for two labels in three.
 
-
 ### Added
 
 - **`GET /stats` now reports the embedding backlog** as `embedQueue: { pending, processing, failed }`.
@@ -1903,7 +1924,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     Rewriting a record requeues it, so there is a way back without touching the queue.
   - Summed across members for a proxy space, matching the record counts beside it — a zero there would
     read as "nothing pending" rather than "not counted".
-
 
 ### Fixed
 
@@ -1920,7 +1940,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     parked with `ttlDays: 1`.
   - Gated across **both** write surfaces, not just the one that broke.
 
-
 ### Added
 
 - **`GET /stats` now reports the embedding backlog** as `embedQueue: { pending, processing, failed }`.
@@ -1932,7 +1951,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     Rewriting a record requeues it, so there is a way back without touching the queue.
   - Summed across members for a proxy space, matching the record counts beside it — a zero there would
     read as "nothing pending" rather than "not counted".
-
 
 ### Fixed
 
@@ -1946,7 +1964,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Gated on CONSISTENCY, not on presence** — the check fails when the four routes disagree, so it holds
     whichever way a future change moves, and it also requires each route to validate the flag rather than
     trust the body. Mutation-verified.
-
 
 ### Documentation
 

--- a/docs/integration-guide/13-audit-log-api.md
+++ b/docs/integration-guide/13-audit-log-api.md
@@ -99,6 +99,17 @@ used to say" ages out.
 `changesRedacted` exists so a reader can distinguish *"this operation records no changes"* from *"it did, and
 they have expired"*. Without it an absent `changes` would quietly imply nothing was ever captured.
 
+> **Upgrading from 2.6.0 or earlier: expect one large redaction, once.** The sweep was pointed at the wrong
+> collection name from the release it was introduced in (2.0.0) until 2.6.1, so it matched nothing and this
+> window was never enforced — record-edit `changes` kept their content for the full `retentionDays` instead.
+> After upgrading, the first sweep redacts everything that had accumulated past the window in a single pass,
+> and logs the count. A four-figure number there is the backlog, not a fault.
+>
+> The sweep now also logs its first pass of each process even when it redacts nothing, naming the collection
+> and how many record-edit entries it can see. That line is what makes "working" distinguishable from
+> "pointed at nothing" — the two were identical before, because an update against a collection that does not
+> exist succeeds and reports zero.
+
 #### What a record edit records
 
 | Operation | Recorded fields |

--- a/server/src/audit/audit.ts
+++ b/server/src/audit/audit.ts
@@ -16,7 +16,16 @@ import type { AuditLogEntry } from '../config/types.js';
 import type { AuditChange } from './audit-changes.js';
 import type { Collection, Filter, Sort } from 'mongodb';
 
-const COLLECTION = 'audit_log';
+/**
+ * The audit collection, EXPORTED so nothing has to spell it a second time.
+ *
+ * `change-retention.ts` had its own copy and spelled it `_audit_log`. Nothing has ever written to that
+ * name, so its sweep ran on an empty collection every ten minutes for fourteen releases and reported
+ * nothing, because `updateMany` on a collection that does not exist returns `modifiedCount: 0` and the
+ * sweep only logs when the count is above zero. A silence indistinguishable from success.
+ */
+export const AUDIT_COLLECTION = 'audit_log';
+const COLLECTION = AUDIT_COLLECTION;
 const DEFAULT_RETENTION_DAYS = 90;
 
 function col(): Collection<AuditLogEntry> {

--- a/server/src/audit/change-retention.ts
+++ b/server/src/audit/change-retention.ts
@@ -27,7 +27,21 @@ import { col, asFilter } from '../db/mongo.js';
 import { getConfig } from '../config/loader.js';
 import { log } from '../util/log.js';
 
-const COLLECTION = '_audit_log';
+/**
+ * IMPORTED, not spelled again.
+ *
+ * This file had `const COLLECTION = '_audit_log'` from the day it was written (#491, 2026-07-28). The audit
+ * log has been `audit_log` since #61. So the sweep ran every ten minutes against a collection nothing has
+ * ever written to, across **fourteen releases**, and redacted nothing — while the documentation promised a
+ * 14-day window on the `changes` payload and `doc-cited-constants` kept the number honest.
+ *
+ * It was silent rather than wrong-looking because `updateMany` on a non-existent collection succeeds with
+ * `modifiedCount: 0`, and the sweep logs only when the count is above zero. Zero redacted is exactly what a
+ * healthy instance with nothing aged out also reports.
+ */
+import { AUDIT_COLLECTION } from './audit.js';
+
+const COLLECTION = AUDIT_COLLECTION;
 
 /** Days a `changes` payload survives when the operation is a brain record edit. */
 export const DEFAULT_RECORD_CHANGE_RETENTION_DAYS = 14;
@@ -106,6 +120,24 @@ export async function redactExpiredChanges(now: number = Date.now()): Promise<nu
     );
     const n = res.modifiedCount ?? 0;
     if (n > 0) log.info(`Audit: redacted changes on ${n} record-edit entr${n === 1 ? 'y' : 'ies'} older than ${cutoff.toISOString()}`);
+    // The FIRST sweep of a process reports even when it redacted nothing, and names the collection and how
+    // many candidate entries it can see.
+    //
+    // This is the line that would have exposed the wrong-collection bug on day one. A sweep that speaks only
+    // on success is indistinguishable from a sweep pointed at nothing: `updateMany` on a collection that does
+    // not exist returns `modifiedCount: 0`, which is also what a healthy instance with nothing aged out
+    // returns. Once per process is the whole cost — this runs every six hours, and a per-sweep info line
+    // would be noise nobody reads, which is its own way of hiding.
+    if (!_announced) {
+      _announced = true;
+      const seen = await col(COLLECTION).countDocuments(
+        asFilter({ operation: { $in: RECORD_CHANGE_OPERATIONS } }),
+        { limit: 1_000 },
+      ).catch(() => -1);
+      log.info(`Audit change-retention: sweeping '${COLLECTION}', ${recordChangeRetentionDays()}d window, `
+        + `${seen < 0 ? 'count unavailable' : `${seen} record-edit entr${seen === 1 ? 'y' : 'ies'} present`}, `
+        + `${n} redacted this pass`);
+    }
     return n;
   } catch (err) {
     log.warn(`Audit change-retention sweep: ${err}`);
@@ -115,6 +147,9 @@ export async function redactExpiredChanges(now: number = Date.now()): Promise<nu
 
 const SWEEP_INTERVAL_MS = 6 * 60 * 60 * 1000;   // 6h — the same cadence as the other housekeeping sweeps
 let _timer: NodeJS.Timeout | null = null;
+
+/** Whether this process has already reported one sweep. Reset by `stopAuditChangeRetention` for tests. */
+let _announced = false;
 
 /**
  * Start the sweep. Always on: it only removes content that policy says should already be gone, and an
@@ -129,4 +164,7 @@ export function startAuditChangeRetention(): void {
 
 export function stopAuditChangeRetention(): void {
   if (_timer) { clearInterval(_timer); _timer = null; }
+  // Also clear the once-per-process announcement, so a test that starts the sweep twice sees it twice.
+  // A latch that outlives its owner is a test seam that lies about the second run.
+  _announced = false;
 }

--- a/testing/standalone/audit-retention-targets-the-audit-log.test.js
+++ b/testing/standalone/audit-retention-targets-the-audit-log.test.js
@@ -1,0 +1,113 @@
+/**
+ * The audit change-retention sweep must target the collection the audit log is actually written to.
+ *
+ * ## What happened
+ *
+ * `change-retention.ts` was written in #491 with its own `const COLLECTION = '_audit_log'`. The audit log has
+ * been `audit_log` since #61. So the sweep ran every six hours against a collection **nothing has ever
+ * written to**, across fourteen releases, and redacted nothing — while `13-audit-log-api.md` documented a
+ * 14-day window on a brain record edit's `changes` payload, and `doc-cited-constants` kept that number
+ * faithful to the constant. Every check was green. The behaviour never happened.
+ *
+ * The `changes` payload is allowlisted user record content. So the actual consequence is a documented
+ * privacy window that was never enforced, and entries that should have been redacted at 14 days keeping
+ * their content for the full 90.
+ *
+ * ## Why nothing caught it
+ *
+ * `updateMany` against a collection that does not exist **succeeds** with `modifiedCount: 0`, and the sweep
+ * logged only when the count was above zero. Zero redacted is also exactly what a healthy instance with
+ * nothing aged out reports. There was no failure to see — the same shape as counting through an endpoint
+ * that was never real and reading the zero as an answer.
+ *
+ * ## What this pins
+ *
+ * The fix is not "spell it correctly" — that leaves two copies. The name is exported from `audit.ts` and
+ * imported here, so the pruner cannot name a collection the writer does not use. This asserts that SHAPE
+ * rather than comparing two string literals, because two literals that agree today drift tomorrow.
+ *
+ * Both files now discuss `_audit_log` in prose, so **comments are stripped before anything is matched**. A
+ * gate that fires on the comment explaining its own fix, or passes because of it, has happened three times
+ * in this repo.
+ *
+ * Run: node --test testing/standalone/audit-retention-targets-the-audit-log.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const WRITER = 'server/src/audit/audit.ts';
+const PRUNER = 'server/src/audit/change-retention.ts';
+const BOOTSTRAP = 'server/src/bootstrap.ts';
+
+/** Source with comments removed — block, line, and JSDoc alike. */
+function code(path) {
+  return readFileSync(path, 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+describe('the check itself works before it is trusted', () => {
+  it('strips comments, including the ones naming the old collection', () => {
+    const pruner = code(PRUNER);
+    assert.ok(readFileSync(PRUNER, 'utf8').includes('_audit_log'),
+      'the file should still EXPLAIN the bug in prose — if this fails the comment was deleted and the '
+      + 'stripping below is no longer being exercised');
+    assert.ok(!pruner.includes('_audit_log'),
+      'comment stripping failed: the explanation of the old name is still visible to the matcher');
+  });
+
+  it('is reading real source', () => {
+    assert.ok(code(WRITER).includes('AUDIT_COLLECTION'), `${WRITER} did not parse as expected`);
+    assert.ok(code(PRUNER).includes('redactExpiredChanges'), `${PRUNER} did not parse as expected`);
+  });
+});
+
+describe('the pruner and the writer cannot disagree about the collection', () => {
+  it('the writer EXPORTS the collection name', () => {
+    assert.match(code(WRITER), /export const AUDIT_COLLECTION\s*=\s*'audit_log'/,
+      'the audit collection name must be exported so there is exactly one copy of it');
+  });
+
+  it('the pruner IMPORTS it rather than naming a collection itself', () => {
+    const pruner = code(PRUNER);
+    assert.match(pruner, /import\s*\{[^}]*AUDIT_COLLECTION[^}]*\}\s*from\s*'\.\/audit\.js'/,
+      'change-retention.ts must import the name from audit.ts');
+    // The actual rule: no string literal that looks like a collection may be declared here. This is what
+    // catches a reintroduction, including a correctly-spelled one — a second copy is the defect, not the
+    // typo. `audit_log` spelled right in two files is one rename away from being wrong again.
+    const literals = [...pruner.matchAll(/=\s*'([a-z_][a-z0-9_]*)'/g)].map(m => m[1])
+      .filter(v => /log|audit|collection/.test(v));
+    assert.deepEqual(literals, [],
+      `change-retention.ts declares its own collection-ish literal(s): ${literals.join(', ')} — import `
+      + 'AUDIT_COLLECTION instead. Two copies that agree today are what produced this bug.');
+  });
+});
+
+describe('the sweep is wired up and cannot go silent', () => {
+  it('bootstrap starts it', () => {
+    // I briefly believed this function was never called, because a grep that excluded its own file could
+    // not see the caller one scroll below the definition. It is called; this pins that.
+    assert.match(code(BOOTSTRAP), /startAuditChangeRetention\s*\(\s*\)/,
+      'bootstrap must start the change-retention sweep');
+    assert.match(code(PRUNER), /setInterval\(/, 'the sweep must be scheduled, not one-shot');
+  });
+
+  it('reports its first pass even when it redacts nothing', () => {
+    // The whole reason this bug survived fourteen releases: a housekeeping sweep that speaks only on
+    // success is indistinguishable from one pointed at an empty collection.
+    const pruner = code(PRUNER);
+    assert.match(pruner, /_announced/, 'a once-per-process announcement must exist');
+    assert.match(pruner, /log\.info\([^)]*COLLECTION/,
+      'the announcement must NAME the collection it is sweeping — that is the line that would have shown '
+      + "'_audit_log' on day one");
+  });
+
+  it('the announcement latch is cleared when the sweep is stopped', () => {
+    // Otherwise a second start in the same process is silent, and a test of the second run would be
+    // asserting on a latch rather than on behaviour.
+    const stop = code(PRUNER).slice(code(PRUNER).indexOf('export function stopAuditChangeRetention'));
+    assert.match(stop.slice(0, 300), /_announced\s*=\s*false/,
+      'stopAuditChangeRetention must reset the announcement latch');
+  });
+});


### PR DESCRIPTION
First finding of the **Data Integrity & Correctness** lens (audit lens 8), which the empty queue opened.

`change-retention.ts` declared its own `const COLLECTION = '_audit_log'` when it was introduced in #491. The audit log has been `audit_log` since #61.

So the sweep ran every six hours against a collection that **has never existed**, and redacted nothing, across **fourteen releases** (2.0.0 → 2.6.0).

## What was actually retained

The `changes` payload on a brain record edit is allowlisted **user content** — the old text of a memory, the previous description of an entity. It lives in a store with different access rules: any admin can read the audit log, *including for spaces their token could not otherwise reach*. That is precisely why the payload has a shorter window than the entry around it.

It kept its content for the full `retentionDays` (default 90) instead of the documented 14.

## Every check was green

- `doc-cited-constants` verifies the documentation quotes `recordChangeRetentionDays: 14` faithfully. **It does.**
- `13-audit-log-api.md` describes the sweep accurately.
- The constant, the prose, and the gate all agreed with each other — about behaviour that never ran.

Nothing compared the pruner's collection to the writer's, because there was no reason to imagine they differed.

## Why it was silent rather than broken-looking

`updateMany` against a collection that does not exist **succeeds**, with `modifiedCount: 0`. The sweep logged only when the count was above zero. Zero redacted is *also* exactly what a healthy instance with nothing aged out reports.

There was no failure to notice.

## The fix is one copy, not a corrected second one

`AUDIT_COLLECTION` is exported from `audit.ts` and imported by the pruner.

The gate asserts that **shape**, and this is the part worth reviewing: it fails on a collection literal declared in the pruner **even when spelled correctly**. The second copy is the defect; the typo was only its symptom, and `audit_log` spelled right in two files is one rename away from being wrong again.

Both mutations were run — `'_audit_log'` and `'audit_log'` — and both fail the gate. Comments are stripped first, because both files now *discuss* `_audit_log` in prose and a gate that passes on the comment explaining its own fix has happened three times here.

## And the sweep can no longer go quiet

The first pass of each process now reports even when it redacts nothing, naming the collection and how many record-edit entries it can see:

```
Audit change-retention: sweeping 'audit_log', 14d window, 312 record-edit entries present, 0 redacted this pass
```

That is the line that would have exposed this on day one. Once per process rather than per sweep — this runs every six hours, and an info line every time is noise nobody reads, which is its own way of hiding. `stopAuditChangeRetention` clears the latch so a second start in the same process is not silent.

## One thing I nearly got wrong

I first concluded `redactExpiredChanges` was never called at all — because a `git grep` that excluded its own file could not see the caller one scroll below the definition. It is called, from `startAuditChangeRetention`, which `bootstrap.ts` wires up. The gate now pins that wiring too, so the retraction is worth something.

## Upgrade note, in the docs as well as here

The first sweep after upgrading redacts the whole accumulated backlog in one pass and logs the count. A four-figure number there is the backlog, not a fault.

## Verified

- `npm run preflight` — PASSED
- the new gate mutation-tested against both a wrong-spelled and a correctly-spelled second literal
- `git grep '_audit_log'` now returns only the two comments that explain the bug
