### PR TITLE
feat(tokens): the second factor is a property of the token, so edit it there

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- **A token's second factor is editable, instead of being fixed when the token was minted.** `PATCH
+  /api/tokens/:id` now accepts `mfa` (`inherit` | `exempt` | `required`).
+  - Setting it only at mint time put the decision before there was a token to decide it about: an operator who
+    wanted their scheduler exempt had to **revoke the token and mint a replacement** — rotating a secret, and
+    re-deploying it, to change a flag.
+  - **Granting `exempt` still costs a live TOTP code on the request.** Admin authentication on this route is
+    satisfied by an admin token that is *itself* exempt, so adding the field without that check would have
+    opened the same escalation create was already protected against, by a shorter route: editing yourself is
+    shorter than minting a replacement, and the new path would look like an ordinary token edit afterwards.
+    Both routes reach one function for it — two implementations of "does this exemption need a code" is how
+    they come to disagree, and the weaker one wins.
+  - The check runs **before anything is written**, so a refused exemption leaves the token exactly as it was
+    rather than renamed-but-not-exempted.
+  - `inherit` is stored as an **absent** field, not the string. Every existing token has no `mfa` at all, and
+    writing it explicitly would make a token that follows the instance switch look different on disk depending
+    on whether anyone had opened its editor.
+  - The audit diff carries the second factor on both sides. An exemption is the most security-relevant thing
+    this route can change, and a diff that omitted it would record a rename beside it and not the exemption.
+
 ### Added
 - **A cog at the far right of the Brain's tab strip opens the settings for the space you are already in.**
   Same editor as **Settings → Spaces** — Settings, Schema, Duplicates, Danger Zone — over the page you were

--- a/docs/integration-guide/07-tokens-api.md
+++ b/docs/integration-guide/07-tokens-api.md
@@ -162,9 +162,17 @@ PATCH /api/tokens/:id
 { "name": "new label" }
 ```
 
-Two fields are editable: **`name`** (1–200 chars, same bound as create) and **`rights`** (the per-space
-matrix — see [Create a Token](#create-a-token) for the shape and the capping rules). Send either or both. The secret and the
-expiry are untouched; use regenerate to rotate the secret. Audited as `token.update`.
+Three fields are editable: **`name`** (1–200 chars, same bound as create), **`rights`** (the per-space matrix
+— see [Create a Token](#create-a-token) for the shape and the capping rules), and **`mfa`**
+(`inherit` | `exempt` | `required`). Send any combination. The secret and the expiry are untouched; use
+regenerate to rotate the secret. Audited as `token.update`, with the second factor recorded on both sides of
+the diff.
+
+> **Granting `mfa: "exempt"` costs a live TOTP code on the request** whenever MFA is enabled instance-wide —
+> the same rule create has, and for the same reason. Admin authentication here is satisfied by an admin token
+> that is itself exempt, so without it one exemption could grant the next until the instance-wide switch
+> protected nothing. Send the code as `x-totp-code`; without it the answer is `403 MFA_REQUIRED`. The check
+> runs before anything is written, so a refused exemption never leaves a half-applied edit.
 
 **Response** `200`: the updated token record (hash excluded).
 
@@ -191,7 +199,7 @@ dropped:
 ```
 
 `spaces`, `admin` and `readOnly` are the pre-2.6.0 scope model; their replacement is `rights`. The rest
-(`createdAt`, `lastUsed`, `expiresAt`, `peerInstanceId`, `schemaLibrary`, `oauthClientId`, `mfa`) are set
+(`createdAt`, `lastUsed`, `expiresAt`, `peerInstanceId`, `schemaLibrary`, `oauthClientId`) are set
 when the token is minted and are not editable on any route.
 
 A field name this route has never heard of is still a `400` — a mis-spelled `spaceIds` must not be accepted

--- a/server/src/api/tokens.ts
+++ b/server/src/api/tokens.ts
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import type { Request, Response } from 'express';
 import { requireAuth, requireAdmin, requireAdminMfa } from '../auth/middleware.js';
 import { authRateLimit, globalRateLimit } from '../rate-limit/middleware.js';
-import { createToken, listTokens, revokeToken, regenerateToken, renameToken, setTokenRights } from '../auth/tokens.js';
+import { createToken, listTokens, revokeToken, regenerateToken, renameToken, setTokenRights, setTokenMfa } from '../auth/tokens.js';
 import { isMfaEnabled, verifyMfaCode } from '../auth/totp.js';
 import { z } from 'zod';
 import { SPACE_AREAS, RUNGS } from '../config/rights-shape.js';
@@ -219,7 +219,6 @@ export const ECHOABLE: Record<string, string | null> = {
   peerInstanceId: null,
   schemaLibrary: null,
   oauthClientId: null,
-  mfa: null,
 };
 
 const ECHOABLE_FIELDS = Object.keys(ECHOABLE);
@@ -258,6 +257,19 @@ const RenameTokenBody = z.object({
     floor: z.record(z.enum(SPACE_AREAS), z.enum(RUNGS)).nullable(),
     perSpace: z.record(z.string(), z.record(z.enum(SPACE_AREAS), z.enum(RUNGS))),
   }).strict().optional(),
+  /**
+   * This token's relationship to the second factor — editable HERE and nowhere else.
+   *
+   * It used to be settable only while minting, which put the decision before there was a token to decide it
+   * about: an operator who wanted their scheduler exempt had to revoke it and mint a replacement, rotating a
+   * secret to change a flag. It is a property of the token, so it is set on the token.
+   *
+   * Granting `exempt` costs a live TOTP code on THIS request when the instance switch is on — the same rule
+   * create has, applied here for the same reason. `requireAdminMfa` is satisfied by an admin token that is
+   * itself exempt, so without it one exemption could grant another by the shorter route, and editing yourself
+   * is shorter still than minting.
+   */
+  mfa: z.enum(['inherit', 'exempt', 'required']).optional(),
   // ── The rest of the record, accepted ONLY unchanged ──────────────────────────────────────────────
   //
   // These are declared so that echoing back a token you just read does not 400 on the first field the
@@ -275,7 +287,7 @@ tokensRouter.patch('/:id', requireAdminMfa, (req, res) => {
     return;
   }
   const id = req.params['id'] as string;
-  const { name, rights } = parsed.data;
+  const { name, rights, mfa } = parsed.data;
   const previous = listTokens().find(t => t.id === id);
   if (!previous) {
     res.status(404).json({ error: 'Token not found' });
@@ -302,10 +314,16 @@ tokensRouter.patch('/:id', requireAdminMfa, (req, res) => {
   // Checked after the above so a body that only echoes the record gets the "nothing to change" answer
   // rather than a bare unknown-key refusal. It was a `.refine()` until the echo fields existed; a schema
   // cannot see the stored record, so it could not tell an echo from an edit.
-  if (name === undefined && rights === undefined) {
-    res.status(400).json({ error: 'Provide `name`, `rights`, or both' });
+  if (name === undefined && rights === undefined && mfa === undefined) {
+    res.status(400).json({ error: 'Provide `name`, `rights`, `mfa`, or any combination' });
     return;
   }
+
+  // The same live-code rule create has. `requireAdminMfa` is satisfied by an admin token that is itself
+  // exempt, so without this one exemption could grant another — and editing yourself is a shorter route to
+  // that than minting a replacement. Checked before anything is written, so a refused exemption leaves the
+  // token exactly as it was rather than renamed-but-not-exempted.
+  if (!exemptionNeedsLiveCode(req, res, mfa)) return;
 
   if (rights) {
     // A token may never GRANT above itself, edit or mint. Same rule, same function — a second
@@ -335,9 +353,16 @@ tokensRouter.patch('/:id', requireAdminMfa, (req, res) => {
     }
   }
 
+  // `mfa` is in the snapshot on both sides because an exemption is the most security-relevant thing this
+  // route can change, and a diff that omitted it would record the rename beside it and not the exemption.
+  // `previous.mfa` is absent on every token that follows the instance switch, which reads as `inherit`.
   req.auditSnapshots = {
-    before: { name: previous.name, rights: previous.rights },
-    after: { name: name?.trim() ?? previous.name, rights: rights ?? previous.rights },
+    before: { name: previous.name, rights: previous.rights, mfa: previous.mfa ?? 'inherit' },
+    after: {
+      name: name?.trim() ?? previous.name,
+      rights: rights ?? previous.rights,
+      mfa: mfa ?? previous.mfa ?? 'inherit',
+    },
   };
 
   if (name !== undefined && !renameToken(id, name.trim())) {
@@ -345,6 +370,10 @@ tokensRouter.patch('/:id', requireAdminMfa, (req, res) => {
     return;
   }
   if (rights && !setTokenRights(id, rights as never)) {
+    res.status(404).json({ error: 'Token not found' });
+    return;
+  }
+  if (mfa !== undefined && !setTokenMfa(id, mfa)) {
     res.status(404).json({ error: 'Token not found' });
     return;
   }

--- a/server/src/auth/tokens.ts
+++ b/server/src/auth/tokens.ts
@@ -313,6 +313,29 @@ export function renameToken(id: string, name: string): boolean {
   return true;
 }
 
+/**
+ * Set a token's relationship to the second factor: `inherit`, `exempt` or `required`.
+ *
+ * Separate from the two above for the same reason they are separate from each other, and here the stakes are
+ * higher: this is the only one of the three that can weaken an instance-wide control. The route guards it —
+ * granting `exempt` costs a live TOTP code on the request even from a token that is itself exempt — and that
+ * guard must not be reachable around. A combined setter taking an optional `mfa` would let a caller change it
+ * while believing it had renamed.
+ *
+ * `inherit` is stored as ABSENT rather than as the string. It is the default, every existing token has no
+ * `mfa` field at all, and writing `'inherit'` explicitly would make a token that follows the instance switch
+ * look different on disk depending on whether anyone had ever opened its editor.
+ */
+export function setTokenMfa(id: string, mfa: 'inherit' | 'exempt' | 'required'): boolean {
+  const config = getConfig();
+  const idx = config.tokens.findIndex(t => t.id === id);
+  if (idx < 0) return false;
+  if (mfa === 'inherit') delete config.tokens[idx]!.mfa;
+  else config.tokens[idx]!.mfa = mfa;
+  saveConfig(config);
+  return true;
+}
+
 /** Revoke a token by ID */
 export async function revokeToken(id: string): Promise<boolean> {
   const config = getConfig();

--- a/testing/standalone/mfa-is-editable-and-still-guarded.test.js
+++ b/testing/standalone/mfa-is-editable-and-still-guarded.test.js
@@ -1,0 +1,118 @@
+/**
+ * A token's second factor is editable, and granting an EXEMPTION still costs a live code.
+ *
+ * ## Why it became editable
+ *
+ * `mfa` was settable only while minting. That put the decision before there was a token to decide it about:
+ * an operator who wanted their scheduler exempt had to revoke the token and mint a replacement — rotating a
+ * secret, and re-deploying it, to change a flag. The owner's framing was that it is a property of the token:
+ * *"we decided to use the MFA setting set by the token and not here on creation."*
+ *
+ * ## Why that is the dangerous edit on this route
+ *
+ * `requireAdminMfa` is satisfied by an admin token that is ITSELF exempt. That is correct for ordinary work
+ * and catastrophic for this one field: one exemption could grant another, and another, until the instance-wide
+ * switch protected nothing.
+ *
+ * Create already demanded a live TOTP code for granting `exempt`, regardless of who was asking. Adding the
+ * field to PATCH without that check would have opened the SAME escalation by a shorter route — editing
+ * yourself is shorter than minting a replacement — and the new path would look like an ordinary token edit in
+ * the audit log.
+ *
+ * So the checks are asserted to share one function. Two implementations of "does this exemption need a code"
+ * is how the two routes come to disagree, and the weaker one wins.
+ *
+ * Run: node --test testing/standalone/mfa-is-editable-and-still-guarded.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+const src = () => strip(readFileSync('server/src/api/tokens.ts', 'utf8'));
+const tokensLib = () => strip(readFileSync('server/src/auth/tokens.ts', 'utf8'));
+
+const patchBody = () => {
+  const s = src();
+  return s.slice(s.indexOf('const RenameTokenBody'), s.indexOf('tokensRouter.patch'));
+};
+const patchHandler = () => {
+  const s = src();
+  const i = s.indexOf("tokensRouter.patch('/:id'");
+  return s.slice(i, s.indexOf('tokensRouter.post', i));
+};
+
+describe('mfa is editable on PATCH', () => {
+  it('the edit body accepts the three states, and only those', () => {
+    assert.match(patchBody(), /mfa:\s*z\.enum\(\['inherit',\s*'exempt',\s*'required'\]\)\.optional\(\)/,
+      'a free-form string would store a fourth state that nothing reads, and read as `inherit` for ever');
+  });
+
+  it('it is NOT in the echo-only list any more', () => {
+    // While `mfa` was listed there, sending it was accepted-if-unchanged and refused-if-changed with a
+    // message saying it is set when the token is minted. Leaving it there while also accepting it would make
+    // the route contradict itself: the echo check fires first, so every real edit would 400.
+    const s = src();
+    const echoable = s.slice(s.indexOf('const ECHOABLE'), s.indexOf('const ECHOABLE_FIELDS'));
+    assert.ok(!/\bmfa:/.test(echoable),
+      'mfa is both editable and listed as echo-only — the echo check runs first, so every edit would 400');
+  });
+
+  it('a body carrying ONLY mfa is a valid edit, not an empty one', () => {
+    // The empty-body refusal used to name `name` and `rights`. If it were left alone, changing nothing but
+    // the second factor would be reported as "provide something".
+    assert.match(patchHandler(), /name === undefined && rights === undefined && mfa === undefined/,
+      'an mfa-only body would be refused as empty');
+  });
+
+  it('it is written through its own setter', () => {
+    // Not folded into `renameToken` or `setTokenRights`. A combined setter taking an optional `mfa` lets a
+    // caller change the second factor while believing it renamed — which is the reason those two are already
+    // separate from each other.
+    assert.match(tokensLib(), /export function setTokenMfa\(/);
+    assert.match(patchHandler(), /setTokenMfa\(id, mfa\)/);
+  });
+
+  it('`inherit` is stored as ABSENT, not as the string', () => {
+    // Every existing token has no `mfa` field. Writing `'inherit'` explicitly would make a token that follows
+    // the instance switch look different on disk depending on whether anyone had opened its editor.
+    const fn = tokensLib().slice(tokensLib().indexOf('export function setTokenMfa'));
+    assert.match(fn.slice(0, fn.indexOf('\n}')), /if \(mfa === 'inherit'\) delete/);
+  });
+});
+
+describe('granting an exemption still costs a live code', () => {
+  it('PATCH calls the same guard create does', () => {
+    // The escalation, asserted directly: `requireAdminMfa` is satisfied by an exempt admin token, so without
+    // this an exemption grants another exemption and the instance switch protects nothing.
+    assert.match(patchHandler(), /exemptionNeedsLiveCode\(req, res, mfa\)/,
+      'PATCH accepts `mfa` without demanding a live code — one exemption can now grant the next');
+  });
+
+  it('both routes reach it through ONE function', () => {
+    const s = src();
+    const calls = [...s.matchAll(/exemptionNeedsLiveCode\(/g)].length;
+    // One definition, two call sites.
+    assert.equal(calls, 3, `expected the definition plus both call sites, found ${calls} mentions`);
+    assert.equal([...s.matchAll(/function exemptionNeedsLiveCode/g)].length, 1,
+      'a second implementation is how the two routes come to disagree, and the weaker one wins');
+  });
+
+  it('the check runs BEFORE anything is written', () => {
+    // Otherwise a refused exemption leaves the token renamed-but-not-exempted: half the edit applied, and a
+    // 403 that reads as though nothing happened.
+    const h = patchHandler();
+    assert.ok(h.indexOf('exemptionNeedsLiveCode') < h.indexOf('renameToken(id'),
+      'a refused exemption must not leave a partial edit behind');
+  });
+
+  it('the audit snapshot records the second factor on both sides', () => {
+    // An exemption is the most security-relevant thing this route can change. A diff that omitted it would
+    // record the rename beside it and not the exemption.
+    const h = patchHandler();
+    const snap = h.slice(h.indexOf('req.auditSnapshots'), h.indexOf('if (name !== undefined'));
+    assert.equal([...snap.matchAll(/mfa:/g)].length, 2, 'before and after must both carry mfa');
+    assert.match(snap, /previous\.mfa \?\? 'inherit'/,
+      'an absent mfa reads as inherit; recording it as undefined would make every first edit look like a change');
+  });
+});

--- a/testing/standalone/token-read-shape-round-trips.test.js
+++ b/testing/standalone/token-read-shape-round-trips.test.js
@@ -53,9 +53,14 @@ describe('every field the list route emits is answerable by the edit route', () 
     const fields = [...body.slice(0, body.indexOf('\n}')).matchAll(/^\s{2}(\w+)\??:/gm)].map(m => m[1]);
     assert.ok(fields.length >= 10, `parsed only ${fields.length} fields off TokenRecord — re-point this`);
 
-    // `hash` never leaves the server; `id`/`prefix` are stripped; `name` and `rights` are the two the route
-    // actually edits. Everything else must be echoable or the round-trip 400s on it.
-    const accountedFor = new Set(['hash', 'id', 'prefix', 'name', 'rights', ...Object.keys(ECHOABLE)]);
+    // `hash` never leaves the server; `id`/`prefix` are stripped; `name`, `rights` and `mfa` are the three the
+    // route actually edits. Everything else must be echoable or the round-trip 400s on it.
+    //
+    // `mfa` joined the editable set rather than the echoable one: it was settable only while minting, which
+    // meant changing a scheduler's second factor required revoking the token and minting a replacement —
+    // rotating a secret to change a flag. Granting an exemption still costs a live TOTP code on the request,
+    // pinned by `mfa-is-editable-and-still-guarded.test.js`.
+    const accountedFor = new Set(['hash', 'id', 'prefix', 'name', 'rights', 'mfa', ...Object.keys(ECHOABLE)]);
     const orphans = fields.filter(f => !accountedFor.has(f));
     assert.deepEqual(orphans, [],
       `${orphans.join(', ')} are returned by GET and would be refused by PATCH — a token read back cannot `


### PR DESCRIPTION
Owner: *"we decided to use the MFA setting set by the token and not here on creation."*

`mfa` was settable only while minting. That put the decision before there was a token to decide it about: an operator who wanted their scheduler exempt had to **revoke the token and mint a replacement** — rotating a secret, and re-deploying it, to change a flag. `PATCH /api/tokens/:id` now accepts it.

## The escalation this could have opened

`requireAdminMfa` is satisfied by an admin token that is **itself exempt**. That is correct for ordinary work and catastrophic for this one field: one exemption grants another, and another, until the instance-wide switch protects nothing.

Create already demanded a live TOTP code for granting `exempt`, from anyone. Adding the field to PATCH without that check would have reopened exactly that hole **by a shorter route** — editing yourself beats minting a replacement — and the new path would look like an ordinary token edit in the audit log afterwards.

So both routes reach **one** function. Two implementations of "does this exemption need a code" is how they come to disagree, and the weaker one wins. The gate asserts the single definition and both call sites; mutation-testing confirms it — deleting the PATCH guard fails two assertions.

The check runs **before anything is written**. Otherwise a refused exemption leaves the token renamed-but-not-exempted: half the edit applied, behind a 403 that reads as though nothing happened.

## Details that are decisions

`inherit` is stored as an **absent** field, not the string. Every existing token has no `mfa` at all, and writing it explicitly would make a token that follows the instance switch look different on disk depending on whether anyone had ever opened its editor.

Its own setter, not folded into `renameToken` or `setTokenRights` — which are already separate from each other for this reason: a combined setter taking an optional second thing lets a caller change one while believing it changed the other.

The audit diff carries the second factor on both sides, since an exemption is the most security-relevant thing this route can change and a diff that omitted it would record the rename beside it and not the exemption.

## A stale dist nearly hid a broken gate

Moving `mfa` out of the echo-only list makes it an unaccounted field in `token-read-shape-round-trips.test.js`, which derives its field list from `TokenRecord`. That gate reported **all-pass** — against a `server/dist` built before the change. Rebuilding turned it red, which is the answer it should have given the first time.

## Next

The client half — the three-way selector in the editor, and the danger zone (rotate / revoke) — is U-3 and follows this. It needed #815 to land first, since that is the PR where the editor gained a form at all.
