### PR TITLE
fix(reindex): a proxy has no index of its own, so refuse it by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+- **Reindexing a proxy space answered `200` and then did the work twice.** It re-embedded the member spaces —
+  which the caller was usually reindexing individually as well, because they are in the same space list. It is
+  idempotent, so nothing broke: on the reporting operator's largest instance it was simply the longest job of
+  the run, and all of it waste.
+  - Now a `400` naming the members, so the remedy is the response rather than a second lookup. A proxy has no
+    index of its own, and a *write* to a proxy already requires an explicit `targetSpace` — accepting one here
+    without comment was the inconsistency.
+  - Refused **before** the singleton check, so a proxy request during a running reindex is not answered `409`
+    "already in progress" — which reads as *try again later*, and would have the caller retrying a request that
+    can never be right. And before any flag is set, since leaving that global flag set would block every real
+    reindex on the instance until a restart.
+- **The docs said the reindex `409` was "for the space". It is instance-wide.** One reindex runs at a time
+  across the whole instance and a second request is *refused rather than queued* — the operator who found this
+  fired thirteen and got one `200` and twelve `409`s. A loop counting only non-200s as failures reports thirteen
+  dispatched having dispatched one. Retry-on-409 is documented as the correct client, since it self-paces.
+  - Two other parts of the same report were already true and are now pinned rather than changed: the async
+    response is documented, `GET /api/brain/spaces/:spaceId/reindex-status` exists, and `GET /api/spaces` already
+    carries `proxyFor` — so a client can skip proxies without discovering the refusal by trying it.
+
+### Fixed
 - **A transient `429` from the embedding endpoint no longer kills the query.** It went straight to the caller
   with no retry, no jitter and no backoff, so one busy moment lost the search outright.
   - Reported by an operator who moved their text embedder onto a shared GPU endpoint: while a reindex saturated

--- a/docs/integration-guide/04d-brain-ops-api.md
+++ b/docs/integration-guide/04d-brain-ops-api.md
@@ -167,7 +167,23 @@ Re-computes all embeddings with the current model. **Runs asynchronously** — t
 { "spaceId": "general", "reindexed": 0, "errors": 0, "status": "started" }
 ```
 
-Returns `409 { "error": "Reindex already in progress" }` if one is already running for the space.
+Returns `409 { "error": "Reindex already in progress" }` if one is already running — **instance-wide, not
+per space.** One reindex runs at a time across the whole instance, and a second request is *refused rather
+than queued*. An operator who fired thirteen at once got one `200` and twelve `409`s; a loop that counts only
+non-200s as failures would report thirteen dispatched having dispatched one. **Retry on 409** is the correct
+client, and it self-paces.
+
+Returns `400` with the member spaces named if `:spaceId` is a **proxy**:
+
+```json
+{ "error": "'team' is a proxy space and has no index of its own. Reindex its members instead: qa, research.",
+  "proxyFor": ["qa", "research"] }
+```
+
+A proxy has no index of its own — its members do. This used to answer `200` and re-embed those members, which
+the caller was usually reindexing individually as well, so everything under the proxy was embedded twice.
+`GET /api/spaces` carries `proxyFor` on any space that has one, so a client can skip proxies without
+discovering this by trying.
 
 > **Reindexing does NOT repair "search returns nothing".** It re-computes the embeddings *stored on*
 > your records. Recall queries those vectors through a separate `$vectorSearch` index, and that index

--- a/server/src/api/brain/search.ts
+++ b/server/src/api/brain/search.ts
@@ -558,6 +558,34 @@ searchRouter.post('/spaces/:spaceId/reindex', globalRateLimit, requireSpaceAuth,
     return;
   }
 
+  /**
+   * A PROXY is refused, by name, with its members listed.
+   *
+   * It used to answer `200 {"status":"started"}` and then re-embed the member spaces — which the caller was
+   * also reindexing individually, because they are in the same space list. Everything under the proxy got
+   * embedded twice. It is idempotent, so nothing broke: on the reporting operator's largest instance it was
+   * simply the longest job of the run and all of it was waste.
+   *
+   * The caller could not avoid it either. `GET /api/spaces` returns ids with no indication of which are
+   * proxies, so there was nothing to branch on — which is why this is a refusal here rather than a note in
+   * the docs.
+   *
+   * It is also what the rest of the model already does: a WRITE to a proxy requires an explicit
+   * `targetSpace`, because a proxy is not a place records live. Accepting one here without comment was the
+   * inconsistency.
+   *
+   * The members are named in the message so the remedy is the response rather than a second lookup.
+   */
+  const space = cfg.spaces.find(s => s.id === spaceId)!;
+  if (space.proxyFor && space.proxyFor.length > 0) {
+    res.status(400).json({
+      error: `'${spaceId}' is a proxy space and has no index of its own. `
+        + `Reindex its members instead: ${space.proxyFor.join(', ')}.`,
+      proxyFor: space.proxyFor,
+    });
+    return;
+  }
+
   if (reindexJobRunning) {
     res.status(409).json({ error: 'Reindex already in progress' });
     return;

--- a/testing/standalone/reindex-refuses-a-proxy.test.js
+++ b/testing/standalone/reindex-refuses-a-proxy.test.js
@@ -1,0 +1,88 @@
+/**
+ * Reindexing a PROXY space is a 400 that names its members, not a 200 that does the work twice.
+ *
+ * ## What happened
+ *
+ * `POST /api/brain/spaces/<proxy>/reindex` answered `200 {"status":"started"}` and then re-embedded the member
+ * spaces — which the caller was also reindexing individually, because they are in the same space list. So
+ * everything under the proxy was embedded twice. It is idempotent, so nothing broke: on the reporting
+ * operator's largest instance it was simply the longest job of the run, and all of it was waste.
+ *
+ * It is also inconsistent with the rest of the model. A WRITE to a proxy already requires an explicit
+ * `targetSpace`, because a proxy is not a place records live. Accepting one here without comment was the odd
+ * one out.
+ *
+ * ## One half of their report was wrong, and it is worth recording which
+ *
+ * They wrote that the caller *"cannot avoid it: `GET /api/spaces` returns ids with no indication of which are
+ * proxies."* It does return one — `proxyFor` is on the list projection whenever a space has it, and this test
+ * pins that, because it is the field a client would branch on and the reason the refusal can be actionable.
+ *
+ * Their conclusion still held: a 200 that silently doubles the work is the wrong answer. But the premise that
+ * nothing distinguishes a proxy was not the reason, and shipping a new `isProxy` field to "fix" it would have
+ * added a second spelling of a fact already on the wire.
+ *
+ * Run: node --test testing/standalone/reindex-refuses-a-proxy.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+const search = () => strip(readFileSync('server/src/api/brain/search.ts', 'utf8'));
+const spaces = () => strip(readFileSync('server/src/api/spaces.ts', 'utf8'));
+
+const handler = () => {
+  const s = search();
+  const i = s.indexOf("searchRouter.post('/spaces/:spaceId/reindex'");
+  assert.ok(i > 0, 'the reindex route moved — re-point this test');
+  return s.slice(i, s.indexOf('setImmediate', i));
+};
+
+describe('a proxy is refused', () => {
+  it('the handler checks proxyFor and answers 400', () => {
+    const h = handler();
+    assert.match(h, /space\.proxyFor && space\.proxyFor\.length > 0/,
+      'an empty proxyFor array is not a proxy — treating it as one would refuse a normal space');
+    assert.match(h, /res\.status\(400\)/, 'a proxy must be refused, not started');
+  });
+
+  it('the message names the member spaces', () => {
+    // A bare 400 sends the caller looking for a permissions problem. The remedy is the response itself, not a
+    // second lookup — and they have to know WHICH spaces to reindex instead.
+    assert.match(handler(), /Reindex its members instead: \$\{space\.proxyFor\.join\(', '\)\}/,
+      'the members must be named in the message');
+  });
+
+  it('the refusal comes BEFORE the singleton check', () => {
+    // Otherwise a proxy request during a running reindex answers 409 "already in progress", which reads as
+    // "try again later" — so the caller retries a request that can never be right.
+    const h = handler();
+    assert.ok(h.indexOf('proxyFor') < h.indexOf('reindexJobRunning'),
+      'a proxy must be refused for being a proxy, not queued behind the singleton');
+  });
+
+  it('and AFTER the 404, so an unknown id is still not-found', () => {
+    const h = handler();
+    assert.ok(h.indexOf('not found') < h.indexOf('proxyFor'),
+      'an id that does not exist must 404 rather than being told it is not a proxy');
+  });
+
+  it('nothing is marked running before the refusal', () => {
+    // The flag is a global singleton. Setting it and then returning early would block every real reindex on
+    // the instance until a restart — a worse bug than the one being fixed.
+    const h = handler();
+    assert.ok(h.indexOf('res.status(400)') < h.indexOf('reindexJobRunning = true'),
+      'the proxy refusal must not leave the singleton flag set');
+  });
+});
+
+describe('the caller can already tell a proxy from a real space', () => {
+  it('GET /api/spaces emits proxyFor', () => {
+    // The half of the report that was wrong. Asserted so nobody "fixes" it by adding a second field that
+    // means the same thing.
+    assert.match(spaces(), /\.\.\.\(proxyFor \? \{ proxyFor \} : \{\}\)/,
+      'proxyFor is no longer on the list projection — a client has nothing to branch on, and the refusal '
+      + 'above becomes something they can only discover by trying it');
+  });
+});


### PR DESCRIPTION
`POST /api/brain/spaces/<proxy>/reindex` answered `200 {"status":"started"}` and then re-embedded the member spaces — which the caller was usually reindexing individually as well, because they are in the same space list. So everything under the proxy was embedded **twice**.

Idempotent, so nothing broke: on the reporting operator's largest instance it was simply the longest job of the run, and all of it waste.

It was also the odd one out in our own model. A **write** to a proxy already requires an explicit `targetSpace`, because a proxy is not a place records live. Accepting one here without comment was the inconsistency.

Now a `400` naming the members, so the remedy is the response rather than a second lookup.

## Ordering, which is where this could still be wrong

- **Before the singleton check.** Otherwise a proxy request during a running reindex answers `409 already in progress` — which reads as *try again later*, so the caller retries a request that can never be right.
- **After the 404.** An id that does not exist should be not-found, not told it is not a proxy.
- **Before anything is marked running.** That flag is a global singleton; setting it and then returning early would block every real reindex on the instance until a restart — a worse bug than the one being fixed.

All three are asserted, because each is a one-line move away from being wrong.

## Two halves of their report were already true

They wrote that the caller *"cannot avoid it: `GET /api/spaces` returns ids with no indication of which are proxies."* It does — `proxyFor` is on the list projection for any space that has one.

Their conclusion held (a 200 that doubles the work is the wrong answer) but that premise was not the reason — and adding an `isProxy` field to "fix" it would have shipped a second spelling of a fact already on the wire. Pinned so nobody does.

They also reported finding no status endpoint and no note that reindex is async. Both are documented: `GET /api/brain/spaces/:spaceId/reindex-status` exists, and the async response is described.

## One doc line WAS wrong

> Returns `409` if one is already running **for the space**.

It is **instance-wide**. That is what produced their thirteen requests, one `200` and twelve `409`s: a loop counting only non-200s as failures reports thirteen dispatched having dispatched one. Corrected, with retry-on-409 named as the correct client since it self-paces.

## Closes the platform report

With #818 (one embedding per recall, not one per space) and #819 (a transient 429 is retried), all four findings from that report are now either fixed or answered with evidence.
