### PR TITLE
fix(auth): the proxy lens was grantable and never narrowed, so a scoped token reading a proxy got nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- **The proxy lens shipped grantable and never narrowing, so a scoped token reading a proxy got nothing.**
+  Reported by an operator who deployed 2.6.0 the same day it was published.
+  - The ask it answered named the shape exactly: *"expand it through the token's own scope rather than through
+    its full member list."* Instead `spaceTargets()` returned the **full** member list and the area/rung check
+    walked it, refusing on the first member the token lacked. A token scoped to 22 spaces with the commons
+    deliberately absent got `403 Token needs 'read' on knowledge in space 'general'` for the whole proxy — so a
+    token holding `['qa','team']` recalled across **nothing**.
+  - **The reporter located it for us:** a proxy over the same members *minus* the commons read 200 and returned
+    results. Proxy-to-a-scoped-token worked; only the narrowing did not, and the difference between the two
+    cases was a member the token cannot see.
+  - The reach check had already computed that narrowed subset and thrown it away, so two callers went on asking
+    the un-narrowed question. The narrowing now lives in the one place both read from, using the same
+    `reachesSpace` predicate rather than a second rule — a member the token cannot reach is **dropped from the
+    expansion**, never converted into a refusal for the whole proxy.
+  - Narrowing to nothing still refuses, from the reach guard: an empty target list would mean "check no space at
+    all", which is access rather than a refusal.
+  - The empty-versus-absent asymmetry is asserted inside the narrowing too — `spaces === undefined` is
+    unrestricted, an empty allowlist reaches nothing. That conflation granted whole instances on three routes in
+    2.6.0 and must not come back where it would turn the narrowest token into the widest.
+
 ### Internal
 - **The space-settings pop-up is its own component.** No behaviour change: 84 lines of template moved out of
   `spaces.component` into `space-settings-popup.component`, asserted **byte-identical** against the original

--- a/server/src/auth/middleware.ts
+++ b/server/src/auth/middleware.ts
@@ -280,10 +280,50 @@ function enforceMfa(
  */
 /** The spaces a request actually touches: a proxy's members, or the space itself. Shared so the reach check
  *  and the area check can never disagree about WHAT they are checking. */
-function spaceTargets(spaceId: string | undefined): string[] {
+/**
+ * The members of `spaceId` this token may actually see — the proxy NARROWED, not the proxy expanded.
+ *
+ * ## The defect this closes
+ *
+ * A proxy space became grantable to a scoped token in 2.6.0, and the ask it answered was explicit about the
+ * shape: *"expand it through the token's own scope rather than through its full member list. A token holding
+ * ['qa','team'] would recall across qa and nothing else."*
+ *
+ * It shipped grantable and never narrowing. This function returned the FULL member list, and
+ * `enforceAreaRung` then walked it refusing on the first member the token lacked — so a token scoped to 22
+ * spaces, with the commons deliberately absent, got `403 Token needs 'read' on knowledge in space 'general'`
+ * for the whole proxy. A token holding `['qa','team']` recalled across **nothing**.
+ *
+ * The reporter located it precisely: a proxy over the same members MINUS the commons read 200 and returned
+ * results. So proxy-to-a-scoped-token worked; only the narrowing did not, and the difference between the two
+ * cases was a member the token cannot see.
+ *
+ * ## Why here rather than in the area guard
+ *
+ * The reach check already computed this subset and threw it away. Two callers then asked the un-narrowed
+ * question, which is the same "one rule, two answers" shape that produced the ER lane bug the same day. So the
+ * narrowing lives in the one place both the reach check and the area check read from, and a member the token
+ * cannot reach is DROPPED from the expansion — never converted into a refusal for the whole proxy.
+ *
+ * A caller that may see NO member still gets a 403, from the reach check: narrowing to nothing is not access.
+ */
+function spaceTargets(spaceId: string | undefined, record?: Omit<TokenRecord, 'hash'> | OidcTokenRecord): string[] {
   if (!spaceId) return [];
   const memberIds = resolveMemberSpaces(spaceId);
-  return memberIds.length > 0 ? memberIds : [spaceId];
+  const all = memberIds.length > 0 ? memberIds : [spaceId];
+  if (!record) return all;
+
+  const rights = (record as { rights?: Parameters<typeof reachesSpace>[0] }).rights;
+  const reachable = rights
+    ? all.filter(sid => reachesSpace(rights, sid))
+    // Same asymmetry as the reach check, for the same reason: `spaces === undefined` is unrestricted and
+    // reaches everything, while an EMPTY allowlist reaches nothing. Reading empty as absent would turn the
+    // narrowest token into the widest — the bug we removed three copies of in 2.6.0.
+    : record.spaces === undefined ? all : all.filter(sid => record.spaces!.includes(sid));
+
+  // Narrowing a real (non-proxy) space to nothing must not silently become "check no space at all": the reach
+  // guard owns that refusal, and handing back the original keeps its 403 the one a caller sees.
+  return reachable.length > 0 ? reachable : all;
 }
 
 function enforceAreaRung(
@@ -463,7 +503,7 @@ export async function requireSpaceAuth(
 
   const spaceId = req.params['spaceId'] as string | undefined;
   if (!enforceSpaceScope(res, record, spaceId)) return;
-  if (!enforceAreaRung(res, record, req, spaceTargets(spaceId))) return;
+  if (!enforceAreaRung(res, record, req, spaceTargets(spaceId, record))) return;
 
   authAttemptsTotal.inc({ result: 'success' });
   attachToken(req, record, bearer);
@@ -492,7 +532,7 @@ export function requireAdminMfaScoped(paramName: string) {
     // Tokens without a spaces allowlist (unrestricted admin) are always allowed.
     const spaceId = req.params[paramName] as string | undefined;
     if (!enforceSpaceScope(res, record, spaceId)) return;
-  if (!enforceAreaRung(res, record, req, spaceTargets(spaceId))) return;
+  if (!enforceAreaRung(res, record, req, spaceTargets(spaceId, record))) return;
 
     attachToken(req, record, bearer);
     next();

--- a/testing/standalone/area-rung-is-staged.test.js
+++ b/testing/standalone/area-rung-is-staged.test.js
@@ -70,8 +70,12 @@ describe('the area check', () => {
     // contents would be governed at different levels — and the weaker one would win silently.
     assert.ok(body('spaceTargets'), 'the shared resolver is gone; the two checks can now drift');
     assert.match(body('spaceTargets'), /resolveMemberSpaces\(/);
-    assert.match(code, /enforceAreaRung\(res, record, req, spaceTargets\(spaceId\)\)/,
-      'the area check no longer uses the shared target resolution');
+    // The record is now part of that resolution, and deliberately: `spaceTargets` NARROWS a proxy to the
+    // members the token may see, so both checks read the same narrowed list. Passing only the id asks the
+    // un-narrowed question, which is what made a scoped token's proxy read refuse on the first member it
+    // lacked — the container governed by a member the caller was never granted.
+    assert.match(code, /enforceAreaRung\(res, record, req, spaceTargets\(spaceId, record\)\)/,
+      'the area check must use the shared, NARROWED target resolution');
   });
 
   it('refuses with the area and the level, not a bare 403', () => {

--- a/testing/standalone/proxy-reach.test.js
+++ b/testing/standalone/proxy-reach.test.js
@@ -15,6 +15,7 @@
  */
 import { describe, it, before } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 
 let memberSpacesForToken, narrowsOnly, mayUseProxy;
 before(async () => {
@@ -155,5 +156,63 @@ describe('the rule is reached through ONE seam', () => {
     const hits = execSync('git grep --untracked -l "memberSpacesForToken(" -- server/src || true',
       { encoding: 'utf8' }).trim().split('\n').filter(Boolean).sort();
     assert.deepEqual(hits, ['server/src/auth/proxy-reach.ts', 'server/src/spaces/proxy-scoped.ts']);
+  });
+});
+
+/**
+ * ── The proxy lens must NARROW, not fail closed on the whole member list ────────────────────────────
+ *
+ * Shipped grantable in 2.6.0 and never narrowing. `spaceTargets()` returned the full member list, and
+ * `enforceAreaRung` then walked it refusing on the first member the token lacked. So a token scoped to 22
+ * spaces with the commons deliberately absent got, for the whole proxy:
+ *
+ *     403 Token needs 'read' on knowledge in space 'general'
+ *
+ * A token holding ['qa','team'] recalled across NOTHING — the exact opposite of the ask it answered.
+ *
+ * The reporter located it for us: a proxy over the same members MINUS the commons read 200 and returned
+ * results. So proxy-to-a-scoped-token worked; only the narrowing did not, and the difference between the two
+ * cases was a member the token cannot see.
+ *
+ * Asserted on the source because the behaviour needs a live proxy, a scoped token and a route inventory to
+ * observe, and the mechanism is what regressed: the area check must read the NARROWED list. A test that
+ * mocked all three would be asserting its own mock.
+ */
+describe('the proxy lens narrows instead of failing closed', () => {
+  const src = readFileSync('server/src/auth/middleware.ts', 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+  it('the area/rung check is handed the token record, so it can narrow', () => {
+    // The regression is exactly this argument going missing: without the record there is nothing to narrow by,
+    // and the function silently falls back to the full member list.
+    const calls = [...src.matchAll(/enforceAreaRung\(res, record, req, spaceTargets\(([^)]*)\)\)/g)]
+      .map(m => m[1].replace(/\s/g, ''));
+    assert.ok(calls.length >= 2, `expected the space-auth call sites, found ${calls.length}`);
+    assert.deepEqual([...new Set(calls)], ['spaceId,record'],
+      'every call must pass the record — a call site that passes only the id asks the un-narrowed question');
+  });
+
+  it('spaceTargets filters the members by reach', () => {
+    const fn = src.slice(src.indexOf('function spaceTargets'), src.indexOf('function enforceAreaRung'));
+    assert.match(fn, /reachesSpace\(rights, sid\)/,
+      'the narrowing must use the same reach predicate the reach guard uses, not a second rule');
+  });
+
+  it('reads an EMPTY allowlist as reaching nothing, and an ABSENT one as reaching everything', () => {
+    // The conflation that granted whole instances on three routes in 2.6.0. It must not come back inside the
+    // narrowing, where it would turn the narrowest token into the widest.
+    const fn = src.slice(src.indexOf('function spaceTargets'), src.indexOf('function enforceAreaRung'));
+    assert.match(fn, /record\.spaces === undefined \? all :/,
+      'absent means unrestricted; length === 0 would read empty as absent');
+    assert.ok(!/spaces\?\.length === 0|spaces\.length === 0/.test(fn),
+      'an empty allowlist must not be treated as unrestricted');
+  });
+
+  it('a narrowing that empties still refuses, via the reach guard', () => {
+    // Returning [] here would mean "check no space at all", which is access rather than a refusal. The reach
+    // guard owns that 403, so the fallback hands back the original list and lets it answer.
+    const fn = src.slice(src.indexOf('function spaceTargets'), src.indexOf('function enforceAreaRung'));
+    assert.match(fn, /reachable\.length > 0 \? reachable : all/,
+      'an empty narrowing must fall back so the reach guard produces the refusal');
   });
 });


### PR DESCRIPTION
Reported by an operator who deployed 2.6.0 **the same day it was published**, with a real scoped token. A-1 in the queue.

## What shipped versus what was asked for

The ask named the shape rather than the mechanism: *"expand it through the token's own scope rather than through its full member list. A token holding `['qa','team']` would recall across qa and nothing else."*

What shipped was grantable and never narrowing. `spaceTargets()` returned the **full** member list, and `enforceAreaRung` walked it refusing on the first member the token lacked:

```
token: 22 spaces in rights.perSpace, general absent, floor none
  GET  /api/brain/spaces/liaison/entities   200
  GET  /api/brain/spaces/general/entities   403  needs 'read' on knowledge in 'general'
  GET  /api/brain/spaces/team/entities      403  needs 'read' on knowledge in 'general'
  POST /api/brain/spaces/team/recall        403  needs 'read' on knowledge in 'general'
```

So a token holding `['qa','team']` recalled across **nothing** — the opposite of the ask.

## The reporter located it, which is what made this quick

A proxy over the same members **minus** the commons read 200 and returned ten hits. Proxy-to-a-scoped-token worked; only the narrowing did not, and the difference between the two cases was a member the token cannot see. That isolates the fault to the expansion rather than the grant.

## One question, two answers — again

The reach check had **already computed** the narrowed subset, and threw it away. Two callers then asked `spaceTargets(spaceId)`, the un-narrowed question.

Same shape as the ER lane bug fixed earlier today: a side guessed for sizing and decided again for drawing. So the narrowing moves into the one place both checks read from, using the same `reachesSpace` predicate rather than a second rule. **A member the token cannot reach is dropped from the expansion, never converted into a refusal for the whole proxy.**

## Two things the fix must not become

**Narrowing to nothing still refuses**, from the reach guard: an empty target list would mean "check no space at all", which is access rather than a refusal. So an empty narrowing falls back and lets that guard answer.

**The empty-versus-absent asymmetry is asserted inside the narrowing:** `spaces === undefined` is unrestricted, an empty allowlist reaches nothing. That exact conflation granted whole instances on three routes in 2.6.0, and inside a narrowing it would turn the narrowest token into the widest.

## Gates

Four new assertions in `proxy-reach.test.js`, **mutation-tested by dropping the `record` argument** — precisely the regression, since without it the function silently falls back to the full member list.

`area-rung-is-staged` pinned the old call shape and now pins the new one. Its intent is unchanged and stronger: both checks share the resolver, and the resolver narrows.

## Verified

- `npm run preflight` — PASSED
- 22 assertions in `proxy-reach.test.js`
- **Not verified against their instance** — they operate it and we cannot reach it. The behaviour needs a live proxy, a scoped token and the route inventory to observe; the mechanism is what regressed and is what is asserted.