### PR TITLE
release: 2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.7.0] — 2026-08-12
 ### Internal
 - **Preflight lists TRACKED test files, not whatever is on disk.** It used `readdirSync`, which picks up
   untracked files too — so a scratch `*.test.js` left in `testing/standalone/` would run locally and **not** in

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/client",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ythril",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ythril",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "workspaces": [
         "server",
@@ -18,7 +18,7 @@
     },
     "client": {
       "name": "@ythril/client",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@angular/animations": "^21.0.0",
@@ -21022,7 +21022,7 @@
     },
     "server": {
       "name": "@ythril/server",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ythril",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "type": "module",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/server",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
**Minor, not patch** — this carries features, and nothing breaking.

## What is in it

**Tokens** got the most attention, and most of it came from operators:

- a token you read back could not be written back — **ten of the twelve** fields GET emits were refused by PATCH;
- an unknown rights *area* stored at `200` and granted nothing, which took a live agent offline for four minutes;
- the proxy lens shipped grantable and never narrowing, so a scoped token recalled across **nothing**;
- the create form offered three controls for one decision, two of them mutually exclusive with the third on the wire.

**Recall** got faster and more robust in one pair of changes: a cross-space recall embedded the identical query once per *space*, and a transient `429` from the embedder killed the whole query instead of being retried.

**The Brain**: a cog for the space you are already in; memories, chrono and files finally drawn on the data-model diagram after a release of the server computing counts nothing rendered; a usage panel that can be reset.

New features: the Brain space-settings cog, all four record kinds on the diagram, the token editor's second factor and danger zone, and the usage reset.

## The version bump

By JSON surgery on the one top-level `version` line per `package.json`, and by **name-matched** entries in the lockfile — never a global replace.

Eighteen lockfile lines still say `2.6.0` and are **meant to**: they are dependencies that happen to be at that version. A blanket replace corrupted `watchpack` plus seven others on an earlier release without `npm ci` ever noticing. The lockfile diff is exactly four lines.

## Both release lenses ran

- **Docs** — `release:gate` passes: docs match code, CHANGELOG dated, NOTICE complete.
- **Gate coverage** — every gate written this cycle is actually executed. That audit found preflight discovering tests with `readdirSync`, which picks up untracked files, so preflight and CI could disagree about which gates exist. Fixed in #832.

The Unreleased section was 454 lines across eighteen headings; it is four now, clustered by topic, verified as a move rather than a rewrite by comparing the prose as a multiset — 417 lines either side, none lost, none invented.
