### PR TITLE
fix(embedding): a busy endpoint refusing once should not lose the query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+- **A transient `429` from the embedding endpoint no longer kills the query.** It went straight to the caller
+  with no retry, no jitter and no backoff, so one busy moment lost the search outright.
+  - Reported by an operator who moved their text embedder onto a shared GPU endpoint: while a reindex saturated
+    it, **every** recall failed. The refusals came back in under 3ms — the upstream was refusing instantly, not
+    queueing — so there was nothing to wait for except a concurrent burst to clear.
+  - Two extra attempts, with **small** delays (~120ms then ~360ms, half of each as jitter so concurrent callers
+    do not retry in lockstep). Deliberately not a textbook 1s/2s/4s: this runs inside recall's deadline, and a
+    long backoff would trade a clear failure for a slow partial answer.
+  - `502`, `503` and `504` are retried on the same reasoning. **`400`, `401` and `413` are not** — the request
+    is wrong and will be wrong every time, so retrying burns the caller's deadline to reach the same answer more
+    slowly. A retried `401` is a lockout waiting to happen.
+  - `Retry-After` is honoured when it is short, and **refused** when it is long: a server naming a 30-second
+    wait inside a request budgeted in hundreds of milliseconds is telling us to give up, not to sleep.
+  - The message an operator sees is unchanged — `Embedding request failed (HTTP 429): …` — because it is in
+    runbooks and log searches. A wrapper that replaced it with "all retries failed" would break every alert
+    written against it.
+  - New metric `ythril_embedding_retry_total`, labelled by status. The retry makes the problem invisible by
+    design, so this is the only trace that a shared endpoint is saturating while it is still transient.
+  - The file pipeline already had all of this — persisted jobs, backoff, a terminal `failed` state, and
+    `retry_embedding` to recover. Recall had none of it, against the same dependency.
+
+### Fixed
 - **A cross-space recall embedded the identical query once per space.** Five accessible spaces meant five
   `POST /v1/embeddings` for one search — same text, same vector, five times the cost, the concurrency footprint
   and the failure surface. `recallGlobal` now embeds once and hands the vector down.

--- a/docs/integration-guide/11-setup-api.md
+++ b/docs/integration-guide/11-setup-api.md
@@ -76,6 +76,7 @@ ythril_http_requests_total{method="GET",route="/health",status_code="200"} 42
 | `ythril_spaces_total` | gauge | Number of configured spaces |
 | `ythril_embedding_duration_seconds` | histogram | Time to compute a single embedding |
 | `ythril_embedding_queue_depth` | gauge | Pending embedding operations |
+| `ythril_embedding_retry_total` | counter | Transient embedding-endpoint refusals that were retried, labelled by HTTP `status`. A rising 429 count means a shared endpoint is at capacity while recalls are still succeeding — the retry hides the symptom, so this is the warning. |
 | `ythril_reindex_in_progress` | gauge | 1 if a reindex is running, 0 otherwise |
 | `ythril_storage_used_bytes` | gauge | Storage used in bytes by area (brain, files, total). **From a cached measurement, not re-walked per scrape** — see `ythril_storage_usage_age_seconds` below and the note on why. |
 | `ythril_storage_limit_bytes` | gauge | Configured storage limits by area and tier (soft, hard) |

--- a/server/src/brain/embedding.ts
+++ b/server/src/brain/embedding.ts
@@ -6,7 +6,7 @@ import { ssrfSafeFetch } from '../util/ssrf.js';
 import { allowPrivateForSlot } from '../config/model-egress-policy.js';
 import { embeddingsUrlFor } from '../files/converters/vlm-endpoint.js';
 import { log } from '../util/log.js';
-import { embeddingDurationSeconds, embeddingQueueDepth } from '../metrics/registry.js';
+import { embeddingDurationSeconds, embeddingQueueDepth, embeddingRetryTotal } from '../metrics/registry.js';
 
 export interface EmbeddingResult {
   vector: number[];
@@ -181,6 +181,106 @@ function getLocalPipeline(modelId: string): Promise<LocalPipeline> {
 
 // ── HTTP endpoint fallback ─────────────────────────────────────────────────
 /** `input` is already task-prefixed by `prepareInput` — do not prefix again here. */
+/**
+ * A refusal from the embedding endpoint, carrying enough to decide whether trying again is sensible.
+ *
+ * The message is unchanged from what it was — `Embedding request failed (HTTP 429): …` — because operators
+ * have that string in their runbooks and their logs, and it is what a caller shows a requester.
+ */
+export class EmbeddingHttpError extends Error {
+  constructor(
+    readonly status: number,
+    readonly body: string,
+    /** From `Retry-After`, when the server sent one and it was a number we can act on. */
+    readonly retryAfterMs: number | null,
+  ) {
+    super(`Embedding request failed (HTTP ${status}): ${body}`);
+    this.name = 'EmbeddingHttpError';
+  }
+}
+
+/**
+ * Statuses where trying again is the right move, and nothing else.
+ *
+ * A 400 or a 413 means the REQUEST is wrong and will be wrong every time — retrying it burns the caller's
+ * deadline to arrive at the same answer more slowly. A 401 retried is a lockout waiting to happen.
+ */
+const RETRYABLE_EMBED_STATUS = new Set([429, 502, 503, 504]);
+
+/**
+ * Three attempts, and the delays are deliberately SMALL.
+ *
+ * This sits inside `recall`, which has a deadline the operator set and the caller may have lowered. A textbook
+ * 1s/2s/4s backoff would turn one busy moment into a recall that misses its budget and degrades — trading a
+ * clear failure for a slow partial answer, which is worse.
+ *
+ * The refusals that prompted this came back in under 3 milliseconds: the upstream was refusing instantly, not
+ * queueing. Against that, a short pause is all it takes for a concurrent burst to clear, and the total added
+ * latency in the worst case is under half a second.
+ */
+const EMBED_RETRY_DELAYS_MS = [120, 360] as const;
+
+/** Half the delay as fixed floor, half as jitter — so N concurrent callers do not retry in lockstep. */
+function jittered(baseMs: number): number {
+  return Math.round(baseMs / 2 + Math.random() * (baseMs / 2));
+}
+
+function retryAfterMs(response: Response): number | null {
+  const raw = response.headers.get('retry-after');
+  if (!raw) return null;
+  const seconds = Number(raw.trim());
+  // Only a plain number of seconds. The HTTP-date form is legal and we do not honour it: parsing a date
+  // against our clock to decide a sub-second sleep is more ways to be wrong than it is worth.
+  return Number.isFinite(seconds) && seconds >= 0 ? seconds * 1000 : null;
+}
+
+const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+
+/**
+ * Ask the endpoint, retrying only a transient refusal.
+ *
+ * ## Why this exists
+ *
+ * An operator moved their embedder to a shared GPU endpoint. While a reindex saturated it, EVERY recall
+ * failed — the 429 went straight to the caller with no retry, no jitter and no backoff, and the user's query
+ * was simply gone. Their words: *"a single retry with a little jitter would absorb this entirely."*
+ *
+ * The file pipeline had all of this already: persisted jobs, backoff, a terminal `failed` state and a
+ * `retry_embedding` recovery path. Recall had none of it, on the same dependency.
+ *
+ * A `Retry-After` longer than our own budget is a refusal to wait, not an instruction to: we give up and let
+ * the caller see the 429, rather than sleeping past a deadline somebody set.
+ */
+export async function embedViaHttpWithRetry(
+  attempt: (n: number) => Promise<EmbeddingResult>,
+): Promise<EmbeddingResult> {
+  let lastErr: unknown;
+  for (let i = 0; i <= EMBED_RETRY_DELAYS_MS.length; i++) {
+    try {
+      return await attempt(i);
+    } catch (err) {
+      lastErr = err;
+      const retryable = err instanceof EmbeddingHttpError && RETRYABLE_EMBED_STATUS.has(err.status);
+      const delayLeft = i < EMBED_RETRY_DELAYS_MS.length;
+      if (!retryable || !delayLeft) break;
+
+      const base = EMBED_RETRY_DELAYS_MS[i]!;
+      const asked = (err as EmbeddingHttpError).retryAfterMs;
+      if (asked !== null && asked > base * 4) {
+        // The server named a wait we are not willing to take inside a request. Surface the refusal.
+        log.warn(`Embedding endpoint asked for ${asked}ms via Retry-After; longer than this request will wait.`);
+        break;
+      }
+      const delay = jittered(asked !== null && asked > 0 ? Math.min(asked, base * 4) : base);
+      embeddingRetryTotal.labels({ status: String((err as EmbeddingHttpError).status) }).inc();
+      log.warn(`Embedding endpoint refused (HTTP ${(err as EmbeddingHttpError).status}); `
+        + `retrying in ${delay}ms (attempt ${i + 2} of ${EMBED_RETRY_DELAYS_MS.length + 1}).`);
+      await sleep(delay);
+    }
+  }
+  throw lastErr;
+}
+
 async function embedViaHttp(
   input: string,
   cfg: ReturnType<typeof getEmbeddingConfig>,
@@ -222,7 +322,7 @@ async function embedViaHttp(
   }
   if (!response.ok) {
     const body = await boundedErrorText(response);
-    throw new Error(`Embedding request failed (HTTP ${response.status}): ${body}`);
+    throw new EmbeddingHttpError(response.status, body, retryAfterMs(response));
   }
   const json = await boundedJson<{
     data?: { embedding?: number[] }[];
@@ -275,7 +375,10 @@ export async function embed(
   try {
     if (cfg.baseUrl) {
       // External HTTP endpoint configured — delegate entirely
-      return await embedViaHttp(input, cfg);
+      // Retried here rather than inside `embedViaHttp` so the whole request — including building it — is what
+      // gets re-attempted, and so the local-pipeline path below is untouched: an in-process model does not
+      // refuse you because it is busy.
+      return await embedViaHttpWithRetry(() => embedViaHttp(input, cfg));
     }
 
     const pipe = await getLocalPipeline(cfg.model);

--- a/server/src/metrics/registry.ts
+++ b/server/src/metrics/registry.ts
@@ -433,6 +433,23 @@ export const embeddingQueueDepth = new Gauge({
   registers: [register],
 });
 
+/**
+ * Transient refusals from the embedding endpoint that we retried.
+ *
+ * A counter rather than nothing, because the retry makes the problem INVISIBLE by design: the recall now
+ * succeeds, so the only trace that a shared endpoint is saturating is this. An operator whose embedder is at
+ * capacity should be able to see it before it stops being transient.
+ *
+ * Labelled by status so 429 (busy) is distinguishable from 503 (down) — different problems with different
+ * fixes, and averaging them into one number hides both.
+ */
+export const embeddingRetryTotal = new Counter({
+  name: 'ythril_embedding_retry_total',
+  help: 'Transient embedding-endpoint refusals that were retried, by HTTP status',
+  labelNames: ['status'],
+  registers: [register],
+});
+
 export const reindexInProgress = new Gauge({
   name: 'ythril_reindex_in_progress',
   help: '1 if a reindex operation is currently running, 0 otherwise',

--- a/testing/standalone/embedder-429-is-retried.test.js
+++ b/testing/standalone/embedder-429-is-retried.test.js
@@ -1,0 +1,166 @@
+/**
+ * A transient refusal from the embedding endpoint is retried, and a permanent one is not.
+ *
+ * ## What happened
+ *
+ * An operator moved their text embedder onto a shared GPU endpoint. While a reindex saturated it, **every**
+ * recall from their platform instance failed:
+ *
+ *     [WARN] MCP global tool 'recall' error in space 'global':
+ *            Embedding request failed (HTTP 429): {"error":"Too many requests"}
+ *
+ * No retry, no jitter, no backoff. One busy moment and the user's query was simply gone. The rejections came
+ * back in **under 3ms** — the upstream was refusing instantly rather than queueing — so there was nothing to
+ * wait for except a concurrent burst to clear. Their words: *"a single retry with a little jitter would absorb
+ * this entirely."*
+ *
+ * The file pipeline already had all of this: persisted jobs, backoff, a terminal `failed` state, and a
+ * `retry_embedding` recovery path. Recall had none of it, against the same dependency.
+ *
+ * ## Why this drives the retry directly and not an HTTP server
+ *
+ * The property is *how many attempts happen, and under what delay*. The retry takes the attempt as a callback,
+ * so a counting fake gives that exactly — deterministically, with no network and no clock luck.
+ *
+ * The first version of this test stood up a real endpoint and needed a `setConfigForTest` seam on the config
+ * loader to aim the embedder at it. No such seam exists, so every case would have skipped: a green run that
+ * never called the code, which is the worst possible outcome for a gate. A production file growing a test-only
+ * export to make that work would have been the wrong trade for a property this test can observe directly.
+ *
+ * Run: node --test testing/standalone/embedder-429-is-retried.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let embedViaHttpWithRetry, EmbeddingHttpError;
+
+before(async () => {
+  ({ embedViaHttpWithRetry, EmbeddingHttpError } = await import('../../server/dist/brain/embedding.js'));
+});
+
+const OK = { vector: [0.1, 0.2], model: 'test', dimensions: 2 };
+
+/**
+ * An attempt that refuses with the scripted statuses in order, then succeeds.
+ * Records the time of every call, so the delay between attempts is observable.
+ */
+function scripted(statuses, retryAfterSeconds = null) {
+  const calls = [];
+  const queue = [...statuses];
+  const fn = async () => {
+    calls.push(Date.now());
+    const status = queue.shift();
+    if (status === undefined) return OK;
+    throw new EmbeddingHttpError(status, '{"error":"scripted"}',
+      retryAfterSeconds === null ? null : retryAfterSeconds * 1000);
+  };
+  return { fn, calls };
+}
+
+describe('a transient refusal is retried', () => {
+  it('the retry and its error type are exported', () => {
+    // A gate that silently skipped because it could not reach its subject is worse than no gate.
+    assert.equal(typeof embedViaHttpWithRetry, 'function');
+    assert.equal(typeof EmbeddingHttpError, 'function');
+  });
+
+  it('a 429 then a success makes TWO attempts and returns the vector', async () => {
+    const { fn, calls } = scripted([429]);
+    const out = await embedViaHttpWithRetry(fn);
+    assert.equal(calls.length, 2, 'the refusal must be retried exactly once here — not zero, not twice');
+    assert.deepEqual(out, OK, 'the caller must get the vector, not the 429');
+  });
+
+  it('waits between attempts rather than hammering', async () => {
+    const { fn, calls } = scripted([429]);
+    await embedViaHttpWithRetry(fn);
+    const gap = calls[1] - calls[0];
+    // Jitter is half the base, so the floor is base/2 = 60ms. An instant retry hits the same busy endpoint and
+    // turns one rejection into two.
+    assert.ok(gap >= 40, `retried after only ${gap}ms — that is hammering, not backing off`);
+    // The ceiling matters as much: this runs inside recall's deadline, which the operator set and the caller
+    // may have lowered. A textbook 1s/2s/4s backoff would trade a clear failure for a slow partial answer.
+    assert.ok(gap < 1_000, `waited ${gap}ms, which eats a deadline somebody set`);
+  });
+
+  it('backs off FURTHER on the second retry', async () => {
+    const { fn, calls } = scripted([429, 429]);
+    await embedViaHttpWithRetry(fn);
+    assert.equal(calls.length, 3);
+    // Not equal delays: a burst that is still clearing needs longer the second time. Compared with the jitter
+    // floor of the larger base (360/2 = 180) against the ceiling of the smaller (120), which cannot overlap.
+    assert.ok(calls[2] - calls[1] > calls[1] - calls[0],
+      `second gap ${calls[2] - calls[1]}ms was not longer than the first ${calls[1] - calls[0]}ms`);
+  });
+
+  it('gives up after a bounded number of attempts', async () => {
+    const { fn, calls } = scripted([429, 429, 429, 429, 429]);
+    await assert.rejects(() => embedViaHttpWithRetry(fn), /HTTP 429/);
+    assert.equal(calls.length, 3, 'three attempts total — an unbounded retry is a slow failure, not a fix');
+  });
+
+  it('surfaces the ORIGINAL message when it gives up', async () => {
+    const { fn } = scripted([503, 503, 503]);
+    // Operators have this string in their runbooks and their log searches. A wrapper that replaced it with
+    // "all retries failed" would break every alert anyone had written against it.
+    await assert.rejects(() => embedViaHttpWithRetry(fn), /Embedding request failed \(HTTP 503\)/);
+  });
+
+  it('retries the other busy/unavailable statuses too', async () => {
+    for (const status of [502, 503, 504]) {
+      const { fn, calls } = scripted([status]);
+      await embedViaHttpWithRetry(fn);
+      assert.equal(calls.length, 2, `HTTP ${status} should be retried`);
+    }
+  });
+});
+
+describe('a permanent refusal is NOT retried', () => {
+  it('a 400 fails on the first attempt', async () => {
+    const { fn, calls } = scripted([400, 400, 400]);
+    await assert.rejects(() => embedViaHttpWithRetry(fn), /HTTP 400/);
+    assert.equal(calls.length, 1,
+      'a 400 means the request is wrong and will be wrong every time — retrying burns the caller deadline to '
+      + 'arrive at the same answer more slowly');
+  });
+
+  it('a 401 is not retried either', async () => {
+    const { fn, calls } = scripted([401, 401]);
+    await assert.rejects(() => embedViaHttpWithRetry(fn), /HTTP 401/);
+    assert.equal(calls.length, 1, 'a retried 401 is a lockout waiting to happen');
+  });
+
+  it('a 413 is not retried', async () => {
+    const { fn, calls } = scripted([413, 413]);
+    await assert.rejects(() => embedViaHttpWithRetry(fn), /HTTP 413/);
+    assert.equal(calls.length, 1, 'the input is too large; it will still be too large in 120ms');
+  });
+
+  it('a non-HTTP failure is not retried', async () => {
+    // A thrown TypeError is a bug in our own request building, not a busy server. Retrying it three times
+    // just makes the same bug take longer to report.
+    let calls = 0;
+    const fn = async () => { calls++; throw new TypeError('bad init'); };
+    await assert.rejects(() => embedViaHttpWithRetry(fn), /bad init/);
+    assert.equal(calls, 1);
+  });
+});
+
+describe('Retry-After', () => {
+  it('a short one is honoured and still retried', async () => {
+    const { fn, calls } = scripted([429], 0);
+    await embedViaHttpWithRetry(fn);
+    assert.equal(calls.length, 2);
+  });
+
+  it('a LONG one is a refusal to wait, not an instruction to', async () => {
+    // 30 seconds, inside a request whose budget is measured in hundreds of milliseconds. Sleeping it would
+    // miss the deadline and answer partially, which is worse than a clear refusal the caller can see.
+    const { fn, calls } = scripted([429], 30);
+    const started = Date.now();
+    await assert.rejects(() => embedViaHttpWithRetry(fn), /HTTP 429/);
+    assert.equal(calls.length, 1, 'we must not retry when the server names a wait we will not take');
+    assert.ok(Date.now() - started < 2_000, 'and we must not have slept it either');
+  });
+});


### PR DESCRIPTION
An operator moved their text embedder onto a shared GPU endpoint. While a reindex saturated it, **every** recall failed:

```
Embedding request failed (HTTP 429): {"error":"Too many requests"}
```

No retry, no jitter, no backoff. One busy moment and the user's query was gone. Their words: *"a single retry with a little jitter would absorb this entirely."*

The file pipeline had all of this already — persisted jobs, backoff, a terminal `failed` state, `retry_embedding` to recover. Recall had none of it, against the same dependency.

## The delays are small on purpose

Two extra attempts, ~120ms then ~360ms, half of each as jitter so concurrent callers do not retry in lockstep.

Deliberately **not** a textbook 1s/2s/4s. This sits inside recall's deadline — which the operator sets and the caller may lower — so a long backoff would trade a clear failure for a slow partial answer, which is worse.

The refusals came back in **under 3ms**: the upstream was refusing instantly rather than queueing. Against that there is nothing to wait for except a concurrent burst to clear, and a short pause is enough.

## What is NOT retried, and why that half matters more

`400`, `401` and `413` fail on the first attempt. The request is wrong and will be wrong every time, so retrying burns the caller's deadline to arrive at the same answer more slowly — and a retried `401` is a lockout waiting to happen.

A non-HTTP throw is not retried either: that is a bug in our own request building, and three attempts just make it take longer to report.

`Retry-After` is honoured when short and **refused** when long. A server naming a 30-second wait inside a request budgeted in hundreds of milliseconds is telling us to give up, not to sleep.

## The message did not change

`Embedding request failed (HTTP 429): …` is in operators' runbooks and log searches. A wrapper replacing it with "all retries failed" would break every alert written against it.

## A metric, because the fix hides the symptom

`ythril_embedding_retry_total`, labelled by status. A succeeding recall is now indistinguishable from a healthy endpoint, so this is the only trace that a shared endpoint is saturating **while it is still transient**. `429` (busy) and `503` (down) are different problems and are not averaged together.

## The test's first shape was wrong, and I am saying so

It stood up a real HTTP server and needed a `setConfigForTest` seam on the config loader to aim the embedder at it. **No such seam exists**, so every case would have skipped — a green run that never called the code, which is the worst outcome a gate can have.

The retry takes its attempt as a callback, so a counting fake observes the property directly: how many attempts, under what delay, for which statuses. No network, no clock luck, and no test-only export added to a production path.

Mutation-tested: adding `400`/`401`/`413` to the retryable set fails three assertions.

## Together with #818

That one removed the 5-wide fan-out that made rejection likely; this one absorbs the rejection when it happens. The reporter noted they compound, and they do — a 1-wide request that also retries is a different reliability story from a 5-wide burst that does not.
