### PR TITLE
feat(tokens): rotate and revoke, in the editor, as a danger zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- **Rotate and revoke moved into the token editor, as a danger zone.** They were reachable only as two small
+  icons on the list row, so a token was managed in two places.
+  - The editor **requests** them rather than performing them. The page owns the confirmation, the failure toast,
+    the list removal, and the copy-once banner a rotated secret appears in — a second implementation inside the
+    modal would mean a second confirmation flow and, for rotate, a second place a credential is shown once.
+  - The dialog **closes before the action runs**, and that is load-bearing rather than tidy: the banner renders
+    on the page, behind the modal. A rotate that left the editor open would put the only copy of a new
+    credential underneath it.
+  - Last in the dialog and visually separated, with revoke marked destructive. A destructive control beside Save
+    is a mis-click, and two identical buttons are worse.
 - **The data-model diagram shows memories, chrono entries and files**, not just entity types. One box per kind
   carrying that kind's total, joined to each entity type it links to with the per-type count on the join.
   - The owner found this by asking whether memories were missing from the diagram. They were — **entirely**.

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1867,5 +1867,8 @@
   "brain.tab.spaceSettingsTitle": "Diesen Space konfigurieren — Bezeichnung, Schema, Duplikate, Gefahrenzone",
   "tokens.mfa.codeLabel": "Authenticator-Code",
   "tokens.mfa.codeHint": "Eine Ausnahme zu erteilen erfordert einen aktuellen Code aus deiner Authenticator-App — auch wenn dieses Token selbst ausgenommen ist.",
-  "brain.overview.er.linkedRecords": "Verknüpfte Datensätze"
+  "brain.overview.er.linkedRecords": "Verknüpfte Datensätze",
+  "tokens.danger.title": "Gefahrenzone",
+  "tokens.danger.rotateHint": "Erzeugt ein neues Secret; das alte funktioniert sofort nicht mehr. Der neue Wert wird nur einmal angezeigt.",
+  "tokens.danger.revokeHint": "Löscht dieses Token. Es kann nie wieder verwendet werden."
 }

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1867,5 +1867,8 @@
   "brain.tab.spaceSettingsTitle": "Configure this space — label, schema, duplicates, danger zone",
   "tokens.mfa.codeLabel": "Authenticator code",
   "tokens.mfa.codeHint": "Granting an exemption needs a current code from your authenticator, even if this token is exempt itself.",
-  "brain.overview.er.linkedRecords": "Records linking here"
+  "brain.overview.er.linkedRecords": "Records linking here",
+  "tokens.danger.title": "Danger zone",
+  "tokens.danger.rotateHint": "Generates a new secret and stops the old one working immediately. The new value is shown once.",
+  "tokens.danger.revokeHint": "Deletes this token. It can never be used again."
 }

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1867,5 +1867,8 @@
   "brain.tab.spaceSettingsTitle": "Skonfiguruj tę przestrzeń — etykieta, schemat, duplikaty, strefa zagrożenia",
   "tokens.mfa.codeLabel": "Kod z aplikacji",
   "tokens.mfa.codeHint": "Nadanie wyjątku wymaga aktualnego kodu z aplikacji uwierzytelniającej — nawet jeśli ten token sam jest wyłączony.",
-  "brain.overview.er.linkedRecords": "Powiązane rekordy"
+  "brain.overview.er.linkedRecords": "Powiązane rekordy",
+  "tokens.danger.title": "Strefa zagrożenia",
+  "tokens.danger.rotateHint": "Generuje nowy sekret; stary natychmiast przestaje działać. Nowa wartość jest pokazywana tylko raz.",
+  "tokens.danger.revokeHint": "Usuwa ten token. Nie będzie już nigdy działać."
 }

--- a/client/src/app/pages/settings/token-editor-mfa.spec.ts
+++ b/client/src/app/pages/settings/token-editor-mfa.spec.ts
@@ -42,6 +42,25 @@ function make(token: Record<string, unknown>) {
   return { fixture, c: fixture.componentInstance as any, updateSpy };
 }
 
+/** A harness whose API spies record calls, so "the dialog did not do it itself" is checkable. */
+function makeWithSpies() {
+  const api = {
+    updateToken: vi.fn().mockReturnValue(of({ token: { id: 't1', name: 'CI' } })),
+    regenerateToken: vi.fn(),
+    revokeToken: vi.fn(),
+  };
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    imports: [TokenRightsDialogComponent, getTranslocoModule()],
+    providers: [{ provide: AuthApi, useValue: api as any }],
+  });
+  const fixture = TestBed.createComponent(TokenRightsDialogComponent);
+  fixture.componentRef.setInput('token', { id: 't1', name: 'CI', rights: RIGHTS });
+  fixture.componentRef.setInput('availableSpaces', []);
+  fixture.detectChanges();
+  return { fixture, c: fixture.componentInstance as any, api };
+}
+
 describe('the token editor: second factor', () => {
   beforeEach(() => TestBed.resetTestingModule());
 
@@ -131,5 +150,56 @@ describe('the token editor: second factor', () => {
     c.save();
     expect(c.error()).toBe('needs a current TOTP code');
     expect(c.saving()).toBe(false);
+  });
+});
+
+/**
+ * ── The danger zone REQUESTS, it does not act ─────────────────────────────────────────────────────
+ *
+ * Rotate and revoke were reachable only as two small icons on the list row, so a token was managed in two
+ * places. They belong in the editor — but the editor must not perform them.
+ *
+ * The page owns the confirmation dialog, the failure toast, the list removal, and the **copy-once banner** that
+ * a rotated secret appears in. A second implementation inside the modal would mean a second confirmation flow
+ * and, for rotate, a second place a credential is shown exactly once.
+ *
+ * And the ordering is load-bearing rather than tidy: that banner renders on the PAGE, behind the modal. A
+ * rotate that left the dialog open would put the only copy of a new credential underneath it.
+ */
+describe('the token editor danger zone', () => {
+  it('emits rotate instead of calling the API', () => {
+    const rotated: unknown[] = [];
+    const { c, api } = makeWithSpies();
+    c.rotate.subscribe(() => rotated.push(1));
+    c.rotate.emit();
+    expect(rotated).toHaveLength(1);
+    expect(api.regenerateToken).not.toHaveBeenCalled();
+  });
+
+  it('emits revoke instead of calling the API', () => {
+    const revoked: unknown[] = [];
+    const { c, api } = makeWithSpies();
+    c.revoke.subscribe(() => revoked.push(1));
+    c.revoke.emit();
+    expect(revoked).toHaveLength(1);
+    expect(api.revokeToken).not.toHaveBeenCalled();
+  });
+
+  it('renders both controls, with revoke marked destructive', () => {
+    const { fixture } = makeWithSpies();
+    const zone = fixture.nativeElement.querySelector('.danger-zone');
+    expect(zone).toBeTruthy();
+    const buttons = [...zone.querySelectorAll('button')];
+    expect(buttons).toHaveLength(2);
+    // The destructive one has to look destructive; two identical buttons is a mis-click waiting to happen.
+    expect(buttons.some((b: HTMLElement) => b.classList.contains('btn-danger'))).toBe(true);
+  });
+
+  it('the danger zone is the LAST thing in the dialog', () => {
+    // A destructive control beside Save is a mis-click. The reader should have to travel to reach it.
+    const { fixture } = makeWithSpies();
+    const html = fixture.nativeElement.innerHTML;
+    // Save lives in the footer; the danger zone must appear before it in the DOM but after the editable fields.
+    expect(html.indexOf('danger-zone')).toBeGreaterThan(html.indexOf('tokenMfa'));
   });
 });

--- a/client/src/app/pages/settings/token-rights-dialog.component.ts
+++ b/client/src/app/pages/settings/token-rights-dialog.component.ts
@@ -35,7 +35,37 @@ import type { Space, TokenRecord } from '../../core/api.types';
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [TranslocoPipe, PhIconComponent, ModalDirective, RightsMatrixComponent, FormsModule],
-  styles: [DIALOG_STYLES],
+  styles: [DIALOG_STYLES, `
+    /* Visually separated, and last. A destructive control beside Save is a mis-click; the reader should have
+       to travel to reach it. The border is the boundary, not decoration. */
+    .danger-zone {
+      margin-top: 20px;
+      border: 1px solid var(--danger-border, var(--border));
+      border-radius: var(--radius-md);
+      padding: 12px 14px;
+    }
+    .danger-title {
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: .04em;
+      color: var(--danger, var(--text-secondary));
+      margin-bottom: 10px;
+    }
+    .danger-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+    }
+    .danger-row + .danger-row {
+      margin-top: 10px;
+      padding-top: 10px;
+      border-top: 1px solid var(--border);
+    }
+    .danger-label { font-size: 13px; font-weight: 500; }
+    .danger-hint { font-size: 11.5px; color: var(--text-muted); margin-top: 2px; }
+  `],
   template: `
     <div class="dialog-backdrop">
       <div class="dialog" [appModal]="'tokens.rights.title' | transloco"
@@ -98,6 +128,33 @@ import type { Space, TokenRecord } from '../../core/api.types';
           </div>
         }
 
+        <!-- Danger zone. Present because this editor is where a token is managed, and rotate/revoke were
+             reachable only as two small icons on the list row — so the whole token was managed in two places.
+             Both EMIT rather than acting: the page owns the confirmation, the failure toast, the list removal,
+             and the copy-once banner that a rotated secret appears in. It also closes this dialog first,
+             because that banner renders behind it. -->
+        <div class="danger-zone">
+          <div class="danger-title">{{ 'tokens.danger.title' | transloco }}</div>
+          <div class="danger-row">
+            <div>
+              <div class="danger-label">{{ 'tokens.rotateButton' | transloco }}</div>
+              <div class="danger-hint">{{ 'tokens.danger.rotateHint' | transloco }}</div>
+            </div>
+            <button class="btn btn-secondary btn-sm" type="button" (click)="rotate.emit()">
+              {{ 'tokens.rotateButton' | transloco }}
+            </button>
+          </div>
+          <div class="danger-row">
+            <div>
+              <div class="danger-label">{{ 'common.revoke' | transloco }}</div>
+              <div class="danger-hint">{{ 'tokens.danger.revokeHint' | transloco }}</div>
+            </div>
+            <button class="btn btn-danger btn-sm" type="button" (click)="revoke.emit()">
+              {{ 'common.revoke' | transloco }}
+            </button>
+          </div>
+        </div>
+
         <div class="form-grid-bottom" style="margin-top:12px;">
           <button class="btn-secondary btn" type="button" (click)="close.emit()">
             {{ 'common.cancel' | transloco }}
@@ -119,6 +176,16 @@ export class TokenRightsDialogComponent {
   availableSpaces = input<Space[]>([]);
   close = output<void>();
   saved = output<TokenRecord>();
+  /**
+   * The danger actions, as requests rather than deeds.
+   *
+   * Neither is performed here. The host owns the confirm dialog, the failure toast, the list removal, and the
+   * copy-once banner a rotated secret appears in — and it closes this dialog before acting, because that
+   * banner renders behind the modal. Doing either here would mean a second confirmation flow and, for rotate,
+   * a second place a credential is shown once.
+   */
+  rotate = output<void>();
+  revoke = output<void>();
 
   saving = signal(false);
   error = signal('');

--- a/client/src/app/pages/settings/tokens.component.spec.ts
+++ b/client/src/app/pages/settings/tokens.component.spec.ts
@@ -221,3 +221,43 @@ describe('TokensComponent — create payload, characterized before the Q-5 extra
     expect(body.rights.perSpace.qa).toEqual({ knowledge: 'admin', files: 'write', schema: 'none', dataQuality: 'read' });
   });
 });
+
+/**
+ * ── The host closes the editor BEFORE acting ──────────────────────────────────────────────────────
+ *
+ * Rotate's new secret appears in a copy-once banner on the PAGE. If the editor stayed open, the only copy of a
+ * new credential would render behind the modal — visible to nobody, and unrecoverable, because a secret is
+ * shown exactly once.
+ */
+describe('TokensComponent — danger actions from the editor', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('closes the editor before running the action', () => {
+    const { c } = makeList([{ id: 't1', name: 'CI', admin: false }]);
+    // Stubbed, because this test is about the ORDERING and letting the real handler run would fire a
+    // confirm-dialog promise and an API call into a list harness that has neither — passing the assertion
+    // while leaving an unhandled rejection behind it. That shape is how 11 of those accumulated once before.
+    vi.spyOn(c, 'regenerate').mockResolvedValue(undefined as never);
+    c.editRightsFor.set({ id: 't1', name: 'CI' } as never);
+    expect(c.editRightsFor()).not.toBeNull();
+
+    c.dangerFromEditor({ id: 't1', name: 'CI' } as never, 'rotate');
+    // Synchronous: the confirm dialog is awaited inside `regenerate`, so by the time that promise settles the
+    // modal must already be gone.
+    expect(c.editRightsFor()).toBeNull();
+  });
+
+  it('routes rotate and revoke to the page handlers rather than duplicating them', () => {
+    const { c } = makeList([{ id: 't1', name: 'CI', admin: false }]);
+    const rotate = vi.spyOn(c, 'regenerate').mockResolvedValue(undefined as never);
+    const revoke = vi.spyOn(c, 'revoke').mockResolvedValue(undefined as never);
+
+    c.dangerFromEditor({ id: 't1', name: 'CI' } as never, 'rotate');
+    expect(rotate).toHaveBeenCalledTimes(1);
+    expect(revoke).not.toHaveBeenCalled();
+
+    c.dangerFromEditor({ id: 't1', name: 'CI' } as never, 'revoke');
+    expect(revoke).toHaveBeenCalledTimes(1);
+    expect(rotate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/app/pages/settings/tokens.component.ts
+++ b/client/src/app/pages/settings/tokens.component.ts
@@ -265,7 +265,9 @@ import { httpErrorReason } from '../../core/http-error';
         [token]="t"
         [availableSpaces]="availableSpaces()"
         (close)="editRightsFor.set(null)"
-        (saved)="onRightsSaved($event)"/>
+        (saved)="onRightsSaved($event)"
+        (rotate)="dangerFromEditor(t, 'rotate')"
+        (revoke)="dangerFromEditor(t, 'revoke')"/>
     }
 
     <!-- The create dialog lives in TokenCreateDialogComponent. It was over a quarter of this file and
@@ -474,6 +476,23 @@ export class TokensComponent implements OnInit {
 
 
 
+
+  /**
+   * A danger action asked for from inside the editor.
+   *
+   * The editor emits rather than doing it: this page already owns the confirm dialog, the toast on failure,
+   * the list removal, and — the part that decides the shape — the **copy-once banner** that rotate's new
+   * secret appears in. A second implementation inside the modal would mean a second banner, and a secret is
+   * shown exactly once.
+   *
+   * The editor CLOSES first, and that is not tidiness: the banner renders on this page, behind the modal. A
+   * rotate that left the dialog open would put the only copy of a new credential underneath it.
+   */
+  dangerFromEditor(t: TokenRecord, action: 'rotate' | 'revoke'): void {
+    this.editRightsFor.set(null);
+    if (action === 'rotate') void this.regenerate(t);
+    else void this.revoke(t);
+  }
 
   async regenerate(t: TokenRecord): Promise<void> {
     const ok = await this.confirmDialog.confirm({

--- a/testing/standalone/no-new-god-files.test.js
+++ b/testing/standalone/no-new-god-files.test.js
@@ -77,7 +77,14 @@ const FROZEN = {
   // `token-rights-dialog.component.ts`; what landed here is the entry point, which belongs to the page that
   // owns the rows. Raised rather than worked around — hiding a row action somewhere it does not belong to
   // keep a number down is the trade this list exists to let us decline.
-  'client/src/app/pages/settings/tokens.component.ts': 526,
+  // 526 -> 532: the danger zone moved into the token editor, which added the routing method the editor emits
+  // into plus its two bindings. Six code lines.
+  //
+  // Note the direction this file COULD go instead: rotate and revoke are now in the editor, so the two row
+  // icons on the list are a second way to reach the same actions and removing them would pay this back with
+  // change to spare. Not done here, because dropping a familiar affordance from a page is the owner's call and
+  // not a side effect of adding one elsewhere. Recorded under G-1.
+  'client/src/app/pages/settings/tokens.component.ts': 532,
   // RAISED 1617 -> 1618 by one line: the Q-10 timestamp swap replaced a `| date:` cell with `<app-timestamp>` and
   // needed an import, gaining an import line while losing none. At 1618 code lines this file is by far the largest
   // here and wants splitting on its own terms — but not inside a one-cell rendering change, where the split would be


### PR DESCRIPTION
Rotate and revoke were reachable only as two small icons on the list row, so a token was managed in two places: its label, rights and second factor in the editor, and the two irreversible actions somewhere else.

## The editor REQUESTS, it does not act

Both are outputs. The page owns the confirmation dialog, the failure toast, the list removal, and — the part that decides the shape — the **copy-once banner** that a rotated secret appears in. A second implementation inside the modal would mean a second confirmation flow and, for rotate, a second place a credential is shown exactly once.

## Closing first is load-bearing, not tidiness

That banner renders on the **page**, behind the modal. A rotate that left the editor open would put the only copy of a new credential underneath it — and there is no second chance to read it.

Asserted, and mutation-tested: removing the close leaves the ordering test red.

## Placement

Last in the dialog, visually separated, revoke marked destructive. A destructive control beside Save is a mis-click, and two identically styled buttons are worse than one.

## What this file could have paid instead

`tokens.component.ts` grew 526 → 532 code lines and I raised the ratchet. The alternative is real, and I have **recorded it rather than taken it**: rotate and revoke now live in the editor, so the two row icons are a second route to the same actions and removing them would pay this back with change to spare.

Dropping a familiar affordance from a page is the owner's call, not a side effect of adding one elsewhere. Tracked under G-1 with the other god-file debt.

## A test that passed while leaving a mess

The first version of the ordering spec let the real `regenerate` run against a list harness with no `regenerateToken` and no confirm dialog. All 1064 tests passed and vitest reported **one unhandled error** — the same shape as the eleven that once accumulated behind a fully green suite. Stubbed, because the assertion is about ordering and not about rotating.

## Completes U-3

With #816 (`PATCH` accepts `mfa`) and #817 (the selector), the token editor now covers everything the owner asked for: label, rights matrix, second factor, and the danger zone.
