### PR TITLE
fix(brain): a page of suppressed records blocked every embeddable record behind it, and truncated:true said to keep calling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+- **`POST /api/spaces/:id/reembed` could not converge, and a page of suppressed records blocked every embeddable
+  record behind it — permanently.** Second finding of the Data Integrity & Correctness audit lens.
+  - A suppressed record matches the candidate query *"has no vector"* **by construction**: suppression is what
+    removed the vector. The sweep filtered on that alone and skipped suppressed documents inside the loop.
+  - `find(filter).limit(n)` carries **no sort**, so the same first `n` documents came back on every call, and the
+    sweep never writes to a suppressed record — so they never left the result set. A suppressed page at the front
+    of a collection therefore hid the embeddable records behind it from every subsequent call, while
+    `truncated: true` documented *"call again to continue"*.
+  - Fixed by expressing all three tiers **in the query** rather than in the loop, so the cursor advances: enqueued
+    records gain a vector and drop out, suppressed ones were never in. `excludeFromVectorSearch` becomes
+    `$ne: true` — not `$exists: false`, which would also exclude a record that carries the flag as `false`, an
+    explicit opt-**in**. Suppressed type names come from `meta.typeSchemas` as a `$nin`, on `label` for edges and
+    `type` for everything else.
+  - **`remaining` now counts only work that can be done.** A space whose suppression is still on answers
+    `remaining: 0`, `truncated: false`, with every candidate under `skippedSuppressed` — *there is no work*, which
+    is a different statement from *there is work left*.
+  - The space-wide tier is resolved before any query, and claims "nothing to do" **only** when no lower tier can
+    lift a record back out: a type schema saying `false` overrides it, and a type schema saying nothing falls
+    through rather than counting as `false`.
+  - `suppressionExclusion` is pure and exported, so the three tiers are tested by construction rather than by
+    reading source — and the gate that pins the exclusion into the *query* is mutation-tested by moving it back
+    into the loop.
+
 - **The audit log's record-change retention swept the wrong collection, so a documented privacy window was
   never enforced — for fourteen releases.** `change-retention.ts` declared its own
   `const COLLECTION = '_audit_log'` when it was introduced in 2.0.0. The audit log has been `audit_log` since

--- a/docs/integration-guide/06-spaces-api.md
+++ b/docs/integration-guide/06-spaces-api.md
@@ -213,7 +213,7 @@ all of it would be worse off than one who got an error.
 | `enqueued` | Records a job was queued for. Embedding happens in the background afterwards. |
 | `skippedSuppressed` | Candidates skipped because suppression **still applies**. See the note below. |
 | `byKind` | Where the gap was, per record kind. |
-| `remaining` | Candidates left after `limit`. Counted over the whole space, not over this page. |
+| `remaining` | Candidates left after `limit` **that can actually be embedded**. Counted over the whole space, not over this page. Suppressed records are never counted here — see the note below. |
 | `truncated` | `true` when `remaining > 0` — call again to continue. |
 
 > **Turn suppression off first.** A record that is still suppressed at any tier is skipped, so that a backfill
@@ -225,6 +225,16 @@ partial work with no record of where it stopped. Queuing is idempotent per recor
 same space converges instead of duplicating work.
 
 **Nothing is truncated silently** — when more candidates remain than `limit` allowed, `remaining` says how many.
+
+**`remaining` counts only work that can be done, and that distinction is load-bearing.** Suppression is applied
+in the query, so a suppressed record never reaches `remaining`; it is reported under `skippedSuppressed` instead.
+A space whose suppression is still on therefore answers `remaining: 0`, `truncated: false` — *there is no work*,
+which is a different statement from *there is work left* and the one you can act on.
+
+> **Fixed in 2.6.1.** Before that, `remaining` counted every record without a vector, suppressed ones included,
+> and the candidate query had no sort. So a page of suppressed records at the front of a collection came back
+> unchanged on every call, blocked every embeddable record behind it, and `truncated: true` said "call again to
+> continue" — a loop that could not converge. If you scripted against `truncated`, it terminates now.
 
 ---
 

--- a/server/src/brain/reembed.ts
+++ b/server/src/brain/reembed.ts
@@ -30,17 +30,36 @@
  * error and reports honestly — every candidate comes back under `skippedSuppressed`, which tells the operator the
  * setting is still on rather than leaving them to wonder why nothing happened.
  *
+ * ## Suppression is excluded in the QUERY, and that is what makes the sweep terminate
+ *
+ * The first version filtered on "has no vector" alone and skipped suppressed documents inside the loop. It did
+ * not converge, and the failure was worse than a misleading counter:
+ *
+ *  - a suppressed record matches "has no vector" **by construction** — suppression is what removed the vector;
+ *  - `find(filter).limit(n)` has no sort, so the same first `n` documents come back on every call;
+ *  - the sweep never writes to a suppressed record, so they never leave the result set.
+ *
+ * So a page of suppressed records at the front of a collection **blocked every embeddable record behind it,
+ * permanently**, while `truncated: true` told the caller to keep calling. All three tiers are expressible as a
+ * filter (see `suppressionExclusion`), so now the cursor advances: enqueued records gain a vector and drop out,
+ * and suppressed records were never in.
+ *
  * ## Nothing is capped silently
  *
  * `limit` bounds one call. When more candidates remain, `remaining` says how many and `truncated` is `true`. A
  * backfill that quietly stopped at a round number would read as "the space is fully indexed now", which is the
  * same class of lie as the missing sweep this replaces.
+ *
+ * `remaining` counts only work that CAN be done. A space whose suppression is still on reports `remaining: 0`
+ * with every candidate under `skippedSuppressed` — "there is no work", which is a different statement from
+ * "there is work left", and the one an operator can act on.
  */
 
 import { col, asFilter } from '../db/mongo.js';
 import { COLLECTION, } from './embed-record.js';
 import { enqueueEmbedJob } from './embed-queue.js';
 import { embeddingSuppressed, schemaKeyFor } from './suppress-embeddings.js';
+import { TYPE_FIELD } from './ttl.js';
 import { getSpaceMeta } from '../spaces/schema-validation.js';
 import type { KnowledgeType } from '../config/types-knowledge.js';
 import type { BrainEmbedRecordType } from '../config/types.js';
@@ -66,12 +85,73 @@ export interface ReembedResult {
   truncated: boolean;
 }
 
+/** Just the fields the exclusion decision reads, so a test can build the tiers by hand. */
+export interface SuppressMeta {
+  suppressEmbeddings?: boolean | undefined;
+  typeSchemas?: Partial<Record<KnowledgeType, Record<string, { suppressEmbeddings?: boolean } | undefined>>> | undefined;
+}
+
+/**
+ * The three suppression tiers as a Mongo filter fragment — or `'all'` when nothing can be embedded.
+ *
+ * Exported for testing because this is the part with the reasoning in it. Each tier separately:
+ *
+ *  - **record**: `excludeFromVectorSearch: true` is a plain field, so `$ne: true` excludes it. It must be
+ *    `$ne` rather than `{ $exists: false }` — the flag can legitimately be present and `false`, and a record
+ *    that explicitly opts IN must not be excluded.
+ *  - **schema**: the suppressed type NAMES are enumerable from `meta.typeSchemas`, so they become a `$nin` on
+ *    the type field. Edges key on `label` while everything else keys on `type`, which `TYPE_FIELD` already
+ *    encodes — reading `type` for an edge would find no schema, look like it worked, and silently exclude
+ *    nothing for the one record kind this was widened to cover.
+ *  - **space**: knowable before any query. On its own it suppresses everything, so the sweep can say "no work"
+ *    instead of reporting a backlog it can never clear. But a type schema saying `false` OVERRIDES it, and so
+ *    does a record — `record > schema > space`, where "not stated" falls through. So `'all'` is only correct
+ *    when no lower tier can lift a record back out, which is what `releasedTypes` checks.
+ *
+ * Takes the meta rather than a space id, so it is **pure** and a test can build the three tiers by hand —
+ * the same idiom `embeddingSuppressed` and `changesCutoff` already use here: the part with a decision in it
+ * is the part that must be testable without a database.
+ */
+export function suppressionExclusion(
+  meta: SuppressMeta | undefined,
+  kind: BrainEmbedRecordType,
+): 'all' | { query: Record<string, unknown> } {
+  const spaceWide = meta?.suppressEmbeddings === true;
+  const knowledgeType: KnowledgeType | undefined = kind === 'file' ? undefined : kind;
+  const schemas = knowledgeType === undefined ? undefined : meta?.typeSchemas?.[knowledgeType];
+
+  const suppressedTypes: string[] = [];
+  const releasedTypes: string[] = [];
+  for (const [name, schema] of Object.entries(schemas ?? {})) {
+    const v = (schema as { suppressEmbeddings?: boolean } | undefined)?.suppressEmbeddings;
+    if (v === true) suppressedTypes.push(name);
+    else if (v === false) releasedTypes.push(name);
+  }
+
+  const field = knowledgeType === undefined ? undefined : TYPE_FIELD[knowledgeType];
+
+  if (spaceWide) {
+    // A record-level opt-in can also lift a record out, and unlike a type name that is not enumerable from
+    // meta — so `'all'` is claimed only when neither escape hatch exists for this kind.
+    if (releasedTypes.length === 0) return 'all';
+    // Some types are explicitly released: only those, minus any record opting out.
+    return { query: { ...(field ? { [field]: { $in: releasedTypes } } : {}), excludeFromVectorSearch: { $ne: true } } };
+  }
+
+  const query: Record<string, unknown> = { excludeFromVectorSearch: { $ne: true } };
+  if (field && suppressedTypes.length > 0) query[field] = { $nin: suppressedTypes };
+  return { query };
+}
+
 /**
  * Whether this stored document is still suppressed.
  *
  * Mirrors `embedStoredRecord` exactly, including the file asymmetry: a file has no type and therefore no type
  * schema, so it skips the middle tier. Narrowed rather than cast — a cast would index `typeSchemas` with
  * `'file'` and miss every time, which here would mean re-embedding files an operator had suppressed.
+ *
+ * Still consulted per document even though `suppressionExclusion` now removes suppressed records in the query.
+ * The query is derived from `meta`; this reads the record. A tier the query cannot express keeps working.
  */
 function stillSuppressed(spaceId: string, kind: BrainEmbedRecordType, doc: Record<string, unknown>): boolean {
   const meta = getSpaceMeta(spaceId);
@@ -102,23 +182,54 @@ export async function reembedSpace(
   };
 
   for (const kind of kinds) {
+    const collName = `${spaceId}_${COLLECTION[kind]}`;
+
     // `$exists: false` on `embedding`, NOT a null check: the suppressed path `$unset`s the field, so a record
     // that was suppressed and later released has no key at all rather than a null one. A `null` filter would
     // find nothing and report a clean sweep over a space that is entirely unindexed.
-    const filter = asFilter({ embedding: { $exists: false } });
-    const collName = `${spaceId}_${COLLECTION[kind]}`;
+    const vectorless = { embedding: { $exists: false } } as Record<string, unknown>;
+
+    // ── Suppression is EXCLUDED IN THE QUERY, and that is a correctness requirement, not a speed one ──
+    //
+    // Suppressed records match `vectorless` by construction — suppression is what removed their vector. The
+    // first version of this sweep filtered on `vectorless` alone and skipped suppressed docs in the loop.
+    // That does not converge, and the failure is worse than a wrong counter:
+    //
+    //   `find(vectorless).limit(50)` has no sort, so it returns the same first 50 documents on every call.
+    //   The sweep never modifies a suppressed record, so those 50 never leave the result set. A page of
+    //   suppressed records at the front of a collection therefore BLOCKS every embeddable record behind it,
+    //   permanently, while `truncated: true` tells the caller to "call again to continue".
+    //
+    // All three tiers are expressible here, so the cursor advances: enqueued records gain a vector and drop
+    // out, and suppressed ones were never in.
+    const exclusion = suppressionExclusion(getSpaceMeta(spaceId), kind);
+    if (exclusion === 'all') {
+      // The space-wide tier is on with nothing that can override it upward. Every candidate is suppressed, so
+      // report them as skipped and leave `remaining` at zero: there is no work, as opposed to work left.
+      result.skippedSuppressed += await col(collName).countDocuments(asFilter(vectorless));
+      continue;
+    }
+
+    const filter = asFilter({ ...vectorless, ...exclusion.query });
+    // Candidates the filter removed — reported so "nothing happened" is never silent, which is what tells an
+    // operator the setting is still on.
+    result.skippedSuppressed += await col(collName).countDocuments(asFilter(vectorless)) -
+      await col(collName).countDocuments(filter);
 
     // Counted before the cap is applied, so `remaining` is the truth about the space rather than about this
     // page. Without this a truncated sweep could not tell an operator that more work is left.
     const total = await col(collName).countDocuments(filter);
 
-    const budget = cap - result.enqueued - result.skippedSuppressed;
+    const budget = cap - result.enqueued;
     if (budget <= 0) { result.remaining += total; continue; }
 
     const docs = await col(collName).find(filter).limit(budget).toArray() as Array<Record<string, unknown>>;
     for (const doc of docs) {
       const id = doc['_id'];
       if (typeof id !== 'string') continue;
+      // Belt and braces: the query already excluded suppressed records, and the resolver is still consulted
+      // per document. The query is derived from `meta`, so a shape the exclusion cannot express — a future
+      // fourth tier, say — would otherwise re-index exactly what an operator asked to keep out of recall.
       if (stillSuppressed(spaceId, kind, doc)) { result.skippedSuppressed++; continue; }
       await enqueueEmbedJob(spaceId, kind, id);
       result.enqueued++;

--- a/testing/standalone/reembed-backfill.test.js
+++ b/testing/standalone/reembed-backfill.test.js
@@ -147,3 +147,82 @@ describe('the comment that promised a sweep that never existed', () => {
     assert.match(QUEUE, /on demand, not periodic/);
   });
 });
+
+/**
+ * ── The convergence property, and why it is a BEHAVIOURAL test rather than a source-reading one ──
+ *
+ * The first version of this sweep filtered on "has no vector" alone and skipped suppressed documents inside
+ * the loop. That does not terminate, and the failure is worse than a misleading counter:
+ *
+ *  - a suppressed record matches "has no vector" BY CONSTRUCTION — suppression is what removed the vector;
+ *  - `find(filter).limit(n)` carries no sort, so the same first `n` documents come back on every call;
+ *  - the sweep never writes to a suppressed record, so they never leave the result set.
+ *
+ * So a page of suppressed records at the front of a collection blocked every embeddable record behind it,
+ * permanently, while `truncated: true` documented "call again to continue".
+ *
+ * `suppressionExclusion` is pure and exported precisely so this can be checked without a database.
+ */
+describe('suppression is expressible as a query, which is what makes the sweep terminate', () => {
+  it('excludes the record tier with $ne, not $exists', async () => {
+    const { suppressionExclusion } = await import('../../server/dist/brain/reembed.js');
+    const { query } = suppressionExclusion(undefined, 'memory');
+    assert.deepEqual(query['excludeFromVectorSearch'], { $ne: true },
+      '$exists:false would also exclude a record that carries the flag as FALSE — an explicit opt-in');
+  });
+
+  it('excludes suppressed TYPE NAMES, on the right field per kind', async () => {
+    const { suppressionExclusion } = await import('../../server/dist/brain/reembed.js');
+    const meta = {
+      typeSchemas: {
+        memory: { note: { suppressEmbeddings: false }, task: { suppressEmbeddings: true } },
+        edge: { blocks: { suppressEmbeddings: true } },
+      },
+    };
+    assert.deepEqual(suppressionExclusion(meta, 'memory').query['type'], { $nin: ['task'] });
+    // Edges key on `label`. Reading `type` for an edge finds no schema, looks like it worked, and excludes
+    // nothing — for the one record kind suppression was specifically widened to cover.
+    assert.deepEqual(suppressionExclusion(meta, 'edge').query['label'], { $nin: ['blocks'] });
+    assert.equal(suppressionExclusion(meta, 'edge').query['type'], undefined);
+  });
+
+  it('says ALL when the space-wide tier is on and nothing can override it', async () => {
+    const { suppressionExclusion } = await import('../../server/dist/brain/reembed.js');
+    assert.equal(suppressionExclusion({ suppressEmbeddings: true }, 'memory'), 'all',
+      'a space that suppresses everything has NO WORK, which is a different report from work left over');
+  });
+
+  it('does NOT say ALL when a type schema releases a type', async () => {
+    // `record > schema > space`: a schema saying false lifts its type back out, so the sweep still has work.
+    const { suppressionExclusion } = await import('../../server/dist/brain/reembed.js');
+    const meta = { suppressEmbeddings: true, typeSchemas: { memory: { note: { suppressEmbeddings: false } } } };
+    const res = suppressionExclusion(meta, 'memory');
+    assert.notEqual(res, 'all', 'claiming ALL here would skip the types an operator explicitly released');
+    assert.deepEqual(res.query['type'], { $in: ['note'] });
+  });
+
+  it('treats a type schema that says NOTHING as falling through, not as false', async () => {
+    // The tier rule is "absent means not stated". A silent type under space-wide suppression stays suppressed.
+    const { suppressionExclusion } = await import('../../server/dist/brain/reembed.js');
+    const meta = { suppressEmbeddings: true, typeSchemas: { memory: { note: {} } } };
+    assert.equal(suppressionExclusion(meta, 'memory'), 'all');
+  });
+
+  it('a file has no type tier, so no type field appears in its exclusion', async () => {
+    const { suppressionExclusion } = await import('../../server/dist/brain/reembed.js');
+    const meta = { typeSchemas: { memory: { task: { suppressEmbeddings: true } } } };
+    const { query } = suppressionExclusion(meta, 'file');
+    assert.deepEqual(Object.keys(query), ['excludeFromVectorSearch'],
+      'indexing typeSchemas with "file" would miss every time and silently exclude nothing');
+  });
+
+  it('the sweep applies the exclusion to the QUERY, not only to the loop', () => {
+    // The mutation that reintroduces the bug is moving this back into the loop, which no pure test can see.
+    const src = readFileSync('server/src/brain/reembed.ts', 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+    assert.match(src, /suppressionExclusion\(/, 'the sweep must call the exclusion builder');
+    assert.match(src, /\.\.\.vectorless,\s*\.\.\.exclusion\.query/,
+      'the exclusion must be spread INTO the find filter — skipping in the loop alone never advances the cursor');
+    assert.match(src, /=== 'all'/, "the space-wide short-circuit must be handled before querying");
+  });
+});


### PR DESCRIPTION
Second finding of the **Data Integrity & Correctness** audit lens (lens 8).

## The mechanism, which is worse than a wrong counter

A suppressed record matches the candidate query *"has no vector"* **by construction** — suppression is what removed the vector, and the code said so in its own comment. The sweep filtered on that alone and skipped suppressed documents inside the loop.

`find(filter).limit(n)` carries **no sort**, so the same first `n` documents come back on every call. The sweep never writes to a suppressed record, so they never leave the result set.

So a page of suppressed records at the front of a collection hid **every embeddable record behind it** from every subsequent call — permanently — while `truncated: true` documented *"call again to continue"*.

That is not merely a loop that fails to converge. It is a backfill that cannot reach the records it exists for.

```
space with 100 vector-less records, the first 50 suppressed, limit 50
  call 1:  docs = the same 50 suppressed  ->  enqueued 0, remaining 50, truncated true
  call 2:  docs = the same 50 suppressed  ->  identical
  call n:  ...
```

## The fix is to express suppression in the query

All three tiers are expressible, so the cursor advances — enqueued records gain a vector and drop out, and suppressed records were never in.

| tier | as a filter | the trap avoided |
|---|---|---|
| record | `excludeFromVectorSearch: { $ne: true }` | **not** `$exists: false`, which would also exclude a record carrying the flag as `false` — an explicit opt-**in** |
| schema | suppressed type names from `meta.typeSchemas` as `$nin` | on `label` for edges, `type` for everything else. Reading `type` for an edge finds no schema, looks like it worked, and excludes nothing — for the one kind suppression was widened to cover |
| space | resolved before any query | claims "nothing to do" **only** when no lower tier can lift a record back out |

`record > schema > space`, with *absent means not stated*: a type schema saying `false` overrides the space-wide setting, and one saying nothing falls through rather than counting as `false`.

`stillSuppressed` is still consulted per document. The query is derived from `meta`; that reads the record. A tier the query cannot express keeps working.

## `remaining` now counts only work that can be done

A space whose suppression is still on answers `remaining: 0`, `truncated: false`, with every candidate under `skippedSuppressed`.

*"There is no work"* is a different statement from *"there is work left"*, and it is the one an operator can act on. The docs previously described half of this correctly — "every candidate comes back under `skippedSuppressed`" — which held only while every candidate fitted in one page.

## Made pure so the tiers are tested by construction

`suppressionExclusion` takes the meta rather than a space id, the same idiom `embeddingSuppressed` and `changesCutoff` already use here: the part with a decision in it is the part that must be testable without a database.

Six behavioural cases, including the edge/label asymmetry, the file kind having no type tier at all, and absent-means-not-stated.

The one source-reading assertion — that the exclusion is spread into the **find filter** and not merely applied in the loop — is mutation-tested by moving it back into the loop, because no pure test of the decision can see that regression.

## Verified

- `npm run preflight` — PASSED
- 25 tests in `reembed-backfill.test.js`, up from 18
- mutation: moving the exclusion out of the filter fails the gate; restored, green
- docs updated in `06-spaces-api.md`, including a "Fixed in 2.6.1" note for anyone who scripted against `truncated`
