### PR TITLE
feat(tokens): the second-factor selector, in the editor where it belongs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     this route can change, and a diff that omitted it would record a rename beside it and not the exemption.
 
 ### Added
+- **The token editor carries the second factor**, alongside the label and the rights matrix — *Follow the
+  instance setting*, *Exempt*, or *Required*.
+  - It is on the token rather than on the create form because that is what it is a property of. Before this,
+    changing a scheduler's exemption meant revoking the token and minting a replacement: rotating a secret to
+    change a flag.
+  - **Granting an exemption asks for your authenticator code in the dialog**, before the request, rather than
+    surfacing a `403` afterwards. The server's refusal is correct and unactionable — nothing in it tells the
+    operator that the field they changed is the reason.
+  - The field appears only when **granting** one: not when editing an already-exempt token, and not when taking
+    an exemption away. Save is not gated on it, because whether a code is needed depends on the instance-wide
+    switch and the server owns that answer — a local guess would refuse a save the instance would accept.
+  - An **absent** `mfa` reads as `inherit`, so opening any pre-existing token and pressing Save does not record
+    an edit nobody made. Each field is sent only when it actually changed, which matters most here: that audit
+    entry is what someone will read to find out when an exemption was granted.
+
+### Added
 - **A cog at the far right of the Brain's tab strip opens the settings for the space you are already in.**
   Same editor as **Settings → Spaces** — Settings, Schema, Duplicates, Danger Zone — over the page you were
   reading, so closing it returns you to the tab you were on.

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1864,5 +1864,7 @@
   "tokens.rights.saved": "Rechte aktualisiert",
   "tokens.error.rightsFailed": "Rechte konnten nicht aktualisiert werden",
   "brain.tab.spaceSettings": "Space-Einstellungen",
-  "brain.tab.spaceSettingsTitle": "Diesen Space konfigurieren — Bezeichnung, Schema, Duplikate, Gefahrenzone"
+  "brain.tab.spaceSettingsTitle": "Diesen Space konfigurieren — Bezeichnung, Schema, Duplikate, Gefahrenzone",
+  "tokens.mfa.codeLabel": "Authenticator-Code",
+  "tokens.mfa.codeHint": "Eine Ausnahme zu erteilen erfordert einen aktuellen Code aus deiner Authenticator-App — auch wenn dieses Token selbst ausgenommen ist."
 }

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1864,5 +1864,7 @@
   "tokens.rights.saved": "Rights updated",
   "tokens.error.rightsFailed": "Could not update rights",
   "brain.tab.spaceSettings": "Space settings",
-  "brain.tab.spaceSettingsTitle": "Configure this space — label, schema, duplicates, danger zone"
+  "brain.tab.spaceSettingsTitle": "Configure this space — label, schema, duplicates, danger zone",
+  "tokens.mfa.codeLabel": "Authenticator code",
+  "tokens.mfa.codeHint": "Granting an exemption needs a current code from your authenticator, even if this token is exempt itself."
 }

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1864,5 +1864,7 @@
   "tokens.rights.saved": "Uprawnienia zaktualizowane",
   "tokens.error.rightsFailed": "Nie udało się zaktualizować uprawnień",
   "brain.tab.spaceSettings": "Ustawienia przestrzeni",
-  "brain.tab.spaceSettingsTitle": "Skonfiguruj tę przestrzeń — etykieta, schemat, duplikaty, strefa zagrożenia"
+  "brain.tab.spaceSettingsTitle": "Skonfiguruj tę przestrzeń — etykieta, schemat, duplikaty, strefa zagrożenia",
+  "tokens.mfa.codeLabel": "Kod z aplikacji",
+  "tokens.mfa.codeHint": "Nadanie wyjątku wymaga aktualnego kodu z aplikacji uwierzytelniającej — nawet jeśli ten token sam jest wyłączony."
 }

--- a/client/src/app/core/auth-api.service.ts
+++ b/client/src/app/core/auth-api.service.ts
@@ -66,8 +66,16 @@ export class AuthApi {
    * name was write-once in practice. Two requests would also mean a rename that lands while the rights change
    * 403s on the mint cap, leaving the operator with half of what they asked for and one audit entry for it.
    */
-  updateToken(id: string, patch: { name?: string; rights?: TokenRights }): Observable<{ token: TokenRecord }> {
-    return this.http.patch<{ token: TokenRecord }>(`/api/tokens/${id}`, patch);
+  updateToken(
+    id: string,
+    patch: { name?: string; rights?: TokenRights; mfa?: 'inherit' | 'exempt' | 'required' },
+    totpCode?: string,
+  ): Observable<{ token: TokenRecord }> {
+    // Granting an MFA exemption costs a live TOTP code on this request, even from a token that is itself
+    // exempt — otherwise one exemption grants the next. The header goes only when there is a code to send:
+    // an empty one turns the server's "you need a code" into "your code is wrong".
+    return this.http.patch<{ token: TokenRecord }>(`/api/tokens/${id}`, patch,
+      totpCode ? { headers: { 'x-totp-code': totpCode } } : {});
   }
 
   renameToken(id: string, name: string): Observable<{ token: TokenRecord }> {

--- a/client/src/app/pages/settings/token-editor-mfa.spec.ts
+++ b/client/src/app/pages/settings/token-editor-mfa.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * The second factor, edited on the token — and the code field that granting an exemption needs.
+ *
+ * ## What this is about
+ *
+ * `mfa` used to be settable only while minting, so changing a scheduler's exemption meant revoking the token
+ * and minting a replacement — rotating a secret to change a flag. It is a property of the token, so it is
+ * edited on the token.
+ *
+ * The part worth testing is not that a dropdown exists. It is the three decisions around it:
+ *
+ *  1. **An absent `mfa` IS `inherit`.** Every token minted before this reads as `inherit`, and if the two
+ *     spellings did not land on the same option, opening any existing token's editor and pressing Save would
+ *     send `mfa: 'inherit'` as a *change* — writing an audit entry for an edit nobody made.
+ *  2. **Each field goes only when it changed.** Same reason, and for the second factor it matters most: that
+ *     audit entry is what someone will read one day to find out when an exemption was granted.
+ *  3. **The code field appears when GRANTING**, not whenever a token is exempt. Asking for a code to edit the
+ *     label of an already-exempt token is a prompt for a secret that changes nothing.
+ *
+ * Run: npx vitest run src/app/pages/settings/token-editor-mfa.spec.ts
+ */
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { of, throwError } from 'rxjs';
+import { AuthApi } from '../../core/auth-api.service';
+import { getTranslocoModule } from '../../testing/transloco-testing';
+import { TokenRightsDialogComponent } from './token-rights-dialog.component';
+
+const RIGHTS = { instanceAdmin: false, createSpaces: false, floor: null, perSpace: {} };
+
+function make(token: Record<string, unknown>) {
+  const updateSpy = vi.fn().mockReturnValue(of({ token: { ...token, name: 'saved' } }));
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    imports: [TokenRightsDialogComponent, getTranslocoModule()],
+    providers: [{ provide: AuthApi, useValue: { updateToken: updateSpy } as any }],
+  });
+  const fixture = TestBed.createComponent(TokenRightsDialogComponent);
+  fixture.componentRef.setInput('token', { id: 't1', name: 'CI', rights: RIGHTS, ...token });
+  fixture.componentRef.setInput('availableSpaces', [{ id: 'qa', label: 'QA' }]);
+  fixture.detectChanges();
+  return { fixture, c: fixture.componentInstance as any, updateSpy };
+}
+
+describe('the token editor: second factor', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('an ABSENT mfa opens as `inherit`', () => {
+    // The whole pre-existing fleet has no `mfa` field. If this landed on '' or undefined, the select would
+    // show nothing and a save would look like a change.
+    expect(make({}).c.draftMfa).toBe('inherit');
+  });
+
+  it('a stored value opens as itself', () => {
+    expect(make({ mfa: 'exempt' }).c.draftMfa).toBe('exempt');
+    expect(make({ mfa: 'required' }).c.draftMfa).toBe('required');
+  });
+
+  it('saving without touching it does NOT send mfa', () => {
+    // The audit entry for an exemption is the one someone will read to find out when it was granted. A save
+    // that always sent the field would put an entry there for every unrelated edit.
+    const { c, updateSpy } = make({ mfa: 'exempt' });
+    c.save();
+    expect('mfa' in updateSpy.mock.calls[0][1]).toBe(false);
+  });
+
+  it('an absent-to-inherit save does not count as a change either', () => {
+    // The asymmetric case: stored is absent, the select says `inherit`. Comparing the raw values would see
+    // undefined !== 'inherit' and send it.
+    const { c, updateSpy } = make({});
+    c.save();
+    expect('mfa' in updateSpy.mock.calls[0][1]).toBe(false);
+  });
+
+  it('changing it sends exactly the new value', () => {
+    const { c, updateSpy } = make({});
+    c.draftMfa = 'required';
+    c.save();
+    expect(updateSpy.mock.calls[0][1].mfa).toBe('required');
+  });
+
+  it('the code field appears only when GRANTING an exemption', () => {
+    const fresh = make({});
+    expect(fresh.c.needsCode()).toBe(false);
+    fresh.c.draftMfa = 'exempt';
+    expect(fresh.c.needsCode()).toBe(true);
+
+    // Already exempt and editing something else: no code, because nothing is being granted.
+    const already = make({ mfa: 'exempt' });
+    expect(already.c.needsCode()).toBe(false);
+
+    // Moving AWAY from an exemption is a narrowing and needs nothing.
+    already.c.draftMfa = 'inherit';
+    expect(already.c.needsCode()).toBe(false);
+  });
+
+  it('the code travels as an argument, not in the body', () => {
+    // It is a header on the request. Putting a secret in the PATCH body would land it in any request log that
+    // records bodies, and the server does not read it there.
+    const { c, updateSpy } = make({});
+    c.draftMfa = 'exempt';
+    c.totpCode = ' 123456 ';
+    c.save();
+    expect(updateSpy.mock.calls[0][2]).toBe('123456');
+    expect('totpCode' in updateSpy.mock.calls[0][1]).toBe(false);
+  });
+
+  it('an empty code is sent as undefined, not as an empty string', () => {
+    // An empty header turns the server's "you need a code" into "your code is wrong".
+    const { c, updateSpy } = make({});
+    c.save();
+    expect(updateSpy.mock.calls[0][2]).toBeUndefined();
+  });
+
+  it('surfaces the server MESSAGE for a refused exemption, not the bare code', () => {
+    // The 403 body is `{ error: 'MFA_REQUIRED', message: '...requires a current TOTP code...' }`. Showing
+    // `error` reads as "you are not allowed"; the message is the half that says what to do.
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [TokenRightsDialogComponent, getTranslocoModule()],
+      providers: [{ provide: AuthApi, useValue: {
+        updateToken: () => throwError(() => ({ error: { error: 'MFA_REQUIRED', message: 'needs a current TOTP code' } })),
+      } as any }],
+    });
+    const f = TestBed.createComponent(TokenRightsDialogComponent);
+    f.componentRef.setInput('token', { id: 't1', name: 'CI', rights: RIGHTS });
+    f.componentRef.setInput('availableSpaces', []);
+    f.detectChanges();
+    const c = f.componentInstance as any;
+    c.draftMfa = 'exempt';
+    c.save();
+    expect(c.error()).toBe('needs a current TOTP code');
+    expect(c.saving()).toBe(false);
+  });
+});

--- a/client/src/app/pages/settings/token-rights-dialog.component.ts
+++ b/client/src/app/pages/settings/token-rights-dialog.component.ts
@@ -66,6 +66,38 @@ import type { Space, TokenRecord } from '../../core/api.types';
         <label style="display:block;margin-bottom:6px;">{{ 'tokens.create.permission' | transloco }}</label>
         <app-rights-matrix [rights]="draft()" [spaces]="spaceIds()" (changed)="draft.set($event)"/>
 
+        <!-- The second factor, on the token rather than on the mint request. It was settable only while
+             minting, so changing a scheduler's exemption meant revoking the token and minting a replacement —
+             rotating a secret to change a flag. -->
+        <div class="field" style="margin-top:14px;margin-bottom:0;">
+          <label for="tokenMfa">{{ 'tokens.create.mfa' | transloco }}</label>
+          <select id="tokenMfa" [(ngModel)]="draftMfa" name="mfa">
+            <option value="inherit">{{ 'tokens.mfa.inherit' | transloco }}</option>
+            <option value="exempt">{{ 'tokens.mfa.exempt' | transloco }}</option>
+            <option value="required">{{ 'tokens.mfa.required' | transloco }}</option>
+          </select>
+          <p class="permission-help">
+            <ph-icon name="info" [size]="14" />
+            <span>{{ ('tokens.mfa.' + draftMfa + '.desc') | transloco }}</span>
+          </p>
+        </div>
+
+        <!-- Granting an exemption costs a live TOTP code on the request, even from a token that is itself
+             exempt — otherwise one exemption grants the next. Asked for HERE rather than after a 403, because
+             the server's refusal is correct and unactionable: the operator cannot tell from it that the field
+             they changed is the reason. Shown only when it is actually needed. -->
+        @if (needsCode()) {
+          <div class="field" style="margin-top:12px;margin-bottom:0;">
+            <label for="tokenTotp">{{ 'tokens.mfa.codeLabel' | transloco }}</label>
+            <input id="tokenTotp" type="text" inputmode="numeric" autocomplete="one-time-code"
+                   [(ngModel)]="totpCode" name="totp" maxlength="10" />
+            <p class="permission-help">
+              <ph-icon name="info" [size]="14" />
+              <span>{{ 'tokens.mfa.codeHint' | transloco }}</span>
+            </p>
+          </div>
+        }
+
         <div class="form-grid-bottom" style="margin-top:12px;">
           <button class="btn-secondary btn" type="button" (click)="close.emit()">
             {{ 'common.cancel' | transloco }}
@@ -95,6 +127,23 @@ export class TokenRightsDialogComponent {
   draft = signal<TokenRights>({ instanceAdmin: false, createSpaces: false, floor: null, perSpace: {} });
   /** Same reasoning for the label: prefilled, so saving without touching it is not a rename to empty. */
   draftName = '';
+  /** An absent `mfa` on the record IS `inherit`, so the two spellings must land on the same option. */
+  draftMfa: 'inherit' | 'exempt' | 'required' = 'inherit';
+  totpCode = '';
+
+  /**
+   * Ask for a code only when GRANTING an exemption — not when a token already has one and something else is
+   * being edited, and not when moving away from one.
+   *
+   * Deliberately not conditioned on whether MFA is enabled instance-wide: this component would have to fetch
+   * that, and a second source for "is MFA on" is a second answer that can disagree with the server's. When the
+   * switch is off the server ignores the code, so offering the field costs nothing; when it is on, the code is
+   * required and asking here beats a 403 the operator cannot connect to the field they changed.
+   *
+   * Save is NOT gated on it for the same reason — the server owns that decision, and gating locally would
+   * refuse a save the instance would have accepted.
+   */
+  needsCode = () => this.draftMfa === 'exempt' && (this.token().mfa ?? 'inherit') !== 'exempt';
 
   spaceIds = () => this.availableSpaces().map(s => s.id);
 
@@ -102,23 +151,30 @@ export class TokenRightsDialogComponent {
     const r = this.token().rights;
     if (r) this.draft.set({ ...r } as TokenRights);
     this.draftName = this.token().name;
+    this.draftMfa = this.token().mfa ?? 'inherit';
   }
 
   save(): void {
     this.saving.set(true);
     this.error.set('');
-    // The name goes only when it actually changed. Sending it unchanged would work — PATCH accepts it — but
-    // it would write a `token.update` audit entry claiming a rename that did not happen.
+    // Each field goes only when it actually changed. Sending one unchanged would work — PATCH accepts it — but
+    // it would write a `token.update` audit entry claiming an edit that did not happen, and for the second
+    // factor that is the entry someone will one day read to find out when an exemption was granted.
     const trimmed = this.draftName.trim();
     const renamed = trimmed && trimmed !== this.token().name;
+    const mfaChanged = this.draftMfa !== (this.token().mfa ?? 'inherit');
     this.authApi.updateToken(this.token().id, {
       rights: this.draft(),
       ...(renamed ? { name: trimmed } : {}),
-    }).subscribe({
+      ...(mfaChanged ? { mfa: this.draftMfa } : {}),
+    }, this.totpCode.trim() || undefined).subscribe({
       next: ({ token }) => { this.saving.set(false); this.saved.emit(token); },
       error: (err) => {
         this.saving.set(false);
-        this.error.set(err.error?.error ?? this.transloco.translate('tokens.error.rightsFailed'));
+        // The exemption refusal is a 403 whose `message` carries the actionable half; `error` is the code
+        // `MFA_REQUIRED`, which on its own reads as "you are not allowed" rather than "type your code".
+        this.error.set(err.error?.message ?? err.error?.error
+          ?? this.transloco.translate('tokens.error.rightsFailed'));
       },
     });
   }

--- a/docs/userguide/04-settings.md
+++ b/docs/userguide/04-settings.md
@@ -137,6 +137,16 @@ This dialog has no "Library Access" toggle. Library Access tokens (for sharing y
 
 **Editing a token.** Each row has a pencil button. It opens the token editor, where the **label** and the **rights matrix** are both editable and are saved together in one request — so a rename and a scope change are one audited edit, not two that can half-fail. The secret is untouched; use **Rotate** for that.
 
+The editor also carries the **second factor** for this token — *Follow the instance setting* (the default),
+*Exempt*, or *Required*. It lives here rather than on the create form because it is a property of the token:
+before this, changing a scheduler’s exemption meant revoking the token and minting a replacement, rotating a
+secret to change a flag.
+
+> **Granting an exemption asks for your authenticator code**, even if the token you are using is itself
+> exempt. Without that, one exemption could grant the next until the instance-wide MFA switch protected
+> nothing. The field appears only when you are granting one — not when you are editing an already-exempt
+> token, and not when you are taking an exemption away.
+
 ### Rotating a token
 
 Click the ↺ icon on any token row. A new secret is generated; the old one stops working immediately. The new value is shown once.


### PR DESCRIPTION
The client half of the change whose server half is #816. `mfa` is now a property you edit on the token, so the editor offers it: *Follow the instance setting*, *Exempt*, *Required*.

## The code field, and why it is asked for here

Granting an exemption costs a live TOTP code on the request, even from a token that is itself exempt — otherwise one exemption grants the next. The server enforces that, and its `403` is correct but **unactionable**: nothing in *"requires a current TOTP code"* tells the operator that the dropdown they just changed is the reason. So the field appears in the dialog, before the request.

It appears only when **granting**. Not when editing an already-exempt token — asking for a secret that changes nothing — and not when taking an exemption away, which is a narrowing.

**Save is deliberately not gated on it.** Whether a code is needed depends on the instance-wide MFA switch, and the server owns that answer; a local guess would refuse a save the instance would have accepted. This component could fetch the switch state instead, and that would be a second source for one fact, able to disagree with the one actually enforcing it.

The code travels as a header argument, never in the PATCH body: a secret in a body lands in any log that records bodies, and the server does not read it there.

## Absent IS inherit

Every token minted before this has no `mfa` field. If the two spellings did not land on the same option, opening any existing token and pressing Save would send `mfa: 'inherit'` as a **change** and write an audit entry for an edit nobody made.

Mutation-tested: comparing the raw values instead of normalising fails that assertion.

Each field is sent only when it actually changed. That matters most for this one — the audit entry is what somebody will read to find out when an exemption was granted.

## Error surfacing

The refusal body is `{ error: 'MFA_REQUIRED', message: '…' }`. Showing `error` reads as *"you are not allowed"*; the `message` is the half that says what to do, so it wins when present.

## Still open

The danger zone (rotate / revoke) in the editor is the remaining part of U-3. Rotate returns the secret **once**, so it has to hand the plaintext to the page's existing copy-once banner rather than rendering a second one.
