### PR TITLE
fix(tokens): the dialog was not a dialog, and the label was write-once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     compared, with its own per-row cog.
 
 ### Fixed
+- **Both token dialogs rendered as flat blocks instead of pop-ups.** `.dialog-backdrop` and `.dialog` were
+  defined in `tokens.component.ts`, and Angular **scopes** component styles — so when the create-token markup
+  was extracted into its own component, the CSS stayed behind. The "dialog" became a full-width slab at the
+  top of the page: no backdrop, no centring, pushing the token list down.
+  - Nothing failed. It compiled, it rendered, every test passed, and the page was simply wrong to look at. A
+    missing style is not an error anywhere in the toolchain.
+  - The shell is now a shared `DIALOG_STYLES` constant, which a move cannot leave behind, and a gate fails any
+    component that renders `.dialog-backdrop` without carrying rules for it.
+  - **The gate immediately found a second one:** the *rights* dialog — the one for editing an existing token —
+    had the same problem and had never been styled at all. Editing a token appeared not to work because the
+    editor did not look like an editor.
+- **A token's label was write-once.** `PATCH /api/tokens/:id` has always accepted `name`, but the UI only ever
+  sent `rights`, so a label could be set while minting and never corrected. The edit dialog now edits the
+  label and the matrix, in **one** request — a rename and a rights change are one audited edit rather than two
+  that can half-fail.
 - **A token you read back could not be written back: `PATCH /api/tokens/:id` refused ten of the twelve fields
   `GET /api/tokens` emits.** Read a token, change its name, send it back, and the answer was
   `400 Unrecognized key(s) in object: 'spaces'`.
@@ -80,6 +95,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The empty-versus-absent asymmetry is asserted inside the narrowing too — `spaces === undefined` is
     unrestricted, an empty allowlist reaches nothing. That conflation granted whole instances on three routes in
     2.6.0 and must not come back where it would turn the narrowest token into the widest.
+
+### Changed
+- **The create-token form is a label, an expiry and the rights matrix.** It also carried a spaces checkbox
+  list, a three-way permission radio (read-only / standard / admin), and the matrix hidden behind a "Use the
+  per-space matrix" button.
+  - Those are **two vocabularies for one decision**, and the server treats them as mutually exclusive — so the
+    form could compose a body the API refuses, and the operator would read that 400 as a bug rather than as a
+    choice they had made.
+  - The matrix expresses everything the radio and the checkbox list expressed, and things they could not
+    (`admin` on Files in one space and nothing anywhere else). So they are gone, not kept beside it.
+  - The **second-factor** selector is gone from create for a different reason: MFA is a property of the token,
+    set on the token, not a decision folded into minting it.
+
 
 ### Internal
 - **The space-settings pop-up is its own component.** No behaviour change: 84 lines of template moved out of

--- a/client/src/app/core/auth-api.service.ts
+++ b/client/src/app/core/auth-api.service.ts
@@ -59,6 +59,17 @@ export class AuthApi {
     return this.http.patch<{ token: TokenRecord }>(`/api/tokens/${id}`, { rights });
   }
 
+  /**
+   * Edit a token's label and rights in ONE request.
+   *
+   * The route has always taken both; the UI sent them separately, and only ever sent `rights` — so a token's
+   * name was write-once in practice. Two requests would also mean a rename that lands while the rights change
+   * 403s on the mint cap, leaving the operator with half of what they asked for and one audit entry for it.
+   */
+  updateToken(id: string, patch: { name?: string; rights?: TokenRights }): Observable<{ token: TokenRecord }> {
+    return this.http.patch<{ token: TokenRecord }>(`/api/tokens/${id}`, patch);
+  }
+
   renameToken(id: string, name: string): Observable<{ token: TokenRecord }> {
     return this.http.patch<{ token: TokenRecord }>(`/api/tokens/${id}`, { name });
   }

--- a/client/src/app/pages/settings/dialog.styles.ts
+++ b/client/src/app/pages/settings/dialog.styles.ts
@@ -1,0 +1,49 @@
+/**
+ * The modal shell: backdrop, panel, header.
+ *
+ * ## Why this is a shared constant and not six copies
+ *
+ * Angular component styles are SCOPED. `tokens.component.ts` defined `.dialog-backdrop` and `.dialog`, and
+ * for as long as the create-token markup lived inside that component it was styled by them. Extracting the
+ * dialog into its own component moved the markup and left the CSS behind — so the "dialog" rendered as a
+ * plain block at the top of the page: full width, no backdrop, no centring, pushing the token list down.
+ *
+ * Nothing failed. The template compiled, the component rendered, every test passed, and the page was simply
+ * wrong to look at. The owner found it, not the build: *"its also no pop-up"*.
+ *
+ * That is the failure mode of a per-component copy of shared CSS — it is invisible at the moment the markup
+ * moves, which is exactly when it breaks. A constant both files import cannot be left behind by a move, and
+ * `dialogs-carry-their-own-shell.test.js` fails any component that writes `.dialog-backdrop` in a template
+ * without taking these rules with it.
+ *
+ * Sizing stays with the caller: dialogs legitimately differ in width (a confirm is not a schema editor), so
+ * `--dialog-max-width` is a variable the host sets rather than a value baked in here.
+ */
+export const DIALOG_STYLES = `
+  .dialog-backdrop {
+    position: fixed;
+    inset: 0;
+    background: var(--bg-scrim);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+    padding: 16px;
+  }
+  .dialog {
+    background: var(--bg-primary);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 24px;
+    width: 100%;
+    max-width: var(--dialog-max-width, 600px);
+    max-height: 90vh;
+    overflow-y: auto;
+  }
+  .dialog-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 16px;
+  }
+`;

--- a/client/src/app/pages/settings/token-create-dialog.component.ts
+++ b/client/src/app/pages/settings/token-create-dialog.component.ts
@@ -6,30 +6,48 @@ import { PhIconComponent } from '../../shared/ph-icon.component';
 import { ModalDirective } from '../../shared/modal.directive';
 import { AuthApi } from '../../core/auth-api.service';
 import { RightsMatrixComponent } from './rights-matrix.component';
+import { DIALOG_STYLES } from './dialog.styles';
 import type { TokenRights } from './rights-glyph.component';
 import type { Space, TokenRecord } from '../../core/api.types';
 
 /**
- * The create-token dialog.
+ * The create-token dialog: a label, an optional expiry, and the rights matrix.
  *
  * ## Why it is its own component
  *
- * It was over a quarter of `tokens.component.ts` and pushed that file past the god-file ceiling. It is also
- * a self-contained flow: thirteen pieces of state that exist only while the dialog is open, and one decision
- * — legacy permission fields or the per-space matrix — that the rest of the page has no opinion about.
+ * It was over a quarter of `tokens.component.ts` and pushed that file past the god-file ceiling.
+ *
+ * That extraction also produced the bug this file's styles now fix. `.dialog-backdrop` and `.dialog` were
+ * defined in `tokens.component.ts`, and Angular scopes component styles — so moving the markup out left the
+ * CSS behind and the "dialog" rendered as a plain full-width block at the top of the page, no backdrop, no
+ * centring, pushing the token list down. Nothing failed: it compiled, it rendered, the tests passed, and it
+ * was simply wrong to look at. The shell now comes from `DIALOG_STYLES`, which a move cannot leave behind.
+ *
+ * ## Why three controls became one
+ *
+ * The form used to carry a spaces checkbox list, a three-way permission radio (read-only / standard / admin)
+ * AND the matrix behind a "Use the per-space matrix" button. Those are two vocabularies for one decision, and
+ * the server treats them as **mutually exclusive** — so the form could compose a body the API refuses, and
+ * the operator would read that 400 as a bug rather than as a choice they had made.
+ *
+ * The matrix expresses everything the radio and the checkbox list expressed, and things they could not
+ * (admin on Files in one space and nothing anywhere else). So they are gone, not kept beside it.
+ *
+ * The second-factor selector is gone from CREATE for a different reason: MFA is a property of the token, set
+ * on the token, not a decision folded into minting it.
  *
  * ## The contract this must not change
  *
- * The REQUEST BODY. It is what the server's mint cap and the audit log see, and
- * `tokens.component.spec.ts` characterizes it: legacy fields and `rights` are mutually exclusive, `mfa` is
- * omitted when `inherit`, `spaces` only when some are selected. Those tests were written and proven green
- * against the pre-extraction code precisely so this move could be judged by them rather than by the diff.
+ * The REQUEST BODY. It is what the server's mint cap and the audit log see, and `tokens.component.spec.ts`
+ * characterizes it. Those tests were rewritten with this change rather than around it: the body is now always
+ * `{ name, rights }` plus an optional `expiresAt`, and never the legacy trio.
  */
 @Component({
   selector: 'app-token-create-dialog',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, ModalDirective, RightsMatrixComponent],
+  styles: [DIALOG_STYLES],
   template: `
       <div class="dialog-backdrop">
         <div class="dialog" [appModal]="'tokens.create.title' | transloco" (dismiss)="close.emit()" (click)="$event.stopPropagation()">
@@ -54,95 +72,24 @@ import type { Space, TokenRecord } from '../../core/api.types';
               </div>
             </div>
 
-            <div class="field" style="margin-top:12px; margin-bottom:0;">
-              <label>{{ 'tokens.create.spaces' | transloco }}</label>
+            <!-- The per-space matrix, and it is the whole permission model now.
+                 It used to sit behind a "Use the per-space matrix" button, below a spaces checkbox list and a
+                 three-way permission radio that described the SAME access in the pre-2.6.0 vocabulary. Three
+                 controls for one decision, two of which the server treats as mutually exclusive with the
+                 third — so the form could express bodies the API refuses. The matrix says everything they
+                 said and things they could not (admin on Files in one space and nothing anywhere else), so
+                 they are gone rather than kept beside it. -->
+            <div class="field" style="margin-top:14px; margin-bottom:0;">
+              <label>{{ 'tokens.create.permission' | transloco }}</label>
+              <p class="permission-help">
+                <ph-icon name="info" [size]="14" />
+                <span>{{ 'tokens.matrix.help' | transloco }}</span>
+              </p>
               @if (spacesLoadFailed()) {
-                <div class="alert alert-error" style="margin-bottom:6px; font-size:12px;">{{ 'tokens.create.spacesLoadFailed' | transloco }}</div>
-                <input type="text" [(ngModel)]="newSpacesFallback" name="spaces" [placeholder]="'tokens.create.spacesFallbackPlaceholder' | transloco" />
+                <div class="alert alert-error" style="margin-top:6px; font-size:12px;">{{ 'tokens.create.spacesLoadFailed' | transloco }}</div>
               } @else if (availableSpaces().length === 0) {
                 <div style="font-size:12px; color:var(--text-muted); margin-top:4px;">{{ 'tokens.create.loadingSpaces' | transloco }}</div>
               } @else {
-                <div class="table-wrapper" hscrollTop style="max-height:200px; overflow-y:auto; border:1px solid var(--border); border-radius:var(--radius-sm);">
-                  <table style="margin:0;">
-                    <thead>
-                      <tr>
-                        <th style="width:40px; text-align:center;">
-                          <input type="checkbox" [checked]="newSelectedSpaces.length === 0" (change)="selectAllSpaces()" [attr.title]="'tokens.create.allSpacesTitle' | transloco" />
-                        </th>
-                        <th>{{ 'auditLog.filter.space' | transloco }} <span style="font-size:10px; color:var(--text-muted); font-weight:400;">— {{ 'tokens.create.spacesCheckNoneHint' | transloco }}</span></th>
-                        <th>{{ 'spaces.table.column.id' | transloco }}</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      @for (s of availableSpaces(); track s.id) {
-                        <tr style="cursor:pointer;" (click)="toggleSpace(s.id)">
-                          <td style="text-align:center;">
-                            <input type="checkbox" [checked]="isSpaceSelected(s.id)" (click)="$event.stopPropagation()" (change)="toggleSpace(s.id)" />
-                          </td>
-                          <td>{{ s.label }}</td>
-                          <td><span class="badge badge-gray mono">{{ s.id }}</span></td>
-                        </tr>
-                      }
-                    </tbody>
-                  </table>
-                </div>
-              }
-              <div class="scope-hint">{{ 'tokens.create.spacesHint' | transloco }}</div>
-            </div>
-
-            <!-- Second factor, per token. The instance-wide switch is all-or-nothing, which is what makes
-                 MFA mutually exclusive with automation — a scheduler cannot type a code. Inherit is the
-                 default and means exactly what it means today. -->
-            <div class="field" style="margin-top:12px; margin-bottom:0;">
-              <label for="tokenMfa">{{ 'tokens.create.mfa' | transloco }}</label>
-              <select id="tokenMfa" [(ngModel)]="newMfa" name="mfa">
-                <option value="inherit">{{ 'tokens.mfa.inherit' | transloco }}</option>
-                <option value="exempt">{{ 'tokens.mfa.exempt' | transloco }}</option>
-                <option value="required">{{ 'tokens.mfa.required' | transloco }}</option>
-              </select>
-              <p class="permission-help">
-                <ph-icon name="info" [size]="14" />
-                <span>{{ ('tokens.mfa.' + newMfa + '.desc') | transloco }}</span>
-              </p>
-            </div>
-
-            <div class="field" style="margin-top:12px; margin-bottom:0;">
-              <label>{{ 'tokens.create.permission' | transloco }}</label>
-              <div class="permission-radio-group">
-                <label class="permission-radio-item">
-                  <input type="radio" name="permission" value="readOnly" [(ngModel)]="newPermission" />
-                  {{ 'tokens.permission.readOnly' | transloco }}
-                </label>
-                <label class="permission-radio-item">
-                  <input type="radio" name="permission" value="standard" [(ngModel)]="newPermission" />
-                  {{ 'tokens.permission.standard' | transloco }}
-                </label>
-                @if (callerIsAdmin()) {
-                  <label class="permission-radio-item">
-                    <input type="radio" name="permission" value="admin" [(ngModel)]="newPermission" />
-                    {{ 'tokens.permission.admin' | transloco }}
-                  </label>
-                }
-              </div>
-              <p class="permission-help">
-                <ph-icon name="info" [size]="14" />
-                <span>{{ ('tokens.permission.' + newPermission + '.desc') | transloco }}</span>
-              </p>
-            </div>
-
-            <!-- The per-space matrix, shown only when the operator asks for it. Collapsed by default because
-                 the legacy permission control above already answers the common case, and the two are
-                 mutually exclusive on the wire: the server refuses a body carrying both rather than
-                 silently preferring one. Opening this is therefore a deliberate switch, not an extra. -->
-            <div style="margin-top:14px;">
-              <button class="btn-secondary btn btn-sm" type="button" (click)="useMatrix.set(!useMatrix())">
-                {{ useMatrix() ? ('tokens.matrix.hide' | transloco) : ('tokens.matrix.show' | transloco) }}
-              </button>
-              @if (useMatrix()) {
-                <p class="permission-help" style="margin-top:8px;">
-                  <ph-icon name="info" [size]="14" />
-                  <span>{{ 'tokens.matrix.help' | transloco }}</span>
-                </p>
                 <app-rights-matrix
                   [rights]="draftRights()"
                   [spaces]="spaceIds()"
@@ -168,9 +115,6 @@ export class TokenCreateDialogComponent {
 
   availableSpaces = input<Space[]>([]);
   spacesLoadFailed = input(false);
-  /** Whether the CALLER is an admin — only an admin may offer the admin permission. Passed in rather than
-   *  re-fetched: two components asking `getMe()` is two answers that can disagree mid-dialog. */
-  callerIsAdmin = input(false);
   close = output<void>();
   created = output<{ token: TokenRecord; plaintext: string }>();
 
@@ -178,56 +122,23 @@ export class TokenCreateDialogComponent {
   createError = signal('');
   /** Just the ids: the matrix keys rows by id and does not need the rest of a space. */
   spaceIds = computed(() => this.availableSpaces().map(s => s.id));
-  useMatrix = signal(false);
   draftRights = signal<TokenRights>({ instanceAdmin: false, createSpaces: false, floor: null, perSpace: {} });
   newName = '';
   newExpiry = '';
-  newPermission: 'readOnly' | 'standard' | 'admin' = 'standard';
-  newMfa: 'inherit' | 'exempt' | 'required' = 'inherit';
-  newSelectedSpaces: string[] = [];
-  newSpacesFallback = '';
-
-  /** Empty selection means "all spaces" in this form, matching what the server does with an absent list. */
-  selectAllSpaces(): void { this.newSelectedSpaces = []; }
-
-  isSpaceSelected(id: string): boolean { return this.newSelectedSpaces.includes(id); }
-
-  toggleSpace(id: string): void {
-    this.newSelectedSpaces = this.isSpaceSelected(id)
-      ? this.newSelectedSpaces.filter(s => s !== id)
-      : [...this.newSelectedSpaces, id];
-  }
 
   createToken(): void {
     if (!this.newName.trim()) return;
     this.creating.set(true);
     this.createError.set('');
 
-    const body: {
-      name: string; expiresAt?: string; admin?: boolean; readOnly?: boolean; spaces?: string[];
-      mfa?: 'exempt' | 'required'; rights?: TokenRights;
-    } = { name: this.newName.trim() };
-    // Sent only when it says something — `inherit` is the absent state on the server too.
-    if (this.newMfa !== 'inherit') body.mfa = this.newMfa;
+    // ONE description of access, always the matrix. The legacy `spaces`/`admin`/`readOnly` trio is mutually
+    // exclusive with `rights` on the server, so a form offering both could compose a body the API refuses —
+    // and the operator would read that 400 as a bug rather than as a choice they had made.
+    const body: { name: string; expiresAt?: string; rights: TokenRights } = {
+      name: this.newName.trim(),
+      rights: this.draftRights(),
+    };
     if (this.newExpiry) body.expiresAt = new Date(this.newExpiry).toISOString();
-
-    if (this.useMatrix()) {
-      // EITHER the matrix OR the legacy fields, never both. The server refuses a body carrying both rather
-      // than silently preferring one, so sending the permission radio alongside would turn a deliberate
-      // choice into a 400 the operator did not make.
-      body.rights = this.draftRights();
-    } else {
-      if (this.newPermission === 'admin') body.admin = true;
-      if (this.newPermission === 'readOnly') body.readOnly = true;
-
-      let spaceIds: string[];
-      if (this.spacesLoadFailed()) {
-        spaceIds = this.newSpacesFallback.split(',').map(s => s.trim()).filter(Boolean);
-      } else {
-        spaceIds = [...this.newSelectedSpaces];
-      }
-      if (spaceIds.length) body.spaces = spaceIds;
-    }
 
     this.authApi.createToken(body).subscribe({
       next: ({ token, plaintext }) => {
@@ -236,9 +147,6 @@ export class TokenCreateDialogComponent {
         this.created.emit({ token, plaintext });
         this.newName = '';
         this.newExpiry = '';
-        this.newPermission = 'standard';
-        this.newSelectedSpaces = [];
-        this.newSpacesFallback = '';
       },
       error: (err) => {
         this.creating.set(false);

--- a/client/src/app/pages/settings/token-rights-dialog.component.ts
+++ b/client/src/app/pages/settings/token-rights-dialog.component.ts
@@ -4,6 +4,8 @@ import { PhIconComponent } from '../../shared/ph-icon.component';
 import { ModalDirective } from '../../shared/modal.directive';
 import { AuthApi } from '../../core/auth-api.service';
 import { RightsMatrixComponent } from './rights-matrix.component';
+import { DIALOG_STYLES } from './dialog.styles';
+import { FormsModule } from '@angular/forms';
 import type { TokenRights } from './rights-glyph.component';
 import type { Space, TokenRecord } from '../../core/api.types';
 
@@ -32,7 +34,8 @@ import type { Space, TokenRecord } from '../../core/api.types';
   selector: 'app-token-rights-dialog',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [TranslocoPipe, PhIconComponent, ModalDirective, RightsMatrixComponent],
+  imports: [TranslocoPipe, PhIconComponent, ModalDirective, RightsMatrixComponent, FormsModule],
+  styles: [DIALOG_STYLES],
   template: `
     <div class="dialog-backdrop">
       <div class="dialog" [appModal]="'tokens.rights.title' | transloco"
@@ -50,6 +53,17 @@ import type { Space, TokenRecord } from '../../core/api.types';
           <p class="form-error" role="alert" style="white-space:pre-wrap;">{{ error() }}</p>
         }
 
+        <!-- The label, editable here and nowhere else. This dialog used to edit the rights matrix ALONE, so a
+             token's name was write-once: it could be set while minting and never corrected afterwards, even
+             though PATCH has always accepted it. The two travel in one request, so a rename and a rights
+             change are one audited edit rather than two that can half-fail. -->
+        <div class="field" style="margin-bottom:14px;">
+          <label for="tokenLabel">{{ 'tokens.create.label' | transloco }}</label>
+          <input id="tokenLabel" type="text" [(ngModel)]="draftName" name="name"
+                 [placeholder]="'tokens.create.labelPlaceholder' | transloco" maxlength="200" />
+        </div>
+
+        <label style="display:block;margin-bottom:6px;">{{ 'tokens.create.permission' | transloco }}</label>
         <app-rights-matrix [rights]="draft()" [spaces]="spaceIds()" (changed)="draft.set($event)"/>
 
         <div class="form-grid-bottom" style="margin-top:12px;">
@@ -79,18 +93,28 @@ export class TokenRightsDialogComponent {
 
   /** Starts from what the token HAS — an empty start would make every save narrow everything not re-entered. */
   draft = signal<TokenRights>({ instanceAdmin: false, createSpaces: false, floor: null, perSpace: {} });
+  /** Same reasoning for the label: prefilled, so saving without touching it is not a rename to empty. */
+  draftName = '';
 
   spaceIds = () => this.availableSpaces().map(s => s.id);
 
   ngOnInit(): void {
     const r = this.token().rights;
     if (r) this.draft.set({ ...r } as TokenRights);
+    this.draftName = this.token().name;
   }
 
   save(): void {
     this.saving.set(true);
     this.error.set('');
-    this.authApi.setTokenRights(this.token().id, this.draft()).subscribe({
+    // The name goes only when it actually changed. Sending it unchanged would work — PATCH accepts it — but
+    // it would write a `token.update` audit entry claiming a rename that did not happen.
+    const trimmed = this.draftName.trim();
+    const renamed = trimmed && trimmed !== this.token().name;
+    this.authApi.updateToken(this.token().id, {
+      rights: this.draft(),
+      ...(renamed ? { name: trimmed } : {}),
+    }).subscribe({
       next: ({ token }) => { this.saving.set(false); this.saved.emit(token); },
       error: (err) => {
         this.saving.set(false);

--- a/client/src/app/pages/settings/tokens.component.spec.ts
+++ b/client/src/app/pages/settings/tokens.component.spec.ts
@@ -44,25 +44,61 @@ function make(createSpy = vi.fn().mockReturnValue(of({ token: 'tok_x' }))) {
   return { fixture, c: fixture.componentInstance, createSpy };
 }
 
-describe('TokensComponent — permission → create payload', () => {
+/**
+ * The create body: one description of access, always the matrix.
+ *
+ * This replaces a characterization of the OLD form, which offered a spaces checkbox list, a three-way
+ * permission radio and the matrix behind a button — two vocabularies for one decision, mutually exclusive on
+ * the wire. That form could compose a body the server refuses, and the operator would read the 400 as a bug
+ * rather than as a choice they had made.
+ *
+ * The old tests asserted `admin: true` / `readOnly: true` came out of the radio. They are not adapted here,
+ * they are REPLACED: those fields must now never be sent, which is a different claim and the one worth
+ * pinning. Keeping them adapted would have meant asserting the legacy path still works, on a form that no
+ * longer has it.
+ */
+describe('TokensComponent — create payload is the matrix, and only the matrix', () => {
   beforeEach(() => TestBed.resetTestingModule());
 
-  it('read-only sends readOnly:true; standard sends neither flag; admin sends admin:true', () => {
-    const cases = [
-      { perm: 'readOnly', admin: undefined, readOnly: true },
-      { perm: 'standard', admin: undefined, readOnly: undefined },
-      { perm: 'admin',    admin: true,      readOnly: undefined },
-    ] as const;
-    for (const { perm, admin, readOnly } of cases) {
-      const { c, createSpy } = make();
-      c.newName = 'ci-token';
-      c.newPermission = perm;
-      c.createToken();
-      const body = createSpy.mock.calls[0][0];
-      expect(body.name).toBe('ci-token');
-      expect(body.admin).toBe(admin);
-      expect(body.readOnly).toBe(readOnly);
+  it('sends name + rights, and NONE of the legacy scope fields', () => {
+    const { c, createSpy } = make();
+    c.newName = 'ci-token';
+    c.draftRights.set({ instanceAdmin: false, createSpaces: false, floor: null, perSpace: { qa: { knowledge: 'write', files: 'none', schema: 'none', dataQuality: 'none' } } });
+    c.createToken();
+
+    const body = createSpy.mock.calls[0][0];
+    expect(body.name).toBe('ci-token');
+    expect(body.rights?.perSpace?.['qa']?.knowledge).toBe('write');
+    // The four that made the body ambiguous. `rights` plus any of these is a 400 from the server.
+    for (const legacy of ['admin', 'readOnly', 'spaces', 'mfa']) {
+      expect(body[legacy]).toBeUndefined();
     }
+  });
+
+  it('always sends rights, even when nothing was granted', () => {
+    // An empty matrix is a real answer — a token that reaches nothing yet — and it must go as an explicit
+    // empty `rights`, not as an absent field. Absent would fall back to the legacy model on the server,
+    // where an absent `spaces` means EVERY space: the widest possible token from the narrowest input.
+    const { c, createSpy } = make();
+    c.newName = 'nothing-yet';
+    c.createToken();
+
+    const body = createSpy.mock.calls[0][0];
+    expect(body.rights).toEqual({ instanceAdmin: false, createSpaces: false, floor: null, perSpace: {} });
+    expect(body.spaces).toBeUndefined();
+  });
+
+  it('omits expiresAt when no date was picked, and sends an ISO string when one was', () => {
+    const { c, createSpy } = make();
+    c.newName = 't';
+    c.createToken();
+    expect(createSpy.mock.calls[0][0].expiresAt).toBeUndefined();
+
+    const second = make();
+    second.c.newName = 't';
+    second.c.newExpiry = '2027-01-31';
+    second.c.createToken();
+    expect(second.createSpy.mock.calls[0][0].expiresAt).toMatch(/^2027-01-31T/);
   });
 });
 
@@ -141,11 +177,14 @@ describe('TokensComponent — permission capability help (U6)', () => {
 describe('TokensComponent — create payload, characterized before the Q-5 extraction', () => {
   beforeEach(() => TestBed.resetTestingModule());
 
-  it('sends only the name when nothing else is chosen', () => {
+  it('trims the label, and sends nothing but the label and the matrix', () => {
     const { c, createSpy } = make();
     c.newName = '  spaced  ';
     c.createToken();
-    expect(createSpy.mock.calls[0][0]).toEqual({ name: 'spaced' });
+    expect(createSpy.mock.calls[0][0]).toEqual({
+      name: 'spaced',
+      rights: { instanceAdmin: false, createSpaces: false, floor: null, perSpace: {} },
+    });
   });
 
   it('refuses to fire at all on an empty name', () => {
@@ -155,55 +194,30 @@ describe('TokensComponent — create payload, characterized before the Q-5 extra
     expect(createSpy).not.toHaveBeenCalled();
   });
 
-  it('omits mfa when it is `inherit`, because absent IS inherit on the server', () => {
+  it('never sends `mfa` — the second factor is a property of the token, not of minting it', () => {
+    // The create form used to carry a three-way second-factor selector. It is gone: MFA is set ON the token,
+    // so folding it into the mint request meant deciding it before there was a token to decide it about.
     const { c, createSpy } = make();
-    c.newName = 't'; c.newMfa = 'inherit';
+    c.newName = 't';
     c.createToken();
     expect('mfa' in createSpy.mock.calls[0][0]).toBe(false);
-    const second = make();
-    second.c.newName = 't'; second.c.newMfa = 'exempt';
-    second.c.createToken();
-    expect(second.createSpy.mock.calls[0][0].mfa).toBe('exempt');
   });
 
-  it('sends spaces only when some are selected', () => {
+  it('a granted matrix survives into the body unchanged', () => {
+    // Not "rights is present" — the VALUES. A matrix that reached the server flattened or defaulted would
+    // still pass a presence check while granting something nobody chose.
     const { c, createSpy } = make();
     c.newName = 't';
-    c.newSelectedSpaces = new Set(['qa', 'research']);
-    c.createToken();
-    expect(createSpy.mock.calls[0][0].spaces.sort()).toEqual(['qa', 'research']);
-    const none = make();
-    none.c.newName = 't';
-    none.c.createToken();
-    expect('spaces' in none.createSpy.mock.calls[0][0]).toBe(false);
-  });
-
-  it('with the matrix on, sends `rights` and NONE of the legacy fields', () => {
-    // The mutual exclusion is the part most likely to be lost in an extraction: the server refuses a body
-    // carrying both, so a refactor that leaves the permission radio wired would turn every matrix create
-    // into a 400.
-    const { c, createSpy } = make();
-    c.newName = 't';
-    c.newPermission = 'admin';
-    c.newSelectedSpaces = new Set(['qa']);
-    c.useMatrix.set(true);
-    c.draftRights.set({ instanceAdmin: false, createSpaces: false, floor: null, perSpace: { qa: { knowledge: 'read', files: 'none', schema: 'none', dataQuality: 'none' } } });
+    c.draftRights.set({
+      instanceAdmin: false,
+      createSpaces: true,
+      floor: { knowledge: 'read', files: 'none', schema: 'none', dataQuality: 'none' },
+      perSpace: { qa: { knowledge: 'admin', files: 'write', schema: 'none', dataQuality: 'read' } },
+    });
     c.createToken();
     const body = createSpy.mock.calls[0][0];
-    expect(body.rights.perSpace.qa.knowledge).toBe('read');
-    expect('admin' in body).toBe(false);
-    expect('readOnly' in body).toBe(false);
-    expect('spaces' in body).toBe(false);
-  });
-
-  it('with the matrix OFF, never sends `rights` — even if a draft was edited first', () => {
-    // Someone can open the matrix, edit it, change their mind and close it. The draft survives in memory,
-    // and sending it anyway would be the same mutual-exclusion 400 from the other direction.
-    const { c, createSpy } = make();
-    c.newName = 't';
-    c.draftRights.set({ instanceAdmin: true, createSpaces: false, floor: null, perSpace: {} });
-    c.useMatrix.set(false);
-    c.createToken();
-    expect('rights' in createSpy.mock.calls[0][0]).toBe(false);
+    expect(body.rights.createSpaces).toBe(true);
+    expect(body.rights.floor.knowledge).toBe('read');
+    expect(body.rights.perSpace.qa).toEqual({ knowledge: 'admin', files: 'write', schema: 'none', dataQuality: 'read' });
   });
 });

--- a/client/src/app/pages/settings/tokens.component.ts
+++ b/client/src/app/pages/settings/tokens.component.ts
@@ -275,7 +275,6 @@ import { httpErrorReason } from '../../core/http-error';
       <app-token-create-dialog
         [availableSpaces]="availableSpaces()"
         [spacesLoadFailed]="spacesLoadFailed()"
-        [callerIsAdmin]="!!selfToken()?.admin"
         (close)="showCreateDialog.set(false)"
         (created)="onTokenCreated($event)"/>
     }

--- a/docs/userguide/04-settings.md
+++ b/docs/userguide/04-settings.md
@@ -121,11 +121,21 @@ Tokens can also be **space-scoped** — restricted to a specific list of spaces.
 
 ### Creating a token
 
-Click **Create Token**. Enter a name, choose a permission level, optionally set an expiry date, and optionally restrict it to specific spaces. A help line under the permission choices spells out exactly what the selected level can and cannot do (Read-only reads only; Standard reads and writes data; Admin adds token/space/config management). Click **Create** — the token value is shown **once**. Copy it immediately. The tokens list shows each token's permission level and space scope at any time, with the permission pill **colour-coded by privilege** so the riskiest tokens stand out at a glance: **admin is red**, **standard is green**, and **read-only is yellow** (Library Access tokens keep their own blue).
+Click **Create Token**. The dialog asks for three things: a **label**, an optional **expiry date**, and the
+**per-space rights matrix**. Click **Create** — the token value is shown **once**. Copy it immediately.
+
+The matrix is the whole permission model. Earlier versions also offered a spaces checkbox list and a
+three-way Read-only / Standard / Admin choice; those described the same access in an older vocabulary, and
+the server refuses a request that uses both at once. The matrix says everything they said and things they
+could not — such as **admin on Files in one space and nothing anywhere else**.
+
+The tokens list shows each token’s scope at any time, with the permission pill **colour-coded by privilege**
+so the riskiest tokens stand out: **admin is red**, **standard is green**, **read-only is yellow** (Library
+Access tokens keep their own blue).
 
 This dialog has no "Library Access" toggle. Library Access tokens (for sharing your schema library with other instances) are created separately, from the **Schema Library** page's own **Create token** dialog — see [Schema Library](03-files-and-schemas.md#schema-library).
 
-**Renaming a token.** Each row in the tokens list has a pencil button — click it to rename the token inline (Enter saves, Esc cancels). Only the label changes; the token's secret, permission level and space scope stay exactly as they were.
+**Editing a token.** Each row has a pencil button. It opens the token editor, where the **label** and the **rights matrix** are both editable and are saved together in one request — so a rename and a scope change are one audited edit, not two that can half-fail. The secret is untouched; use **Rotate** for that.
 
 ### Rotating a token
 

--- a/testing/standalone/dialogs-carry-their-own-shell.test.js
+++ b/testing/standalone/dialogs-carry-their-own-shell.test.js
@@ -1,0 +1,69 @@
+/**
+ * A component that renders `.dialog-backdrop` must carry the rules that make it a dialog.
+ *
+ * ## What happened
+ *
+ * `tokens.component.ts` defined `.dialog-backdrop` and `.dialog`. The create-token markup lived inside it and
+ * was styled by them. Extracting that markup into `token-create-dialog.component.ts` moved the template and
+ * **left the CSS behind** — and Angular scopes component styles, so the new component inherited nothing.
+ *
+ * The result was a "dialog" that rendered as a plain full-width block at the top of the page: no backdrop, no
+ * centring, no panel, pushing the token list down the screen. Nothing failed. The template compiled, the
+ * component rendered, every unit test passed. The owner found it by looking at the page:
+ *
+ *   > "ux on the token page is really bad and does not look like we mocked... its also no pop-up"
+ *
+ * That is the failure mode of a per-component copy of shared CSS: it breaks at the exact moment the markup
+ * moves, and it breaks silently, because a missing style is not an error anywhere in the toolchain.
+ *
+ * ## What this asserts
+ *
+ * Any component whose template contains `.dialog-backdrop` must either import `DIALOG_STYLES` or define the
+ * backdrop rule itself. Importing is preferred and is what new dialogs should do — a constant cannot be left
+ * behind by a move — but a component that spells the rules out is styled correctly, and this gate is about
+ * "is it styled", not "is it DRY".
+ *
+ * Run: node --test testing/standalone/dialogs-carry-their-own-shell.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+
+/** git, not readdir: a scratch copy of a component outside the repo is not something to gate on. */
+const files = execSync('git ls-files "client/src/**/*.ts"', { encoding: 'utf8' })
+  .trim().split('\n').filter(f => f && !f.endsWith('.spec.ts'));
+
+const USES_BACKDROP = /class="dialog-backdrop"/;
+/** The rule itself, not the class name — a selector mentioned in a comment styles nothing. */
+const DEFINES_BACKDROP = /\.dialog-backdrop\s*\{/;
+const IMPORTS_SHELL = /styles:\s*\[[^\]]*DIALOG_STYLES/;
+
+describe('every dialog carries the shell it renders', () => {
+  const hosts = files.filter(f => USES_BACKDROP.test(readFileSync(f, 'utf8')));
+
+  it('finds the dialogs it is meant to be checking', () => {
+    // A gate that enumerates nothing passes vacuously, and would keep passing if the class were renamed.
+    assert.ok(hosts.length >= 4, `expected several dialog components, found ${hosts.length}`);
+  });
+
+  it('each one either imports DIALOG_STYLES or defines the backdrop itself', () => {
+    const unstyled = hosts.filter(f => {
+      const src = readFileSync(f, 'utf8');
+      return !IMPORTS_SHELL.test(src) && !DEFINES_BACKDROP.test(src);
+    });
+    assert.deepEqual(unstyled, [],
+      `${unstyled.join(', ')} render a .dialog-backdrop with no rules for it. Angular scopes component `
+      + 'styles, so this renders as a plain full-width block instead of a modal — and nothing in the build, '
+      + 'the types or the tests says so.');
+  });
+
+  it('the shared constant actually contains the rules, so importing it is not a no-op', () => {
+    // The other half. A component could import an EMPTY constant and satisfy the check above while
+    // rendering exactly as badly as before.
+    const shell = readFileSync('client/src/app/pages/settings/dialog.styles.ts', 'utf8');
+    assert.match(shell, DEFINES_BACKDROP, 'DIALOG_STYLES no longer defines .dialog-backdrop');
+    assert.match(shell, /position:\s*fixed/, 'without fixed positioning the backdrop is an inline block');
+    assert.match(shell, /\.dialog\s*\{/, 'the panel rule is missing, so the dialog has no width or padding');
+  });
+});


### PR DESCRIPTION
The owner, on the create-token screen: *"ux on the token page is really bad and does not look like we mocked... its also no pop-up ... I also cant edit existing tokens"*.

## Why it was not a pop-up

`.dialog-backdrop` and `.dialog` were defined in `tokens.component.ts`. **Angular scopes component styles**, so when the create-token markup was extracted into its own component the CSS stayed behind. The dialog became a full-width slab at the top of the page: no backdrop, no centring, pushing the token list down.

Nothing failed. It compiled, it rendered, all 1044 client tests passed. A missing style is not an error anywhere in the toolchain, which is why this shipped and why a person had to find it.

The shell is now `DIALOG_STYLES` — a constant a move cannot leave behind — and `dialogs-carry-their-own-shell.test.js` fails any component that renders a `.dialog-backdrop` without carrying rules for it.

**That gate immediately found the second one.** `token-rights-dialog`, the editor for an existing token, had never been styled at all. That is why editing appeared not to work: the button was there, and the editor did not look like an editor. Fixing only the reported screen would have left it.

## Three controls for one decision

The create form carried a spaces checkbox list, a three-way permission radio (read-only / standard / admin), **and** the matrix behind a "Use the per-space matrix" button.

Those are two vocabularies for the same decision, and the server treats them as **mutually exclusive** — so the form could compose a body the API refuses, and the operator would read that 400 as a bug rather than as a choice they had made.

The matrix says everything they said and things they could not (`admin` on Files in one space and nothing anywhere else), so they are gone rather than kept beside it. What is left is **label, expiry, matrix**.

The second-factor selector is gone for a different reason, and it is the owner's: MFA is a property of the token, set on the token, not a decision folded into minting it.

## The label was write-once

`PATCH` has always accepted `name`; the UI only ever sent `rights`. So a token label could be set while minting and never corrected. The editor now saves label and matrix in **one** request — a rename and a rights change are one audited edit rather than two that can half-fail — and the name is sent only when it actually changed, so a save does not write a `token.update` entry claiming a rename that did not happen.

## Tests

The create-body characterization is **replaced, not adapted**. It asserted `admin: true` / `readOnly: true` came out of the radio; the claim worth pinning now is that those fields are *never* sent, which is a different claim. Adapting them would have meant asserting the legacy path still works on a form that no longer has it.

`rights` is now always present, including when nothing was granted — absent would fall back to the legacy model on the server, where an absent `spaces` means **every** space: the widest token from the narrowest input.

## Not in this PR

The second-factor selector on the *editor* and the danger zone (rotate / revoke) are tracked as U-3. MFA cannot move to the editor until `PATCH` accepts it — it currently sits in the mint-time group — and the live-TOTP rule for granting an exemption has to apply to the edit route too, or an exemption escalates by a shorter path.
