### PR TITLE
fix(tokens): the shape you read back was not a shape you could write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+- **A token you read back could not be written back: `PATCH /api/tokens/:id` refused ten of the twelve fields
+  `GET /api/tokens` emits.** Read a token, change its name, send it back, and the answer was
+  `400 Unrecognized key(s) in object: 'spaces'`.
+  - Reported by an integrator: *"the shape you read is not the shape you may write, and nothing says which
+    fields are which."* `spaces` was only the first field alphabetically — `createdAt`, `lastUsed`,
+    `expiresAt`, `admin`, `readOnly`, `mfa`, `schemaLibrary`, `peerInstanceId` and `oauthClientId` were all in
+    the same position. Worse, the message *denied the field existed*, when in truth its remedy had moved to
+    `rights`.
+  - **The distinction that was missing is echo versus change.** Stripping these fields the way `id`/`hash`/
+    `prefix` are stripped would have recreated a bug this route already fixed — a body carrying
+    `spaces: ['other']` beside the name was dropped and answered **200**, so an attempt to widen a token looked
+    exactly like one that had worked. Refusing them is what produced the report. So the same value back is a
+    round-trip and is ignored; a **different** value is a `400` that names the field to write instead.
+  - That check needs the stored record, which is why it cannot be a `.refine()`: a schema sees only the body and
+    is structurally unable to tell an echo from an edit.
+  - `.strict()` is unchanged, so a mis-spelled `spaceIds` is still refused rather than accepted and dropped.
+  - `spaces` is compared as a **set**, since a round-trip may reorder an allowlist — but `undefined` stays equal
+    only to `undefined`. Absent means every space including future ones and `[]` means none; reading them as
+    equal inside an equality check is how that conflation would have come back for a fifth time.
+  - An absent boolean and an explicit `false` are the same token, so `admin: false` on a non-admin token is an
+    echo. A *demotion* is still a change and still refused by name.
+  - The docs described this route as editing "**only** the token's label", which had been untrue since `rights`
+    became editable in 2.6.0. They now document both editable fields and the round-trip.
 - **An unknown rights AREA was accepted at 200 and granted nothing — it took a live agent offline for four
   minutes.** `POST` and `PATCH /api/tokens` validated the rung *values* against `none|read|write|admin` and left
   the area *name* unvalidated, so `{"brain": "write"}` stored happily while the real area is `knowledge`.

--- a/docs/integration-guide/07-tokens-api.md
+++ b/docs/integration-guide/07-tokens-api.md
@@ -155,15 +155,16 @@ Issues a new plaintext credential for an existing token record. The old value is
 
 ---
 
-### Rename a Token
+### Edit a Token
 
 ```http
 PATCH /api/tokens/:id
 { "name": "new label" }
 ```
 
-Updates **only** the token's human-readable label. The secret, permissions, spaces and expiry are
-untouched. `name` follows the same bound as create (1–200 chars). Audited as `token.update`.
+Two fields are editable: **`name`** (1–200 chars, same bound as create) and **`rights`** (the per-space
+matrix — see [Create a Token](#create-a-token) for the shape and the capping rules). Send either or both. The secret and the
+expiry are untouched; use regenerate to rotate the secret. Audited as `token.update`.
 
 **Response** `200`: the updated token record (hash excluded).
 
@@ -171,7 +172,32 @@ untouched. `name` follows the same bound as create (1–200 chars). Audited as `
 { "token": { "id": "…", "name": "new label", "admin": false, "...": "…" } }
 ```
 
-Returns `404` if no token has that id, `400` for an empty/oversized name.
+#### Sending a token you read back
+
+The response carries the whole record. You can PATCH that record straight back — the fields this route does
+not edit are accepted **as long as they are unchanged**, so read-modify-write works without stripping
+anything first:
+
+```http
+GET  /api/tokens          →  { "tokens": [ { "id": "t_1", "name": "old", "spaces": ["qa"], … } ] }
+PATCH /api/tokens/t_1        { "id": "t_1", "name": "new", "spaces": ["qa"], … }   →  200
+```
+
+Changing one of those fields is a `400` that names what to write instead, rather than being silently
+dropped:
+
+```json
+{ "error": "Cannot change `spaces` on this route. For `spaces`, set `rights.perSpace` (or `rights.floor` for every space). Sending these fields UNCHANGED is fine — a token you read back round-trips." }
+```
+
+`spaces`, `admin` and `readOnly` are the pre-2.6.0 scope model; their replacement is `rights`. The rest
+(`createdAt`, `lastUsed`, `expiresAt`, `peerInstanceId`, `schemaLibrary`, `oauthClientId`, `mfa`) are set
+when the token is minted and are not editable on any route.
+
+A field name this route has never heard of is still a `400` — a mis-spelled `spaceIds` must not be accepted
+and dropped.
+
+Returns `404` if no token has that id, `400` for an empty/oversized name or a body that changes nothing.
 
 ---
 

--- a/server/src/api/tokens.ts
+++ b/server/src/api/tokens.ts
@@ -186,6 +186,63 @@ tokensRouter.post('/', authRateLimit, requireAdminMfa, async (req, res) => {
   res.status(201).json({ token: safeRecord, plaintext });
 });
 
+/**
+ * Fields `GET /api/tokens` emits that `PATCH` does not edit — and the remedy for each, where one exists.
+ *
+ * ## Why this list exists at all
+ *
+ * A reporter round-tripped a token — GET it, change the name, PATCH it back — and got
+ * `Unrecognized key(s) in object: 'spaces'`. Their words: *"the shape you read is not the shape you may
+ * write, and nothing says which fields are which."* The response carries twelve fields; PATCH accepted two.
+ *
+ * ## Why neither obvious fix is right
+ *
+ * **Stripping them** (the `SERVER_OWNED_TOKEN_FIELDS` treatment) recreates a bug this route already fixed:
+ * a body carrying `spaces` or `admin` beside the name was dropped and answered **200**, so an attempt to
+ * widen a token through the legacy field looked exactly like one that had worked.
+ *
+ * **Rejecting them** is what produced the report.
+ *
+ * So the rule distinguishes an ECHO from a CHANGE, which is the distinction both of those answers lose:
+ * the same value back is a round-trip and is ignored; a different value is a refusal that names the field
+ * to use instead. `spaces`/`admin`/`readOnly` have a real remedy in the rights matrix and say so — the rest
+ * are set at mint and cannot be edited on any route, which the message states rather than implying.
+ */
+export const ECHOABLE: Record<string, string | null> = {
+  spaces: 'set `rights.perSpace` (or `rights.floor` for every space)',
+
+  admin: 'set `rights.instanceAdmin`',
+  readOnly: 'set the area rungs in `rights` to `read`',
+  createdAt: null,
+  lastUsed: null,
+  expiresAt: null,
+  peerInstanceId: null,
+  schemaLibrary: null,
+  oauthClientId: null,
+  mfa: null,
+};
+
+const ECHOABLE_FIELDS = Object.keys(ECHOABLE);
+
+/**
+ * Is this the value already stored, or an attempted change?
+ *
+ * `spaces` is compared as a SET, because a round-trip may reorder it and an allowlist has no order — but
+ * `undefined` is only ever equal to `undefined`. Absent means "all spaces" and `[]` means "no spaces", the
+ * conflation this repo has now fixed in four separate files, and it must not come back inside an equality
+ * check where reading them as the same would let a token be widened to the whole instance in silence.
+ */
+export function isEcho(field: string, sent: unknown, stored: unknown): boolean {
+  if (field === 'spaces') {
+    if (sent === undefined || stored === undefined) return sent === stored;
+    if (!Array.isArray(sent) || !Array.isArray(stored) || sent.length !== stored.length) return false;
+    return [...sent].sort().join(' ') === [...stored].sort().join(' ');
+  }
+  // `admin: false` and an absent `admin` are the same token. Only the booleans get this reading.
+  if (typeof stored === 'boolean' || typeof sent === 'boolean') return !!sent === !!stored;
+  return JSON.stringify(sent ?? null) === JSON.stringify(stored ?? null);
+}
+
 const RenameTokenBody = z.object({
   // Same bound as create's `name`, so a label can't be edited to something the create flow would reject.
   name: z.string().min(1).max(200).optional(),
@@ -201,9 +258,14 @@ const RenameTokenBody = z.object({
     floor: z.record(z.enum(SPACE_AREAS), z.enum(RUNGS)).nullable(),
     perSpace: z.record(z.string(), z.record(z.enum(SPACE_AREAS), z.enum(RUNGS))),
   }).strict().optional(),
-}).strict().refine(d => d.name !== undefined || d.rights !== undefined, {
-  message: 'Provide `name`, `rights`, or both',
-});
+  // ── The rest of the record, accepted ONLY unchanged ──────────────────────────────────────────────
+  //
+  // These are declared so that echoing back a token you just read does not 400 on the first field the
+  // schema had never heard of. They are NOT editable here; the handler compares each one it was sent
+  // against what is stored, and a DIFFERENT value is a 400 that names what to write instead. See
+  // `ECHOABLE` below for why "ignore it" and "reject it" are both wrong answers on their own.
+  ...Object.fromEntries(ECHOABLE_FIELDS.map(f => [f, z.unknown()])),
+}).strict();
 
 // PATCH /api/tokens/:id — rename a token's label (only) — admin + MFA
 tokensRouter.patch('/:id', requireAdminMfa, (req, res) => {
@@ -217,6 +279,31 @@ tokensRouter.patch('/:id', requireAdminMfa, (req, res) => {
   const previous = listTokens().find(t => t.id === id);
   if (!previous) {
     res.status(404).json({ error: 'Token not found' });
+    return;
+  }
+
+  // An echoed field is a round-trip and is ignored; a CHANGED one is refused by name. Presence is read off
+  // the raw body rather than the parsed data, because `z.unknown()` cannot distinguish an absent key from
+  // one explicitly set to `undefined` — and "absent" vs "present and null" is the whole question here.
+  const sentBody = (stripServerOwnedToken(req.body) ?? {}) as Record<string, unknown>;
+  const stored = previous as unknown as Record<string, unknown>;
+  const attempted = ECHOABLE_FIELDS
+    .filter(f => Object.prototype.hasOwnProperty.call(sentBody, f))
+    .filter(f => !isEcho(f, sentBody[f], stored[f]));
+  if (attempted.length > 0) {
+    res.status(400).json({
+      error: `Cannot change ${attempted.map(f => `\`${f}\``).join(', ')} on this route. `
+        + attempted.map(f => ECHOABLE[f] ? `For \`${f}\`, ${ECHOABLE[f]}.` : `\`${f}\` is set when the token is minted.`).join(' ')
+        + ' Sending these fields UNCHANGED is fine — a token you read back round-trips.',
+    });
+    return;
+  }
+
+  // Checked after the above so a body that only echoes the record gets the "nothing to change" answer
+  // rather than a bare unknown-key refusal. It was a `.refine()` until the echo fields existed; a schema
+  // cannot see the stored record, so it could not tell an echo from an edit.
+  if (name === undefined && rights === undefined) {
+    res.status(400).json({ error: 'Provide `name`, `rights`, or both' });
     return;
   }
 

--- a/testing/standalone/token-read-shape-round-trips.test.js
+++ b/testing/standalone/token-read-shape-round-trips.test.js
@@ -1,0 +1,171 @@
+/**
+ * A token you READ must be a token you can WRITE back.
+ *
+ * ## What was reported
+ *
+ * `GET /api/tokens` returns the whole record minus the hash — twelve fields. `PATCH /api/tokens/:id`
+ * accepted two, `name` and `rights`, and refused everything else by way of `.strict()`. So the ordinary
+ * integration shape — read a token, change its name, send it back — answered:
+ *
+ *     400  Unrecognized key(s) in object: 'spaces'
+ *
+ * The reporter's words: *"the shape you read is not the shape you may write, and nothing says which fields
+ * are which."* `spaces` is only the first field alphabetically; `createdAt`, `expiresAt`, `lastUsed`,
+ * `admin`, `readOnly`, `mfa`, `schemaLibrary`, `peerInstanceId` and `oauthClientId` were all in the same
+ * position. The 400 named one of them and implied the field did not exist, when the truth is that its
+ * remedy moved to `rights`.
+ *
+ * ## Why neither obvious fix is right, and what the third one is
+ *
+ * **Strip them**, the way `id`/`hash`/`prefix` are stripped, and a body carrying `spaces: ['other']` beside
+ * the name is silently dropped and answered **200** — an attempt to widen a token that looks exactly like
+ * one that worked. This route already had that bug and already fixed it; re-fixing the round-trip that way
+ * would trade one silent failure for the one it replaced.
+ *
+ * **Refuse them** and you have the report.
+ *
+ * The distinction both answers lose is ECHO versus CHANGE. The same value back is a round-trip: ignore it.
+ * A different value is an attempt to edit through a field that no longer writes: refuse it, and name the
+ * field that does. That needs the stored record, which is why it cannot live in the schema — a `.refine()`
+ * sees only the body, and every check below is one a schema is structurally unable to make.
+ *
+ * Run: node --test testing/standalone/token-read-shape-round-trips.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+let ECHOABLE, isEcho;
+before(async () => {
+  ({ ECHOABLE, isEcho } = await import('../../server/dist/api/tokens.js'));
+});
+
+const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+const src = () => strip(readFileSync('server/src/api/tokens.ts', 'utf8'));
+
+describe('every field the list route emits is answerable by the edit route', () => {
+  it('covers the record, field for field — derived from the type, not hand-listed', () => {
+    // The point of deriving: a field added to `TokenRecord` tomorrow appears in `GET` for free and would
+    // silently go back to 400-ing the round-trip. Hand-listing the names here would keep passing.
+    const types = strip(readFileSync('server/src/config/types.ts', 'utf8'));
+    const body = types.slice(types.indexOf('export interface TokenRecord'));
+    const fields = [...body.slice(0, body.indexOf('\n}')).matchAll(/^\s{2}(\w+)\??:/gm)].map(m => m[1]);
+    assert.ok(fields.length >= 10, `parsed only ${fields.length} fields off TokenRecord — re-point this`);
+
+    // `hash` never leaves the server; `id`/`prefix` are stripped; `name` and `rights` are the two the route
+    // actually edits. Everything else must be echoable or the round-trip 400s on it.
+    const accountedFor = new Set(['hash', 'id', 'prefix', 'name', 'rights', ...Object.keys(ECHOABLE)]);
+    const orphans = fields.filter(f => !accountedFor.has(f));
+    assert.deepEqual(orphans, [],
+      `${orphans.join(', ')} are returned by GET and would be refused by PATCH — a token read back cannot `
+      + 'be written back, which is the exact report this fixed');
+  });
+
+  it('the three legacy scope fields name their replacement; the mint-time ones do not pretend to have one', () => {
+    // A 400 that says "unknown key" for `spaces` is worse than useless: the field IS real, it is just no
+    // longer where scope is written. The message has to carry the remedy or the caller probes for it.
+    for (const f of ['spaces', 'admin', 'readOnly']) {
+      assert.match(ECHOABLE[f], /rights/,
+        `\`${f}\` moved to the rights matrix; its refusal must say so rather than denying the field exists`);
+    }
+    assert.equal(ECHOABLE['createdAt'], null, 'createdAt has no remedy — claiming one would send the caller looking');
+    assert.equal(ECHOABLE['oauthClientId'], null);
+  });
+});
+
+describe('echo versus change', () => {
+  it('the same value back is an echo, whatever the type', () => {
+    assert.equal(isEcho('createdAt', '2026-08-01T00:00:00Z', '2026-08-01T00:00:00Z'), true);
+    assert.equal(isEcho('mfa', 'exempt', 'exempt'), true);
+    assert.equal(isEcho('expiresAt', null, null), true);
+    assert.equal(isEcho('spaces', ['qa', 'team'], ['qa', 'team']), true);
+  });
+
+  it('a different value is a change', () => {
+    assert.equal(isEcho('createdAt', '2026-08-02T00:00:00Z', '2026-08-01T00:00:00Z'), false);
+    assert.equal(isEcho('mfa', 'exempt', 'required'), false);
+    assert.equal(isEcho('spaces', ['qa', 'ops'], ['qa', 'team']), false);
+  });
+
+  it('a REORDERED allowlist is still an echo', () => {
+    // An allowlist has no order, and a client that round-trips through a map or a set may hand it back
+    // permuted. Refusing that would fail a caller who changed nothing.
+    assert.equal(isEcho('spaces', ['team', 'qa'], ['qa', 'team']), true);
+  });
+
+  it('a LONGER allowlist containing the stored one is NOT an echo', () => {
+    // The widening this whole check exists to catch, and the one a "does it contain everything stored"
+    // reading would wave through.
+    assert.equal(isEcho('spaces', ['qa', 'team', 'secret'], ['qa', 'team']), false);
+    assert.equal(isEcho('spaces', ['qa'], ['qa', 'team']), false);
+  });
+
+  it('a DUPLICATE that keeps the length is not an echo', () => {
+    // `['qa','qa']` against `['qa','team']`: same length, same first element, and `team` silently dropped.
+    // A length check plus a first-element check would pass it.
+    assert.equal(isEcho('spaces', ['qa', 'qa'], ['qa', 'team']), false);
+  });
+
+  it('ABSENT and EMPTY spaces are not the same value', () => {
+    // Absent means every space including future ones; `[]` means none. Reading them as equal here would let
+    // a token scoped to nothing be echoed as unrestricted, or the reverse — the same conflation this repo
+    // has now fixed in four separate files, arriving through an equality check.
+    assert.equal(isEcho('spaces', [], undefined), false);
+    assert.equal(isEcho('spaces', undefined, []), false);
+    assert.equal(isEcho('spaces', undefined, undefined), true);
+    assert.equal(isEcho('spaces', [], []), true);
+  });
+
+  it('an absent boolean and an explicit false ARE the same token', () => {
+    // `admin` is optional on the record and omitted when false, so a client that reads a non-admin token
+    // and sends `admin: false` back has changed nothing. This is the one place a loose reading is correct,
+    // and it is correct because both spellings mean exactly one thing — unlike `spaces`.
+    assert.equal(isEcho('admin', false, undefined), true);
+    assert.equal(isEcho('readOnly', false, undefined), true);
+    assert.equal(isEcho('admin', true, undefined), false, 'undefined is not admin; true would be an escalation');
+    assert.equal(isEcho('admin', false, true), false, 'a DEMOTION is still a change, and still refused by name');
+  });
+});
+
+describe('the route wires it in the only order that works', () => {
+  const patch = () => {
+    const s = src();
+    const i = s.indexOf("tokensRouter.patch('/:id'");
+    return s.slice(i, s.indexOf('tokensRouter.post', i));
+  };
+
+  it('presence is read off the RAW body, not the parsed data', () => {
+    // `z.unknown()` cannot tell an absent key from one explicitly set to `undefined`, and that is the
+    // difference between "did not mention spaces" and "sent spaces: undefined" — which for this field is
+    // the difference between no change and a change to all-spaces.
+    assert.match(patch(), /hasOwnProperty\.call\(sentBody, f\)/,
+      'reading presence off the parsed object cannot distinguish absent from undefined');
+  });
+
+  it('the change check runs BEFORE the nothing-to-change answer', () => {
+    // Order is the message quality. A body of `{spaces: ['other']}` must say "spaces moved to rights", not
+    // "provide name or rights" — the latter is true and tells the caller nothing about what they attempted.
+    const b = patch();
+    assert.ok(b.indexOf('attempted.length > 0') < b.indexOf("name === undefined && rights === undefined"),
+      'the empty-body refusal would mask the useful one');
+  });
+
+  it('both answers come after the token is known to exist', () => {
+    // Otherwise a PATCH to a nonexistent id reports on its BODY, which tells an unauthenticated prober that
+    // the id was at least well-formed. 404 first.
+    const b = patch();
+    assert.ok(b.indexOf("res.status(404)") < b.indexOf('attempted.length > 0'),
+      'a 400 about field shape must not precede the 404 for a token that is not there');
+  });
+
+  it('the echo fields are declared on the schema, so strictness still catches a MIS-SPELLING', () => {
+    // The half that must not be lost: `.strict()` is what stops `spaceIds` from being accepted and dropped.
+    // Widening the schema to `.passthrough()` would have fixed the round-trip and re-opened that.
+    const s = src();
+    const schema = s.slice(s.indexOf('const RenameTokenBody'), s.indexOf('tokensRouter.patch'));
+    assert.match(schema, /\}\)\.strict\(\)/, 'the edit body must stay strict — a mis-spelled field is a silent no-op');
+    assert.match(schema, /ECHOABLE_FIELDS\.map/,
+      'the echo fields must be declared from the one list, not spelled again beside it');
+  });
+});


### PR DESCRIPTION
`GET /api/tokens` returns the whole record minus the hash — twelve fields. `PATCH /api/tokens/:id` accepted two. So the ordinary integration shape — read a token, change its name, send it back — answered:

```
400  Unrecognized key(s) in object: 'spaces'
```

The reporter: *"the shape you read is not the shape you may write, and nothing says which fields are which."* `spaces` was only the first field alphabetically. `createdAt`, `lastUsed`, `expiresAt`, `admin`, `readOnly`, `mfa`, `schemaLibrary`, `peerInstanceId` and `oauthClientId` were all in the same position, and the message denied the field existed when the truth is that its remedy had moved to `rights`.

## Why both obvious fixes are wrong

**Strip them**, the way `id`/`hash`/`prefix` are stripped, and a body carrying `spaces: ['other']` beside the name is silently dropped and answered **200** — an attempt to widen a token that looks exactly like one that worked. This route already had that bug and already fixed it; re-fixing the round-trip that way trades one silent failure for the one it replaced.

**Refuse them** and you have the report.

The distinction both answers lose is **echo versus change**. The same value back is a round-trip: ignore it. A different value is an attempt to edit through a field that no longer writes: refuse it, and name the field that does.

```
Cannot change `spaces` on this route. For `spaces`, set `rights.perSpace`
(or `rights.floor` for every space). Sending these fields UNCHANGED is fine
— a token you read back round-trips.
```

That check needs the stored record, which is why it cannot be a `.refine()`: a schema sees only the body and is structurally unable to tell an echo from an edit.

## What did not change

`.strict()` stays, so a mis-spelled `spaceIds` is still refused rather than accepted and dropped. That was the point of the strictness and it is not what was wrong.

Presence is read off the **raw** body, not the parsed data: `z.unknown()` cannot distinguish an absent key from one explicitly set to `undefined`, and for `spaces` that is the difference between no change and a change to every space.

`spaces` is compared as a **set**, since a round-trip may reorder an allowlist — but `undefined` stays equal only to `undefined`. Absent means every space including future ones, `[]` means none, and reading them as equal inside an equality check is how that conflation would have returned for a fifth time.

An absent boolean and an explicit `false` are the same token, so `admin: false` on a non-admin token is an echo. A **demotion** is still a change and still refused by name.

Order matters and is pinned: 404 before any body complaint, and the change refusal before the "nothing to change" one — otherwise `{spaces: ['other']}` gets told to provide a name, which is true and says nothing about what was attempted.

## The gate

`token-read-shape-round-trips.test.js` **derives** the field list from `TokenRecord` rather than spelling it, so a field added tomorrow appears in GET for free and cannot silently go back to 400-ing the round-trip.

Mutation-tested against the pre-fix code: conflating absent with empty and dropping `spaces` from the list fails **three assertions in two suites**.

## Docs

`07-tokens-api.md` described this route as editing "**only**" the token's label — untrue since `rights` became editable in 2.6.0. It now documents both editable fields, the round-trip, and which fields have a remedy versus which are set at mint.
