### PR TITLE
fix(preflight): list tracked test files, not whatever is on disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Internal
+- **Preflight lists TRACKED test files, not whatever is on disk.** It used `readdirSync`, which picks up
+  untracked files too — so a scratch `*.test.js` left in `testing/standalone/` would run locally and **not** in
+  CI. Preflight and CI disagreeing about which gates exist is the one divergence that makes a green preflight
+  worthless.
+  - The counts match today (331 tracked, 331 on disk, 314 of them offline). This keeps them matching on the day
+    somebody leaves a probe behind, which is the only day it matters.
+  - Found by auditing whether every gate written this release is actually RUN. All of them are; this was the
+    hole the audit turned up on the way.
+
 ### Added
 - **A space's recorded usage can be reset** — `POST /api/spaces/:spaceId/activity/reset`, admin + MFA, scoped to
   the space. Deletes the hourly buckets behind the Overview usage panel, so a space hammered once during a

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -22,7 +22,7 @@
  *
  * Usage:  npm run preflight
  */
-import { execSync } from 'node:child_process';
+import { execSync, execFileSync } from 'node:child_process';
 import { readdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
 
 import { join } from 'node:path';
@@ -106,7 +106,12 @@ for (const [file, why] of BUILT_GATES) gate(file, why, file);
 // the very gate that polices this split, because that file necessarily mentions the marker in its
 // assertions — the same "matched test data, not behaviour" mistake the heuristic made, one level up.
 const NEEDS_INSTANCE = /^\s*\*\s*@needs-instance/m;
-const allStandalone = readdirSync('testing/standalone').filter(f => f.endsWith('.test.js')).sort();
+// TRACKED files, not whatever is on disk. `readdirSync` picks up untracked ones too, so a scratch
+// `*.test.js` left in this folder would run here and NOT in CI — preflight and CI disagreeing about which
+// gates exist is the one divergence that makes a green preflight worthless. The counts match today (331 = 331);
+// this keeps them matching on the day somebody leaves a probe behind.
+const allStandalone = execFileSync('git', ['ls-files', 'testing/standalone'], { encoding: 'utf8' })
+  .split('\n').map(f => f.split('/').pop()).filter(f => f && f.endsWith('.test.js')).sort();
 const pure = allStandalone.filter(f => !NEEDS_INSTANCE.test(readFileSync(`testing/standalone/${f}`, 'utf8')));
 console.log(`\n── standalone tests that need no running instance (${pure.length} of ${allStandalone.length}; ` +
   `${allStandalone.length - pure.length} declare @needs-instance and run in CI) ──`);


### PR DESCRIPTION
The gate-coverage lens for this release asked one question: **is every gate written this run actually run by something?** All nine are — and the audit turned up this instead.

`scripts/preflight.mjs` discovered the standalone suite with `readdirSync`, which picks up **untracked** files. So a scratch `probe.test.js` left in `testing/standalone/` runs locally and never runs in CI — and the reverse can never be detected. Preflight and CI disagreeing about which gates exist is the one divergence that makes a green preflight worthless.

It now reads `git ls-files`, which is what CI sees.

Counts before and after are identical — **331 tracked, 314 of them offline** — because there is nothing untracked in there today. That is the point: this keeps them matching on the day somebody leaves a probe behind, which is the only day it matters.

The repo already had this rule written down for exactly this reason (*repo-file checks use `git ls-files`*), and this file predated it.

## Release status

This is the second of the two lenses for this release. The docs lens (`release:gate`) passed, the CHANGELOG's Unreleased section was consolidated from eighteen headings to four in #831, and this is the only finding either lens produced. The tag follows once this merges.
