### PR TITLE
perf(recall): one query, one vector — not one per space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- **A cross-space recall embedded the identical query once per space.** Five accessible spaces meant five
+  `POST /v1/embeddings` for one search — same text, same vector, five times the cost, the concurrency footprint
+  and the failure surface. `recallGlobal` now embeds once and hands the vector down.
+  - Found from the outside by an operator who moved their text embedder onto a shared GPU endpoint: with the
+    endpoint saturated by a reindex, **every** recall failed, and their access log showed exactly five 429s per
+    recall, never four, never six.
+  - The fan-out is also what made the failure certain: a 1-wide request fits where a 5-wide burst does not.
+  - **They read the five as one call per knowledge type**, and said plainly they were inferring from the count.
+    It is one per *space* — there has only ever been one `embed` call in the module. The count was real and the
+    mechanism was not, which is the difference between a two-line fix at the fan-out and a fruitless read of
+    the per-type search.
+  - Single-space recall is unchanged: it embeds for itself, so the per-space routes and traverse are untouched.
+  - `findSimilar` already had this right — it loops spaces with one vector taken from the source record — and a
+    gate now pins that it never grows an `embed` call inside that loop.
+
 ### Changed
 - **A token's second factor is editable, instead of being fixed when the token was minted.** `PATCH
   /api/tokens/:id` now accepts `mfa` (`inherit` | `exempt` | `required`).

--- a/server/src/brain/recall.ts
+++ b/server/src/brain/recall.ts
@@ -8,6 +8,7 @@
 import { col, isVectorSearchAvailable, asFilter } from '../db/mongo.js';
 import { NotFoundError } from '../util/errors.js';
 import { embed } from './embedding.js';
+import type { EmbeddingResult } from './embedding.js';
 import { getEmbeddingConfig } from '../config/loader.js';
 import { needsReindex } from '../spaces/_shared.js';
 import { vectorFilterFieldsFor } from '../spaces/vector-index.js';
@@ -224,6 +225,16 @@ export async function recall(
      */
     degraded?: string[];
     /**
+     * The query, already embedded — set by `recallGlobal` so a fan-out over N spaces costs ONE embedding
+     * instead of N identical ones.
+     *
+     * Not a public option: nothing outside this module should be computing a query vector, because a caller
+     * that embedded with a different `task` than `'query'` would search with a vector prepared for a
+     * different purpose and quietly get worse results. It is here rather than as a positional argument
+     * because this signature was already eight parameters long.
+     */
+    embedded?: EmbeddingResult;
+    /**
      * Also scan the newest records straight from each collection, so a record written seconds ago is
      * findable before the index has ingested it.
      *
@@ -284,7 +295,15 @@ export async function recall(
   const searchDeadline = (): number =>
     Math.max(MIN_SEARCH_DEADLINE_MS, effectiveBudgetMs - (Date.now() - startedAt));
 
-  const embResult = await embed(query, 'query');
+  // One text, one vector. `recallGlobal` embeds the query ONCE and hands it down, because it fans out over
+  // spaces and every one of those calls would otherwise embed the identical string again — N spaces, N calls,
+  // N times the cost, the concurrency footprint and the failure surface, for a byte-identical vector.
+  //
+  // breituai-platform found this from the outside while a reindex saturated their shared embedder: every
+  // recall produced exactly five `POST /v1/embeddings`, all five 429'd, and the query died. They read the five
+  // as one per knowledge type; it is one per SPACE, which is why the fix lives at the fan-out and not in the
+  // per-type search. A 1-wide request fits where an N-wide burst does not.
+  const embResult = opts?.embedded ?? await embed(query, 'query');
 
   const activeTypes: RecallKnowledgeType[] = (types && types.length > 0)
     ? types
@@ -1173,7 +1192,14 @@ export async function recallGlobal(
     degraded?: string[];
   },
 ): Promise<RecallResult[]> {
-  const results = await Promise.all(spaceIds.map(id => recall(id, query, topK, tags, types, minPerType, minScore, filter, opts)));
+  // Embed ONCE for the whole fan-out. Every space below searches the same text, so without this the query is
+  // embedded once per space: identical input, identical vector, N times the cost and N times the chance that
+  // a busy embedder refuses one of them and takes the whole recall with it.
+  const embedded = await embed(query, 'query');
+
+  const results = await Promise.all(spaceIds.map(
+    id => recall(id, query, topK, tags, types, minPerType, minScore, filter, { ...opts, embedded }),
+  ));
   const flat = results.flat();
   // Sort by score descending, deduplicate by _id
   const seen = new Set<string>();

--- a/testing/standalone/no-new-god-files.test.js
+++ b/testing/standalone/no-new-god-files.test.js
@@ -114,7 +114,16 @@ const FROZEN = {
   // a module only the loader would ever call.
   'server/src/config/loader.ts': 764,
   'client/src/app/pages/brain/review-tab.component.ts': 748,
-  'server/src/brain/recall.ts': 739,
+  // 739 -> 744: the cross-space fan-out now embeds the query ONCE and hands the vector down, instead of
+  // embedding the identical text in every space. Five real code lines — an options field, the `??` that
+  // prefers a handed-down vector, and the embed-and-spread in `recallGlobal`.
+  //
+  // Raised rather than paid for with an extraction, deliberately and with the trade named: the alternative
+  // was leaving a 5x embedding cost on every cross-space recall on every instance, which an operator was
+  // already paying and reported. A file this size wants a real split, and that is its own change with its own
+  // characterization tests — not something to improvise while fixing a perf defect. Recorded as such in the
+  // tracker rather than left as a raise nobody has to justify twice.
+  'server/src/brain/recall.ts': 744,
   'client/src/app/pages/settings/media-processing/models-tab.component.ts': 678,
   // 675 -> 677: `rights` on TokenRecord, plus its import. FOURTH raise of this file in one session, and the
   // first attempt wanted SIX lines because the shape was written inline. That was the signal, so the shape

--- a/testing/standalone/recall-embeds-the-query-once.test.js
+++ b/testing/standalone/recall-embeds-the-query-once.test.js
@@ -1,0 +1,95 @@
+/**
+ * A cross-space recall embeds the query ONCE, not once per space.
+ *
+ * ## How this was found, and why the reported mechanism was wrong
+ *
+ * breituai-platform moved their text embedder onto a shared GPU endpoint and reindexed six instances. With the
+ * endpoint saturated, every `recall` from their platform instance failed, and their access log showed the shape
+ * exactly:
+ *
+ *     192.0.2.215  POST /v1/embeddings  429  29B  0.4-3ms   (recall, x5, every time)
+ *
+ * **Five rejections per recall, never four, never six.** They inferred one embedding call per knowledge type —
+ * memories, entities, edges, chrono, files — and said plainly that they were inferring from the count rather
+ * than reading our code.
+ *
+ * The count was real and the mechanism was not. `recall.ts` contains exactly ONE `embed(...)` call, inside
+ * `recall(spaceId, …)`. The fan-out is `recallGlobal`, which calls `recall` once per space. Their five was five
+ * SPACES. That distinction is the whole value of checking: the fix belongs at the fan-out, and someone reading
+ * the per-type search for a five-way loop would have found nothing and concluded the report was wrong.
+ *
+ * ## Why the assertion is on the call COUNT
+ *
+ * A latency assertion would pass on a faster machine while the fan-out was still N-wide, and a "results are
+ * correct" assertion passes either way — the vectors were identical, which is why nothing noticed for as long
+ * as the embedder kept saying yes. The count is the property; everything else is a side effect of it.
+ *
+ * Run: node --test testing/standalone/recall-embeds-the-query-once.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+const src = () => strip(readFileSync('server/src/brain/recall.ts', 'utf8'));
+
+const fn = (name) => {
+  const s = src();
+  const i = s.indexOf(`export async function ${name}(`);
+  if (i < 0) return null;
+  // To the next top-level export, or the end.
+  const next = s.indexOf('\nexport ', i + 10);
+  return s.slice(i, next < 0 ? undefined : next);
+};
+
+describe('the query is embedded once per RECALL, not once per space', () => {
+  it('recallGlobal embeds it itself', () => {
+    const g = fn('recallGlobal');
+    assert.ok(g, 'recallGlobal is gone — re-point this test');
+    assert.match(g, /await embed\(query, 'query'\)/,
+      'the fan-out must embed once up front; without it each space embeds the identical text again');
+  });
+
+  it('and hands the SAME vector to every space', () => {
+    const g = fn('recallGlobal');
+    assert.match(g, /\{ \.\.\.opts, embedded \}/,
+      'the precomputed vector must reach each recall call, or embedding it up front is pure waste added to N '
+      + 'per-space calls that still embed');
+    // Spreading `opts` matters as much as adding `embedded`: replacing the bag would silently drop
+    // maxTimeMS/degraded/includeFreshWrites, so a deadline the caller set would stop being honoured.
+    assert.ok(!/filter, \{ embedded \}\)/.test(g),
+      'the options bag must be SPREAD, not replaced — otherwise maxTimeMS and degraded are silently dropped');
+  });
+
+  it('recall uses the handed-down vector when it has one', () => {
+    assert.match(src(), /const embResult = opts\?\.embedded \?\? await embed\(query, 'query'\)/,
+      'recall must prefer the precomputed vector; ignoring it would keep the N-wide fan-out');
+  });
+
+  it('recall still embeds for its own single-space callers', () => {
+    // The fallback is load-bearing: recall is called directly from the per-space routes and from traverse.
+    // Making `embedded` required would have pushed the embed call out to every one of them.
+    assert.match(src(), /opts\?\.embedded \?\? await embed/,
+      'a single-space caller passes no vector and must still get one');
+  });
+
+  it('there is exactly ONE embed call site for a query in this module', () => {
+    // Two would be two places to keep in step, and the second is where a future fan-out re-appears.
+    const calls = [...src().matchAll(/await embed\(query, 'query'\)/g)].length;
+    assert.equal(calls, 2,
+      `expected exactly two: the fallback in recall and the one in recallGlobal. Found ${calls} — a third is a `
+      + 'new fan-out, and it will embed the same text again');
+  });
+
+  it('findSimilar was already doing it right, and still is', () => {
+    // Worth pinning as the precedent: it loops spaces with ONE vector taken from the source record. It is the
+    // shape recallGlobal now has, and if it ever grew an embed call inside its loop that would be this same
+    // bug in the other function.
+    const s = src();
+    const i = s.indexOf('const searchSpaces = crossSpaceIds');
+    assert.ok(i > 0, 'the findSimilar space loop moved — re-point this');
+    const loop = s.slice(i, s.indexOf('allResults.push(...spaceResults)', i));
+    assert.ok(!/await embed\(/.test(loop),
+      'findSimilar must not embed inside its per-space loop — it has a vector already');
+  });
+});


### PR DESCRIPTION
An operator moved their text embedder onto a shared GPU endpoint and reindexed six instances. With the endpoint saturated, **every** recall from their platform instance failed, and their access log gave the shape exactly:

```
POST /v1/embeddings  429  29B  0.4-3ms   (recall, x5, every time)
```

Five rejections per recall, never four, never six.

## Their count was right and their mechanism was wrong

They read the five as one embedding **per knowledge type** — memories, entities, edges, chrono, files — and said plainly they were inferring from the count rather than reading our code.

`recall.ts` has exactly **one** `embed()` call, inside `recall(spaceId, …)`. The fan-out is `recallGlobal`, which calls `recall` once per space. Their five was five **spaces**.

That distinction is the whole value of checking before pricing it: the fix is two lines at the fan-out, and someone reading the per-type search for a five-way loop would have found nothing and concluded the report was mistaken.

## The fix

`recallGlobal` embeds once and passes the vector down through the options bag.

Single-space recall is unchanged — it still embeds for itself, so the per-space routes and traverse are untouched. `embedded` is deliberately **not** a public option: a caller that embedded with `task: 'document'` would search with a vector prepared for a different purpose and quietly get worse results.

The options bag is **spread**, not replaced. Passing `{ embedded }` alone would silently drop `maxTimeMS`, `degraded` and `includeFreshWrites`, so a deadline the caller set would stop being honoured. Asserted, because that is the mistake this shape invites.

## Why the fan-out also made the outage certain

A 1-wide request fits where a 5-wide burst does not. It was not only five times the cost — it was five times the chance that a busy embedder refused one of them and took the whole query with it.

## findSimilar was already right

It loops spaces with one vector taken from the source record. That is the shape `recallGlobal` now has, and the gate pins that it never grows an `embed` call inside that loop — the same bug in the other function.

## Two gates caught me on the way, and both were right

- The **private-address** gate refused their real access-log IP, which I had quoted verbatim into the test header. Replaced with a synthetic address in a range that still classifies as private, so the example still demonstrates what it needs to.
- The **god-file ratchet** refused `recall.ts` growing 739 → 744 code lines. Raised with the trade named rather than paid for with an improvised extraction: the alternative was leaving a 5x embedding cost on every cross-space recall on every instance, which an operator was already paying. The file wants a real split — that is its own change, with its own characterization tests.

## Still open from the same report

`P-2` a transient 429 still fails the whole recall (no retry, no backoff) — smaller now that the burst is 1-wide, but still real. `P-3` reindex on a proxy returns 200 and doubles the work. `P-4` reindex is async and a global singleton, both undocumented.
