### PR TITLE
fix(brain): the data model drew edges outside itself, stacked its unconnected types, and its links went nowhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+- **The data-model diagram: four reported defects, three of them geometry.** Owner report 2026-08-11, tested
+  against an emulated 30-type model because the small, evenly-filled one always looked fine.
+  - **Clicking a record count rewrote the URL and changed nothing.** The Brain page read its query params once
+    from the snapshot, deliberately, fearing that re-reading its own writes would fight the tab setter. Now
+    subscribed and applying only *differences* — when the page writes `tab=x` it has already set that, so the
+    handler no-ops. Idempotence rather than abstinence, and it cannot loop because a no-op writes no URL.
+  - **Unconnected types now sit on a shelf along the bottom**, a wrapping grid that fills each row, instead of
+    falling into the right column and being centred against the hub — which pushed the meaningful part of the
+    diagram off-screen on any real space.
+  - **Edges left the diagram entirely.** A join between two boxes in the *same* column fell through the
+    `a.x < b.x` test as right-to-left and ran leftwards out of its own column: negative x for column 0. It now
+    borrows the adjacent gap and leaves and enters the face looking at it.
+  - **Lanes and labels overlapped past four joins.** The lane index was `(n++ % 4)`, so the fifth join on a side
+    reused the first one's line. One lane per join now, the gap sized from the real count, and labels stepped
+    down their own lane with a `paint-order` halo so one crossing another stays readable.
+  - **Both geometry bugs were one question answered twice:** the side was guessed from `pointsAtHub` to size the
+    gaps, then decided again from geometry when drawing. It is answered once now and both readers use that
+    answer, so a lane cannot be drawn into a gap that was not measured for it.
+  - **Hover highlighting needed a hit target.** Each join is a group carrying the visible stroke, an invisible
+    14 px path, and the label. A 1.25 px line is not a pointer target — without it the feature would have been
+    untriggerable. Hovering also dims the other joins, so one edge can be followed across a busy model.
 - **An entity merge left every FILE linked to the absorbed entity pointing at a record it had just deleted.**
   Third finding of the Data Integrity & Correctness audit lens.
   - A file metadata record is a knowledge-graph document like any other and carries `entityIds` — that is how a

--- a/client/src/app/pages/brain/brain.component.spec.ts
+++ b/client/src/app/pages/brain/brain.component.spec.ts
@@ -15,6 +15,7 @@
  */
 import { TestBed, DeferBlockBehavior } from '@angular/core/testing';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EMPTY } from 'rxjs';
 import { of } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
 import { SpacesApi } from '../../core/spaces-api.service';
@@ -67,7 +68,7 @@ describe('BrainComponent (OnPush)', () => {
         { provide: AdminApi, useValue: makeApi() },
         { provide: NetworksApi, useValue: makeApi() },
         { provide: AuthService, useValue: { token: () => '' } },
-        { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: { get: () => '' } } } },
+        { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: { get: () => '' } }, queryParamMap: EMPTY } },
       ],
     });
     const fixture = TestBed.createComponent(BrainComponent);
@@ -142,7 +143,7 @@ describe('BrainComponent (OnPush)', () => {
         { provide: AdminApi, useValue: makeApi() },
         { provide: NetworksApi, useValue: makeApi() },
         { provide: AuthService, useValue: { token: () => '' } },
-        { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: { get: () => '' } } } },
+        { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: { get: () => '' } }, queryParamMap: EMPTY } },
       ],
     });
     const fixture = TestBed.createComponent(BrainComponent);
@@ -189,7 +190,7 @@ describe('BrainComponent (OnPush)', () => {
         { provide: AdminApi, useValue: makeApi() },
         { provide: NetworksApi, useValue: makeApi() },
         { provide: AuthService, useValue: { token: () => '' } },
-        { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: { get: () => '' } } } },
+        { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: { get: () => '' } }, queryParamMap: EMPTY } },
       ],
     });
     const fixture = TestBed.createComponent(BrainComponent);

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -702,15 +702,37 @@ export class BrainComponent implements OnInit, OnDestroy {
    * WRITING the URL, and re-reading its own write would fight `setTab`.
    */
   private applyUrlState(spaces: { id: string }[]): void {
+    this.applyQueryParams(spaces);
+    /**
+     * ...and keep applying it, because a link INTO this page from a component already on it is a query-param
+     * change and nothing else.
+     *
+     * The data-model panel's record count is such a link. Read-once meant clicking it rewrote the URL —
+     * `?tab=entities&type=x` — and changed nothing on screen: reported as *"clicking the number does not jump
+     * to the correct tab. it just appends a route to the url"*. Exactly right, and the URL being correct while
+     * the page ignored it is the worst version of the bug, because the address bar says it worked.
+     *
+     * The original comment feared re-reading our own writes fighting `setTab`. That fear is answered by
+     * applying only DIFFERENCES rather than by not subscribing: when this component writes `tab=x` it has
+     * already set `activeTab` to x, so the incoming value equals current state and the handler does nothing.
+     * Idempotence, not abstinence — and it cannot loop, because a no-op writes no URL.
+     */
+    this.route.queryParamMap.subscribe(() => this.applyQueryParams(spaces));
+  }
+
+  /** Apply `?space=` / `?tab=` if — and only if — they differ from what is on screen. */
+  private applyQueryParams(spaces: { id: string }[]): void {
     const qp = this.route.snapshot.queryParamMap;
     const wanted = qp.get('space') ?? undefined;
     const initial = wanted && spaces.some(s => s.id === wanted) ? wanted : spaces[0]!.id;
-    this.selectSpace(initial);
+    // Only when it CHANGES: selectSpace reloads the space's data, so calling it on every query-param event
+    // would refetch on each tab switch this component itself performs.
+    if (initial !== this.activeSpaceId()) this.selectSpace(initial);
 
     // Only a tab that exists. An unknown value in a hand-edited URL must land on the default rather than a
     // blank pane, and `BRAIN_TABS` is the same list the strip renders from.
     const tab = (qp.get('tab') ?? undefined) as BrainTab | undefined;
-    if (tab && (BRAIN_TABS as readonly string[]).includes(tab)) this.activeTab.set(tab);
+    if (tab && tab !== this.activeTab() && (BRAIN_TABS as readonly string[]).includes(tab)) this.activeTab.set(tab);
   }
 
   /**

--- a/client/src/app/pages/brain/er-layout.spec.ts
+++ b/client/src/app/pages/brain/er-layout.spec.ts
@@ -127,3 +127,138 @@ describe('every join starts and ends on a box', () => {
     expect(boxes[0]!.h).toBeGreaterThan(20);
   });
 });
+
+/**
+ * ── A BIG, LOPSIDED MODEL — because the small even one was always fine ──────────────────────────────
+ *
+ * Owner, 2026-08-11: *"test the layout on a big dataset you emulate. i guess with only a few records that are
+ * welldefined and evenly filled its ok but not in real wordl."* That is exactly what happened: the four-lane
+ * scheme and the single-column treatment of unrelated types both look correct on six tidy types and fall apart
+ * past that.
+ *
+ * So this dataset is deliberately un-tidy: 30 types, of which 14 are connected and 16 are isolated, property
+ * counts from 0 to 9, and 22 relationships concentrated on one hub. The assertions are geometric invariants,
+ * not snapshots — a snapshot of a diagram this size would be unreadable and would fail on every tweak.
+ */
+describe('er-layout on a big, lopsided model', () => {
+  const type = (name, props, count = 10) => ({
+    type: name,
+    count,
+    declared: true,
+    properties: Array.from({ length: props }, (_, i) => ({ name: `p${i}`, type: 'string', required: i === 0 })),
+    linkedFrom: { memories: 0, chrono: 0, files: 0 },
+  });
+
+  const connected = Array.from({ length: 14 }, (_, i) => type(`joined${i}`, i % 10));
+  const isolatedTypes = Array.from({ length: 16 }, (_, i) => type(`lonely${i}`, i % 4));
+  const types = [...connected, ...isolatedTypes];
+
+  // A hub with a fan of 12 in and 9 out, plus a self-join — the shape a real space grows into.
+  const rels = [
+    ...Array.from({ length: 8 }, (_, i) => ({ from: `joined${i + 1}`, to: 'joined0', label: `in${i}`, count: i + 1 })),
+    ...Array.from({ length: 5 }, (_, i) => ({ from: 'joined0', to: `joined${i + 9}`, label: `out${i}`, count: i + 1 })),
+    { from: 'joined0', to: 'joined0', label: 'parent', count: 3 },
+    ...Array.from({ length: 8 }, (_, i) => ({ from: `joined${i + 1}`, to: `joined${i + 2}`, label: `chain${i}`, count: 1 })),
+  ];
+
+  const out = layoutErModel(types, rels);
+  const boxOf = (t) => out.boxes.find(b => b.type === t);
+
+  it('places every type exactly once', () => {
+    expect(out.boxes.length).toBe(types.length);
+    expect(new Set(out.boxes.map(b => b.type)).size).toBe(types.length);
+  });
+
+  it('puts every ISOLATED type on the shelf, and nothing else there', () => {
+    const shelf = out.boxes.filter(b => b.col === 3).map(b => b.type).sort();
+    expect(shelf).toEqual(isolatedTypes.map(t => t.type).sort());
+  });
+
+  it('puts the whole shelf BELOW every joined box', () => {
+    // The reported symptom was unrelated types stacked among the joined ones, pushing the meaningful part of
+    // the diagram out of view.
+    const joinedBottom = Math.max(...out.boxes.filter(b => b.col !== 3).map(b => b.y + b.h));
+    for (const b of out.boxes.filter(b => b.col === 3)) {
+      expect(b.y, `${b.type} must start below the joined picture`).toBeGreaterThanOrEqual(joinedBottom);
+    }
+  });
+
+  it('FILLS each shelf row instead of stacking one per line', () => {
+    const shelf = out.boxes.filter(b => b.col === 3);
+    const rows = new Map();
+    for (const b of shelf) rows.set(b.y, (rows.get(b.y) ?? 0) + 1);
+    const counts = [...rows.values()];
+    expect(counts.length, 'sixteen isolated types must not be sixteen rows').toBeLessThan(shelf.length);
+    expect(Math.max(...counts), 'at least one row has to hold several').toBeGreaterThan(1);
+    // Every row except the last is full — that is what "fills the space" means.
+    const full = Math.max(...counts);
+    const notLast = [...rows.keys()].sort((a, b) => a - b).slice(0, -1).map(y => rows.get(y));
+    for (const n of notLast) expect(n).toBe(full);
+  });
+
+  it('keeps every shelf box inside the diagram width', () => {
+    for (const b of out.boxes.filter(b => b.col === 3)) {
+      expect(b.x + b.w, `${b.type} overflows the viewBox`).toBeLessThanOrEqual(out.width);
+    }
+  });
+
+  it('gives every join its OWN lane — no two share a vertical run', () => {
+    // The four-lane cycle is the defect: the fifth join reused the first one's lane, and from there each new
+    // relationship landed on an existing line.
+    const lanes = out.paths.filter(p => !p.selfJoin).map(p => {
+      const m = /^M[\d.]+ [\d.]+ H([\d.]+) V/.exec(p.d);
+      return m ? Number(m[1]) : NaN;
+    });
+    expect(lanes.every(Number.isFinite), 'every non-self join must run down a vertical lane').toBe(true);
+    // Per SIDE. Two lanes in opposite gaps may share an x by coincidence and never touch, because each only
+    // exists between its own pair of boxes — asserting global uniqueness was asserting something the design
+    // never claimed, which is how a test fails on correct code.
+    const perSide = new Map();
+    for (const p of out.paths.filter(x => !x.selfJoin)) {
+      const lane = Number(/^M[\d.]+ [\d.]+ H([\d.]+) V/.exec(p.d)[1]);
+      const key = 'lane:' + lane;
+      expect(perSide.has(key), 'two joins on the same side share lane ' + lane).toBe(false);
+      perSide.set(key, p);
+    }
+  });
+
+  it('does not let a lane run through a box', () => {
+    const boxes = out.boxes;
+    for (const p of out.paths.filter(x => !x.selfJoin)) {
+      const lane = Number(/^M[\d.]+ [\d.]+ H([\d.]+) V/.exec(p.d)[1]);
+      // Only boxes the lane VERTICALLY overlaps can be cut. A lane exists between its two endpoints' mid
+      // heights, so a shelf box far below it shares an x range and is never crossed — checking x alone
+      // reported the shelf as an obstruction and was wrong about the geometry.
+      const yTop = Math.min(...[...p.d.matchAll(/[HV]([\d.]+)/g)].map(m => Number(m[1])), Infinity);
+      const from = boxOf(p.from), to = boxOf(p.to);
+      const lo = Math.min(from.y + from.h / 2, to.y + to.h / 2);
+      const hi = Math.max(from.y + from.h / 2, to.y + to.h / 2);
+      void yTop;
+      for (const b of boxes) {
+        const yOverlap = b.y < hi && b.y + b.h > lo;
+        const inside = yOverlap && lane > b.x + 1 && lane < b.x + b.w - 1;
+        expect(inside, `${p.from}->${p.to} lane at ${lane} cuts through ${b.type}`).toBe(false);
+      }
+    }
+  });
+
+  it('separates the labels enough to be read', () => {
+    // Not "no overlap at all" — two labels may share a y if they are far apart horizontally. The failure
+    // reported was labels ON each other, so the invariant is that no two share BOTH coordinates closely.
+    const labels = out.paths.map(p => ({ x: p.labelX, y: p.labelY, id: `${p.from}->${p.to}` }));
+    for (let i = 0; i < labels.length; i++) {
+      for (let j = i + 1; j < labels.length; j++) {
+        const near = Math.abs(labels[i].x - labels[j].x) < 8 && Math.abs(labels[i].y - labels[j].y) < 11;
+        expect(near, `${labels[i].id} and ${labels[j].id} labels sit on top of each other`).toBe(false);
+      }
+    }
+  });
+
+  it('every label says which side of its lane it hangs off', () => {
+    for (const p of out.paths) expect(['start', 'end', 'middle']).toContain(p.labelAnchor);
+  });
+
+  it('stays deterministic — the same model twice is the same picture', () => {
+    expect(layoutErModel(types, rels)).toEqual(out);
+  });
+});

--- a/client/src/app/pages/brain/er-layout.ts
+++ b/client/src/app/pages/brain/er-layout.ts
@@ -27,16 +27,24 @@ import type { ErEntityType, ErRelationship } from '../../core/api.types';
 export interface ErBox {
   type: string;
   x: number; y: number; w: number; h: number;
-  /** Column index, kept so a caller can group or animate by depth without recomputing it. */
-  col: 0 | 1 | 2;
+  /**
+   * Column index, kept so a caller can group or animate by depth without recomputing it.
+   *
+   * `3` is the unconnected shelf along the bottom, which is not a column at all — it is a wrapping grid. It
+   * keeps the same field because every caller wants the same thing from it: a way to tell these boxes apart
+   * from the joined ones without re-deriving degree.
+   */
+  col: 0 | 1 | 2 | 3;
 }
 
 export interface ErPath {
   from: string; to: string; label: string; count: number;
   /** The rendered path. Every point is derived from a box rectangle. */
   d: string;
-  /** Where the label sits — on the lane, clear of both boxes. */
+  /** Where the label sits — on its own lane, stepped so neighbouring lanes do not collide. */
   labelX: number; labelY: number;
+  /** Which side of the lane the text hangs off, so it never straddles its own line. */
+  labelAnchor: 'start' | 'end' | 'middle';
   /** A self-join is drawn and read differently, so the caller does not have to infer it from `from === to`. */
   selfJoin: boolean;
 }
@@ -51,6 +59,9 @@ export interface ErLayout {
 const BOX_W = 216;
 const HUB_W = 248;
 const GAP_Y = 24;
+/** Horizontal gap between shelf boxes, and the gap between the joined picture and the shelf above it. */
+const GAP_X = 20;
+const SHELF_GAP = 40;
 const COL_GAP = 120;
 const PAD = 16;
 const HEAD_H = 26;
@@ -79,16 +90,75 @@ export function layoutErModel(types: ErEntityType[], rels: ErRelationship[]): Er
   const pointsAtHub = new Set(rels.filter(r => r.to === hub.type && r.from !== hub.type).map(r => r.from));
   const hubPointsAt = new Set(rels.filter(r => r.from === hub.type && r.to !== hub.type).map(r => r.to));
 
+  /**
+   * Unconnected types go on a SHELF at the bottom, not into a column.
+   *
+   * They used to fall into the right-hand column together with everything the hub points at, so on a real
+   * space they were a tall centred stack of unrelated boxes with the joined ones hidden among them — and the
+   * hub was vertically centred against that stack, pushing the part of the diagram that has meaning
+   * off-screen. Reported directly: *"unconnected nodes should go on the bottom of the card and those
+   * unconnected card should fill the space and not be centered and stacked on top of each other."*
+   *
+   * A type is unconnected when no relationship names it at all, self-joins included: a self-join is a
+   * relationship and belongs in the connected picture.
+   */
+  const isolated = (t: ErEntityType): boolean => degree(rels, t.type) === 0;
+
   const left: ErEntityType[] = [];
   const right: ErEntityType[] = [];
+  const shelf: ErEntityType[] = [];
   for (const t of types) {
     if (t.type === hub.type) continue;
-    if (pointsAtHub.has(t.type)) left.push(t);
-    else right.push(t);          // includes hubPointsAt and anything unrelated
+    if (isolated(t)) shelf.push(t);
+    else if (pointsAtHub.has(t.type)) left.push(t);
+    else right.push(t);          // hubPointsAt, plus anything joined to something other than the hub
   }
   void hubPointsAt;
 
-  const colX = [PAD, PAD + BOX_W + COL_GAP, PAD + BOX_W + COL_GAP + HUB_W + COL_GAP];
+  /**
+   * The column gap is SIZED FROM THE LANE COUNT, not fixed.
+   *
+   * Every join gets its own lane (see below), and the lanes live in the gaps either side of the hub. With a
+   * constant 120 px gap, a model with nine joins on one side either overlapped them or drew them outside the
+   * gap and across the boxes. So the joins are counted first, and the columns are placed around the space
+   * their lanes actually need. A small model looks exactly as it did; a large one gets wider instead of
+   * illegible.
+   */
+  /**
+   * TWO PASSES, because the side a join runs on is a fact about the geometry and the geometry depends on how
+   * many joins run on each side. Guessing the side from `pointsAtHub` and then deciding it again from `a.x <
+   * b.x` in the path loop is what put a lane through a box, and what sent a same-column join out of the
+   * diagram entirely — reported as *"i saw edges go out of the diagram space completely"*.
+   *
+   * Pass one places the columns at the old fixed gap purely to learn which column each type lands in. Nothing
+   * from it is kept except that. Pass two sizes the gaps from the real counts and places the boxes for good.
+   */
+  const columnOf = (t: string): 0 | 1 | 2 =>
+    t === hub.type ? 1 : left.some(x => x.type === t) ? 0 : 2;
+
+  /**
+   * Which gap a join's lane belongs in, decided once and reused by both the counting and the drawing.
+   *
+   * A join between two boxes in the SAME column has no gap between them, so it borrows the ADJACENT one and
+   * leaves and enters on the same face. Previously it fell through the `a.x < b.x` test as right-to-left and
+   * ran leftwards out of its own column — negative x for column 0, i.e. off the canvas.
+   */
+  const gapOf = (r: ErRelationship): 'L' | 'R' | null => {
+    if (r.from === r.to) return null;                      // self-joins loop over their own box
+    const cf = columnOf(r.from), ct = columnOf(r.to);
+    if (cf === ct) return cf === 0 ? 'L' : 'R';            // same column: borrow the neighbouring gap
+    return Math.min(cf, ct) === 0 ? 'L' : 'R';             // 0↔1 and 0↔2 use the left gap; 1↔2 the right
+  };
+
+  const placeable = rels.filter(r => types.some(t => t.type === r.from) && types.some(t => t.type === r.to));
+  const nL = placeable.filter(r => gapOf(r) === 'L').length;
+  const nR = placeable.filter(r => gapOf(r) === 'R').length;
+  // 20 px clear of the source face, one lane every 22, then 20 px clear of the target face.
+  const gapFor = (n: number): number => Math.max(COL_GAP, 20 + n * 22 + 20);
+  const gapL = gapFor(nL);
+  const gapR = gapFor(nR);
+
+  const colX = [PAD, PAD + BOX_W + gapL, PAD + BOX_W + gapL + HUB_W + gapR];
 
   const boxes: ErBox[] = [];
   const stack = (list: ErEntityType[], col: 0 | 2): void => {
@@ -116,6 +186,19 @@ export function layoutErModel(types: ErEntityType[], rels: ErRelationship[]): Er
 
   // Lanes are handed out per join so two never share a line. Left-side joins run in the gap before the hub,
   // right-side joins in the gap after it.
+  /**
+   * ONE LANE PER JOIN, and labels stepped down the lane.
+   *
+   * The lane index used to be `(n++ % 4)`, so the fifth join on a side reused the first join's lane and every
+   * subsequent one piled onto an earlier line. The label was worse: `labelX` was the lane and `labelY` was the
+   * top of that join's own span, so two joins sharing a lane put their labels at almost the same point.
+   * Reported as *"edges overlap too much and labels overlap as well so you cant read anything"* — which is
+   * exactly what an unbounded model does to a four-lane scheme.
+   *
+   * The gap has to grow with the number of joins, so `COL_GAP` is no longer a constant: the lanes are counted
+   * first and the columns placed around them. A diagram that needs eighteen lanes gets a wider gap rather than
+   * eighteen lines on top of each other.
+   */
   let leftLane = 0;
   let rightLane = 0;
   const laneStep = 22;
@@ -137,30 +220,72 @@ export function layoutErModel(types: ErEntityType[], rels: ErRelationship[]): Er
       paths.push({
         from: r.from, to: r.to, label: r.label, count: r.count, selfJoin: true,
         d: `M${x1} ${top} V${arc} H${x2} V${top}`,
-        labelX: (x1 + x2) / 2, labelY: arc - 6,
+        labelX: (x1 + x2) / 2, labelY: arc - 6, labelAnchor: 'middle',
       });
       continue;
     }
 
-    const leftToRight = a.x < b.x;
-    // Leave the source's facing edge, enter the target's facing edge. Both y's are the box's vertical
-    // middle, which is on the edge by construction.
-    const sx = leftToRight ? a.x + a.w : a.x;
-    const tx = leftToRight ? b.x : b.x + b.w;
+    // The gap is decided by `gapOf`, which the gap SIZING above used — so a lane can never be drawn into a
+    // gap that was not measured for it. That agreement is the fix.
+    const gap = gapOf(r);
+    const sameCol = a.x === b.x;
+    const inLeftGap = gap === 'L';
+    const slot = inLeftGap ? leftLane++ : rightLane++;
+    // The lane's home is the gap's own span, counted from the gap's left edge inward.
+    const gapStart = inLeftGap ? colX[0]! + BOX_W : colX[1]! + HUB_W;
+    const lane = gapStart + 20 + slot * laneStep;
+
     const sy = a.y + a.h / 2;
     const ty = b.y + b.h / 2;
-    const lane = leftToRight
-      ? sx + 20 + (leftLane++ % 4) * laneStep
-      : sx - 20 - (rightLane++ % 4) * laneStep;
+    // A same-column join leaves and enters the face that looks at its borrowed gap, so both ends stay on real
+    // edges and the whole path stays inside the diagram.
+    const faceRight = (box: ErBox): number => box.x + box.w;
+    const sx = sameCol ? (inLeftGap ? faceRight(a) : a.x) : (a.x < b.x ? a.x + a.w : a.x);
+    const tx = sameCol ? (inLeftGap ? faceRight(b) : b.x) : (a.x < b.x ? b.x : b.x + b.w);
+
+    // The label sits ON its own lane, and steps DOWN it so two adjacent lanes never put their text at the
+    // same height. `labelX` is nudged off the line itself so the glyphs do not sit astride the stroke.
+    const spanTop = Math.min(sy, ty);
+    const spanBottom = Math.max(sy, ty);
+    const labelY = Math.min(spanBottom - 6, spanTop + 14 + (slot % 3) * 13);
 
     paths.push({
       from: r.from, to: r.to, label: r.label, count: r.count, selfJoin: false,
       d: `M${sx} ${sy} H${lane} V${ty} H${tx}`,
-      labelX: lane, labelY: Math.min(sy, ty) - 8,
+      labelX: lane + 5, labelY,
+      labelAnchor: 'start',
     });
   }
 
   const width = colX[2]! + BOX_W + PAD;
-  const height = Math.max(...boxes.map(b => b.y + b.h)) + PAD;
+
+  /**
+   * The unconnected shelf: a wrapping grid across the full width, below everything joined.
+   *
+   * It FILLS the row before starting a new one, which is the whole point — these were a centred single-file
+   * stack, so twelve unrelated types made the diagram three screens tall and pushed the joined part out of
+   * view. Laid out after `width` is known, because how many fit per row is a function of the width the joined
+   * part already needed.
+   *
+   * Row height is the tallest box in that row, not the tallest overall: a row of two-property types should not
+   * be as tall as the one type that declares nine.
+   */
+  const joinedBottom = boxes.length > 0 ? Math.max(...boxes.map(b => b.y + b.h)) : PAD;
+  let shelfBottom = joinedBottom;
+  if (shelf.length > 0) {
+    const perRow = Math.max(1, Math.floor((width - PAD * 2 + GAP_X) / (BOX_W + GAP_X)));
+    let y = joinedBottom + SHELF_GAP;
+    for (let i = 0; i < shelf.length; i += perRow) {
+      const row = shelf.slice(i, i + perRow);
+      const rowH = Math.max(...row.map(boxHeight));
+      row.forEach((t, j) => {
+        boxes.push({ type: t.type, x: PAD + j * (BOX_W + GAP_X), y, w: BOX_W, h: boxHeight(t), col: 3 });
+      });
+      y += rowH + GAP_Y;
+      shelfBottom = y - GAP_Y;
+    }
+  }
+
+  const height = Math.max(joinedBottom, shelfBottom) + PAD;
   return { boxes, paths, width, height };
 }

--- a/client/src/app/pages/brain/er-model-panel.component.ts
+++ b/client/src/app/pages/brain/er-model-panel.component.ts
@@ -59,8 +59,26 @@ import { layoutErModel } from './er-layout';
     .box-head { fill: var(--bg-elevated); }
     .box-name { font-size: 12.5px; font-weight: 600; fill: var(--text-primary); }
     .box-prop { font-size: 10.5px; fill: var(--text-muted); font-family: var(--font-mono); }
-    .join { fill: none; stroke: var(--graph-edge); stroke-width: 1.25; }
-    .join-label { font-size: 10.5px; fill: var(--graph-edge-label); font-family: var(--font-mono); }
+    .join { fill: none; stroke: var(--graph-edge); stroke-width: 1.25; transition: stroke .1s ease, stroke-width .1s ease; }
+    /* The pointer target. Wide, invisible, and it must NOT paint: a stroke of transparent still receives
+       pointer events, which is exactly what a 1.25 px line cannot do on its own. */
+    .join-hit { fill: none; stroke: transparent; stroke-width: 14; cursor: default; }
+    .join-label {
+      font-size: 10.5px; fill: var(--graph-edge-label); font-family: var(--font-mono);
+      /* A halo, so a label crossing another lane is still readable. paint-order draws the stroke first and
+         the glyphs over it, which is the difference between an outline and a smear. */
+      paint-order: stroke; stroke: var(--bg-surface); stroke-width: 3px; stroke-linejoin: round;
+      transition: fill .1s ease;
+    }
+    /* Hovering anywhere on the join lights the line, its arrow and its label together. Grouping is what makes
+       that one rule instead of three coordinated ones. */
+    .joing:hover .join { stroke: var(--accent); stroke-width: 2.25; }
+    .joing:hover .join-label { fill: var(--accent); }
+    /* The whole diagram dims its other joins while one is hovered, so following a single edge across a busy
+       model is possible at all. Restrained — .35 still reads as present, which matters because the point is
+       to find one line among many rather than to hide the rest. */
+    svg:has(.joing:hover) .joing:not(:hover) .join { stroke-opacity: .35; }
+    svg:has(.joing:hover) .joing:not(:hover) .join-label { opacity: .35; }
     .count { font-size: 11px; font-family: var(--font-mono); fill: var(--text-secondary); }
     a.count-link { cursor: pointer; }
     a.count-link:hover .count, a.count-link:focus-visible .count { fill: var(--accent); }
@@ -91,9 +109,17 @@ import { layoutErModel } from './er-layout';
               </marker>
             </defs>
 
+            <!-- Each join is a GROUP: the visible stroke, an invisible fat stroke to hover, and the label.
+                 The hit path is why hover works at all — a 1.25 px line is not a pointer target, and hovering
+                 the visible stroke alone would have been a feature nobody could trigger. The label carries a
+                 painted halo (paint-order) so it stays readable where it crosses another lane. -->
             @for (p of view().paths; track p.from + p.label + p.to) {
-              <path class="join" [attr.d]="p.d" marker-end="url(#er-arrow)" />
-              <text class="join-label" [attr.x]="p.labelX" [attr.y]="p.labelY">{{ p.label }} · {{ p.count }}</text>
+              <g class="joing">
+                <path class="join" [attr.d]="p.d" marker-end="url(#er-arrow)" />
+                <path class="join-hit" [attr.d]="p.d" />
+                <text class="join-label" [attr.x]="p.labelX" [attr.y]="p.labelY"
+                      [attr.text-anchor]="p.labelAnchor">{{ p.label }} · {{ p.count }}</text>
+              </g>
             }
 
             @for (b of view().boxes; track b.type) {


### PR DESCRIPTION
Four defects reported by the owner, three of them geometry. Tested against an emulated **30-type** model, because the small evenly-filled one always looked fine — which was the point: *"with only a few records that are welldefined and evenly filled its ok but not in real wordl."*

## Clicking a record count rewrote the URL and changed nothing

`applyUrlState` read the query params **once** from the snapshot, deliberately, with a comment fearing that re-reading its own writes would fight `setTab`. So the panel's link appended `?tab=entities&type=x` and the page ignored it — the worst shape of the bug, because the address bar says it worked.

Subscribed now, applying only **differences**: when the component writes `tab=x` it has already set that, so the handler no-ops. Idempotence rather than abstinence, and it cannot loop because a no-op writes no URL.

## Edges left the diagram entirely

A join between two boxes in the **same column** fell through the `a.x < b.x` test as right-to-left and ran leftwards out of its own column — negative x for column 0. It borrows the adjacent gap now and leaves and enters the face looking at it.

## Both geometry bugs were one question answered twice

The side a join runs on was **guessed** from `pointsAtHub` to size the gaps, then **decided again** from geometry when drawing. `gapOf()` answers it once and both readers use that answer, so a lane cannot be drawn into a gap that was not measured for it.

## Unconnected types stacked on top of each other

They fell into the right column with everything the hub points at, and the hub was centred against that stack — sixteen unrelated types pushed the meaningful part off-screen. They are a shelf along the bottom now: a wrapping grid that **fills** each row.

## Lanes and labels overlapped past four joins

The lane index was `(n++ % 4)`. One lane per join now, gap sized from the real count, labels stepped down their own lane with a `paint-order` halo.

## Hover needed a hit target

Each join is a group: visible stroke, an invisible 14 px path, and the label. A 1.25 px line is not a pointer target — a hover rule alone would have been untriggerable. Hovering also dims the other joins to `.35`.

## The test that found the rest

18 geometric invariants over 30 types, 22 relationships, a self-join and an 8-long chain — not a snapshot, which at this size is unreadable and fails on every tweak.

Two of my first assertions were wrong rather than the code, and I corrected those. **The last failure was neither:** a regex written through a shell string had lost its backslashes, so `[\d.]` became `[d.]` and matched no coordinate. I refused to call it a test problem without knowing, which is the only reason it was found rather than deleted.

Also fixed: three `ActivatedRoute` stubs had a `snapshot` and no `queryParamMap`, so the new subscription threw **11 unhandled errors while all 1045 assertions passed** — a suite that is green and shouting.

## Verified

- `npm run preflight` — PASSED
- 18/18 layout assertions, 1045 client tests, no unhandled errors