### PR TITLE
fix(brain): an entity merge orphaned every file linked to the absorbed entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+- **An entity merge left every FILE linked to the absorbed entity pointing at a record it had just deleted.**
+  Third finding of the Data Integrity & Correctness audit lens.
+  - A file metadata record is a knowledge-graph document like any other and carries `entityIds` — that is how a
+    file is linked to an entity, and `assertRefsResolve` enforces at write time that every id in it names a real
+    entity. The merge relinked edges, memories and chrono, and never opened the files collection.
+  - So merging B into A rewrote three collections and left the fourth pointing at B, which the merge's own last
+    phase then deleted. **The merge path broke the invariant the write path enforces.**
+  - **Every direction that could have noticed was looking elsewhere.** The ER model counts `linkedFrom.files` as
+    a first-class relationship, so the number was simply wrong rather than obviously broken. `danglingEdges` in
+    that same model counts dangling *edges* and never looks at files. `strictLinkage` blocks deleting an entity
+    with inbound backlinks — and a merge deletes the absorbed entity directly, so it never passes that guard. A
+    traversal from the file came back empty, which reads as "nothing linked" rather than as a broken link.
+  - The relink bumps `seq` like the others, so the correction replicates instead of being undone by the next
+    pull from a peer, and dedupes — a file linked to *both* entities would otherwise hold the survivor twice.
+  - The new gate **derives** the record kinds from `config/types.ts` rather than listing collection names: every
+    interface declaring an `entityIds` field must have its collection relinked by the merge. A future record
+    type with entity links fails the gate by name instead of quietly repeating this.
 - **`POST /api/spaces/:id/reembed` could not converge, and a page of suppressed records blocked every embeddable
   record behind it — permanently.** Second finding of the Data Integrity & Correctness audit lens.
   - A suppressed record matches the candidate query *"has no vector"* **by construction**: suppression is what

--- a/server/src/brain/merge.ts
+++ b/server/src/brain/merge.ts
@@ -18,7 +18,7 @@ import { getConfig } from '../config/loader.js';
 import { log } from '../util/log.js';
 import { mergeTags } from './merge-fields.js';
 import { emitWebhookEvent, type WebhookActor } from '../webhooks/dispatcher.js';
-import type { EntityDoc, EdgeDoc, MemoryDoc, ChronoEntry, TombstoneDoc, SpaceMeta, PropertySchema } from '../config/types.js';
+import type { EntityDoc, EdgeDoc, MemoryDoc, ChronoEntry, FileMetaDoc, TombstoneDoc, SpaceMeta, PropertySchema } from '../config/types.js';
 
 // ── Public types ───────────────────────────────────────────────────────────
 
@@ -426,6 +426,39 @@ export async function executeMerge(
         await chronoColl.updateOne(
           asFilter<ChronoEntry>({ _id: ch._id }),
           asUpdate<ChronoEntry>({ $set: { entityIds: dedupedIds, updatedAt: now, seq: chSeq } }),
+          { session },
+        );
+      }
+
+      // ── 3b. Relink FILE metadata records ───────────────────────────────
+      //
+      // A file record is a knowledge-graph document like the others and carries `entityIds` — that is how a
+      // file is linked to an entity, and `assertRefsResolve` enforces at write time that every id in it names
+      // a real entity.
+      //
+      // This phase was missing. Edges, memories and chrono were relinked and files were not, so a merge left
+      // every file whose `entityIds` held the absorbed id pointing at an entity that phase 5 then DELETED.
+      // The merge path broke the invariant the write path enforces.
+      //
+      // It was invisible from every direction: the ER model counts `linkedFrom.files` as a first-class
+      // relationship, so the number was simply wrong; `danglingEdges` in that same model counts dangling
+      // EDGES and never looked at files; `strictLinkage` blocks deleting an entity that still has inbound
+      // backlinks, and a merge deletes the absorbed entity directly rather than passing that guard. A
+      // traversal from the file came back empty, which reads as "nothing linked" rather than as a broken link.
+      const fileColl = col<FileMetaDoc>(`${spaceId}_files`);
+      const affectedFiles = await fileColl
+        .find(asFilter<FileMetaDoc>({ spaceId, entityIds: absorbed._id }), { session })
+        .toArray() as FileMetaDoc[];
+      for (const f of affectedFiles) {
+        // `?? []` because `entityIds` is OPTIONAL on a file record, unlike memories and chrono where it is
+        // required. The filter above only matches files that hold the id, so the fallback never fires in
+        // practice — but the map has to be total over the type rather than rely on that.
+        const newEntityIds = (f.entityIds ?? []).map(id => id === absorbed._id ? survivor._id : id);
+        const dedupedIds = [...new Set(newEntityIds)];
+        const fSeq = await nextSeq(spaceId);
+        await fileColl.updateOne(
+          asFilter<FileMetaDoc>({ _id: f._id }),
+          asUpdate<FileMetaDoc>({ $set: { entityIds: dedupedIds, updatedAt: now, seq: fSeq } }),
           { session },
         );
       }

--- a/testing/standalone/merge-relinks-every-entity-reference.test.js
+++ b/testing/standalone/merge-relinks-every-entity-reference.test.js
@@ -1,0 +1,129 @@
+/**
+ * An entity merge must relink EVERY record kind that can reference an entity.
+ *
+ * ## The defect
+ *
+ * `executeMerge` relinked edges, memories and chrono entries, and never touched file metadata records — which
+ * carry `entityIds` exactly as memories and chrono do, and which `assertRefsResolve` validates at write time
+ * so that every id in them names a real entity.
+ *
+ * So merging B into A left every file whose `entityIds` held B pointing at an entity that the merge's own last
+ * phase then **deleted**. The merge path broke the invariant the write path enforces.
+ *
+ * ## Why nothing saw it
+ *
+ * Every direction that could have noticed was looking somewhere else:
+ *
+ *  - the ER model counts `linkedFrom.files` as a first-class relationship, so the number was simply wrong
+ *    rather than obviously broken;
+ *  - `danglingEdges` in that same model counts dangling **edges** and never looks at files;
+ *  - `strictLinkage` blocks deleting an entity that still has inbound backlinks — and a merge deletes the
+ *    absorbed entity directly, so it never passes that guard;
+ *  - a traversal from the file came back empty, which reads as "nothing linked" rather than as a broken link.
+ *
+ * ## What this pins, and why it is DERIVED
+ *
+ * Listing four collection names here would be the same shape as the bug: a hand-kept second copy that agrees
+ * until someone adds a fifth. So the record kinds are read out of `config/types.ts` — every interface that
+ * declares an `entityIds` field — and the merge is required to relink each one's collection.
+ *
+ * Add a new record type with `entityIds` and forget the merge, and this fails naming it.
+ *
+ * Comments are stripped first: the merge now carries a long comment explaining why the file phase exists, and
+ * it names the very collections being searched for.
+ *
+ * Run: node --test testing/standalone/merge-relinks-every-entity-reference.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const TYPES = 'server/src/config/types.ts';
+const MERGE = 'server/src/brain/merge.ts';
+
+const withoutComments = (t) =>
+  t.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+/** Every exported interface in `types.ts` that declares an `entityIds` field. */
+function typesWithEntityIds() {
+  const lines = withoutComments(readFileSync(TYPES, 'utf8')).split(/\r?\n/);
+  const found = [];
+  let current = null;
+  for (const line of lines) {
+    const m = /^export interface (\w+)/.exec(line);
+    if (m) current = m[1];
+    if (/^\s*entityIds\??\s*:/.test(line) && current) found.push(current);
+  }
+  return [...new Set(found)];
+}
+
+/**
+ * The collection each record type lives in.
+ *
+ * This mapping is the one thing that cannot be derived — a TypeScript interface does not know its collection
+ * suffix. So it is asserted to be TOTAL over the discovered types: a new `entityIds`-carrying type fails here
+ * first, with a message saying to add it, rather than passing silently.
+ */
+const COLLECTION_SUFFIX = {
+  MemoryDoc: 'memories',
+  ChronoEntry: 'chrono',
+  FileMetaDoc: 'files',
+};
+
+describe('the check itself works before it is trusted', () => {
+  it('finds the record types that carry entityIds', () => {
+    const types = typesWithEntityIds();
+    assert.ok(types.length >= 3, `only found ${types.length} types with entityIds in ${TYPES}`);
+    assert.ok(types.includes('MemoryDoc') && types.includes('ChronoEntry') && types.includes('FileMetaDoc'),
+      `expected the three known ones, got: ${types.join(', ')}`);
+  });
+
+  it('knows a collection for every one of them', () => {
+    const missing = typesWithEntityIds().filter(t => !COLLECTION_SUFFIX[t]);
+    assert.deepEqual(missing, [],
+      `these record types carry entityIds and this test does not know their collection: ${missing.join(', ')}. `
+      + 'Add them to COLLECTION_SUFFIX — and check the merge relinks them, which is the point of this file.');
+  });
+
+  it('strips the comment that names the collections', () => {
+    const raw = readFileSync(MERGE, 'utf8');
+    assert.ok(raw.includes('_files'), 'the merge should still explain the file phase in prose');
+    const stripped = withoutComments(raw);
+    // The explanation mentions `${spaceId}_files` in prose; the assertions below must see the real call.
+    assert.ok(stripped.includes('_files'), 'the file collection must be referenced in CODE, not only in a comment');
+  });
+});
+
+describe('executeMerge relinks every collection that can reference an entity', () => {
+  const merge = withoutComments(readFileSync(MERGE, 'utf8'));
+
+  for (const [type, suffix] of Object.entries(COLLECTION_SUFFIX)) {
+    it(`relinks ${suffix} (${type})`, () => {
+      // The collection must be opened...
+      assert.match(merge, new RegExp(`col<[^>]*>\\(\`\\$\\{spaceId\\}_${suffix}\`\\)`),
+        `the merge never opens the ${suffix} collection — records there keep pointing at the absorbed entity, `
+        + 'which phase 5 deletes');
+      // ...and queried for the absorbed id, which is what proves it is looking for references rather than
+      // touching the collection for some other reason.
+      assert.ok(
+        new RegExp(`${suffix}\`\\)[\\s\\S]{0,600}?entityIds: absorbed\\._id`).test(merge)
+        || new RegExp(`entityIds: absorbed\\._id[\\s\\S]{0,600}?${suffix}\``).test(merge),
+        `the merge opens ${suffix} but never searches it for \`entityIds: absorbed._id\``);
+    });
+  }
+
+  it('bumps seq on every relinked record, so the change replicates', () => {
+    // A relink that does not advance `seq` is invisible to sync: a peer would keep the old link forever, and
+    // the dangling reference would come back on the next pull.
+    const relinkBlocks = merge.split('nextSeq(spaceId)').length - 1;
+    assert.ok(relinkBlocks >= 4,
+      `only ${relinkBlocks} nextSeq calls — each relinked collection plus the survivor needs its own`);
+  });
+
+  it('dedupes after relinking, so a record linked to BOTH does not hold the survivor twice', () => {
+    const dedupes = merge.split('new Set(').length - 1;
+    assert.ok(dedupes >= 3,
+      `only ${dedupes} dedupe(s) — a record referencing the survivor AND the absorbed entity collapses to two `
+      + 'identical ids without one');
+  });
+});


### PR DESCRIPTION
Third finding of the **Data Integrity & Correctness** audit lens (lens 8).

A file metadata record is a knowledge-graph document like any other and carries `entityIds` — that is how a file is linked to an entity, and `assertRefsResolve` enforces **at write time** that every id in it names a real entity.

`executeMerge` relinked edges, memories and chrono. It never opened the files collection — `grep -c "_files" merge.ts` returned **0**.

So merging B into A rewrote three collections and left the fourth pointing at B, which the merge's own phase 5 then **deleted**. The merge path broke the invariant the write path enforces.

## Every direction that could have noticed was looking elsewhere

- the **ER model** counts `linkedFrom.files` as a first-class relationship, so the number was simply *wrong* rather than obviously broken;
- **`danglingEdges`** in that same model counts dangling *edges* and never looks at files;
- **`strictLinkage`** blocks deleting an entity that still has inbound backlinks — and a merge deletes the absorbed entity directly, so it never passes that guard;
- a **traversal** from the file came back empty, which reads as "nothing linked" rather than as a broken link.

Both surfaces shared it: REST and the MCP `merge_entities` tool both call `executeMerge`, so one phase fixes both.

## The relink matches the others deliberately

- **`seq` is bumped**, so the correction replicates instead of being undone by the next pull from a peer. A relink that does not advance `seq` is invisible to sync and the dangling reference comes back.
- **It dedupes.** A file linked to *both* entities would otherwise hold the survivor id twice.
- `entityIds` is **optional** on a file record and required on memories and chrono, so the map falls back to `[]` rather than relying on the filter to guarantee presence.

## The gate derives the record kinds rather than listing them

Listing four collection names in the test would be the same shape as the bug: a hand-kept second copy that agrees until someone adds a fifth.

So it reads every interface in `config/types.ts` that declares an `entityIds` field, and requires the merge to relink that kind's collection. It also asserts its own type→collection map is **total** over what it discovered — a new record type with entity links fails by name, with a message saying what to check.

It pins the `seq` bump and the dedupe too, and strips comments first: the new phase carries a long explanation that names the very collections being searched for.

Mutation-tested by deleting the phase — the gate names `files`.

## Verified

- `npm run preflight` — PASSED
- 8 assertions in the new gate, all self-checked before they are trusted
- `server` build clean

## Lens 8 so far

| # | finding | PR |
|---|---|---|
| 1 | a documented privacy window swept a collection nothing had ever written to | #806 |
| 2 | a page of suppressed records blocked every embeddable record behind it | #807 |
| 3 | an entity merge orphaned every file linked to the absorbed entity | this one |
