### PR TITLE
feat(brain): a cog at the end of the tab strip, for the space you are already in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- **A cog at the far right of the Brain's tab strip opens the settings for the space you are already in.**
+  Same editor as **Settings → Spaces** — Settings, Schema, Duplicates, Danger Zone — over the page you were
+  reading, so closing it returns you to the tab you were on.
+  - Renaming a space you were working in previously meant leaving the Brain, finding the row in the admin
+    table, and navigating back: three moves to edit something already on screen.
+  - Deliberately **not** a ninth tab, and deliberately icon-only. It opens a modal, so it selects nothing —
+    among the tabs it would read as another destination and leave the strip looking wrong when the dialog
+    closed. A visible "Settings" label would also compete with the instance-wide Settings page, which is a
+    different scope; the name lives in the accessible label and the tooltip instead.
+  - Greyed out until a space is selected, rather than opening an empty dialog.
+  - The dialog's code is fetched **when the cog is pressed**, not with the page. Loading it eagerly pulled the
+    schema editor, duplicate rules and danger zone into the app's heaviest route — and moved shared code out
+    of the `spaces-component` chunk, which took that chunk off the bundle-budget list entirely.
+  - A save made here patches the space chip behind the dialog. It keeps the per-space record counts already
+    loaded rather than refetching the list, since a label or quota edit changes no count.
+  - **The admin list at Settings → Spaces is unchanged** and remains where spaces are created, reordered and
+    compared, with its own per-row cog.
+
 ### Fixed
 - **An unknown rights AREA was accepted at 200 and granted nothing — it took a live agent offline for four
   minutes.** `POST` and `PATCH /api/tokens` validated the rung *values* against `none|read|write|admin` and left

--- a/client/angular.json
+++ b/client/angular.json
@@ -59,7 +59,7 @@
                 { "type": "all", "maximumWarning": "8mb", "maximumError": "12mb" },
                 { "type": "any", "maximumWarning": "1mb", "maximumError": "1.5mb" },
                 { "type": "bundle", "name": "brain-component", "maximumWarning": "260kB", "maximumError": "400kB" },
-                { "type": "bundle", "name": "spaces-component", "maximumWarning": "270kB", "maximumError": "400kB" },
+                { "type": "bundle", "name": "space-settings-popup-component", "maximumWarning": "175kB", "maximumError": "260kB" },
                 { "type": "bundle", "name": "file-manager-component", "maximumWarning": "160kB", "maximumError": "260kB" },
                 { "type": "bundle", "name": "media-processing-page-component", "maximumWarning": "130kB", "maximumError": "200kB" }
               ],

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1862,5 +1862,7 @@
   "tokens.rights.title": "Rechte",
   "tokens.rights.edit": "Rechte bearbeiten",
   "tokens.rights.saved": "Rechte aktualisiert",
-  "tokens.error.rightsFailed": "Rechte konnten nicht aktualisiert werden"
+  "tokens.error.rightsFailed": "Rechte konnten nicht aktualisiert werden",
+  "brain.tab.spaceSettings": "Space-Einstellungen",
+  "brain.tab.spaceSettingsTitle": "Diesen Space konfigurieren — Bezeichnung, Schema, Duplikate, Gefahrenzone"
 }

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1862,5 +1862,7 @@
   "tokens.rights.title": "Rights",
   "tokens.rights.edit": "Edit rights",
   "tokens.rights.saved": "Rights updated",
-  "tokens.error.rightsFailed": "Could not update rights"
+  "tokens.error.rightsFailed": "Could not update rights",
+  "brain.tab.spaceSettings": "Space settings",
+  "brain.tab.spaceSettingsTitle": "Configure this space — label, schema, duplicates, danger zone"
 }

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1862,5 +1862,7 @@
   "tokens.rights.title": "Uprawnienia",
   "tokens.rights.edit": "Edytuj uprawnienia",
   "tokens.rights.saved": "Uprawnienia zaktualizowane",
-  "tokens.error.rightsFailed": "Nie udało się zaktualizować uprawnień"
+  "tokens.error.rightsFailed": "Nie udało się zaktualizować uprawnień",
+  "brain.tab.spaceSettings": "Ustawienia przestrzeni",
+  "brain.tab.spaceSettingsTitle": "Skonfiguruj tę przestrzeń — etykieta, schemat, duplikaty, strefa zagrożenia"
 }

--- a/client/src/app/pages/brain/brain.component.spec.ts
+++ b/client/src/app/pages/brain/brain.component.spec.ts
@@ -27,6 +27,7 @@ import { AuthService } from '../../core/auth.service';
 import { getTranslocoModule } from '../../testing/transloco-testing';
 import { BrainComponent } from './brain.component';
 import { COLLECTION_TABS } from './brain-tabs';
+import { SpaceSettingsState } from '../settings/space-settings-state.service';
 
 
 /** Read-only stub: brain's init cascade is listSpaces → getSpaceStats/getReindexStatus/getSpaceMeta. */
@@ -286,6 +287,76 @@ describe('BrainComponent (OnPush)', () => {
       c.setTab('graph');                       // opened by hand this time
       expect(c.graphFocusId()).toBeNull();
       expect(c.activeTab()).toBe('graph');
+    });
+  });
+
+  /**
+   * ── The space-settings cog ──────────────────────────────────────────────────────────────────────
+   *
+   * Reaching the space editor meant leaving the Brain for Settings → Spaces, finding the row, and coming
+   * back — three navigations to rename a space that was already on screen. The cog opens the same dialog
+   * on the space already selected here.
+   *
+   * Placement is the owner's call and is asserted rather than described: FAR RIGHT, after Files. It was
+   * first proposed beside Review and rejected for the reason these tests pin — it opens a modal, so it
+   * selects nothing, and sitting it among the tabs makes it read as a ninth destination.
+   */
+  describe('the space-settings cog', () => {
+    // The TAB strip, not the sidebar space chips — which also live in a .space-tabs container and whose
+    // last button is a space. That mistake made three of these pass for the wrong reason on first run.
+    const strip = (f: any) => f.nativeElement.querySelector('.tabs[role="tablist"]') as HTMLElement;
+
+    it('is the LAST control in the strip, after Files', () => {
+      const buttons = [...strip(create()).querySelectorAll('button')];
+      const last = buttons[buttons.length - 1];
+      expect(last?.classList.contains('tab-cog')).toBe(true);
+      // And Files is the one before it, which is what makes this an ordering assertion rather than a
+      // restatement of "there is a cog somewhere in the strip".
+      const prev = buttons[buttons.length - 2];
+      expect(prev?.textContent ?? '').toContain('files');
+    });
+
+    it('is not a tab: no role, no aria-selected, no label text', () => {
+      const cog = strip(create()).querySelector('.tab-cog');
+      expect(cog?.getAttribute('role')).toBeNull();
+      expect(cog?.getAttribute('aria-selected')).toBeNull();
+      // Icon only. A visible "Settings" word here competes with the instance-wide Settings page, which is
+      // a different scope — so the name lives in the accessible label rather than being dropped.
+      expect((cog?.textContent ?? '').trim()).toBe('');
+      expect(cog?.getAttribute('aria-label')).toBeTruthy();
+      expect(cog?.getAttribute('title')).toBeTruthy();
+    });
+
+    it('opens the dialog on the space already selected, with no extra request', () => {
+      const f = create();
+      const state = f.debugElement.injector.get(SpaceSettingsState);
+      expect(state.settingsSpace()).toBeNull();
+
+      f.componentInstance.openSpaceSettings();
+      // The id matters more than the object: opening the dialog on a DIFFERENT space than the one the
+      // sidebar shows selected is exactly the failure this cog exists to avoid.
+      expect(state.settingsSpace()?.id).toBe('work');
+    });
+
+    it('is disabled while no space is selected', () => {
+      const f = create();
+      f.componentInstance.activeSpaceId.set('');
+      f.detectChanges();
+      expect(strip(f).querySelector('.tab-cog')?.hasAttribute('disabled')).toBe(true);
+    });
+
+    it('a saved space patches the sidebar row and KEEPS its stats', () => {
+      // The reason the host listens at all: the dialog patches its own SpacesStore, and the instance here
+      // is a separate empty one. Refetching instead would drop the per-space stats, which cost a request
+      // each — so the record is merged and the stats left alone. A label edit changes no count.
+      const c = create().componentInstance;
+      const before = c.spaces().find((sv: any) => sv.space.id === 'work');
+      expect(before?.stats).toBeTruthy();
+
+      c.onSpaceSaved({ ...before!.space, label: 'Renamed' });
+      const after = c.spaces().find((sv: any) => sv.space.id === 'work');
+      expect(after?.space.label).toBe('Renamed');
+      expect(after?.stats).toEqual(before?.stats);
     });
   });
 });

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -16,6 +16,9 @@ import { ReviewTabComponent } from './review-tab.component';
 import { FormsModule } from '@angular/forms';
 import { Space, SpaceStats, AboutInfo, EmbeddingQueue, VoteRound, TokenAccessEntry, CompletenessReport, SpaceActivity } from '../../core/api.types';
 import { SpacesApi } from '../../core/spaces-api.service';
+import { SpaceSettingsPopupComponent } from '../settings/space-settings-popup.component';
+import { SpacesStore } from '../settings/spaces-store.service';
+import { SpaceSettingsState } from '../settings/space-settings-state.service';
 import { BrainApi } from '../../core/brain-api.service';
 import { AdminApi } from '../../core/admin-api.service';
 import { NetworksApi } from '../../core/networks-api.service';
@@ -48,8 +51,8 @@ interface SpaceView {
   // or happens in a template event handler, both of which mark the view dirty. That coupling is
   // load-bearing and pinned by the specs (the drawer's own version lives in the drawer component).
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ProxySpaceBadgeComponent, CommonModule, FormsModule, GraphComponent, FileManagerComponent, PhIconComponent, RecordDrawerComponent, QueryTabComponent, MemoriesTabComponent, EntitiesTabComponent, EdgesTabComponent, ChronoTabComponent, OverviewTabComponent, ReviewTabComponent, ErrorStateComponent, TranslocoPipe],
-  providers: [BrainStore, EntityRefPicker, RecordDrawerState, RecordListState],
+  imports: [ProxySpaceBadgeComponent, CommonModule, FormsModule, GraphComponent, FileManagerComponent, PhIconComponent, RecordDrawerComponent, QueryTabComponent, MemoriesTabComponent, EntitiesTabComponent, EdgesTabComponent, ChronoTabComponent, OverviewTabComponent, ReviewTabComponent, ErrorStateComponent, TranslocoPipe, SpaceSettingsPopupComponent],
+  providers: [BrainStore, EntityRefPicker, RecordDrawerState, RecordListState, SpacesStore, SpaceSettingsState],
   styles: [`
     .space-tabs {
       display: flex;
@@ -155,6 +158,18 @@ interface SpaceView {
     }
 
     .tab-spacer { flex: 1; }
+    /* The cog. Square rather than label-width, and it never takes the active treatment: it opens a modal,
+       so there is no state for "selected" to describe. Without this it inherited .tab's text padding and
+       sat as a wide empty button beside Files. */
+    .tab-cog {
+      padding: 6px 9px;
+      flex: 0 0 auto;
+      color: var(--text-muted);
+    }
+    .tab-cog:hover:not(:disabled) { color: var(--text); }
+    /* Disabled while no space is selected — the dialog has nothing to edit, and a cog that opens an empty
+       modal is worse than one that is visibly unavailable. */
+    .tab-cog:disabled { opacity: .4; cursor: not-allowed; }
 
     /* The active tab's content region. position:relative anchors the floating load spinner so it
        overlays the tab WITHOUT unmounting it (see the storm note in the template). */
@@ -261,7 +276,32 @@ interface SpaceView {
             <span class="tab-count">{{ s.files }}</span>
           }
         </button>
+        <!-- Space settings, as a cog at the far RIGHT of the strip and deliberately not a tab.
+             It opens a modal, so it does not select anything — sitting it between the record tabs would
+             make it read as a ninth destination and leave the strip looking wrong when the modal closed
+             and nothing was selected. .tab-cog drops the label for the same reason: a "Settings" word
+             here competes with the instance-wide Settings page, which is a different scope entirely.
+             The label lives in the aria-label and the tooltip, where it names the space scope. -->
+        <button class="tab tab-cog" type="button"
+          [attr.aria-label]="'brain.tab.spaceSettings' | transloco"
+          [attr.title]="'brain.tab.spaceSettingsTitle' | transloco"
+          [disabled]="!activeSpace()"
+          (click)="openSpaceSettings()">
+          <ph-icon name="gear" [size]="15" style="display:inline-flex;vertical-align:middle;"/>
+        </button>
       </div>
+
+      <!-- The same dialog the admin spaces table opens, hosted here too. It self-gates on
+           settingsSpace(), so this renders nothing until the cog is pressed. (saved) patches the one
+           row in THIS page's list: the store the dialog patches is a separate instance here, and the
+           sidebar renders from spaces() with per-space stats attached. -->
+      @if (spaceSettings.settingsSpace()) {
+        @defer (on immediate) {
+          <app-space-settings-popup (saved)="onSpaceSaved($event)" />
+        } @loading (minimum 200ms) {
+          <div class="loading-overlay loading-overlay--float" data-tab-defer="space-settings"><span class="spinner"></span></div>
+        }
+      }
 
       <!-- Content. Tabs are gated by activeTab() ONLY — NEVER wrapped in @else of
            @if (recordList.loading()). Each record tab WRITES recordList.loading during its own
@@ -339,6 +379,16 @@ export class BrainComponent implements OnInit, OnDestroy {
   readonly drawerState = inject(RecordDrawerState);
   readonly recordList = inject(RecordListState);
   private spacesApi = inject(SpacesApi);
+  /**
+   * The dialog's state, provided by this component so it opens and closes with the page.
+   *
+   * Public because the template reads `settingsSpace()` to decide whether the dialog's code should be
+   * fetched at all — see the `@defer` around it. The dialog carries the schema editor, the duplicate rules
+   * and the danger zone, and this is already the heaviest page in the app; loading all of that on the
+   * chance someone presses the cog took `spaces-component` off the bundle-budget list entirely, because
+   * the shared code had moved out of it. It now arrives when the cog is pressed and not before.
+   */
+  readonly spaceSettings = inject(SpaceSettingsState);
   private brainApi = inject(BrainApi);
   private adminApi = inject(AdminApi);
   private networksApi = inject(NetworksApi);
@@ -442,6 +492,31 @@ export class BrainComponent implements OnInit, OnDestroy {
   activeSpace = computed(() =>
     this.spaces().find(sv => sv.space.id === this.activeSpaceId())?.space,
   );
+
+  /**
+   * Open the space settings dialog on the space already selected here.
+   *
+   * No request: this page's list already holds the full `Space` record, which is the whole reason the cog
+   * can live here at all. Reaching the same editor previously meant leaving the Brain, finding the row in
+   * the admin table, and coming back — three navigations to change the label of a space that was already
+   * on screen.
+   */
+  openSpaceSettings(): void {
+    const space = this.activeSpace();
+    if (space) this.spaceSettings.openSettings(space);
+  }
+
+  /**
+   * Patch the one row this page renders from, after a save the dialog APPLIED.
+   *
+   * The dialog patches `SpacesStore`, but that instance is provided per host — the one here is empty and
+   * nothing reads it. Refetching the list instead would also discard the per-space stats hanging off each
+   * row, which cost one request each. So the record is merged in place and the stats are left alone: a
+   * label or quota edit does not change any count.
+   */
+  onSpaceSaved(space: Space): void {
+    this.spaces.update(list => list.map(sv => sv.space.id === space.id ? { ...sv, space } : sv));
+  }
 
   spaceTotal(stats: SpaceStats): number {
     return stats.memories + stats.entities + stats.edges + stats.chrono + stats.files;

--- a/client/src/app/pages/settings/space-settings-popup.component.ts
+++ b/client/src/app/pages/settings/space-settings-popup.component.ts
@@ -34,12 +34,13 @@
  * route guard need it. Two copies of "are you sure you want to lose these edits" is two places for the answer
  * to drift.
  */
-import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, output } from '@angular/core';
 import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
 import { PhIconComponent } from '../../shared/ph-icon.component';
 import { ModalDirective } from '../../shared/modal.directive';
 import { StatusPillComponent } from '../../shared/status-pill.component';
 import { SpacesApi } from '../../core/spaces-api.service';
+import type { Space } from '../../core/api.types';
 import { SpaceSettingsState } from './space-settings-state.service';
 import { SpacesStore } from './spaces-store.service';
 import { SpaceSettingsTabComponent } from './space-settings-tab.component';
@@ -152,6 +153,20 @@ export class SpaceSettingsPopupComponent {
   private store = inject(SpacesStore);
 
   /**
+   * A save that was APPLIED, with the updated space.
+   *
+   * The store row behind the modal is already patched by `applySpace`, which is enough for the spaces
+   * page — it renders from that store. The Brain host does not: it holds its own space list (with per-space
+   * stats attached), so without this a rename saved from the Brain cog left the old label in the sidebar
+   * that had just opened the dialog. Emitting the record rather than a bare signal means the host can patch
+   * the one row instead of refetching the list.
+   *
+   * NOT emitted on the 202 vote_pending path: nothing has been applied yet, and a host that patched its
+   * row there would show a change the network has not agreed to.
+   */
+  readonly saved = output<Space>();
+
+  /**
    * Which networks govern this space, as a label list — or null when none do.
    *
    * Deliberately not keyed on `networkStatus`: that reports whether something is *happening* (a vote, a sync,
@@ -206,6 +221,7 @@ export class SpaceSettingsPopupComponent {
           return;                      // stay open so the notice is read, unlike the applied path
         }
         this.store.applySpace(result.space);
+        this.saved.emit(result.space);
         // Re-baseline BEFORE closing. The dirty snapshot was only ever taken when a space was opened, so
         // a successful save left it stale: the editor still compared against the pre-save values and
         // reported unsaved changes for edits that were already persisted. Closing here happened to hide

--- a/client/src/app/pages/settings/spaces.component.ts
+++ b/client/src/app/pages/settings/spaces.component.ts
@@ -47,8 +47,18 @@ import { StatusPillComponent } from '../../shared/status-pill.component';
       <app-space-create-dialog (closed)="showCreateDialog.set(false)" />
     }
 
-    <!-- The space settings pop-up: its own component, opened by setting state.settingsSpace(). -->
-    <app-space-settings-popup />
+    <!-- The space settings pop-up: its own component, opened by setting state.settingsSpace().
+         Deferred behind the same gate the Brain host uses. It is modal-only in both places, so neither page
+         needs the schema editor, the duplicate rules and the danger zone until a cog is pressed — and while
+         one host loaded it eagerly and the other did not, the shared code was hoisted out of this route's
+         chunk, which cost spaces-component its name and took it off the bundle-budget list. A budget that
+         names no chunk is evaluated against nothing, so the page could then grow unbounded while the build
+         stayed green. -->
+    @if (state.settingsSpace()) {
+      @defer (on immediate) {
+        <app-space-settings-popup />
+      }
+    }
 
     <!-- Import conflict dialog -->
 

--- a/docs/userguide/02-brain.md
+++ b/docs/userguide/02-brain.md
@@ -12,6 +12,14 @@ The Brain is where all your knowledge lives. It has eight tabs: **Overview**, **
 
 At the top of the page a row of **space chips** lets you switch space; each chip shows the space's total record count. The tab buttons themselves carry small count badges for the collection they open.
 
+At the **far right of the tab strip**, past Files, a **cog** opens the settings for the space you are already
+looking at — the same editor as **Settings → Spaces**, with its Settings, Schema, Duplicates and Danger Zone
+tabs. It is not a ninth tab: it opens a dialog over the page, so nothing you were reading is lost, and closing
+it returns you to the tab you were on. The cog is greyed out until a space is selected.
+
+The admin list at **Settings → Spaces** is unchanged and remains the place to create, reorder and compare
+spaces; the cog is the shortcut for the one you are working in.
+
 If the search index needs rebuilding (for example after the embedding model changes), a banner appears reading *"Embeddings are stale — the embedding model has changed and this space needs reindexing."* Click **Reindex now** to rebuild it.
 
 > **Reindex and rebuild are different repairs.** *Reindex* re-embeds your content against the current model. It does **not** help when the search index itself is missing or broken — the symptom there is search quietly returning nothing at all, with no error. That one needs **Rebuild search indexes** on the space's **Danger** tab (see below).

--- a/docs/userguide/04-settings.md
+++ b/docs/userguide/04-settings.md
@@ -6,6 +6,10 @@
 
 ## Settings — Spaces
 
+> **Editing one space you are already in?** The Brain has a **cog at the far right of its tab strip** that
+> opens this same editor for the selected space, without leaving the page. Use the list below to create,
+> reorder or compare spaces.
+
 Open **Settings → Spaces** to manage all spaces on this instance. A summary above the list shows the total number of spaces, the storage in use across all of them, and how many are still building (or have failed to build) their search index. If a space's index is still preparing, its row is flagged so you know recall may be incomplete for it.
 
 ### Creating a space

--- a/testing/standalone/bundle-budget-coverage.test.js
+++ b/testing/standalone/bundle-budget-coverage.test.js
@@ -107,10 +107,17 @@ describe('bundle budgets', () => {
 
   it('the app pages that carry real weight are named individually', () => {
     // Not "every page needs a budget" — most are a few kB and an `any` ceiling covers them fine. These
-    // four are the ones that have actually grown: the Brain (once 2x the initial bundle), the Spaces
-    // settings screen, the Files manager (exceljs, mermaid) and Media Processing.
+    // four are the ones that have actually grown: the Brain (once 2x the initial bundle), the space
+    // settings DIALOG, the Files manager (exceljs, mermaid) and Media Processing.
+    //
+    // `spaces-component` used to be on this list and is deliberately not any more: the space settings
+    // dialog is now deferred and shared by two hosts, which moved 217 kB of schema editor, duplicate rules
+    // and danger zone out of the spaces route and into its own chunk. The route dropped to ~41 kB and
+    // stopped being emitted under that name at all — so the budget guarding it named nothing, which is the
+    // exact failure the sibling gate in preflight catches. The weight did not vanish; it moved, and the
+    // ceiling moved with it.
     const named = new Set(budgets.filter(b => b.type === 'bundle').map(b => b.name));
-    for (const heavy of ['brain-component', 'spaces-component', 'file-manager-component', 'media-processing-page-component']) {
+    for (const heavy of ['brain-component', 'space-settings-popup-component', 'file-manager-component', 'media-processing-page-component']) {
       assert.ok(named.has(heavy), `${heavy} has grown before and needs its own ceiling`);
     }
   });


### PR DESCRIPTION
`GET /api/tokens` … see the commit message. Summary:

Renaming a space you were working in meant leaving the Brain, finding the row in the admin table, and navigating back — three moves to edit something already on screen. The cog opens the same editor over the page you were reading; closing it returns you to the tab you were on.

## Placement

Far right, after Files — the owner's call, and asserted rather than described. It was first proposed beside Review and rejected for the reason the specs pin: it opens a modal, so it selects nothing. Among the tabs it reads as a ninth destination and leaves the strip looking wrong when the dialog closes.

Icon-only for a second reason: a visible "Settings" word competes with the instance-wide Settings page, which is a different scope. The name lives in the `aria-label` and the tooltip. Greyed out until a space is selected, rather than opening an empty dialog.

## The bundle, which is the interesting part

Importing the dialog statically made `spaces-component` **vanish from the emitted chunk table**. Angular does not complain when a `bundle` budget names nothing — it simply never evaluates it — so the 270 kB ceiling on that page silently stopped guarding anything. Preflight's budget gate caught it.

Deferring the dialog in **both** hosts fixed it, and is the better answer anyway: it is modal-only in both places, so neither page needs the schema editor, duplicate rules and danger zone until a cog is pressed.

| | before | after |
|---|---|---|
| spaces route | 258 kB | **41 kB** |
| settings dialog | (inside the route) | **151 kB, own chunk, own ceiling** |

The budget list moved *with* the weight rather than being deleted: `spaces-component` is replaced by `space-settings-popup-component`, and the coverage test records why — so the next reader does not restore a name the build no longer emits.

## Wiring

The page already holds the full `Space` record with per-space stats attached, so the cog costs **no request**. A save emits the record and the host patches that one row: the dialog patches its own `SpacesStore`, but that is provided per host and the instance here is empty. Refetching would have discarded the stats, which cost a request each — and a label or quota edit changes no count.

Not emitted on the `202 vote_pending` path: nothing has been applied yet, and a host that patched its row there would show a change the network has not agreed to.

## Docs

The Brain guide describes the cog and says it is not a tab; the Settings guide points at it from the top of Settings → Spaces. **The admin list is unchanged** and remains where spaces are created, reordered and compared, with its own per-row cog.

## Tests

Five specs, mutation-tested — moving the cog before Files fails the ordering assertion. The first version queried `.space-tabs`, which is the sidebar *chip* list; three specs passed against the wrong element until the selector was corrected to the tablist.
