### PR TITLE
refactor(brain): the Overview panel's data leaves the shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Internal
+- **The Brain shell gave up the Overview panel's data.** Five loaders, their five signals and the pending flags
+  moved to `brain/overview-data.service.ts` — 136 lines out, and `brain.component.ts` goes **660 → 571**, from
+  over the god-file ceiling to well under it.
+  - The shell is the tab strip, the space chips, every panel's inputs and eight tabs' worth of orchestration.
+    Shaving handlers would have lowered the number while leaving the shape; moving one tab's data out changes it.
+  - **`activeSpaceId` deliberately did not move.** It arrives as a callback per load. A response for a space the
+    user has left must be discarded, and that question belongs to whoever owns the selection — a copy in the
+    service would be a second answer able to disagree with the shell's.
+  - `loadOverviewVotes` now takes the space's networks directly instead of reaching into a space list, so the
+    service knows nothing about `SpaceView`, which is a shell concept.
+  - The seven characterization tests written before the move (#828) pass with their **assertions unchanged** —
+    only the address changed. That is what they were written first for.
+  - The ratchet entry is **lowered, not deleted**: an entry here is a ratchet, and removing it would hand the
+    file back the 89 lines of headroom the extraction just took away.
+
+### Internal
 - **Infra-managed now locks the Media Processing page by rule, not by 35 separate bindings.** A gate sweeps every
   control on that page **by shape** — every `input`, `select` and `textarea` bound to `ngModel` — and requires
   each to be locked, either by its own `[disabled]` or by an enclosing `@if` that removes it when managed.

--- a/client/src/app/pages/brain/brain.component.spec.ts
+++ b/client/src/app/pages/brain/brain.component.spec.ts
@@ -359,7 +359,12 @@ describe('BrainComponent (OnPush)', () => {
       expect(after?.stats).toEqual(before?.stats);
     });
   });
-  describe('BrainComponent — Overview load cascade (characterization for G-2)', () => {
+    /**
+   * Repointed for G-2: these loaders and their signals moved to `OverviewDataService`, reached through `ov`.
+   * The ASSERTIONS are unchanged — same invariants, same expectations — which is the point of having written
+   * them before the move. Only the address changed.
+   */
+describe('BrainComponent — Overview load cascade (characterization for G-2)', () => {
     beforeEach(() => TestBed.resetTestingModule());
 
     /** Every loader the Overview panel depends on, with the signal it fills and the pending key it clears. */
@@ -374,7 +379,7 @@ describe('BrainComponent (OnPush)', () => {
       // A list that silently omits a loader would let the next one be written without either guard.
       const c = create().componentInstance as any;
       for (const { fn } of LOADERS) {
-        expect(typeof c[fn], fn).toBe('function');
+        expect(typeof c.ov[fn], fn).toBe('function');
       }
     });
 
@@ -385,33 +390,33 @@ describe('BrainComponent (OnPush)', () => {
       expect(c.activeSpaceId()).toBe('work');
 
       // Load for a space that is NOT the active one — the same situation a late response creates.
-      c.spaceActivity.set(null);
-      c.loadSpaceActivity('some-other-space');
-      expect(c.spaceActivity()).toBeNull();
+      c.ov.spaceActivity.set(null);
+      c.ov.loadSpaceActivity('some-other-space', () => c.activeSpaceId() === 'some-other-space');
+      expect(c.ov.spaceActivity()).toBeNull();
     });
 
     it('but it still clears the pending flag, so no skeleton is left up', () => {
       // The opposite pull. The guard must gate the RESULT and not the settle: a stale response that returned
       // early would leave that panel's skeleton spinning until the next space switch.
       const c = create().componentInstance as any;
-      c.loadCompleteness('some-other-space');
-      expect(c.overviewPending().completeness).toBe(false);
+      c.ov.loadCompleteness('some-other-space', () => c.activeSpaceId() === 'some-other-space');
+      expect(c.ov.overviewPending().completeness).toBe(false);
     });
 
     it('a response for the ACTIVE space is stored', () => {
       // The control. Without it the two tests above pass on a loader that stores nothing at all.
       const c = create().componentInstance as any;
-      c.spaceActivity.set(null);
-      c.loadSpaceActivity('work');
-      expect(c.spaceActivity()).not.toBeNull();
+      c.ov.spaceActivity.set(null);
+      c.ov.loadSpaceActivity('work', () => c.activeSpaceId() === 'work');
+      expect(c.ov.spaceActivity()).not.toBeNull();
     });
 
     it('an empty activity window becomes a ZEROED row, not null', () => {
       // "Nothing was asked" is an answer and the panel must render it. Returning null would blank the card and
       // read as a loading failure — which is what it did before the zeroed fallback existed.
       const c = create().componentInstance as any;
-      c.loadSpaceActivity('work');
-      const a = c.spaceActivity();
+      c.ov.loadSpaceActivity('work', () => c.activeSpaceId() === 'work');
+      const a = c.ov.spaceActivity();
       expect(a).not.toBeNull();
       expect(a.calls).toBe(0);
       expect(a.space).toBe('work');
@@ -421,7 +426,7 @@ describe('BrainComponent (OnPush)', () => {
       // The skeletons come down. Asserted over the whole record rather than per key, so a loader added later
       // without a settle is caught here even if nobody adds it to LOADERS above.
       const c = create().componentInstance as any;
-      const stuck = Object.entries(c.overviewPending()).filter(([, v]) => v === true).map(([k]) => k);
+      const stuck = Object.entries(c.ov.overviewPending()).filter(([, v]) => v === true).map(([k]) => k);
       expect(stuck, 'these panels still show a skeleton after the cascade').toEqual([]);
     });
 
@@ -429,9 +434,9 @@ describe('BrainComponent (OnPush)', () => {
       // The one loader that can skip its request entirely. It must still leave a rendered empty state rather
       // than null, or the Governance panel decides it is loading for ever.
       const c = create().componentInstance as any;
-      c.overviewVotes.set(null);
-      c.loadOverviewVotes('work');
-      expect(c.overviewVotes()).toEqual([]);
+      c.ov.overviewVotes.set(null);
+      c.ov.loadOverviewVotes('work', () => c.activeSpaceId() === 'work', []);
+      expect(c.ov.overviewVotes()).toEqual([]);
     });
   });
 });

--- a/client/src/app/pages/brain/brain.component.ts
+++ b/client/src/app/pages/brain/brain.component.ts
@@ -16,6 +16,7 @@ import { ReviewTabComponent } from './review-tab.component';
 import { FormsModule } from '@angular/forms';
 import { Space, SpaceStats, AboutInfo, EmbeddingQueue, VoteRound, TokenAccessEntry, CompletenessReport, SpaceActivity } from '../../core/api.types';
 import { SpacesApi } from '../../core/spaces-api.service';
+import { OverviewDataService } from './overview-data.service';
 import { SpaceSettingsPopupComponent } from '../settings/space-settings-popup.component';
 import { SpacesStore } from '../settings/spaces-store.service';
 import { SpaceSettingsState } from '../settings/space-settings-state.service';
@@ -52,7 +53,7 @@ interface SpaceView {
   // load-bearing and pinned by the specs (the drawer's own version lives in the drawer component).
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [ProxySpaceBadgeComponent, CommonModule, FormsModule, GraphComponent, FileManagerComponent, PhIconComponent, RecordDrawerComponent, QueryTabComponent, MemoriesTabComponent, EntitiesTabComponent, EdgesTabComponent, ChronoTabComponent, OverviewTabComponent, ReviewTabComponent, ErrorStateComponent, TranslocoPipe, SpaceSettingsPopupComponent],
-  providers: [BrainStore, EntityRefPicker, RecordDrawerState, RecordListState, SpacesStore, SpaceSettingsState],
+  providers: [BrainStore, EntityRefPicker, RecordDrawerState, RecordListState, OverviewDataService, SpacesStore, SpaceSettingsState],
   styles: [`
     .space-tabs {
       display: flex;
@@ -354,9 +355,9 @@ interface SpaceView {
         @if (activeTab() === 'overview') {
           @if (activeSpace(); as sp) {
             <app-overview-tab [space]="sp" [stats]="activeStats()" [needsReindex]="needsReindex()"
-              [reindexing]="reindexing()" [about]="aboutInfo()" [embeddingQueue]="embeddingQueue()"
-              [openVotes]="overviewVotes()" [tokenAccess]="tokenAccess()" [completeness]="completeness()" [activity]="spaceActivity()"
-              [pending]="overviewPending()"
+              [reindexing]="reindexing()" [about]="aboutInfo()" [embeddingQueue]="ov.embeddingQueue()"
+              [openVotes]="ov.overviewVotes()" [tokenAccess]="ov.tokenAccess()" [completeness]="ov.completeness()" [activity]="ov.spaceActivity()"
+              [pending]="ov.overviewPending()"
               (reindex)="runReindex()" (retryFailed)="runRetryFailedEmbeddings()"
               (openTab)="setTab($event)"
               [resettingUsage]="resettingUsage()" [usageResetResult]="usageResetResult()"
@@ -381,6 +382,8 @@ export class BrainComponent implements OnInit, OnDestroy {
   readonly drawerState = inject(RecordDrawerState);
   readonly recordList = inject(RecordListState);
   private spacesApi = inject(SpacesApi);
+  /** The Overview panel's data, moved out of this shell — see overview-data.service.ts. */
+  readonly ov = inject(OverviewDataService);
   /**
    * The dialog's state, provided by this component so it opens and closes with the page.
    *
@@ -436,48 +439,8 @@ export class BrainComponent implements OnInit, OnDestroy {
   spacesError = signal<string | null>(null);
   /** Instance identity/health for the Overview's Instance panel — fetched once (instance-wide, not per space). */
   aboutInfo = signal<AboutInfo | null>(null);
-  /** Embedding-job backlog for the ACTIVE space (Overview embedding-queue panel); refreshed on space switch + live events. */
-  embeddingQueue = signal<EmbeddingQueue | null>(null);
-  /** Open governance votes across the ACTIVE space's networks (Overview Governance panel). */
-  overviewVotes = signal<VoteRound[]>([]);
-  /** Tokens that can reach the ACTIVE space (Overview token-access matrix). Null unless the caller is
-   *  admin — the endpoint 403s otherwise, so a null keeps the panel hidden for non-admins. */
-  tokenAccess = signal<TokenAccessEntry[] | null>(null);
-  /** Completeness report for the ACTIVE space (Overview panel). Null until it lands or on failure —
-   *  a governance panel that cannot load is hidden, not rendered as a zero. */
-  completeness = signal<CompletenessReport | null>(null);
-  /**
-   * This space's usage over the window below — one already-summed row, so a proxy space reports the total of
-   * its members rather than a list the panel would have to add up itself.
-   */
-  spaceActivity = signal<SpaceActivity | null>(null);
 
-  /**
-   * Which Overview panels have been blanked for a space switch and are still awaiting their first answer.
-   *
-   * The Overview's cards each render only when their own value arrives, so the board assembled itself one card at
-   * a time and every arrival pushed the ones below it down — the milder half of a canary flicker report. A
-   * skeleton at the card's final size fixes that, but only if it can tell "not yet" from "never".
-   *
-   * `null` alone cannot: `tokenAccess` is null **permanently** for a non-admin (the endpoint 403s), and
-   * `completeness` is null after a failure. A skeleton keyed on null would sit there forever in both cases.
-   *
-   * So pending is set ONLY where the value is blanked — in `selectSpace` — and cleared by both the success and
-   * the failure handler. It is deliberately not set by the live-event refresh: that has good data on screen, and
-   * covering it with a skeleton would be the same defect this exists to remove.
-   */
-  overviewPending = signal<Record<'activity' | 'completeness' | 'queue' | 'tokens', boolean>>({
-    // `stats` and `about` left with the statistics strip and the Instance card (owner, 2026-08-08). `about`
-    // was the one key with a different lifetime — fetched once at init, cleared exactly once — and that
-    // asymmetry is gone with the panel it existed for.
-    activity: false, completeness: false, queue: false, tokens: false,
-  });
 
-  /** Clear one panel's pending flag — called from both handlers of each loader, success or failure. */
-  private settled(key: 'activity' | 'completeness' | 'queue' | 'tokens'): void {
-    if (!this.overviewPending()[key]) return;
-    this.overviewPending.update(p => ({ ...p, [key]: false }));
-  }
 
   // Reindex
   needsReindex = signal(false);
@@ -629,7 +592,7 @@ export class BrainComponent implements OnInit, OnDestroy {
     clearTimeout(this.liveRefreshTimer);
     this.liveRefreshTimer = setTimeout(() => {
       this.loadStats(spaceId);
-      this.loadEmbeddingQueue(spaceId); // file/embed events change the queue
+      this.ov.loadEmbeddingQueue(spaceId, () => this.activeSpaceId() === spaceId); // file/embed events change the queue
       const collection = event.split('.')[0] ?? '';
       if (event.startsWith('bulk') || BrainComponent.TAB_FOR_COLLECTION[collection] === this.activeTab()) {
         this.store.liveRefreshTick.update(t => t + 1);
@@ -653,125 +616,16 @@ export class BrainComponent implements OnInit, OnDestroy {
     this.store.chronoSearch.set('');
     this.recordList.confirmDeleteId.set('');
     this.reindexResult.set('');
-    this.embeddingQueue.set(null);
-    this.overviewVotes.set([]);
-    this.tokenAccess.set(null);
-    this.completeness.set(null);
-    this.spaceActivity.set(null);
-    // Blanked and awaiting a first answer — the ONLY place pending is raised. See `overviewPending`.
-    // update(), not set(): `about` is one-shot and must keep whatever it already resolved to.
-    this.overviewPending.update(p => ({
-      ...p, activity: true, completeness: true, queue: true, tokens: true,
-    }));
+    this.ov.blankForSpaceSwitch();
     this.loadStats(id);
     this.loadSpaceMeta(id);
-    this.loadEmbeddingQueue(id);
-    this.loadOverviewVotes(id);
-    this.loadTokenAccess(id);
-    this.loadCompleteness(id);
-    this.loadSpaceActivity(id);
+    this.ov.loadAll(id, () => this.activeSpaceId() === id, this.spaces().find(sv => sv.space.id === id)?.space.networks ?? []);
   }
 
-  /**
-   * Usage over the last 7 days, for the Overview's usage panel.
-   *
-   * A week rather than a day on purpose: "is this space useful" is a question about a habit, and a space that
-   * is queried every Monday reads as dead in a 24-hour window.
-   *
-   * The endpoint returns one row per member space; they are summed here so the panel receives a single row.
-   * Summing in the shell rather than server-side keeps the endpoint honest for an API caller who wants to see
-   * WHICH member of a proxy is carrying it.
-   */
-  private loadSpaceActivity(spaceId: string): void {
-    this.spacesApi.getSpaceActivity(spaceId, 7 * 24).subscribe({
-      next: r => {
-        // Settle even when the answer is discarded. The guard gates the RESULT, never the skeleton: a stale
-        // response that returned outright left this panel spinning until the next space switch.
-        if (this.activeSpaceId() !== spaceId) { this.settled('activity'); return; }
-        const rows = r.spaces ?? [];
-        if (rows.length === 0) {
-          // An empty window is still an answer — "nothing was asked" — so the panel must render, not vanish.
-          this.spaceActivity.set({
-            space: spaceId, calls: 0, recall: 0, answered: 0, writes: 0,
-            meanMs: null, maxMs: 0, over1s: 0, meanTopScore: null, lastUsedAt: null,
-          });
-          // The skeleton comes down here too. It did not, so a space with NO recorded usage showed its usage
-          // card spinning for ever — and after the reset button clears the buckets, every space lands in exactly
-          // this branch on the next load. Found by a characterization test written for an unrelated refactor.
-          this.settled('activity');
-          return;
-        }
-        const sum = (pick: (row: SpaceActivity) => number) => rows.reduce((t, row) => t + pick(row), 0);
-        const calls = sum(r2 => r2.calls);
-        const answered = sum(r2 => r2.answered);
-        // Means are recombined from their weights, never averaged: averaging per-space means would give a
-        // one-call member the same say as a thousand-call one.
-        const weightedMs = rows.reduce((t, row) => t + (row.meanMs ?? 0) * row.calls, 0);
-        const weightedScore = rows.reduce((t, row) => t + (row.meanTopScore ?? 0) * row.answered, 0);
-        const lastUsed = rows.map(r2 => r2.lastUsedAt).filter((v): v is string => !!v).sort().at(-1) ?? null;
-        this.spaceActivity.set({
-          space: spaceId,
-          calls,
-          recall: sum(r2 => r2.recall),
-          answered,
-          writes: sum(r2 => r2.writes),
-          meanMs: calls > 0 ? Math.round(weightedMs / calls) : null,
-          maxMs: rows.reduce((m, row) => Math.max(m, row.maxMs), 0),
-          over1s: sum(r2 => r2.over1s),
-          meanTopScore: answered > 0 ? Number((weightedScore / answered).toFixed(3)) : null,
-          lastUsedAt: lastUsed,
-        });
-        this.settled('activity');
-      },
-      // A failure leaves the signal null and the panel does not render — the same rule completeness follows.
-      error: () => { if (this.activeSpaceId() === spaceId) this.spaceActivity.set(null); this.settled('activity'); },
-    });
-  }
 
-  /** Fetch the completeness report for a space (Overview panel). Only stores it while that space is
-   *  still active; a failure leaves the signal null and the panel simply does not render. */
-  private loadCompleteness(spaceId: string): void {
-    this.spacesApi.getCompleteness(spaceId).subscribe({
-      next: r => { if (this.activeSpaceId() === spaceId) this.completeness.set(r); this.settled('completeness'); },
-      error: () => { if (this.activeSpaceId() === spaceId) this.completeness.set(null); this.settled('completeness'); },
-    });
-  }
 
-  /** Fetch the embedding-job backlog for a space; only stores it while that space is still active. */
-  private loadEmbeddingQueue(spaceId: string): void {
-    this.brainApi.getEmbeddingQueue(spaceId).subscribe({
-      next: q => { if (this.activeSpaceId() === spaceId) this.embeddingQueue.set(q); this.settled('queue'); },
-      // A failed refresh keeps the last good value on purpose; it only has to stop the skeleton.
-      error: () => this.settled('queue'),
-    });
-  }
 
-  /** Fetch the token-access matrix for a space (Overview panel). ADMIN-only: a 403 for a non-admin
-   *  caller leaves the signal null, which keeps the panel hidden. Only stores it while still active. */
-  private loadTokenAccess(spaceId: string): void {
-    this.brainApi.getTokenAccess(spaceId).subscribe({
-      next: r => { if (this.activeSpaceId() === spaceId) this.tokenAccess.set(r.tokens); this.settled('tokens'); },
-      // A 403 for a non-admin lands here and is permanent — clearing pending is what stops a forever-skeleton.
-      error: () => { if (this.activeSpaceId() === spaceId) this.tokenAccess.set(null); this.settled('tokens'); },
-    });
-  }
 
-  /** Fetch OPEN governance votes across the space's networks (Overview Governance panel). One listVotes
-   *  per network the space belongs to; only stores the result while that space is still active. */
-  private loadOverviewVotes(spaceId: string): void {
-    const nets = this.spaces().find(sv => sv.space.id === spaceId)?.space.networks ?? [];
-    if (nets.length === 0) { this.overviewVotes.set([]); return; }
-    forkJoin(nets.map(n => this.networksApi.listVotes(n.id).pipe(
-      catchError(() => of({ rounds: [] as VoteRound[] })), // one unreachable network must not hide the rest
-    ))).subscribe({
-      next: results => {
-        if (this.activeSpaceId() !== spaceId) return;
-        const open = results.flatMap(r => r.rounds).filter(v => v.status === 'open');
-        this.overviewVotes.set(open);
-      },
-      error: () => {},
-    });
-  }
 
   /**
    * Deep-link state: which space and which tab, read from the URL.
@@ -903,7 +757,7 @@ export class BrainComponent implements OnInit, OnDestroy {
       next: ({ cleared }) => {
         this.resettingUsage.set(false);
         this.usageResetResult.set(`Cleared ${cleared} usage buckets.`);
-        this.loadSpaceActivity(spaceId);
+        this.ov.loadSpaceActivity(spaceId, () => this.activeSpaceId() === spaceId);
       },
       error: () => {
         this.resettingUsage.set(false);
@@ -931,7 +785,7 @@ export class BrainComponent implements OnInit, OnDestroy {
   runRetryFailedEmbeddings(): void {
     const spaceId = this.activeSpaceId();
     this.brainApi.retryFailedEmbeddings(spaceId).subscribe({
-      next: () => { if (this.activeSpaceId() === spaceId) this.loadEmbeddingQueue(spaceId); },
+      next: () => { if (this.activeSpaceId() === spaceId) this.ov.loadEmbeddingQueue(spaceId, () => this.activeSpaceId() === spaceId); },
       error: () => {},
     });
   }

--- a/client/src/app/pages/brain/overview-data.service.ts
+++ b/client/src/app/pages/brain/overview-data.service.ts
@@ -1,0 +1,213 @@
+import { Injectable, inject, signal } from '@angular/core';
+import { forkJoin, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { SpacesApi } from '../../core/spaces-api.service';
+import { BrainApi } from '../../core/brain-api.service';
+import { NetworksApi } from '../../core/networks-api.service';
+import type { CompletenessReport, EmbeddingQueue, SpaceActivity, TokenAccessEntry, VoteRound } from '../../core/api.types';
+
+/** Just the shape `loadOverviewVotes` needs — the shell knows about SpaceView; this service must not. */
+export interface SpaceNetworkRef { id: string }
+
+/**
+ * The Overview panel's data: five loaders, their five signals, and the pending flags that drive the skeletons.
+ *
+ * ## Why this is not in the Brain shell any more
+ *
+ * `brain.component.ts` crossed the god-file ceiling at 659 lines and it is the SHELL — it owns the tab strip,
+ * the space chips, every panel's inputs and eight tabs' worth of orchestration. Shaving handlers would have
+ * lowered the number while leaving the shape; moving one tab's data out is the split that changes it.
+ *
+ * ## The two things it deliberately does NOT own
+ *
+ * `activeSpaceId` arrives as a callback per load, not as state. A response for a space the user has left must
+ * be discarded, and that question belongs to whoever owns the selection — holding a copy here would be a
+ * second answer to it, able to disagree with the shell's.
+ *
+ * `loadOverviewVotes` takes the space's networks directly rather than reaching into a space list. It then
+ * knows nothing about `SpaceView`, which is a shell concept.
+ *
+ * ## The invariant that survived the move
+ *
+ * The guard gates the RESULT, never the skeleton: a discarded response still clears its pending flag. Getting
+ * that half wrong left every quiet space's usage card spinning for ever, which is what the characterization
+ * tests written before this move exist to catch.
+ */
+@Injectable()
+export class OverviewDataService {
+  private spacesApi = inject(SpacesApi);
+  private brainApi = inject(BrainApi);
+  private networksApi = inject(NetworksApi);
+
+  /** Embedding-job backlog for the ACTIVE space (Overview embedding-queue panel); refreshed on space switch + live events. */
+  embeddingQueue = signal<EmbeddingQueue | null>(null);
+
+  /** Open governance votes across the ACTIVE space's networks (Overview Governance panel). */
+  overviewVotes = signal<VoteRound[]>([]);
+
+  /** Tokens that can reach the ACTIVE space (Overview token-access matrix). Null unless the caller is
+   *  admin — the endpoint 403s otherwise, so a null keeps the panel hidden for non-admins. */
+  tokenAccess = signal<TokenAccessEntry[] | null>(null);
+
+  /** Completeness report for the ACTIVE space (Overview panel). Null until it lands or on failure —
+   *  a governance panel that cannot load is hidden, not rendered as a zero. */
+  completeness = signal<CompletenessReport | null>(null);
+
+  /**
+   * This space's usage over the window below — one already-summed row, so a proxy space reports the total of
+   * its members rather than a list the panel would have to add up itself.
+   */
+  spaceActivity = signal<SpaceActivity | null>(null);
+
+  /**
+   * Which Overview panels have been blanked for a space switch and are still awaiting their first answer.
+   *
+   * The Overview's cards each render only when their own value arrives, so the board assembled itself one card at
+   * a time and every arrival pushed the ones below it down — the milder half of a canary flicker report. A
+   * skeleton at the card's final size fixes that, but only if it can tell "not yet" from "never".
+   *
+   * `null` alone cannot: `tokenAccess` is null **permanently** for a non-admin (the endpoint 403s), and
+   * `completeness` is null after a failure. A skeleton keyed on null would sit there forever in both cases.
+   *
+   * So pending is set ONLY where the value is blanked — in `selectSpace` — and cleared by both the success and
+   * the failure handler. It is deliberately not set by the live-event refresh: that has good data on screen, and
+   * covering it with a skeleton would be the same defect this exists to remove.
+   */
+  overviewPending = signal<Record<'activity' | 'completeness' | 'queue' | 'tokens', boolean>>({
+    // `stats` and `about` left with the statistics strip and the Instance card (owner, 2026-08-08). `about`
+    // was the one key with a different lifetime — fetched once at init, cleared exactly once — and that
+    // asymmetry is gone with the panel it existed for.
+    activity: false, completeness: false, queue: false, tokens: false,
+  });
+
+  /** Clear one panel's pending flag — called from both handlers of each loader, success or failure. */
+  private settled(key: 'activity' | 'completeness' | 'queue' | 'tokens'): void {
+    if (!this.overviewPending()[key]) return;
+    this.overviewPending.update(p => ({ ...p, [key]: false }));
+  }
+
+  /**
+   * Usage over the last 7 days, for the Overview's usage panel.
+   *
+   * A week rather than a day on purpose: "is this space useful" is a question about a habit, and a space that
+   * is queried every Monday reads as dead in a 24-hour window.
+   *
+   * The endpoint returns one row per member space; they are summed here so the panel receives a single row.
+   * Summing in the shell rather than server-side keeps the endpoint honest for an API caller who wants to see
+   * WHICH member of a proxy is carrying it.
+   */
+  loadSpaceActivity(spaceId: string, isActive: () => boolean): void {
+    this.spacesApi.getSpaceActivity(spaceId, 7 * 24).subscribe({
+      next: r => {
+        // Settle even when the answer is discarded. The guard gates the RESULT, never the skeleton: a stale
+        // response that returned outright left this panel spinning until the next space switch.
+        if (!isActive()) { this.settled('activity'); return; }
+        const rows = r.spaces ?? [];
+        if (rows.length === 0) {
+          // An empty window is still an answer — "nothing was asked" — so the panel must render, not vanish.
+          this.spaceActivity.set({
+            space: spaceId, calls: 0, recall: 0, answered: 0, writes: 0,
+            meanMs: null, maxMs: 0, over1s: 0, meanTopScore: null, lastUsedAt: null,
+          });
+          // The skeleton comes down here too. It did not, so a space with NO recorded usage showed its usage
+          // card spinning for ever — and after the reset button clears the buckets, every space lands in exactly
+          // this branch on the next load. Found by a characterization test written for an unrelated refactor.
+          this.settled('activity');
+          return;
+        }
+        const sum = (pick: (row: SpaceActivity) => number) => rows.reduce((t, row) => t + pick(row), 0);
+        const calls = sum(r2 => r2.calls);
+        const answered = sum(r2 => r2.answered);
+        // Means are recombined from their weights, never averaged: averaging per-space means would give a
+        // one-call member the same say as a thousand-call one.
+        const weightedMs = rows.reduce((t, row) => t + (row.meanMs ?? 0) * row.calls, 0);
+        const weightedScore = rows.reduce((t, row) => t + (row.meanTopScore ?? 0) * row.answered, 0);
+        const lastUsed = rows.map(r2 => r2.lastUsedAt).filter((v): v is string => !!v).sort().at(-1) ?? null;
+        this.spaceActivity.set({
+          space: spaceId,
+          calls,
+          recall: sum(r2 => r2.recall),
+          answered,
+          writes: sum(r2 => r2.writes),
+          meanMs: calls > 0 ? Math.round(weightedMs / calls) : null,
+          maxMs: rows.reduce((m, row) => Math.max(m, row.maxMs), 0),
+          over1s: sum(r2 => r2.over1s),
+          meanTopScore: answered > 0 ? Number((weightedScore / answered).toFixed(3)) : null,
+          lastUsedAt: lastUsed,
+        });
+        this.settled('activity');
+      },
+      // A failure leaves the signal null and the panel does not render — the same rule completeness follows.
+      error: () => { if (isActive()) this.spaceActivity.set(null); this.settled('activity'); },
+    });
+  }
+
+  /** Fetch the completeness report for a space (Overview panel). Only stores it while that space is
+   *  still active; a failure leaves the signal null and the panel simply does not render. */
+  loadCompleteness(spaceId: string, isActive: () => boolean): void {
+    this.spacesApi.getCompleteness(spaceId).subscribe({
+      next: r => { if (isActive()) this.completeness.set(r); this.settled('completeness'); },
+      error: () => { if (isActive()) this.completeness.set(null); this.settled('completeness'); },
+    });
+  }
+
+  /** Fetch the embedding-job backlog for a space; only stores it while that space is still active. */
+  loadEmbeddingQueue(spaceId: string, isActive: () => boolean): void {
+    this.brainApi.getEmbeddingQueue(spaceId).subscribe({
+      next: q => { if (isActive()) this.embeddingQueue.set(q); this.settled('queue'); },
+      // A failed refresh keeps the last good value on purpose; it only has to stop the skeleton.
+      error: () => this.settled('queue'),
+    });
+  }
+
+  /** Fetch the token-access matrix for a space (Overview panel). ADMIN-only: a 403 for a non-admin
+   *  caller leaves the signal null, which keeps the panel hidden. Only stores it while still active. */
+  loadTokenAccess(spaceId: string, isActive: () => boolean): void {
+    this.brainApi.getTokenAccess(spaceId).subscribe({
+      next: r => { if (isActive()) this.tokenAccess.set(r.tokens); this.settled('tokens'); },
+      // A 403 for a non-admin lands here and is permanent — clearing pending is what stops a forever-skeleton.
+      error: () => { if (isActive()) this.tokenAccess.set(null); this.settled('tokens'); },
+    });
+  }
+
+  /** Fetch OPEN governance votes across the space's networks (Overview Governance panel). One listVotes
+   *  per network the space belongs to; only stores the result while that space is still active. */
+  loadOverviewVotes(spaceId: string, isActive: () => boolean, networks: SpaceNetworkRef[]): void {
+    const nets = networks;
+    if (nets.length === 0) { this.overviewVotes.set([]); return; }
+    forkJoin(nets.map(n => this.networksApi.listVotes(n.id).pipe(
+      catchError(() => of({ rounds: [] as VoteRound[] })), // one unreachable network must not hide the rest
+    ))).subscribe({
+      next: results => {
+        if (!isActive()) return;
+        const open = results.flatMap(r => r.rounds).filter(v => v.status === 'open');
+        this.overviewVotes.set(open);
+      },
+      error: () => {},
+    });
+  }
+
+  /**
+   * Blank every panel and raise its pending flag — the ONE place pending goes up.
+   *
+   * Deliberately not called by the live-event refresh: that has good data on screen already, and covering it
+   * with a skeleton is the flicker this whole mechanism exists to remove.
+   */
+  blankForSpaceSwitch(): void {
+    this.embeddingQueue.set(null);
+    this.overviewVotes.set([]);
+    this.tokenAccess.set(null);
+    this.completeness.set(null);
+    this.spaceActivity.set(null);
+    this.overviewPending.update(p => ({ ...p, activity: true, completeness: true, queue: true, tokens: true }));
+  }
+
+  /** Every Overview loader for one space, in one call — so a caller cannot start four of the five. */
+  loadAll(spaceId: string, isActive: () => boolean, networks: SpaceNetworkRef[]): void {
+    this.loadEmbeddingQueue(spaceId, isActive);
+    this.loadOverviewVotes(spaceId, isActive, networks);
+    this.loadTokenAccess(spaceId, isActive);
+    this.loadCompleteness(spaceId, isActive);
+    this.loadSpaceActivity(spaceId, isActive);
+  }
+}

--- a/testing/standalone/no-new-god-files.test.js
+++ b/testing/standalone/no-new-god-files.test.js
@@ -197,7 +197,13 @@ const FROZEN = {
   //
   // Raised without argument. A ratchet that made a one-line fix negotiable would be a gate encouraging the wrong
   // outcome, which is the opposite of what this list is for.
-  'client/src/app/pages/brain/brain.component.ts': 660,
+  // 660 -> 571. The Overview panel's five loaders, their signals and the pending flags moved to
+  // `overview-data.service.ts` — 136 lines out of the shell, which is now well under the 650 ceiling.
+  //
+  // The entry STAYS, lowered rather than deleted, for the reason written above `tokens.component.ts`: an entry
+  // here is a ratchet, and removing it would hand this file back the 89 lines of headroom the extraction just
+  // took away. G-2's own note said to delete it; the precedent in this file is better and wins.
+  'client/src/app/pages/brain/brain.component.ts': 571,
   'client/src/app/pages/settings/networks.component.ts': 643,
 };
 

--- a/testing/standalone/overview-pending-is-cleared.test.js
+++ b/testing/standalone/overview-pending-is-cleared.test.js
@@ -26,7 +26,12 @@ const ROOT = process.cwd();
 const BRAIN = 'client/src/app/pages/brain/brain.component.ts';
 const OVERVIEW = 'client/src/app/pages/brain/overview-tab.component.ts';
 
-const src = readFileSync(join(ROOT, BRAIN), 'utf8');
+// The loaders and their pending flags moved to `overview-data.service.ts` in the G-2 split; the shell still
+// owns when a space switch happens. Both halves are the subject here, so both are read — a gate that followed
+// only the shell would have gone quietly vacuous the moment the loaders left it, which is worse than the red
+// it actually gave.
+const DATA = 'client/src/app/pages/brain/overview-data.service.ts';
+const src = [BRAIN, DATA].map(f => readFileSync(join(ROOT, f), 'utf8')).join('\n');
 
 /** The four panels, and the loader whose two handlers must clear each one. */
 const PANELS = [
@@ -107,8 +112,14 @@ describe('an Overview skeleton can always be dismissed', () => {
 
     // Anchored on the METHOD, not the first textual match — `selectSpace(` appears in the template first, and
     // slicing from there measured 19k characters of the wrong thing.
-    const at = src.indexOf('  selectSpace(id: string): void {');
-    assert.ok(at > 0, 'selectSpace method not found');
+    // The blanks and the raise moved together into `blankForSpaceSwitch()` when the loaders left the shell
+    // (G-2). The guarantee is unchanged and so is its shape — raised beside the blanks, in one place — so this
+    // anchors on that method, and separately requires the space switch to still call it. Splitting the two is
+    // what keeps "blanked on a switch" true rather than merely "blanked somewhere".
+    assert.match(src, /selectSpace\(id: string\): void \{[\s\S]{0,2000}?this\.ov\.blankForSpaceSwitch\(\)/,
+      'a space switch must still blank the panels, or the skeletons never go up in the first place');
+    const at = src.indexOf('  blankForSpaceSwitch(): void {');
+    assert.ok(at > 0, 'blankForSpaceSwitch method not found');
     const selectSpace = src.slice(at, src.indexOf('\n  }', at));
     for (const key of ['activity', 'completeness', 'queue', 'tokens']) {
       assert.match(selectSpace, new RegExp(`${key}: true`),


### PR DESCRIPTION
`brain.component.ts` was 660 code lines, over the 650 ceiling. The Overview panel's five loaders, their five signals and the pending flags move to `brain/overview-data.service.ts`: **136 lines out**, and the shell drops to **571** — from over the ceiling to well under it.

The shell is the tab strip, the space chips, every panel's inputs and eight tabs' worth of orchestration. Shaving handlers would have lowered the number while leaving the shape; moving one tab's data out changes it.

## Two things deliberately did not move

- **`activeSpaceId`** arrives as a callback per load rather than becoming service state. A response for a space the user has left must be discarded, and that question belongs to whoever owns the selection — a copy in the service would be a second answer to it, able to disagree with the shell's.
- **`loadOverviewVotes`** takes the space's networks directly instead of reaching into a space list, so the service knows nothing about `SpaceView`. That is a shell concept and it stays in the shell.

## The characterization did its job

The seven tests written before this move (#828) pass with their **assertions unchanged** — only the address changed. That is the entire reason they were written first, and it is what makes this judgable by tests rather than by reading the diff.

## Two gates had to follow the code

- `overview-pending-is-cleared` read the shell as *source*. It now reads **both halves** — a gate that followed only the shell would have gone quietly vacuous the moment the loaders left it, which is worse than the red it gave me.
- Its blanking check anchored on `selectSpace`; the blanks now live in `blankForSpaceSwitch()`. It anchors there and **separately** asserts the space switch still calls it, because *"blanked somewhere"* is not the guarantee — *"blanked on a switch"* is.

## The ratchet entry is lowered, not deleted

660 → 571. An entry here is a ratchet, and removing it would hand this file back the 89 lines of headroom the extraction just took away. G-2's own note said to delete it; the precedent written above `tokens.component.ts` is better and wins.

## Closes the queue

With this, `_TODO-ORDERED.md` has no unparked rows left. Next is the docs lens plus one other, then the release.
