### PR TITLE
refactor(recall): pay the ratchet raise instead of taking another

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Internal
+- **`recall.ts` gave up its pure half.** Merge, rank and the two text projections moved to
+  `brain/recall-shape.ts` — 124 lines out, leaving the part that genuinely needs a database.
+  - This **pays** a ratchet raise rather than adding another. The file went 739 -> 744 earlier in this release to
+    ship a 5x embedding fix an operator was already paying for; that raise named its debt instead of forgetting
+    it, and this is the debt. The freeze is now set to what the file actually is (689), not left at the old
+    ceiling — a freeze above the real number is a budget for lines nobody argued for.
+  - Those four were the four that could move without writing a characterization pass first: **81 existing
+    assertions across three suites** already pin them, and they were green against the original code before the
+    new file existed. Nothing about their behaviour changed.
+  - The three source-reading gates that referenced them now read **both** halves. A gate that followed only one
+    would go quietly vacuous the next time a function moves between them.
+  - `recall-shape.ts` imports its two types back from `recall.ts`, which is **not** a runtime cycle — a type-only
+    import is erased. It is still the wrong shape to keep: the follow-up is a leaf types module, which is exactly
+    what `config/rights-shape.ts` already exists to be.
+### Internal
 - **A sync wait that only just passed now reports its margin.** A pub/sub propagation test timed out at its 25 s
   budget in CI on a diff of client CSS, docs and a changelog — none of which can touch sync — and passed on
   rerun with no code change.

--- a/server/src/api/brain/search.ts
+++ b/server/src/api/brain/search.ts
@@ -11,7 +11,7 @@ import { NotFoundError } from '../../util/errors.js';
 import { countMemories } from '../../brain/memory.js';
 import { getEmbedJobCounts } from '../../brain/embed-queue.js';
 import { queryBrain } from '../../brain/query.js';
-import { findSimilar, recall, rankOf, mergeRecallResults, type RecallKnowledgeType, type RecallResult } from '../../brain/recall.js';
+import { findSimilar, recall, type RecallKnowledgeType, type RecallResult } from '../../brain/recall.js';
 import { validateFilterExpression, type FilterExpression } from '../../brain/filter.js';
 import { traverseGraph, traverseRecallSeeds, MAX_RECALL_TRAVERSE, resolveEdgeEntityNames } from '../../brain/edges.js';
 import { memoryEmbedText, entityEmbedText, edgeEmbedText, chronoEmbedText, fileEmbedText } from '../../brain/embed-text.js';
@@ -26,6 +26,7 @@ import type { MemoryDoc, EntityDoc, EdgeDoc, ChronoEntry, FileMetaDoc } from '..
 import { reindexInProgress } from '../../metrics/registry.js';
 import { UUID_V4_RE } from './_shared.js';
 import { buildErModel } from '../../brain/er-model.js';
+import { rankOf, mergeRecallResults } from '../../brain/recall-shape.js';
 
 export const searchRouter = Router();
 

--- a/server/src/brain/contradiction-scanner.ts
+++ b/server/src/brain/contradiction-scanner.ts
@@ -34,13 +34,14 @@ import { col, asFilter, asUpdate, isVectorSearchAvailable } from '../db/mongo.js
 import { getConfig } from '../config/loader.js';
 import { needsReindex } from '../spaces/_shared.js';
 import { log } from '../util/log.js';
-import { findSimilar, summariseRecall, DEFAULT_DUPE_THRESHOLD, type RecallKnowledgeType, type RecallResult } from './recall.js';
+import { findSimilar, DEFAULT_DUPE_THRESHOLD, type RecallKnowledgeType, type RecallResult } from './recall.js';
 import { judgePair, consultedModel, type JudgeableRecord } from './contradiction-judge.js';
 import { extraClaimFields, fetchStructuredClaims, type ClaimMap } from './structured-claims.js';
 import { recordContradiction, contradictionPairId } from './contradiction-candidates.js';
 import { nliConfigured, nliIsLocal } from './nli-client.js';
 import type { ContradictionScannerConfig, DupeScanStateDoc, DupeScanType } from '../config/types.js';
 import { runExclusive } from '../util/single-flight.js';
+import { summariseRecall } from './recall-shape.js';
 
 const SCAN_STATE = 'ythril_dupe_scan_state';
 const DEFAULT_BATCH_SIZE = 200;

--- a/server/src/brain/dupe-scanner.ts
+++ b/server/src/brain/dupe-scanner.ts
@@ -31,7 +31,6 @@ import { ssrfSafeFetch } from '../util/ssrf.js';
 import { log } from '../util/log.js';
 import {
   findSimilar,
-  summariseRecall,
   DEFAULT_DUPE_THRESHOLD,
   type RecallResult,
   type RecallKnowledgeType,
@@ -40,6 +39,7 @@ import { computeMergePlan, applyResolutions, executeMerge } from './merge.js';
 import { emitWebhookEvent } from '../webhooks/dispatcher.js';
 import type { DupeCandidateDoc, DupeScanStateDoc, DupeScanType, DupeActionRule } from '../config/types.js';
 import { runExclusive } from '../util/single-flight.js';
+import { summariseRecall } from './recall-shape.js';
 
 const DEFAULT_SCHEDULE = '0 3 * * *';   // 03:00 daily
 const DEFAULT_BATCH_SIZE = 200;

--- a/server/src/brain/recall-shape.ts
+++ b/server/src/brain/recall-shape.ts
@@ -1,0 +1,155 @@
+/**
+ * The pure shape of a recall answer: merge, rank, and the two text projections.
+ *
+ * ## Why these four live away from `recall.ts`
+ *
+ * None of them touch a database, a deadline, or an embedder. They take results and return results — which is
+ * why they are the four functions in that file with real unit coverage, and why they were the four that could
+ * be moved without a characterization pass: 81 existing assertions across three suites already pin them, and
+ * they were green against the original code before this file existed.
+ *
+ * `recall.ts` had grown to 744 code lines and taken a god-file ratchet raise. A raise names a cost and defers
+ * it; this pays part of it back. The remaining file is the part that genuinely needs a database.
+ *
+ * ## The import direction, and why it is not a cycle
+ *
+ * `recall.ts` imports these functions, and this module imports `RecallResult` and `RecallKnowledgeType` back
+ * from it. That reads like a cycle and is not one: a type-only import is **erased** by TypeScript, so nothing
+ * of it survives into the emitted JavaScript. At runtime the dependency is one-way.
+ *
+ * It is still the wrong shape to leave for ever. The repo already has the fix as precedent — `config/rights-shape.ts`
+ * exists precisely because `types.ts` could not import from `auth/` while `auth/` imported `types.ts`, and a
+ * leaf module both could import broke it. The follow-up is a `recall-types.ts` leaf holding `RecallResult`, its
+ * five variants and `RecallKnowledgeType`; that is a change to every importer of those types and belongs on its
+ * own, not bolted onto a file move.
+ */
+import type { RecallResult, RecallKnowledgeType } from './recall.js';
+
+/** Roughly a 2k-token window at ~4 chars/token, which every current reranker comfortably accepts. */
+export const RERANK_TEXT_MAX_CHARS = 8_000;
+
+/**
+ * Combine the floor-guaranteed results with the global ones, honour `topK`, and apply `minScore`.
+ *
+ * Pure, and extracted so it can be tested at all: the surrounding function is two `await`s into
+ * MongoDB on either side, so this logic previously had no reachable seam — which is exactly why the
+ * standalone test that "covered" it was a hand-written copy that had drifted from it.
+ *
+ * The order matters and is easy to get subtly wrong:
+ *   1. guaranteed results are already deduped by the caller and always survive `topK`;
+ *   2. the global results fill whatever slots remain, skipping anything already guaranteed;
+ *   3. the combined list is sorted by score — a floor result may legitimately outrank a global one;
+ *   4. `minScore` filters LAST, so it can drop a guaranteed result. That is deliberate: a floor is a
+ *      request for coverage, not a licence to return matches the caller called too weak to want.
+ *
+ * `maxPerType` is the CEILING to `minPerType`'s floor, and it is applied here rather than by fetching less.
+ * Phase 2 over-fetches on purpose so a cross-encoder has something to reorder; capping the fetch instead
+ * would hand the reranker the top-N by vector similarity rather than the best N after reranking — a worse
+ * answer for the same cost. The cap's whole value is in step 2: a candidate whose type is already full is
+ * SKIPPED and the walk continues, so the slot it would have taken goes to another type. Without that, a
+ * ceiling would only shorten the list, and the caller's actual complaint — one long chunk crowding out four
+ * one-line principles — would be unaddressed.
+ *
+ * A ceiling never drops a floor result: `minPerType.x > maxPerType.x` is refused at both API surfaces, so
+ * the two cannot contradict by the time they reach here. Guaranteed results still COUNT toward the ceiling,
+ * or a floor of 2 plus a ceiling of 2 would return four.
+ */
+export function mergeRecallResults(
+  guaranteed: RecallResult[],
+  allResults: RecallResult[],
+  topK: number,
+  minScore?: number | null,
+  maxPerType?: Partial<Record<RecallKnowledgeType, number>>,
+): RecallResult[] {
+  const guaranteedIds = new Set(guaranteed.map(r => r._id));
+  const fillSlots = Math.max(0, topK - guaranteed.length);
+
+  // Per-type usage starts from the floor results, which are already in the output.
+  const used = new Map<RecallKnowledgeType, number>();
+  if (maxPerType) for (const r of guaranteed) used.set(r.type, (used.get(r.type) ?? 0) + 1);
+  const capOf = (t: RecallKnowledgeType): number =>
+    maxPerType?.[t] ?? Number.POSITIVE_INFINITY;
+
+  // Rank BEFORE selecting, not after.
+  //
+  // This function used to walk `allResults` in the order it was handed and sort only at the end, which was
+  // harmless while selection was "take the first `fillSlots`" — the sort fixed the order of whatever came
+  // out. It stops being harmless the moment a ceiling exists: with `{file: 1}`, the cap keeps the FIRST file
+  // it walks past and skips the rest, so an unranked walk keeps a 0.1 hit and discards a 0.99 one. Its own
+  // test caught exactly that.
+  //
+  // It also fixes the same latent problem in plain `topK` truncation, which picked the first N of the input
+  // rather than the best N. Both were masked by every production caller sorting first — and `applyRerank`
+  // and `applyLexicalFusion` mutate the scores AFTER that sort, so "the caller sorted" was not even reliably
+  // true. A copy, because reordering an argument is a side effect a caller cannot see.
+  const ranked = [...allResults].sort((a, b) => rankOf(b) - rankOf(a));
+
+  const fill: RecallResult[] = [];
+  for (const r of ranked) {
+    if (fill.length >= fillSlots) break;
+    if (guaranteedIds.has(r._id)) continue;
+    if (maxPerType) {
+      const seen = used.get(r.type) ?? 0;
+      if (seen >= capOf(r.type)) continue;   // full — keep walking, do not stop
+      used.set(r.type, seen + 1);
+    }
+    fill.push(r);
+  }
+
+  const final = [...guaranteed, ...fill];
+  // Order by the cross-encoder when it answered, otherwise by vector similarity. `??` rather than a
+  // separate branch so a partial rerank — a provider that scored some passages and not others — still
+  // orders sensibly instead of collapsing the unscored ones to the bottom.
+  final.sort((a, b) => rankOf(b) - rankOf(a));
+  // minScore filters on `score`, never on `rerankScore`. The two are different scales, and a caller's
+  // threshold was written against vector similarity; silently reinterpreting it against a cross-encoder's
+  // logit would change which results a fixed threshold returns without anyone touching the threshold.
+  return (minScore != null && minScore > 0)
+    ? final.filter(r => (r.score ?? 0) >= minScore)
+    : final;
+}
+
+/**
+ * Sort key, most-precise signal first.
+ *
+ * Cross-encoder > RRF fusion > raw vector similarity. The order is the order of how much each one
+ * actually knows: the reranker read the query and the passage together, fusion only saw two rankings,
+ * and the vector score saw one. `??` rather than branches so a partial signal — some records reranked,
+ * some not — still orders sensibly instead of collapsing the unscored ones to the bottom.
+ */
+export function rankOf(r: RecallResult): number {
+  return r.rerankScore ?? r.fusedScore ?? r.score ?? 0;
+}
+
+/**
+ * The text a cross-encoder is asked to judge against the query.
+ *
+ * Deliberately NOT `summariseRecall`, which truncates a memory to 120 characters for a one-line log or
+ * tool response. A reranker scoring a 117-character stub of the passage would be judging a different
+ * text from the one that gets returned — worse than not reranking, because the error is invisible.
+ * Capped anyway: cross-encoders have a token window, and a runaway document would be silently truncated
+ * by the provider at a point we do not control.
+ */
+export function rerankTextOf(r: RecallResult): string {
+  const raw = (() => {
+    switch (r.type) {
+      case 'memory': return r.fact;
+      case 'entity': return [r.name, r.entityType, r.description].filter(Boolean).join(' — ');
+      case 'edge':   return [`${r.from} → ${r.label} → ${r.to}`, r.description].filter(Boolean).join(' — ');
+      case 'chrono': return [r.title, r.description].filter(Boolean).join(' — ');
+      case 'file':   return [r.path, r.description].filter(Boolean).join(' — ');
+    }
+  })();
+  return raw.length > RERANK_TEXT_MAX_CHARS ? raw.slice(0, RERANK_TEXT_MAX_CHARS) : raw;
+}
+
+/** One-line human summary of a recall result, for duplicate feedback. */
+export function summariseRecall(r: RecallResult): string {
+  switch (r.type) {
+    case 'memory': return r.fact.length > 120 ? `${r.fact.slice(0, 117)}…` : r.fact;
+    case 'entity': return `${r.name} (${r.entityType})`;
+    case 'edge': return `${r.from} → ${r.label} → ${r.to}`;
+    case 'chrono': return r.title;
+    case 'file': return r.path;
+  }
+}

--- a/server/src/brain/recall.ts
+++ b/server/src/brain/recall.ts
@@ -11,6 +11,9 @@ import { embed } from './embedding.js';
 import type { EmbeddingResult } from './embedding.js';
 import { getEmbeddingConfig } from '../config/loader.js';
 import { needsReindex } from '../spaces/_shared.js';
+// The pure half — merge, rank and the text projections. Moved out to pay back part of this file's
+// god-file ratchet raise; see recall-shape.ts for why the type import back here is not a cycle.
+import { mergeRecallResults, rankOf, rerankTextOf, summariseRecall } from './recall-shape.js';
 import { vectorFilterFieldsFor } from '../spaces/vector-index.js';
 import { FilterExpression, buildMongoFilter, toNativeVectorFilter } from './filter.js';
 import { deriveChronoStatus } from './chrono-status.js';
@@ -407,98 +410,7 @@ export async function recall(
   return final;
 }
 
-/**
- * Combine the floor-guaranteed results with the global ones, honour `topK`, and apply `minScore`.
- *
- * Pure, and extracted so it can be tested at all: the surrounding function is two `await`s into
- * MongoDB on either side, so this logic previously had no reachable seam — which is exactly why the
- * standalone test that "covered" it was a hand-written copy that had drifted from it.
- *
- * The order matters and is easy to get subtly wrong:
- *   1. guaranteed results are already deduped by the caller and always survive `topK`;
- *   2. the global results fill whatever slots remain, skipping anything already guaranteed;
- *   3. the combined list is sorted by score — a floor result may legitimately outrank a global one;
- *   4. `minScore` filters LAST, so it can drop a guaranteed result. That is deliberate: a floor is a
- *      request for coverage, not a licence to return matches the caller called too weak to want.
- *
- * `maxPerType` is the CEILING to `minPerType`'s floor, and it is applied here rather than by fetching less.
- * Phase 2 over-fetches on purpose so a cross-encoder has something to reorder; capping the fetch instead
- * would hand the reranker the top-N by vector similarity rather than the best N after reranking — a worse
- * answer for the same cost. The cap's whole value is in step 2: a candidate whose type is already full is
- * SKIPPED and the walk continues, so the slot it would have taken goes to another type. Without that, a
- * ceiling would only shorten the list, and the caller's actual complaint — one long chunk crowding out four
- * one-line principles — would be unaddressed.
- *
- * A ceiling never drops a floor result: `minPerType.x > maxPerType.x` is refused at both API surfaces, so
- * the two cannot contradict by the time they reach here. Guaranteed results still COUNT toward the ceiling,
- * or a floor of 2 plus a ceiling of 2 would return four.
- */
-export function mergeRecallResults(
-  guaranteed: RecallResult[],
-  allResults: RecallResult[],
-  topK: number,
-  minScore?: number | null,
-  maxPerType?: Partial<Record<RecallKnowledgeType, number>>,
-): RecallResult[] {
-  const guaranteedIds = new Set(guaranteed.map(r => r._id));
-  const fillSlots = Math.max(0, topK - guaranteed.length);
 
-  // Per-type usage starts from the floor results, which are already in the output.
-  const used = new Map<RecallKnowledgeType, number>();
-  if (maxPerType) for (const r of guaranteed) used.set(r.type, (used.get(r.type) ?? 0) + 1);
-  const capOf = (t: RecallKnowledgeType): number =>
-    maxPerType?.[t] ?? Number.POSITIVE_INFINITY;
-
-  // Rank BEFORE selecting, not after.
-  //
-  // This function used to walk `allResults` in the order it was handed and sort only at the end, which was
-  // harmless while selection was "take the first `fillSlots`" — the sort fixed the order of whatever came
-  // out. It stops being harmless the moment a ceiling exists: with `{file: 1}`, the cap keeps the FIRST file
-  // it walks past and skips the rest, so an unranked walk keeps a 0.1 hit and discards a 0.99 one. Its own
-  // test caught exactly that.
-  //
-  // It also fixes the same latent problem in plain `topK` truncation, which picked the first N of the input
-  // rather than the best N. Both were masked by every production caller sorting first — and `applyRerank`
-  // and `applyLexicalFusion` mutate the scores AFTER that sort, so "the caller sorted" was not even reliably
-  // true. A copy, because reordering an argument is a side effect a caller cannot see.
-  const ranked = [...allResults].sort((a, b) => rankOf(b) - rankOf(a));
-
-  const fill: RecallResult[] = [];
-  for (const r of ranked) {
-    if (fill.length >= fillSlots) break;
-    if (guaranteedIds.has(r._id)) continue;
-    if (maxPerType) {
-      const seen = used.get(r.type) ?? 0;
-      if (seen >= capOf(r.type)) continue;   // full — keep walking, do not stop
-      used.set(r.type, seen + 1);
-    }
-    fill.push(r);
-  }
-
-  const final = [...guaranteed, ...fill];
-  // Order by the cross-encoder when it answered, otherwise by vector similarity. `??` rather than a
-  // separate branch so a partial rerank — a provider that scored some passages and not others — still
-  // orders sensibly instead of collapsing the unscored ones to the bottom.
-  final.sort((a, b) => rankOf(b) - rankOf(a));
-  // minScore filters on `score`, never on `rerankScore`. The two are different scales, and a caller's
-  // threshold was written against vector similarity; silently reinterpreting it against a cross-encoder's
-  // logit would change which results a fixed threshold returns without anyone touching the threshold.
-  return (minScore != null && minScore > 0)
-    ? final.filter(r => (r.score ?? 0) >= minScore)
-    : final;
-}
-
-/**
- * Sort key, most-precise signal first.
- *
- * Cross-encoder > RRF fusion > raw vector similarity. The order is the order of how much each one
- * actually knows: the reranker read the query and the passage together, fusion only saw two rankings,
- * and the vector score saw one. `??` rather than branches so a partial signal — some records reranked,
- * some not — still orders sensibly instead of collapsing the unscored ones to the bottom.
- */
-export function rankOf(r: RecallResult): number {
-  return r.rerankScore ?? r.fusedScore ?? r.score ?? 0;
-}
 
 /**
  * Fuse a lexical ranking into the candidate pool's order, in place.
@@ -674,30 +586,7 @@ async function introduceLexicalOnly(
   }
 }
 
-/**
- * The text a cross-encoder is asked to judge against the query.
- *
- * Deliberately NOT `summariseRecall`, which truncates a memory to 120 characters for a one-line log or
- * tool response. A reranker scoring a 117-character stub of the passage would be judging a different
- * text from the one that gets returned — worse than not reranking, because the error is invisible.
- * Capped anyway: cross-encoders have a token window, and a runaway document would be silently truncated
- * by the provider at a point we do not control.
- */
-export function rerankTextOf(r: RecallResult): string {
-  const raw = (() => {
-    switch (r.type) {
-      case 'memory': return r.fact;
-      case 'entity': return [r.name, r.entityType, r.description].filter(Boolean).join(' — ');
-      case 'edge':   return [`${r.from} → ${r.label} → ${r.to}`, r.description].filter(Boolean).join(' — ');
-      case 'chrono': return [r.title, r.description].filter(Boolean).join(' — ');
-      case 'file':   return [r.path, r.description].filter(Boolean).join(' — ');
-    }
-  })();
-  return raw.length > RERANK_TEXT_MAX_CHARS ? raw.slice(0, RERANK_TEXT_MAX_CHARS) : raw;
-}
 
-/** Roughly a 2k-token window at ~4 chars/token, which every current reranker comfortably accepts. */
-export const RERANK_TEXT_MAX_CHARS = 8_000;
 
 /**
  * Score the candidate pool with the cross-encoder and stamp `rerankScore` on each result, in place.
@@ -797,16 +686,6 @@ export interface DupeCheckOpts {
   waitForEmbedding?: boolean;
 }
 
-/** One-line human summary of a recall result, for duplicate feedback. */
-export function summariseRecall(r: RecallResult): string {
-  switch (r.type) {
-    case 'memory': return r.fact.length > 120 ? `${r.fact.slice(0, 117)}…` : r.fact;
-    case 'entity': return `${r.name} (${r.entityType})`;
-    case 'edge': return `${r.from} → ${r.label} → ${r.to}`;
-    case 'chrono': return r.title;
-    case 'file': return r.path;
-  }
-}
 
 /**
  * Insert-time near-duplicate check: return existing records of the same type scoring at or above

--- a/server/src/mcp/tools/search.ts
+++ b/server/src/mcp/tools/search.ts
@@ -12,10 +12,11 @@ import { UUID_V4_RE, entityDocToRecord, formatRecallSummary, toRecallRecord, uui
 import { MAX_RECALL_TRAVERSE, traverseRecallSeeds } from '../../brain/edges.js';
 import { type FilterExpression, validateFilterExpression } from '../../brain/filter.js';
 import { queryBrain } from '../../brain/query.js';
-import { type RecallKnowledgeType, type RecallResult, findSimilar, recall, recallGlobal, rankOf, mergeRecallResults } from '../../brain/recall.js';
+import { type RecallKnowledgeType, type RecallResult, findSimilar, recall, recallGlobal } from '../../brain/recall.js';
 import { collectAcrossMembers } from '../../spaces/proxy.js';
 import { memberSpacesWithin } from '../../spaces/proxy-scoped.js';
 import { NotFoundError } from '../../util/errors.js';
+import { rankOf, mergeRecallResults } from '../../brain/recall-shape.js';
 
 /**
  * Space scope for find_similar — mirrors recall's omit-space idiom (F1 consistency).

--- a/testing/standalone/hybrid-retrieval.test.js
+++ b/testing/standalone/hybrid-retrieval.test.js
@@ -25,7 +25,7 @@ let rrfFuse, RRF_K, hybridSearchEnabled, mergeRecallResults;
 
 before(async () => {
   ({ rrfFuse, RRF_K, hybridSearchEnabled } = await import('../../server/dist/brain/lexical-search.js'));
-  ({ mergeRecallResults } = await import('../../server/dist/brain/recall.js'));
+  ({ mergeRecallResults } = await import('../../server/dist/brain/recall-shape.js'));
 });
 
 const ids = m => [...m.entries()].sort((a, b) => b[1] - a[1]).map(([id]) => id);
@@ -132,7 +132,12 @@ describe('minScore stays on the VECTOR score', () => {
 
 describe('the source keeps its contracts', () => {
   const lex = readFileSync(new URL('../../server/src/brain/lexical-search.ts', import.meta.url), 'utf8');
-  const rec = readFileSync(new URL('../../server/src/brain/recall.ts', import.meta.url), 'utf8');
+  // recall.ts holds the database work; the pure merge/rank/text functions moved to recall-shape.ts when that
+  // file was split to pay back its god-file ratchet raise. Both halves are the recall implementation, so the
+  // source these assertions read is both — a gate that followed only one half would go quietly vacuous the
+  // next time a function moves between them.
+  const rec = readFileSync(new URL('../../server/src/brain/recall.ts', import.meta.url), 'utf8')
+    + readFileSync(new URL('../../server/src/brain/recall-shape.ts', import.meta.url), 'utf8');
 
   it('the lexical query applies the caller\'s eligibility match', () => {
     // Without it, a tag- or filter-scoped recall would resurrect records the caller excluded — a
@@ -242,7 +247,10 @@ describe('every aggregation site orders by rankOf, not by raw score', () => {
   // ordered as if neither feature had shipped.
   const rest = readFileSync(new URL('../../server/src/api/brain/search.ts', import.meta.url), 'utf8');
   const mcp = readFileSync(new URL('../../server/src/mcp/tools/search.ts', import.meta.url), 'utf8');
-  const recall = readFileSync(new URL('../../server/src/brain/recall.ts', import.meta.url), 'utf8');
+  // Both halves of the recall implementation: recall.ts kept the database work, recall-shape.ts took the
+  // pure merge/rank/text functions when the file was split. rankOf is in the second one now.
+  const recall = readFileSync(new URL('../../server/src/brain/recall.ts', import.meta.url), 'utf8')
+    + readFileSync(new URL('../../server/src/brain/recall-shape.ts', import.meta.url), 'utf8');
 
   const sortsByRawScore = src =>
     (src.match(/\.sort\(\([^)]*\)\s*=>\s*\(?[a-z]\.score\s*\?\?\s*0\)?\s*-/g) ?? []).length;

--- a/testing/standalone/multi-type-recall.test.js
+++ b/testing/standalone/multi-type-recall.test.js
@@ -33,7 +33,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
 const { formatRecallSummary, toRecallRecord } = await import('../../server/dist/mcp/tools/shared.js');
-const { mergeRecallResults } = await import('../../server/dist/brain/recall.js');
+const { mergeRecallResults } = await import('../../server/dist/brain/recall-shape.js');
 
 // ── Fixtures: the real RecallResult shapes ───────────────────────────────────
 

--- a/testing/standalone/no-new-god-files.test.js
+++ b/testing/standalone/no-new-god-files.test.js
@@ -121,16 +121,16 @@ const FROZEN = {
   // a module only the loader would ever call.
   'server/src/config/loader.ts': 764,
   'client/src/app/pages/brain/review-tab.component.ts': 748,
-  // 739 -> 744: the cross-space fan-out now embeds the query ONCE and hands the vector down, instead of
-  // embedding the identical text in every space. Five real code lines — an options field, the `??` that
-  // prefers a handed-down vector, and the embed-and-spread in `recallGlobal`.
+  // 744 -> 689, and this one is PAID rather than raised.
   //
-  // Raised rather than paid for with an extraction, deliberately and with the trade named: the alternative
-  // was leaving a 5x embedding cost on every cross-space recall on every instance, which an operator was
-  // already paying and reported. A file this size wants a real split, and that is its own change with its own
-  // characterization tests — not something to improvise while fixing a perf defect. Recorded as such in the
-  // tracker rather than left as a raise nobody has to justify twice.
-  'server/src/brain/recall.ts': 744,
+  // The history matters because the pattern is what goes wrong: 739 -> 744 was a raise, taken deliberately to
+  // ship a 5x embedding fix an operator was already paying for, with the debt recorded instead of forgotten.
+  // The four pure functions — merge, rank, and the two text projections — then moved to `recall-shape.ts`,
+  // which took 124 lines out and left the part that genuinely needs a database.
+  //
+  // Frozen at what the file now IS, not at the old ceiling. A freeze left above the real number is a budget
+  // for the next 55 lines nobody argued for.
+  'server/src/brain/recall.ts': 689,
   'client/src/app/pages/settings/media-processing/models-tab.component.ts': 678,
   // 675 -> 677: `rights` on TokenRecord, plus its import. FOURTH raise of this file in one session, and the
   // first attempt wanted SIX lines because the shape was written inline. That was the signal, so the shape

--- a/testing/standalone/rerank.test.js
+++ b/testing/standalone/rerank.test.js
@@ -149,7 +149,12 @@ describe('the source keeps its contracts', () => {
 });
 
 describe('recall wiring', () => {
-  const src = readFileSync(new URL('../../server/src/brain/recall.ts', import.meta.url), 'utf8');
+  // recall.ts holds the database work; the pure merge/rank/text functions moved to recall-shape.ts when that
+  // file was split to pay back its god-file ratchet raise. Both halves are the recall implementation, so the
+  // source these assertions read is both — a gate that followed only one half would go quietly vacuous the
+  // next time a function moves between them.
+  const src = readFileSync(new URL('../../server/src/brain/recall.ts', import.meta.url), 'utf8')
+    + readFileSync(new URL('../../server/src/brain/recall-shape.ts', import.meta.url), 'utf8');
 
   it('over-fetches when a reranker is configured', () => {
     // Reranking exactly topK candidates returns the same set in a different order and buys nothing.
@@ -164,7 +169,7 @@ describe('recall wiring', () => {
     // Asserted BEHAVIOURALLY, not by grepping the sort expression. The grep that used to live here
     // (`r.rerankScore ?? r.score`) broke the moment hybrid retrieval inserted `fusedScore` between the
     // two — a correct change failing a test that was only ever watching a string.
-    const { mergeRecallResults } = await import('../../server/dist/brain/recall.js');
+    const { mergeRecallResults } = await import('../../server/dist/brain/recall-shape.js');
     const rec = (id, score, rerankScore) => ({ _id: id, type: 'memory', score, rerankScore, fact: id });
 
     // Ordering follows the cross-encoder even when it inverts the vector order.


### PR DESCRIPTION
`recall.ts` went 739 → 744 code lines earlier in this release to ship a 5x embedding fix an operator was already paying for. That raise **named its debt** rather than forgetting it. This is the debt.

Merge, rank and the two text projections moved to `brain/recall-shape.ts`: **124 lines out**, and what stays is the part that genuinely needs a database.

## Why these four and not an arbitrary slice

They are the four functions in the file with real unit coverage — **81 assertions across three suites** — and that coverage was proven green against the *original* code before the new file existed.

So the move needed no characterization pass written for it: the characterization was already there, which is the property that makes a refactor safe rather than hopeful. Nothing about their behaviour changed — same assertions, same count, new location.

## The freeze is set to what the file IS

**689**, not left at 744. A freeze above the real number is a budget for 55 lines nobody argued for.

## Three gates had to follow the code

`hybrid-retrieval` and `rerank` read `recall.ts` as *source* to assert on it, and two of those assertions were about functions that had moved. They now read **both** halves.

A gate that followed only one half would go quietly vacuous the next time a function moves between them — which is worse than the red I actually got, because I would never have seen it.

## What is deliberately left

`recall-shape.ts` imports `RecallResult` and `RecallKnowledgeType` back from `recall.ts`. That is **not** a runtime cycle: a type-only import is erased by TypeScript, so the emitted dependency is one-way.

It is still the wrong shape to keep, and the fix is a leaf types module — precisely what `config/rights-shape.ts` already exists to be, for the same reason. That touches every importer of those types and belongs on its own rather than bolted onto a file move.
