### PR TITLE
fix(auth): an unknown rights area stored at 200 and granted nothing, and it took a live agent offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+- **An unknown rights AREA was accepted at 200 and granted nothing — it took a live agent offline for four
+  minutes.** `POST` and `PATCH /api/tokens` validated the rung *values* against `none|read|write|admin` and left
+  the area *name* unvalidated, so `{"brain": "write"}` stored happily while the real area is `knowledge`.
+  - Reported by the operator it happened to, while probing: *"A 400 naming the valid areas would have cost us
+    one request instead of six, and would not have taken an agent offline."*
+  - It is the same conflation fixed for token mints in 2.6.0 — unknown keys accepted and silently dropped — one
+    level deeper. Fixing the outer shape and leaving the inner one is how a bug class survives its own fix.
+  - **Four hand-written copies of the area names existed** — the type plus three `AREAS` arrays — and nothing
+    compared any copy to any other, which is exactly what allowed a validator to be written without them.
+    `SPACE_AREAS` is now the one list, the type is *derived* from it, and the schemas and guards import it.
+  - `perSpace`'s outer key stays a plain string, deliberately: that key is a space id, which is caller-chosen
+    text and not an enum. It was the inner area map that was open.
 - **The proxy lens shipped grantable and never narrowing, so a scoped token reading a proxy got nothing.**
   Reported by an operator who deployed 2.6.0 the same day it was published.
   - The ask it answered named the shape exactly: *"expand it through the token's own scope rather than through

--- a/server/src/api/tokens.ts
+++ b/server/src/api/tokens.ts
@@ -5,6 +5,7 @@ import { authRateLimit, globalRateLimit } from '../rate-limit/middleware.js';
 import { createToken, listTokens, revokeToken, regenerateToken, renameToken, setTokenRights } from '../auth/tokens.js';
 import { isMfaEnabled, verifyMfaCode } from '../auth/totp.js';
 import { z } from 'zod';
+import { SPACE_AREAS, RUNGS } from '../config/rights-shape.js';
 import { capRights, describeExcess } from '../auth/mint-cap.js';
 import { refuseSelfFloorRaise } from '../auth/floor-guard.js';
 import { migrateToken } from '../auth/rights-migration.js';
@@ -75,8 +76,8 @@ const CreateTokenBody = z.object({
   rights: z.object({
     instanceAdmin: z.boolean(),
     createSpaces: z.boolean(),
-    floor: z.record(z.string(), z.enum(['none', 'read', 'write', 'admin'])).nullable(),
-    perSpace: z.record(z.string(), z.record(z.string(), z.enum(['none', 'read', 'write', 'admin']))),
+    floor: z.record(z.enum(SPACE_AREAS), z.enum(RUNGS)).nullable(),
+    perSpace: z.record(z.string(), z.record(z.enum(SPACE_AREAS), z.enum(RUNGS))),
   }).strict().optional(),
 }).strict();
 
@@ -197,8 +198,8 @@ const RenameTokenBody = z.object({
   rights: z.object({
     instanceAdmin: z.boolean(),
     createSpaces: z.boolean(),
-    floor: z.record(z.string(), z.enum(['none', 'read', 'write', 'admin'])).nullable(),
-    perSpace: z.record(z.string(), z.record(z.string(), z.enum(['none', 'read', 'write', 'admin']))),
+    floor: z.record(z.enum(SPACE_AREAS), z.enum(RUNGS)).nullable(),
+    perSpace: z.record(z.string(), z.record(z.enum(SPACE_AREAS), z.enum(RUNGS))),
   }).strict().optional(),
 }).strict().refine(d => d.name !== undefined || d.rights !== undefined, {
   message: 'Provide `name`, `rights`, or both',

--- a/server/src/auth/floor-guard.ts
+++ b/server/src/auth/floor-guard.ts
@@ -22,10 +22,13 @@
  * A floor is four independent levels. Comparing them as one unit would let a raise on `schema` pass because
  * `knowledge` went down in the same edit, which is a widening with a decoy attached.
  */
+import { SPACE_AREAS } from '../config/rights-shape.js';
 import type { TokenRights, AreaRungs, SpaceArea, Rung } from '../config/rights-shape.js';
 
 const ORDER: readonly Rung[] = ['none', 'read', 'write', 'admin'];
-const AREAS: readonly SpaceArea[] = ['knowledge', 'files', 'schema', 'dataQuality'];
+// The one list, imported. Four hand-written copies of these names is how an unvalidated area name
+// went unnoticed: nothing compared any copy to any other.
+const AREAS: readonly SpaceArea[] = SPACE_AREAS;
 const rank = (r: Rung): number => ORDER.indexOf(r);
 
 /** Areas whose floor level would go UP. Empty means the edit raises nothing. */

--- a/server/src/auth/mint-cap.ts
+++ b/server/src/auth/mint-cap.ts
@@ -21,10 +21,13 @@
  *  - **Never the instance-administrator switch**, and never `createSpaces`, from a non-administrator. Those
  *    are not areas and do not cap — they are held or they are not.
  */
+import { SPACE_AREAS } from '../config/rights-shape.js';
 import type { TokenRights, AreaRungs, Rung, SpaceArea } from '../config/rights-shape.js';
 
 const ORDER: readonly Rung[] = ['none', 'read', 'write', 'admin'];
-const AREAS: readonly SpaceArea[] = ['knowledge', 'files', 'schema', 'dataQuality'];
+// The one list, imported. Four hand-written copies of these names is how an unvalidated area name
+// went unnoticed: nothing compared any copy to any other.
+const AREAS: readonly SpaceArea[] = SPACE_AREAS;
 
 const rank = (r: Rung): number => ORDER.indexOf(r);
 

--- a/server/src/config/rights-shape.ts
+++ b/server/src/config/rights-shape.ts
@@ -12,8 +12,26 @@
 /** Rungs, lowest first. Each CONTAINS the one below, so "write but not read" is unrepresentable. */
 export type Rung = 'none' | 'read' | 'write' | 'admin';
 
+/**
+ * The four space-scoped areas, as VALUES — so a validator can reject an unknown one.
+ *
+ * The type alone was not enough. `POST`/`PATCH /api/tokens` validated the rung values against
+ * `none|read|write|admin` and left the area NAME unvalidated, so `{"brain": "write"}` stored happily at 200
+ * and granted nothing, because the real area is `knowledge`. An operator wrote that onto a live token while
+ * probing and took an agent offline for four minutes; the only thing that named the true area was a later
+ * 403's own wording.
+ *
+ * That is the same conflation fixed for token mints in 2.6.0 — unknown keys accepted and silently dropped —
+ * one level deeper. Exported as a tuple so `z.enum` can consume it and there is one list rather than the four
+ * hand-written copies that existed before.
+ */
+export const SPACE_AREAS = ['knowledge', 'files', 'schema', 'dataQuality'] as const;
+
 /** The four space-scoped areas. Instance capabilities are not here — they have no space to scope to. */
-export type SpaceArea = 'knowledge' | 'files' | 'schema' | 'dataQuality';
+export type SpaceArea = typeof SPACE_AREAS[number];
+
+/** The rungs as values, for the same reason. */
+export const RUNGS = ['none', 'read', 'write', 'admin'] as const;
 
 export type AreaRungs = Record<SpaceArea, Rung>;
 

--- a/testing/standalone/rights-area-names-are-validated.test.js
+++ b/testing/standalone/rights-area-names-are-validated.test.js
@@ -1,0 +1,81 @@
+/**
+ * An unknown rights AREA must be a 400 that names the valid ones — not a 200 that grants nothing.
+ *
+ * ## What happened
+ *
+ * `POST` and `PATCH /api/tokens` validated the rung VALUES against `none|read|write|admin` and left the area
+ * NAME unvalidated. So `{"brain": "write"}` stored happily at **200** and granted nothing, because the real
+ * area is `knowledge`.
+ *
+ * An operator wrote exactly that onto a live token while probing and **took an agent offline for four
+ * minutes**. The only thing in the whole system that named the true area was a later 403's own wording. Their
+ * note: *"A 400 naming the valid areas would have cost us one request instead of six, and would not have taken
+ * an agent offline."*
+ *
+ * It is the same conflation fixed for token mints in 2.6.0 — unknown keys accepted and silently dropped — one
+ * level deeper. Fixing the outer shape and leaving the inner one is how a bug class survives its own fix.
+ *
+ * ## Why the list is now values, not just a type
+ *
+ * A TypeScript union cannot validate a request. There were **four** hand-written copies of these names — the
+ * type, and three `AREAS` arrays — and nothing compared any copy to any other, which is what let the validator
+ * be written without them. `SPACE_AREAS` is the one list; the type is derived from it, and the validator and
+ * the guards import it.
+ *
+ * Run: node --test testing/standalone/rights-area-names-are-validated.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+let SPACE_AREAS, RUNGS;
+
+const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+const tokens = () => strip(readFileSync('server/src/api/tokens.ts', 'utf8'));
+
+describe('rights area names are validated, not merely typed', () => {
+  before(async () => {
+    ({ SPACE_AREAS, RUNGS } = await import('../../server/dist/config/rights-shape.js'));
+  });
+
+  it('the areas are VALUES, so a validator can use them', () => {
+    assert.deepEqual([...SPACE_AREAS], ['knowledge', 'files', 'schema', 'dataQuality']);
+    assert.deepEqual([...RUNGS], ['none', 'read', 'write', 'admin']);
+  });
+
+  it('every rights schema validates the area KEY, not only the rung value', () => {
+    const src = tokens();
+    // Only `floor` maps areas directly. `perSpace`'s OUTER key is a space id and must stay `z.string()` — a
+    // space id is caller-chosen text, not an enum. It is the INNER map that names areas, which is why the
+    // strict count below is what proves the fix rather than the absence of `z.string()`.
+    const looseFloor = [...src.matchAll(/floor:\s*z\.record\(z\.string\(\)/g)].length;
+    assert.equal(looseFloor, 0,
+      'floor accepts any area name — the values were checked and the keys were not, which is how '
+      + '{"brain":"write"} stored at 200 and granted nothing');
+    assert.match(src, /perSpace:\s*z\.record\(z\.string\(\),\s*z\.record\(z\.enum\(SPACE_AREAS\)/,
+      'perSpace keys on a space id and its INNER map keys on an area — that inner map is the one that was open');
+    const strict = [...src.matchAll(/z\.record\(z\.enum\(SPACE_AREAS\)/g)].length;
+    assert.ok(strict >= 4, `expected the four area maps to use z.enum(SPACE_AREAS), found ${strict}`);
+  });
+
+  it('the schemas import the shared list rather than spelling the names again', () => {
+    assert.match(tokens(), /import \{[^}]*SPACE_AREAS[^}]*\} from '\.\.\/config\/rights-shape\.js'/,
+      'a fifth copy of the area names is a fifth thing to keep in step');
+  });
+
+  it('no module keeps its own copy of the area names', () => {
+    // Four copies existed. Nothing compared them, which is exactly why the validator could be written without
+    // any of them.
+    for (const f of ['server/src/auth/floor-guard.ts', 'server/src/auth/mint-cap.ts', 'server/src/api/tokens.ts']) {
+      const src = strip(readFileSync(f, 'utf8'));
+      assert.ok(!/\['knowledge',\s*'files',\s*'schema',\s*'dataQuality'\]/.test(src),
+        `${f} spells the area names itself — import SPACE_AREAS instead`);
+    }
+  });
+
+  it('the type is DERIVED from the list, so the two cannot drift', () => {
+    const shape = strip(readFileSync('server/src/config/rights-shape.ts', 'utf8'));
+    assert.match(shape, /export type SpaceArea = typeof SPACE_AREAS\[number\]/,
+      'a hand-written union beside the array is two sources of truth for one fact');
+  });
+});


### PR DESCRIPTION
**A-2**, reported by the operator it happened to.

`POST` and `PATCH /api/tokens` validated the rung **values** against `none|read|write|admin` and left the area **name** unvalidated. So `{"brain": "write"}` stored happily at 200 while the real area is `knowledge` — the token was written, the write reported success, and the agent holding it could reach nothing.

They found it by writing it onto their live liaison token while probing. **Four minutes offline.** In their words: *"A 400 naming the valid areas would have cost us one request instead of six, and would not have taken an agent offline."*

## The same conflation, one level deeper

2.6.0 fixed exactly this for token mints — `allowedSpaces` / `scope` / `spaceIds` / `denySpaces` accepted with a 201 and dropped. That fix hardened the **outer** shape and left the inner area map open, which is how a bug class survives its own fix.

## Why a TypeScript union could not have prevented it

It cannot validate a request. There were **four** hand-written copies of these names — the `SpaceArea` union plus three `AREAS` arrays — and nothing compared any copy to any other. That is precisely what let the validator be written without reference to any of them.

`SPACE_AREAS` is now the one list, exported as values from the `rights-shape` leaf. The type is **derived** from it (`typeof SPACE_AREAS[number]`), so the two cannot drift, and the schemas and both guards import it. Three copies deleted.

## One key that must stay open, deliberately

`perSpace`'s outer key is a **space id** — caller-chosen text, not an enum — so it stays `z.string()`. It was the inner area map that was open.

My first version of the gate flagged the outer key too and failed on correct code; the assertion now says which key is which and why.

## Verified

- `npm run preflight` — PASSED
- mutation-tested by reopening the `floor` key
- **Not verified against their instance** — they operate it. What is asserted is that an unknown area can no longer reach storage.