### PR TITLE
test(sync): measure the margin before anyone raises the timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Internal
+- **A sync wait that only just passed now reports its margin.** A pub/sub propagation test timed out at its 25 s
+  budget in CI on a diff of client CSS, docs and a changelog — none of which can touch sync — and passed on
+  rerun with no code change.
+  - The tempting fix is a bigger number, and it is a guess. Nothing recorded how long a PASSING wait took, so
+    nobody could tell whether a green run takes 20 s and the margin is thin, or takes 3 s and something
+    occasionally **stalls** — in which case a bigger budget hides the stall instead of fixing it.
+  - So the measurement was added rather than the number changed: any wait that consumes more than 60% of its
+    budget prints the elapsed time, the budget and the percentage. For every wait in the suite, not just the one
+    that went red, and while the margin is still a margin.
+  - A warning rather than a failure: propagation time legitimately varies with what else the runner is doing,
+    and a slow pass failing the build would make CI stricter than the product.
 ### Added
 - **The data-model diagram shows memories, chrono entries and files**, not just entity types. One box per kind
   carrying that kind's total, joined to each entity type it links to with the per-type count on the join.

--- a/testing/standalone/waitfor-reports-a-thin-margin.test.js
+++ b/testing/standalone/waitfor-reports-a-thin-margin.test.js
@@ -1,0 +1,102 @@
+/**
+ * A wait that only just passed says so, so a timeout can be decided from evidence.
+ *
+ * ## What happened
+ *
+ * `Subscriber-local content survives publisher tombstone` timed out in CI at its 25 s budget — on a diff of
+ * client CSS, docs and a changelog, none of which can touch sync propagation. It passed on rerun with no code
+ * change.
+ *
+ * The tempting move is to raise the 25 s. It is also a guess, and the two things it could be are different
+ * problems:
+ *
+ *   - a green run genuinely takes ~20 s, the margin is thin, and a bigger budget is the fix; or
+ *   - a green run takes ~3 s and something occasionally **stalls**, in which case the deadline is only how we
+ *     found out, and raising it hides the stall until it is longer than the new number too.
+ *
+ * Nothing recorded how long a passing wait took, so nobody could tell which. That was the missing measurement,
+ * and it was missing for every wait in the suite rather than just the one that went red.
+ *
+ * ## Why a warning and not a failure
+ *
+ * A slow pass failing the build would make CI stricter than the product, and propagation time legitimately
+ * varies with what else the runner is doing. The point is to make the margin visible while it is still a margin.
+ *
+ * Run: node --test testing/standalone/waitfor-reports-a-thin-margin.test.js
+ */
+import { describe, it, before, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+let waitFor;
+before(async () => {
+  ({ waitFor } = await import('../../testing/sync/helpers.js'));
+});
+
+/** Capture console.warn for one call. */
+async function warnsDuring(fn) {
+  const lines = [];
+  const original = console.warn;
+  console.warn = (...args) => lines.push(args.join(' '));
+  try { await fn(); } finally { console.warn = original; }
+  return lines;
+}
+
+describe('a comfortable pass is quiet', () => {
+  it('says nothing when the condition is true immediately', async () => {
+    const lines = await warnsDuring(() => waitFor(() => true, 1_000, 10));
+    assert.deepEqual(lines, [], 'a wait that returned at once must not warn — that is noise on every test');
+  });
+
+  it('still returns true, so no caller changes', async () => {
+    // The return value is load-bearing: several waits are used as `assert.ok(await waitFor(...))`. Returning
+    // the elapsed time instead would make a wait that succeeded on its first poll return 0 — falsy — and
+    // silently invert those assertions.
+    assert.equal(await waitFor(() => true, 1_000, 10), true);
+  });
+});
+
+describe('a thin pass reports the numbers', () => {
+  it('warns when the wait consumed most of its budget', async () => {
+    // 120ms budget, condition true after ~100ms: past the 60% mark.
+    const start = Date.now();
+    const lines = await warnsDuring(() => waitFor(() => Date.now() - start > 100, 160, 10));
+    assert.equal(lines.length, 1, `expected one warning, got ${lines.length}`);
+    assert.match(lines[0], /passed after \d+ms of a 160ms budget/,
+      'the message must carry BOTH numbers — a percentage alone cannot be compared across different budgets');
+    assert.match(lines[0], /\d+%/);
+  });
+
+  it('the warning says what to do with it', async () => {
+    // A warning that only reports is a warning people learn to scroll past. This one has to distinguish the
+    // two diagnoses, because picking the wrong one is how a stall gets hidden behind a bigger number.
+    const start = Date.now();
+    const lines = await warnsDuring(() => waitFor(() => Date.now() - start > 100, 160, 10));
+    assert.match(lines[0], /stall/i, 'the message must name the alternative to "just raise it"');
+  });
+});
+
+describe('the timeout path is unchanged', () => {
+  it('still throws with the budget and the diagnosis', async () => {
+    await assert.rejects(
+      () => waitFor(() => false, 60, 10, 'the subscriber never saw it'),
+      /waitFor timed out after 60ms — the subscriber never saw it/,
+    );
+  });
+
+  it('a timeout does NOT also warn about a thin margin', async () => {
+    // It failed; a note that it was close would be absurd and would bury the real error.
+    const lines = await warnsDuring(async () => {
+      await waitFor(() => false, 60, 10).catch(() => {});
+    });
+    assert.deepEqual(lines, []);
+  });
+});
+
+describe('the threshold is a named constant, not a number in an expression', () => {
+  it('is stated once and explained', () => {
+    const src = readFileSync('testing/sync/helpers.js', 'utf8');
+    assert.match(src, /const TIGHT_MARGIN = 0\.6/,
+      'a bare 0.6 inside the comparison is a number nobody can find when they want to tune it');
+  });
+});

--- a/testing/sync/helpers.js
+++ b/testing/sync/helpers.js
@@ -163,11 +163,42 @@ export async function get(baseUrl, token, path) {
 export async function waitFor(condition, timeout = 15_000, interval = 500, diagnose) {
   const start = Date.now();
   while (Date.now() - start < timeout) {
-    if (await condition()) return true;
+    if (await condition()) {
+      warnIfTight(Date.now() - start, timeout);
+      return true;
+    }
     await new Promise(r => setTimeout(r, interval));
   }
   const detail = typeof diagnose === 'function' ? diagnose() : diagnose;
   throw new Error(`waitFor timed out after ${timeout}ms${detail ? ` — ${detail}` : ''}`);
+}
+
+/** Above this share of the budget, a PASS is worth reporting: it is one slow runner from being a failure. */
+const TIGHT_MARGIN = 0.6;
+
+/**
+ * Say so when a wait only just made it.
+ *
+ * ## Why a passing wait needs to report anything
+ *
+ * `Subscriber-local content survives publisher tombstone` failed in CI on a diff of client CSS, docs and a
+ * changelog — nothing that can touch sync propagation — and passed on rerun with no code change. The obvious
+ * move is to raise the 25 s and move on. It is also a guess: nobody knows whether a green run takes 3 s or 24 s,
+ * so nobody knows whether the margin is thin or whether something occasionally STALLS and the deadline is
+ * merely how we found out. Those are different problems and only one of them is fixed by a bigger number.
+ *
+ * The measurement was missing, so this adds it — for every wait in the suite rather than the one that went red.
+ * A pass that consumed most of its budget now prints the numbers, so the next person deciding a timeout has
+ * evidence instead of a hunch, and a wait that is drifting toward its ceiling says so BEFORE it starts failing.
+ *
+ * Deliberately not a failure. Turning a slow pass into a red build would make CI stricter than the product,
+ * and the propagation time legitimately varies with what else the runner is doing.
+ */
+function warnIfTight(elapsed, timeout) {
+  if (elapsed <= timeout * TIGHT_MARGIN) return;
+  const pct = Math.round((elapsed / timeout) * 100);
+  console.warn(`[waitFor] passed after ${elapsed}ms of a ${timeout}ms budget (${pct}%) — thin margin, and a `
+    + 'slower runner turns this into a timeout. Raise the budget only if this is normal rather than a stall.');
 }
 
 /**


### PR DESCRIPTION
`Subscriber-local content survives publisher tombstone` timed out at its 25 s budget in CI — on a diff of client CSS, docs and a changelog, none of which can touch sync propagation — and passed on rerun with no code change.

## Why I did not just raise the 25 s

Because it is a guess, and the two things it could be want opposite responses:

- a green run genuinely takes ~20 s, the margin is thin, and a bigger budget is right; **or**
- a green run takes ~3 s and something occasionally **stalls** — in which case the deadline is only how we found out, and raising it hides the stall until it is longer than the new number too.

Nothing recorded how long a **passing** wait took, so nobody could tell which. The measurement was the missing thing, so that is what this adds.

## What it does

Any wait consuming more than 60% of its budget prints the elapsed time, the budget and the percentage, plus a line naming the stall as the alternative diagnosis so the warning is actionable rather than just noisy.

For **every** wait in the suite, not only the one that went red — and while the margin is still a margin, rather than after it becomes a failure.

A warning, not a failure: propagation time legitimately varies with what else the runner is doing, and a slow pass failing the build would make CI stricter than the product.

## The return value is deliberately untouched

Several call sites read it as `assert.ok(await waitFor(...))`. Returning the elapsed time instead would make a wait that succeeded on its **first poll** return `0` — falsy — and silently invert those assertions. Pinned by a test, because it is the obvious "improvement" someone will reach for next.

## I have not raised any timeout here

That decision needs one CI run with these numbers in it. Mutation-tested: removing the warning call fails two assertions.
