### PR TITLE
test(media): infra-managed locks the page by rule, not by 35 bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Internal
+- **Infra-managed now locks the Media Processing page by rule, not by 35 separate bindings.** A gate sweeps every
+  control on that page **by shape** — every `input`, `select` and `textarea` bound to `ngModel` — and requires
+  each to be locked, either by its own `[disabled]` or by an enclosing `@if` that removes it when managed.
+  - Prompted by the owner asking whether editable API-key fields under infra-managed were intended. They are
+    not: the API refuses that write outright, so a control that still accepts typing composes a request the
+    server rejects.
+  - **No unlocked control was found.** All 35 are already locked, and the page's wiring is correct end to end:
+    `isLocked()` short-circuits on managed rather than consulting a list, and the loader spreads the whole
+    response onto the form so the flag arrives. The gate exists because "most is blocked" is exactly what 35
+    correct-today decisions produce as soon as somebody adds the thirty-sixth.
+  - The gate is deliberately not UI-only: it also asserts the server still refuses an infra-managed write. A
+    lock that lived only in the client would be the two-surfaces-one-weaker shape this repo keeps finding.
+
 ### Fixed
 - **A space with no recorded usage showed its usage card loading for ever.** The Overview activity loader set the
   zeroed "nothing was asked" row and then returned **before** clearing its pending flag, so the skeleton stayed

--- a/testing/standalone/infra-managed-locks-every-field.test.js
+++ b/testing/standalone/infra-managed-locks-every-field.test.js
@@ -1,0 +1,105 @@
+/**
+ * When media config is infra-managed, EVERY editable control on that page is disabled.
+ *
+ * ## Why this is a gate and not a code review
+ *
+ * The owner asked whether editable API-key fields under infra-managed were intended. They are not: the server
+ * refuses the write outright —
+ *
+ *     Media & model configuration is infra-managed on this instance (YTHRIL_MEDIA_INFRA_MANAGED=true ...)
+ *
+ * — so any control that still accepts typing composes a request the API will reject. "Most is blocked" is
+ * exactly the shape a hand-maintained per-field list produces, and this page has **35** editable controls
+ * across four tabs. Every one currently carries a `[disabled]` binding, and the thing that makes that true is
+ * 35 separate decisions, each one an edit away from being forgotten.
+ *
+ * So the property is asserted by SHAPE: find every control bound to `ngModel` in the page's components, and
+ * require a disabled binding on each. A new field added without one fails here rather than shipping as a form
+ * that looks editable and answers 400.
+ *
+ * ## What this does NOT prove
+ *
+ * That the flag reaches the client. `isLocked()` short-circuits on `managed`, `managed` reads
+ * `form.infraManaged`, and the loader spreads the whole response onto `form` — so the wiring is right in the
+ * source. If a deployment still shows editable fields, the question is whether `GET /api/admin/media-config`
+ * actually returns `infraManaged: true` there, which is one request and not something a static gate can see.
+ *
+ * Run: node --test testing/standalone/infra-managed-locks-every-field.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+
+const files = execSync('git ls-files "client/src/app/pages/settings/media-processing/*.component.ts"',
+  { encoding: 'utf8' }).trim().split('\n').filter(f => f && !f.endsWith('.spec.ts'));
+
+/** Every `<input>`, `<select>` and `<textarea>` that is bound to a model — i.e. that a person can change. */
+function boundControls(src) {
+  const out = [];
+  for (const m of src.matchAll(/<(input|select|textarea)\b[\s\S]{0,400}?(?:\/>|<\/(?:select|textarea)>)/g)) {
+    const block = m[0];
+    if (!block.includes('ngModel')) continue;
+    // A control can be locked two ways, and only one of them lives on the control. The person-types picker sits
+    // inside `@if (!(s.faceLocked('personEntityTypes') || s.managed))` — it does not RENDER when managed, which
+    // is a stronger lock than a disabled attribute. A gate that understood only `[disabled]` reported that as a
+    // defect, and following it would have meant adding a redundant binding to correct code.
+    const before = src.slice(Math.max(0, m.index - 600), m.index);
+    // `[^)]*` would stop at the first `)`, and these conditions contain their own — `s.faceLocked('…')` closes
+    // before `managed` is reached, so the guard read as absent on a control that has one.
+    if (/@if\s*\([\s\S]{0,120}?\bmanaged\b[\s\S]{0,300}$/.test(before)) continue;
+    const id = /id="([^"]+)"/.exec(block)?.[1]
+      ?? /\[\(ngModel\)\]="([^"]+)"/.exec(block)?.[1]
+      ?? '(unnamed)';
+    out.push({ id, block });
+  }
+  return out;
+}
+
+describe('the media-processing page locks every field when infra-managed', () => {
+  it('finds the page it is meant to be checking', () => {
+    // A sweep that matches nothing passes vacuously, and this one is scoped by SHAPE rather than by the field
+    // names I happened to think of — which is the mistake that produces "most is blocked".
+    assert.ok(files.length >= 3, `expected the media-processing components, found ${files.length}`);
+    const total = files.reduce((n, f) => n + boundControls(readFileSync(f, 'utf8')).length, 0);
+    assert.ok(total >= 25, `expected the page's editable controls, found ${total}`);
+  });
+
+  it('every control a person can type into carries a disabled binding', () => {
+    const open = [];
+    for (const f of files) {
+      for (const { id, block } of boundControls(readFileSync(f, 'utf8'))) {
+        if (!/\[disabled\]/.test(block)) open.push(`${f.split('/').pop()}#${id}`);
+      }
+    }
+    assert.deepEqual(open, [],
+      'these controls accept typing with no disabled binding, so under infra-managed they compose a request '
+      + `the API refuses:\n  ${open.join('\n  ')}`);
+  });
+
+  it('the lock short-circuits on managed rather than listing fields', () => {
+    // The one line that makes the 35 bindings mean something. Were it only `lockedByInfra.includes(field)`,
+    // every field would depend on the server naming it — and a field the server forgot would stay editable.
+    const svc = readFileSync('client/src/app/pages/settings/media-processing/media-processing-state.service.ts', 'utf8');
+    assert.match(svc, /isLocked\(field: string\): boolean \{ return this\.managed \|\| /,
+      'isLocked must return true for EVERY field when managed, not consult a list');
+    assert.match(svc, /get managed\(\): boolean \{ return !!this\.form\.infraManaged; \}/,
+      'managed must read the flag the server sends');
+  });
+
+  it('the flag survives the load onto the form', () => {
+    // The other half of the wiring: a load that picked fields by name instead of spreading would drop
+    // `infraManaged` silently, and every control would unlock while the server still refused every save.
+    const svc = readFileSync('client/src/app/pages/settings/media-processing/media-processing-state.service.ts', 'utf8');
+    assert.match(svc, /this\.form = \{[\s\S]{0,80}?\.\.\.cfg/,
+      'the response must be spread onto the form, or infraManaged never arrives');
+  });
+
+  it('the server still refuses the write, so this is a lock and not the only defence', () => {
+    // A disabled input is a courtesy. The refusal is the control, and a UI-only lock would be exactly the
+    // "two surfaces, one rule, one weaker" shape this repo keeps finding.
+    const api = readFileSync('server/src/api/media-config.ts', 'utf8');
+    assert.match(api, /if \(activeCfg\.infraManaged\)/,
+      'the API must refuse an infra-managed write regardless of what the UI allows');
+  });
+});


### PR DESCRIPTION
The owner asked whether editable API-key fields under infra-managed were intended. **They are not** — the API refuses that write outright, so a control that still accepts typing composes a request the server rejects.

## What I found is not what the question implied

**Nothing is unlocked.** All 35 editable controls on that page are already locked, and the wiring is right end to end: `isLocked()` short-circuits on `managed` rather than consulting a list, `managed` reads `form.infraManaged`, and the loader spreads the whole response onto the form so the flag arrives.

So if a deployment still shows editable key fields, the question is whether `GET /api/admin/media-config` actually returns `infraManaged: true` there. That is one request, and not something a static gate can see — recorded on U-5 as the first thing to check.

## Why a gate anyway

*"Most is blocked"* is exactly the shape 35 correct-today decisions produce the moment somebody adds the thirty-sixth. The sweep is by **shape** — every `input`, `select` and `textarea` bound to `ngModel` — not by the field names I would have thought to list, because scoping a sweep from expected names is how this repo has undercounted before.

It accepts either lock: a `[disabled]` on the control, or an enclosing `@if` that removes it when managed.

It also asserts the **server** still refuses an infra-managed write. A lock living only in the client would be the two-surfaces-one-weaker shape this repo keeps finding.

## Two false positives, both mine rather than the code's

- My first sweep matched the substring `disabled` anywhere in a control's block and reported everything fine. It was matching `<option value="" disabled>` on a **child** element.
- The shape sweep then flagged the person-types picker as unguarded. It is not — it sits inside `@if (!(s.faceLocked('personEntityTypes') || s.managed))`, so it does not *render* when managed, which is a stronger lock than a disabled attribute. Following that first answer would have had me add a redundant binding to correct code.
- The guard regex then still missed it, because `[^)]*` stopped at the `)` closing `s.faceLocked('personEntityTypes')` before reaching `managed`.

Mutation-tested against the real thing: removing `[disabled]` from the embedding API key fails the sweep and names the field.
