### PR TITLE
feat(spaces): a space's recorded usage can be reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- **A space's recorded usage can be reset** — `POST /api/spaces/:spaceId/activity/reset`, admin + MFA, scoped to
+  the space. Deletes the hourly buckets behind the Overview usage panel, so a space hammered once during a
+  migration stops reading as busy for the rest of the window.
+  - **"Reset" means clear, and that was a corrected decision.** The first design stored a per-space marker and
+    clamped the read window to it, on the reasoning that deleting nothing is always safer. That was priced before
+    looking: `purgeSpaceActivity` already existed and was already exercised by the space-delete cascade, so a
+    marker would have added a stored field, a merge path and a read-time clamp to reproduce — less well — what
+    one tested call already does.
+  - The data justifies it too: these are hourly counters with a **90-day TTL**, so the store deletes them on its
+    own schedule anyway. A marker would also leave the panel technically honest and practically confusing — the
+    rows still there, just uncounted, so two operators reading one instance disagree about what happened.
+  - **Admin, not write.** Clearing a usage record changes no memory, entity, edge or file. It is bookkeeping on
+    the space itself, so it sits behind the same guard as rebuild-indexes and wipe.
+  - In-memory counters are **flushed first**. Without that, up to a minute of already-counted traffic would land
+    moments later and the panel would appear to un-reset itself.
+  - The response carries how many buckets were `cleared`, and the action is audited as `space.activity.reset` —
+    because afterwards the panel reads zero either way, and nothing on screen tells a reset apart from a space
+    that was genuinely idle.
+  - The route lives in `api/spaces-activity.ts`, not inline: `api/spaces.ts` is on the god-file ratchet and its
+    own entry says a route belongs beside its mount point once the raises stack. Only the import and the
+    registration call landed there.
+  - **The button is not in this change.** The Brain shell has no confirmation-dialog service and its established
+    idiom is an inline confirm; wiring a destructive control through the wrong one would have shipped either a
+    dead button or an unconfirmed delete.
+
 ### Internal
 - **A sync wait's timeout is now sized from a measurement, and a comment that lied about it is fixed.** The
   first propagation wait in `entity created on A syncs to B` read *"60s default"* while `waitFor`'s default is

--- a/client/src/app/core/spaces-api.service.ts
+++ b/client/src/app/core/spaces-api.service.ts
@@ -125,6 +125,22 @@ export class SpacesApi {
    * while this aggregates hourly buckets. Folding them together would make the whole Overview wait on the
    * slower half, and the panel is designed to render its tiles before this arrives.
    */
+  /**
+   * Clear a space's recorded usage.
+   *
+   * Note the path: the READ is under /api/brain, the reset is under /api/spaces. They are not siblings, and that
+   * is deliberate rather than sloppy — reading usage is a brain query, clearing it is an administrative act on
+   * the space, and it lives with rebuild-indexes and wipe behind the same admin guard.
+   *
+   * Returns how many hourly buckets were removed, because afterwards the panel reads zero either way and
+   * nothing on screen tells a reset apart from a space that was genuinely idle.
+   */
+  resetSpaceActivity(spaceId: string): Observable<{ ok: boolean; spaceId: string; cleared: number }> {
+    return this.http.post<{ ok: boolean; spaceId: string; cleared: number }>(
+      `/api/spaces/${spaceId}/activity/reset`, {},
+    );
+  }
+
   getSpaceActivity(spaceId: string, hours = 24): Observable<SpaceActivityResponse> {
     return this.http.get<SpaceActivityResponse>(
       `/api/brain/spaces/${spaceId}/activity?hours=${hours}`,

--- a/docs/integration-guide/04d-brain-ops-api.md
+++ b/docs/integration-guide/04d-brain-ops-api.md
@@ -191,6 +191,37 @@ discovering this by trying.
 > or if the database search process was not ready when the instance started. Reindexing every record
 > in the space will not create it. Use the rebuild endpoint below.
 
+### Reset a space's recorded usage
+
+```http
+POST /api/spaces/:spaceId/activity/reset
+```
+
+Deletes the hourly usage buckets behind the Overview **usage** panel for this space. Admin + MFA, scoped to the
+space — clearing a usage record changes no memory, entity, edge or file, so it is an administrative act on the
+space's own bookkeeping rather than a knowledge write, and it sits with the other destructive space operations.
+
+**Response** `200`:
+
+```json
+{ "ok": true, "spaceId": "general", "cleared": 412 }
+```
+
+`cleared` is how many hourly buckets were removed. It is in the response because afterwards the panel reads zero
+either way, and nothing on screen distinguishes a reset from a space that was genuinely idle. Audited as
+`space.activity.reset` for the same reason — so that answer survives the request.
+
+In-memory counters are flushed first. Without that, up to a minute of already-counted traffic would land in
+Mongo moments later and the panel would appear to un-reset itself.
+
+**Irreversible.** The buckets are deleted, not hidden. Note that usage is *already* transient — buckets carry a
+90-day TTL — so this brings forward a deletion the store would have done anyway rather than destroying a
+permanent record.
+
+Returns `404` if no space has that id.
+
+---
+
 ### Rebuild search indexes
 
 ```http

--- a/server/src/api/spaces-activity.ts
+++ b/server/src/api/spaces-activity.ts
@@ -1,0 +1,68 @@
+/**
+ * POST /api/spaces/:id/activity/reset — clear a space's recorded usage.
+ *
+ * ## Why this is its own module
+ *
+ * Not preference: `api/spaces.ts` is on the god-file ratchet, and its own entry there says a route belongs
+ * beside its mount point rather than inside it once the raises start stacking — which is exactly why
+ * `spaces-reembed.ts` exists. Inline, this route was +18 code lines on a file that has already been raised
+ * four times. Here it is one import and one call.
+ *
+ * The route body is unchanged from the inline version; only its address moved.
+ */
+import type { Router } from 'express';
+import { globalRateLimit } from '../rate-limit/middleware.js';
+import { requireAdminMfaScoped } from '../auth/middleware.js';
+import { getConfig } from '../config/loader.js';
+import { log } from '../util/log.js';
+import { flushSpaceActivity, purgeSpaceActivity } from '../metrics/space-activity-store.js';
+
+export function registerActivityResetRoute(spacesRouter: Router): void {
+  /**
+   * Clear a space's recorded usage — the number the Overview usage panel reports.
+   *
+   * ## Why "reset" means DELETE here, and not a window marker
+   *
+   * The first design for this stored a per-space `usageSince` timestamp and clamped the read window to it, on the
+   * reasoning that deleting nothing is always the safer option. That was priced before looking: `purgeSpaceActivity`
+   * already existed and was already exercised by the space-delete cascade. A marker would have added a stored
+   * field, a merge path and a read-time clamp to reproduce, less well, what one tested call already does.
+   *
+   * The data justifies it too. These are hourly operational counters with a 90-day TTL — the store deletes them on
+   * its own schedule anyway. Clearing them destroys no knowledge, and "reset" is what a reader already understands
+   * that to mean. A marker would also leave the panel technically honest and practically confusing: the rows are
+   * still there, just not counted, so two operators reading the same instance disagree about what happened.
+   *
+   * ## Why space ADMIN and not write
+   *
+   * Clearing a usage record is not a knowledge write — it changes no memory, entity, edge or file. It is an
+   * administrative act on the space's own bookkeeping, so it sits with the other destructive space operations
+   * behind `requireAdminMfaScoped`, exactly where rebuild-indexes and wipe already are.
+   *
+   * ## Why it is audited, and why the count is in the response
+   *
+   * The panel reads zero afterwards either way, so nothing on screen distinguishes "cleared 400 buckets" from
+   * "there was nothing to clear". The deleted count is returned so the caller can tell, and the action is audited
+   * so the answer survives the request — an operator asking "was the usage panel reset, or has this space really
+   * been idle?" has no other way to find out.
+   */
+  spacesRouter.post('/:id/activity/reset', globalRateLimit, requireAdminMfaScoped('id'), async (req, res) => {
+    const spaceId = req.params['id'] as string;
+    if (!getConfig().spaces.some(s => s.id === spaceId)) {
+      res.status(404).json({ error: `Space '${spaceId}' not found` });
+      return;
+    }
+    try {
+      // Flush first. The in-memory counters land in Mongo on a 60 s interval, so a reset that skipped this would
+      // leave up to a minute of already-counted traffic to reappear moments later — a panel that un-resets itself.
+      await flushSpaceActivity();
+      const cleared = await purgeSpaceActivity(spaceId);
+      req.auditSnapshots = { before: { activityBuckets: cleared }, after: { activityBuckets: 0 } };
+      res.json({ ok: true, spaceId, cleared });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error(`POST /api/spaces/${spaceId}/activity/reset: ${err}`);
+      res.status(500).json({ error: msg });
+    }
+  });
+}

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { registerReembedRoute } from './spaces-reembed.js';
+import { registerActivityResetRoute } from './spaces-activity.js';
 import path from 'path';
 import { requireAuth, requireAdmin, requireAdminMfa, requireAdminMfaScoped } from '../auth/middleware.js';
 import { globalRateLimit } from '../rate-limit/middleware.js';
@@ -346,6 +347,7 @@ spacesRouter.post('/:id/rebuild-indexes', globalRateLimit, requireAdminMfaScoped
 });
 
 registerReembedRoute(spacesRouter);
+registerActivityResetRoute(spacesRouter);
 
 // PATCH /api/spaces/:id/rename
 spacesRouter.patch('/:id/rename', globalRateLimit, requireAdminMfaScoped('id'), async (req, res) => {

--- a/server/src/audit/middleware.ts
+++ b/server/src/audit/middleware.ts
@@ -88,6 +88,10 @@ const ROUTE_RULES: RouteRule[] = [
   // if it goes wrong (see the stale-spaceId fixes), that is exactly the operation you want a
   // record of. It must be listed BEFORE the generic space.update rule so it wins.
   { method: 'PATCH',  pattern: /^\/api\/spaces\/([^/]+)\/rename$/,                 operation: 'space.rename',   spaceGroup: 1 },
+  // Clearing a space's recorded usage. Audited because the panel reads zero either way afterwards, so nothing
+  // on screen distinguishes a reset from a genuinely idle space — and an operator asking "was this reset, or has
+  // it really been quiet?" has no other place to look. The deleted count is in the snapshot.
+  { method: 'POST',   pattern: /^\/api\/spaces\/([^/]+)\/activity\/reset$/,          operation: 'space.activity.reset', spaceGroup: 1 },
   // Rebuilding vector indexes leaves recall returning empty until the build finishes, so it is an
   // availability-affecting admin action and belongs in the trail alongside rename and wipe.
   { method: 'POST',   pattern: /^\/api\/spaces\/([^/]+)\/rebuild-indexes$/,        operation: 'space.indexes.rebuild', spaceGroup: 1 },

--- a/testing/standalone/no-new-god-files.test.js
+++ b/testing/standalone/no-new-god-files.test.js
@@ -111,7 +111,11 @@ const FROZEN = {
   // +28 (route body plus its Zod schema), which would have been the SECOND double-digit raise of this file in two
   // PRs — so the route moved to `api/spaces-reembed.ts` instead and only its mount point stayed. That is what the
   // ratchet is for: not to forbid growth, but to make the second raise in two PRs visible enough to answer.
-  'server/src/api/spaces.ts': 849,
+  // RAISED 849 -> 851 for the usage-reset route: an import and a registration call, nothing else. The route
+  // body itself is +47 lines and lives in `api/spaces-activity.ts`, the same shape `spaces-reembed.ts` took and
+  // for the reason written above it — this file has been raised four times, and the answer to the fifth is to
+  // put the route beside its mount point rather than inside it.
+  'server/src/api/spaces.ts': 851,
   // 769 -> 773: `openBrainDrawer` gained two overload signatures and its `lastSaved` effect reads the
   // record inside each branch so the discriminant narrows it. Four lines of TYPES, no new behaviour —
   // raised deliberately rather than worked around, which is what this list is for.


### PR DESCRIPTION
The owner asked for a reset button on the Overview usage panel. A space hammered once during a migration reads as busy for the rest of the window, so the panel stops being useful for the thing it is for.

`POST /api/spaces/:spaceId/activity/reset` — admin + MFA, scoped to the space.

## "Reset" means clear, and that is a corrected decision

My first design stored a per-space marker and clamped the read window to it, on the reasoning that deleting nothing is always safer.

I had priced that **before looking**. `purgeSpaceActivity` already existed and was already exercised by the space-delete cascade, so a marker would have added a stored field, a merge path and a read-time clamp to reproduce — less well — what one tested call already does.

The data justifies the delete too: these are hourly counters with a **90-day TTL**, so the store removes them on its own schedule anyway. This brings that forward rather than destroying a permanent record. And a marker would have left the panel technically honest and practically confusing — rows still present, just uncounted, so two operators reading one instance disagree about what happened.

## Admin, not write

Clearing a usage record changes no memory, entity, edge or file. It is bookkeeping on the space itself, so it sits behind the same guard as rebuild-indexes and wipe.

## Two details that would each have been a bug

- The in-memory counters **flush first**. They land in Mongo on a 60 s interval, so a reset that skipped the flush would let up to a minute of already-counted traffic reappear moments later — a panel that un-resets itself.
- The response carries the deleted `cleared` count, and the action is audited as `space.activity.reset`. Afterwards the panel reads zero either way, so nothing on screen tells a reset apart from a genuinely idle space; without both, *"was this reset, or has it really been quiet?"* has no answer.

## The route is not inline

`api/spaces.ts` is on the god-file ratchet and **its own entry** says a route belongs beside its mount point once the raises stack — which is why `spaces-reembed.ts` exists. Inline this was +18 code lines on a file already raised four times. In `api/spaces-activity.ts` it is one import and one registration call, and the ratchet moves 849 → 851.

## The button is deliberately not here

The Brain shell has no confirmation-dialog service, and its established idiom is an inline confirm. Wiring a destructive control through the wrong one would have shipped either a dead button or an unconfirmed delete, so the panel is untouched and the control is the next slice — tracked on U-4 with the two facts that decide it.
