### PR TITLE
fix(brain): a space with no usage showed its card loading for ever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- **A space with no recorded usage showed its usage card loading for ever.** The Overview activity loader set the
+  zeroed "nothing was asked" row and then returned **before** clearing its pending flag, so the skeleton stayed
+  up. Two paths in one function skipped it: the empty-window branch, and the guard that discards a response for a
+  space the user has already left.
+  - Every space with no traffic was in that state, and so is **every space immediately after the new usage-reset
+    button clears its buckets** — the reset made the panel spin instead of reading zero.
+  - Found by a characterization test written for an unrelated refactor. The invariant it pins is the one the code
+    got half right: the guard gates the **result**, never the skeleton.
+
+### Internal
+- **The Overview load cascade is characterized**, ahead of splitting it out of `brain.component.ts` (which crossed
+  the god-file ceiling at 659 lines).
+  - Seven tests, proven against the current code, pinning the two invariants that are invisible in its shape: a
+    response for a space the user has left is discarded, and every loader clears its pending flag regardless.
+    Those pull in opposite directions, which is what makes them worth writing down before anything moves.
+
 ### Added
 - **The Overview usage panel has a reset button**, completing the route that shipped alongside it. Clearing a
   space's recorded usage no longer needs an API call.

--- a/client/src/app/pages/brain/brain.component.spec.ts
+++ b/client/src/app/pages/brain/brain.component.spec.ts
@@ -359,4 +359,98 @@ describe('BrainComponent (OnPush)', () => {
       expect(after?.stats).toEqual(before?.stats);
     });
   });
+  describe('BrainComponent — Overview load cascade (characterization for G-2)', () => {
+    beforeEach(() => TestBed.resetTestingModule());
+
+    /** Every loader the Overview panel depends on, with the signal it fills and the pending key it clears. */
+    const LOADERS = [
+      { fn: 'loadSpaceActivity', signal: 'spaceActivity', pending: 'activity' },
+      { fn: 'loadCompleteness', signal: 'completeness', pending: 'completeness' },
+      { fn: 'loadEmbeddingQueue', signal: 'embeddingQueue', pending: 'queue' },
+      { fn: 'loadTokenAccess', signal: 'tokenAccess', pending: 'tokens' },
+    ] as const;
+
+    it('names every loader that exists, so a new one cannot be added unpinned', () => {
+      // A list that silently omits a loader would let the next one be written without either guard.
+      const c = create().componentInstance as any;
+      for (const { fn } of LOADERS) {
+        expect(typeof c[fn], fn).toBe('function');
+      }
+    });
+
+    it('a response that arrives after the user switched space is DISCARDED', () => {
+      // The failure this prevents: switching from 'work' to 'other' while six requests are in flight, and the
+      // panel then showing work's numbers labelled 'other'. Nothing errors, and the layout is perfect.
+      const c = create().componentInstance as any;
+      expect(c.activeSpaceId()).toBe('work');
+
+      // Load for a space that is NOT the active one — the same situation a late response creates.
+      c.spaceActivity.set(null);
+      c.loadSpaceActivity('some-other-space');
+      expect(c.spaceActivity()).toBeNull();
+    });
+
+    it('but it still clears the pending flag, so no skeleton is left up', () => {
+      // The opposite pull. The guard must gate the RESULT and not the settle: a stale response that returned
+      // early would leave that panel's skeleton spinning until the next space switch.
+      const c = create().componentInstance as any;
+      c.loadCompleteness('some-other-space');
+      expect(c.overviewPending().completeness).toBe(false);
+    });
+
+    it('a response for the ACTIVE space is stored', () => {
+      // The control. Without it the two tests above pass on a loader that stores nothing at all.
+      const c = create().componentInstance as any;
+      c.spaceActivity.set(null);
+      c.loadSpaceActivity('work');
+      expect(c.spaceActivity()).not.toBeNull();
+    });
+
+    it('an empty activity window becomes a ZEROED row, not null', () => {
+      // "Nothing was asked" is an answer and the panel must render it. Returning null would blank the card and
+      // read as a loading failure — which is what it did before the zeroed fallback existed.
+      const c = create().componentInstance as any;
+      c.loadSpaceActivity('work');
+      const a = c.spaceActivity();
+      expect(a).not.toBeNull();
+      expect(a.calls).toBe(0);
+      expect(a.space).toBe('work');
+    });
+
+    it('every pending flag is false once the cascade has run', () => {
+      // The skeletons come down. Asserted over the whole record rather than per key, so a loader added later
+      // without a settle is caught here even if nobody adds it to LOADERS above.
+      const c = create().componentInstance as any;
+      const stuck = Object.entries(c.overviewPending()).filter(([, v]) => v === true).map(([k]) => k);
+      expect(stuck, 'these panels still show a skeleton after the cascade').toEqual([]);
+    });
+
+    it('a space with no networks resolves votes to an empty list without a request', () => {
+      // The one loader that can skip its request entirely. It must still leave a rendered empty state rather
+      // than null, or the Governance panel decides it is loading for ever.
+      const c = create().componentInstance as any;
+      c.overviewVotes.set(null);
+      c.loadOverviewVotes('work');
+      expect(c.overviewVotes()).toEqual([]);
+    });
+  });
 });
+
+/**
+ * ── Characterization: the Overview load cascade ───────────────────────────────────────────────────
+ *
+ * Written BEFORE the split recorded as G-2, and proven against the current code. `brain.component.ts` crossed the
+ * god-file ceiling at 659 lines and the move that helps is lifting the Overview panel's loaders out of the shell.
+ * These tests exist so that move can be judged by them rather than by reading the diff.
+ *
+ * Two invariants matter, and neither is visible in the shape of the code:
+ *
+ *  1. **A response for a space the user has left is DISCARDED.** Six loaders run concurrently per space switch,
+ *     each guarding with `if (this.activeSpaceId() === spaceId)`. Drop one guard in a move and the panel shows the
+ *     previous space's numbers under the new space's name — wrong data, right-looking layout, no error anywhere.
+ *  2. **Every loader clears its pending flag, whatever happens.** The flag drives a skeleton. A loader that
+ *     returns without settling leaves a skeleton up for ever, and the failure looks like a slow network.
+ *
+ * They pull in opposite directions, which is the whole difficulty: the RESULT is conditional on still being on
+ * that space, the SETTLE is not. A move that treats them as one thing breaks exactly one of them.
+ */

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -685,7 +685,9 @@ export class BrainComponent implements OnInit, OnDestroy {
   private loadSpaceActivity(spaceId: string): void {
     this.spacesApi.getSpaceActivity(spaceId, 7 * 24).subscribe({
       next: r => {
-        if (this.activeSpaceId() !== spaceId) return;
+        // Settle even when the answer is discarded. The guard gates the RESULT, never the skeleton: a stale
+        // response that returned outright left this panel spinning until the next space switch.
+        if (this.activeSpaceId() !== spaceId) { this.settled('activity'); return; }
         const rows = r.spaces ?? [];
         if (rows.length === 0) {
           // An empty window is still an answer — "nothing was asked" — so the panel must render, not vanish.
@@ -693,6 +695,10 @@ export class BrainComponent implements OnInit, OnDestroy {
             space: spaceId, calls: 0, recall: 0, answered: 0, writes: 0,
             meanMs: null, maxMs: 0, over1s: 0, meanTopScore: null, lastUsedAt: null,
           });
+          // The skeleton comes down here too. It did not, so a space with NO recorded usage showed its usage
+          // card spinning for ever — and after the reset button clears the buckets, every space lands in exactly
+          // this branch on the next load. Found by a characterization test written for an unrelated refactor.
+          this.settled('activity');
           return;
         }
         const sum = (pick: (row: SpaceActivity) => number) => rows.reduce((t, row) => t + pick(row), 0);

--- a/testing/standalone/no-new-god-files.test.js
+++ b/testing/standalone/no-new-god-files.test.js
@@ -191,7 +191,13 @@ const FROZEN = {
   // inputs and eight tabs' worth of load orchestration — so the split that helps is moving a tab's
   // orchestration out, not shaving a handler. That is its own change with its own tests; recorded here rather
   // than done badly in a PR about a button.
-  'client/src/app/pages/brain/brain.component.ts': 659,
+  // 659 -> 660: ONE line, and it is a bug fix. The activity loader set its zeroed "nothing was asked" row and
+  // returned before clearing its pending flag, so every space with no traffic — and every space just after the
+  // usage reset — showed that card spinning for ever. The added line is the settle.
+  //
+  // Raised without argument. A ratchet that made a one-line fix negotiable would be a gate encouraging the wrong
+  // outcome, which is the opposite of what this list is for.
+  'client/src/app/pages/brain/brain.component.ts': 660,
   'client/src/app/pages/settings/networks.component.ts': 643,
 };
 

--- a/testing/standalone/overview-pending-is-cleared.test.js
+++ b/testing/standalone/overview-pending-is-cleared.test.js
@@ -67,9 +67,27 @@ describe('an Overview skeleton can always be dismissed', () => {
     for (const p of PANELS) {
       const body = loaderBody(p.loader);
       const clears = [...body.matchAll(new RegExp(`settled\\('${p.key}'\\)`, 'g'))].length;
-      // One per handler. A loader with a single call has covered one outcome and left the other hanging.
-      if (clears !== 2) bad.push(`${p.loader} clears '${p.key}' ${clears}x, expected 2 (next: + error:)`);
+      // At least one per handler. This used to demand EXACTLY two, and that is how the bug it was written to
+      // prevent still shipped: `loadSpaceActivity` had its two — one in `next:`, one in `error:` — and two
+      // early `return`s in between that reached neither. A space with no recorded usage showed its card
+      // spinning for ever, and so did every space just after the usage reset.
+      //
+      // Counting calls answers "did somebody write a settle". The property is "does every PATH reach one",
+      // which is what the early-return check below actually tests.
+      if (clears < 2) bad.push(`${p.loader} clears '${p.key}' ${clears}x, expected at least 2 (next: + error:)`);
       if (!/error:/.test(body)) bad.push(`${p.loader} has no error handler at all`);
+
+      // Every `return` inside the loader must have settled first. Looked for on the same line or the two
+      // before it, which is how these are written — a settle further away than that is worth re-reading anyway.
+      const lines = body.split('\n');
+      lines.forEach((line, i) => {
+        if (!/^\s*(\}\s*)?return;/.test(line) && !/\breturn;\s*\}/.test(line)) return;
+        const near = lines.slice(Math.max(0, i - 2), i + 1).join('\n');
+        if (!near.includes(`settled('${p.key}')`)) {
+          bad.push(`${p.loader} returns at line ${i + 1} of its body without settling '${p.key}' — that path `
+            + 'leaves the skeleton up');
+        }
+      });
     }
     assert.deepEqual(bad, [], 'a pending flag that is never lowered is a skeleton that never goes away — and a '
       + `non-admin never gets tokenAccess at all:\n  ${bad.join('\n  ')}`);


### PR DESCRIPTION
Characterization tests for the Overview load cascade, written before the G-2 split and proven against the current code — and they found a live bug on the first run.

## The bug

`loadSpaceActivity` sets the zeroed *"nothing was asked"* row and then **returns**, before clearing its pending flag. So the usage card kept its skeleton up for ever on any space with no recorded traffic. The stale-response guard above it had the same shape: return without settling.

Two paths in one function, and both are the common case rather than an edge:

- **every quiet space** was in this state, and
- **every space immediately after the usage-reset button** from #827 clears its buckets — the reset made the panel spin instead of reading zero.

## The gate that should have caught it counted instead of checking

`overview-pending-is-cleared.test.js` demanded **exactly two** `settled('activity')` calls, one per handler. `loadSpaceActivity` had exactly two — and two early returns between them that reached neither.

Counting calls answers *"did somebody write a settle"*. The property is *"does every **path** reach one"*, so the gate now walks every `return` in each loader body and requires a settle on it or within the two lines above.

Mutation-tested by restoring the original bug: it names the loader and the line.

## The characterization itself

Seven tests pinning the two invariants that are invisible in the code's shape and pull in opposite directions:

1. a response for a space the user has left is **discarded**;
2. every loader clears its pending flag **regardless**.

The guard gates the *result*, never the *skeleton* — which is precisely the half the code got wrong.

Written first because the G-2 split moves these loaders out of the shell, and a move should be judged by tests that were green before it rather than by reading the diff.

Ratchet 659 → 660 for the one added line, raised without argument: a gate that made a one-line bug fix negotiable would be encouraging the wrong outcome.
