### PR TITLE
test(sync): size a propagation wait from its measurement, not a wrong comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Internal
+- **A sync wait's timeout is now sized from a measurement, and a comment that lied about it is fixed.** The
+  first propagation wait in `entity created on A syncs to B` read *"60s default"* while `waitFor`'s default is
+  **15 s** — four times off, and a wrong comment about a timeout is worse than none, because it is what stops
+  the next person looking.
+  - #823's margin warning caught that wait at **9925 ms of 15000 ms (66%)**, the first number anyone has had for
+    how long propagation actually takes there. The budget is now an explicit 25 s: the measurement plus room for
+    a loaded runner, and still bounded, because the re-trigger below it is the real safety net and a first
+    attempt that never gave up would never reach it.
+  - The test that originally timed out is **not** this one and its 25 s budget is deliberately unchanged. It
+    passed with no margin warning at all, so a green run finishes comfortably inside its budget — which makes
+    that failure a **stall**, and raising the number would have hidden it until it grew past the new one too.
 - **`recall.ts` gave up its pure half.** Merge, rank and the two text projections moved to
   `brain/recall-shape.ts` — 124 lines out, leaving the part that genuinely needs a database.
   - This **pays** a ratchet raise rather than adding another. The file went 739 -> 744 earlier in this release to

--- a/testing/sync/entity-edge-sync.test.js
+++ b/testing/sync/entity-edge-sync.test.js
@@ -84,12 +84,20 @@ describe('Entity/edge sync — cross-instance (A→B)', () => {
     assert.equal(r.status, 201, `Create entity on A: ${JSON.stringify(r.body)}`);
     const entityId = r.body._id;
 
-    // Trigger sync once, then poll via waitFor (60s default).
+    // Trigger sync once, then poll.
+    //
+    // The budget is EXPLICIT and measured. This read "60s default" and `waitFor`'s default is 15 s, so the
+    // comment was four times the real number — and a wrong comment about a timeout is worse than none, because
+    // it is what stops anyone looking. #823's margin warning caught this wait at 9925 ms of that 15 s (66%),
+    // which is the first number anybody has had for how long propagation actually takes here.
+    //
+    // 25 s is that measurement plus room for a loaded runner, and it is deliberately still bounded: the retry
+    // below is the real safety net, and a first attempt that never gives up would never reach it.
     await post(INSTANCES.a, tokenA, '/api/notify/trigger', { networkId });
     await waitFor(async () => {
       const r2 = await reqJson(INSTANCES.b, tokenB, `/api/sync/entities/${entityId}?spaceId=general`);
       return r2.status === 200;
-    }).catch(() => {
+    }, 25_000).catch(() => {
       // Re-trigger once and give a final window
       return post(INSTANCES.a, tokenA, '/api/notify/trigger', { networkId })
         .then(() => waitFor(async () => {


### PR DESCRIPTION
The first wait in `entity created on A syncs to B` carried the comment *"60s default"*. `waitFor`'s default is **15 s** — four times off. A wrong comment about a timeout is worse than no comment, because it is exactly what stops the next person looking.

#823's margin warning then caught that wait at **9925 ms of 15000 ms (66%)** — the first number anybody has had for how long propagation actually takes there.

The budget is now an explicit **25 s**: the measurement plus room for a loaded runner, and still bounded, because the re-trigger underneath it is the real safety net and a first attempt that never gave up would never reach it.

## Two of my own conclusions were wrong, and only reading fixed them

I first recorded this wait as *"the next timeout to go red"*. It is not — the call site already re-triggers and waits another 30 s on failure, so a thin margin costs a re-trigger and about ten seconds rather than a red build. I had reasoned from the warning instead of reading the code underneath it.

Before that, my first attempt to pull the evidence reported **zero** warnings, and I nearly banked it as a finding. The run id had come back from a `gh --template` as `3.1532565568e+10` — scientific notation — so the log fetch matched nothing at all. Absent and never-looked-at are indistinguishable unless you prove the subject was present, so the tombstone test's own presence in that log is now quoted in the tracker beside the numbers.

## The test that actually failed is untouched

Its 25 s budget stands. It passed with **no** margin warning, so a green run finishes comfortably inside it — which makes that failure a **stall**, and raising the number would have hidden the stall until it grew past the new one too.

If it times out again with the warning still absent, that combination — fails sometimes, never close on a pass — confirms the stall, and the question becomes *what blocks propagation* rather than *for how long*.
