### PR TITLE
feat(brain)!: id is id — identity is server-generated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- **BREAKING: a record's id is server-generated. A caller can no longer choose one.** Owner ruling: *"we do not
+  accept custom ids … id is id."*
+  - `create_chrono`, `remember`, `upsert_entity` and `bulk_write` used to **adopt** a supplied id when it named
+    nothing (`_id: fields.id ?? uuidv4()`), documented as idempotency-by-id. A supplied `id` now names an
+    **existing** record to update; one that matches nothing is **ignored**, and the record is created with a
+    fresh server-minted UUID.
+  - **What this removes:** the retry-safety technique of generating a UUID before your first attempt and reusing
+    it. A retried create of a memory, chrono entry or entity can now produce a second record. `checkDuplicates`
+    is on by default and returns `similar`, which is how a duplicated retry becomes detectable instead of silent;
+    edges are unaffected, being idempotent on their natural key `(from, to, label)`.
+  - **Why.** Adopting a caller's id made the caller a co-author of the primary key, and that has a sharp edge
+    across a network: the natural way to produce a stable id is to derive it from a stable key, so two instances
+    following one convention collide **by design**. Inbound sync resolves a collision by `seq` alone with no
+    author comparison — one version silently replaces the other, every reference still resolves to the survivor,
+    nothing dangles, and the link-violation machinery therefore never sees it.
+  - Carry your own reference in `name`, `description` or a property. Those describe a record; `id` identifies one.
+  - `update_*` and `delete_*` ids stay permissive: records written before this ruling may carry a non-UUID id, and
+    constraining those paths would make exactly those records unfixable and undeletable.
+  - `docs/integration-guide/04-brain-api.md`'s Retry Safety section is rewritten rather than patched — it taught
+    the removed technique end to end, including a worked example.
+  - The gate that enforced the OLD contract (*"a supplied id becomes the new record's identity"*) is rewritten to
+    enforce this one, keeping its filename because `release-gate.mjs` lists it by name. A gate whose subject is
+    reversed gets rewritten, not deleted — deleting it would have removed the release gate's only check here and
+    nothing would have said so.
+
 ### Fixed
 - **A caller-supplied `id` is now constrained to a UUID on every write tool that accepts one.** `create_chrono`,
   `remember` and `bulk_write` took any non-empty string and stored it verbatim.

--- a/docs/integration-guide/04-brain-api.md
+++ b/docs/integration-guide/04-brain-api.md
@@ -26,43 +26,55 @@ anything an agent writes is retried.
 
 | type | retried create | how |
 |---|---|---|
-| **memory** | idempotent **if you supply `id`** | a UUID v4 you generate; the retry converges on that record |
-| **chrono** | idempotent **if you supply `id`** | same |
-| **entity** | idempotent **if you supply `id`** | same |
-| **edge** | **always idempotent** | the natural key `(from, to, label)` — no id needed |
+| **edge** | **idempotent** | the natural key `(from, to, label)` — a retry lands on the same edge |
+| **memory** | **not idempotent** | see below; a blind retry can produce a second record |
+| **chrono** | **not idempotent** | same |
+| **entity** | **not idempotent** | same; reconcile by `name` if your space treats names as unique |
 
-### How to make a write retry-safe
+### Identity is server-generated
 
-Generate the UUID **before your first attempt** and reuse it on every retry. That is the whole technique:
+**You cannot choose a record's id.** `id` on a create names an **existing** record to update; an id that matches
+nothing is ignored and the record is created with a fresh, server-minted UUID.
+
+This changed deliberately. Adopting a caller's id made the caller a co-author of the primary key, and that has a
+sharp edge across a network: the natural way to produce a stable id is to derive it from a stable key, so two
+instances following the same convention collide **by design** — and sync resolves a collision by `seq` alone,
+so one version silently replaces the other with every reference still resolving to the survivor. Nothing dangles,
+so nothing reports it.
+
+If you need to carry your own reference into Ythril, put it in **`name`**, **`description`**, or a property. Those
+fields are for describing a record. `id` identifies one.
+
+### How to make a create retry-safe
+
+Use the duplicate check, which is on by default:
 
 ```js
-const id = crypto.randomUUID();          // once, before the first attempt
-
-async function writeWithRetry(fact) {
-  for (let attempt = 0; attempt < 3; attempt++) {
-    try {
-      return await post('/api/brain/spaces/general/memories', { id, fact });
-    } catch (err) {
-      // A timeout here may mean the write SUCCEEDED and the response was lost. Retrying with the same `id`
-      // converges on the same record instead of writing a second one.
-      if (attempt === 2) throw err;
-    }
-  }
+// checkDuplicates is TRUE by default: the response carries `similar` when the write matched
+// something already stored, so a retry that landed twice is detectable rather than silent.
+const res = await post('/api/brain/spaces/general/memories', { fact });
+if (res.similar?.length) {
+  // The first attempt probably succeeded and its response was lost. Reconcile instead of retrying:
+  // read the match, and delete this one if it is a duplicate of it.
 }
 ```
 
-### What "idempotent" means here, precisely
+Two things follow from that:
 
-**It is not a no-op.** The second write really happens — it just lands on the same record:
+- **A duplicate check costs a vector.** `checkDuplicates: true` computes the embedding before the insert, so the
+  write waits on the embedder and fails if it is unreachable. That is the trade: an answerable "is this already
+  here?" in exchange for a synchronous dependency. Pass `checkDuplicates: false` to opt out, and accept that a
+  retry after an ambiguous failure may duplicate.
+- **For an edge, just retry.** `(from, to, label)` is the natural key and a second write converges.
 
-- `seq` and `updatedAt` advance, so the retry is a real write and appears in the audit log and in
+### What happens on a genuine update
+
+When `id` names a record that exists, the write lands on it:
+
+- `seq` and `updatedAt` advance, so it is a real write and appears in the audit log and in
   `ythril_brain_write_seq_total`;
-- **tags union and properties shallow-merge**, they do not replace. A retry sends the identical payload so this
-  makes no difference to it, but reusing an id later with different content behaves as a merge;
-- the webhook event is `memory.updated` / `chrono.updated` / `entity.updated`, **not**
-  `*.created`, so a subscriber can tell a converged retry from a new record.
-
-What you get is the guarantee that matters: **the same content, in one record, however many times you send it.**
+- **tags union and properties shallow-merge**, they do not replace;
+- the webhook event is `memory.updated` / `chrono.updated` / `entity.updated`, **not** the created event.
 
 ### Rules
 
@@ -113,7 +125,7 @@ POST /api/brain/spaces/:spaceId/memories
 }
 ```
 
-**Constraints**: `id` optional — a **UUID v4** you supply to make the write idempotent (a retry with the same id converges on that record instead of creating a second one); anything else is a `400`, and omitting it generates one. See [Retry Safety](#retry-safety). **Constraints**: `fact` max 50 000 chars. `type` optional string — stored on the document and validated against the space's `typeSchemas.memory` allowlist when set. `tags` must be an array of strings. `description` optional string. `properties` optional object; property values should be a string, number, or boolean (unlike the entity endpoint, the memory/edge/chrono write paths don't reject non-primitive values at the API layer — schema validation is the gate when the space defines the property). Every id in `entityIds` must be a UUID v4 **and** name an entity that exists — passing a name, a malformed id, or an id that resolves to nothing returns `400` and stores nothing. This is the default; a space can opt out with `meta.strictLinkage: false` (see [Reference integrity](12-admin-api.md#reference-integrity)). `ttlDays` optional — see [Record Expiry (TTL)](#record-expiry-ttl). `waitForEmbedding` optional boolean — see below.
+**Constraints**: `id` optional — a **UUID v4** naming an **existing** record to update. It is not a way to choose an id: identity is server-generated, so an id that matches nothing is ignored rather than adopted, and the record is created with a fresh one. Anything that is not a UUID v4 is a `400`. To carry your own reference, put it in `name` or `description`. See [Retry Safety](#retry-safety). **Constraints**: `fact` max 50 000 chars. `type` optional string — stored on the document and validated against the space's `typeSchemas.memory` allowlist when set. `tags` must be an array of strings. `description` optional string. `properties` optional object; property values should be a string, number, or boolean (unlike the entity endpoint, the memory/edge/chrono write paths don't reject non-primitive values at the API layer — schema validation is the gate when the space defines the property). Every id in `entityIds` must be a UUID v4 **and** name an entity that exists — passing a name, a malformed id, or an id that resolves to nothing returns `400` and stores nothing. This is the default; a space can opt out with `meta.strictLinkage: false` (see [Reference integrity](12-admin-api.md#reference-integrity)). `ttlDays` optional — see [Record Expiry (TTL)](#record-expiry-ttl). `waitForEmbedding` optional boolean — see below.
 
 #### Catching a near-duplicate at write time (`checkDuplicates`, `checkContradictions`)
 

--- a/docs/integration-guide/04c-chrono-api.md
+++ b/docs/integration-guide/04c-chrono-api.md
@@ -12,7 +12,7 @@ POST /api/brain/spaces/:spaceId/chrono
 
 **Body**:
 
-`id` is optional here too — a **UUID v4** you supply to make the create idempotent, exactly as for a
+`id` is optional here too — a **UUID v4** naming an **existing** entry to update, exactly as for a
 memory. See [Retry Safety](04-brain-api.md#retry-safety).
 
 ```json

--- a/server/src/brain/chrono.ts
+++ b/server/src/brain/chrono.ts
@@ -185,8 +185,12 @@ export async function createChrono(
   }
 
   const doc: ChronoEntry = {
-    // A supplied id that named nothing becomes the entry's identity, so the caller's retry finds it next time.
-    _id: fields.id ?? uuidv4(),
+    // ID IS ID (owner ruling, 2026-08-12): the identity is ours to mint, always. A supplied id may
+    // ADDRESS an existing record — the update path above — but it never becomes a new record's identity.
+    // It used to: a supplied id that named nothing was adopted, which made the caller a co-author of our
+    // primary key and, across a sync, let two instances deriving ids from the same key collide by design.
+    // A caller wanting to carry their own reference puts it in `name` or `description`, which are for that.
+    _id: uuidv4(),
     spaceId,
     title: fields.title,
     type: fields.type,

--- a/server/src/brain/entities.ts
+++ b/server/src/brain/entities.ts
@@ -180,7 +180,12 @@ export async function upsertEntity(
   }
 
   const doc: EntityDoc = {
-    _id: id ?? uuidv4(),
+    // ID IS ID (owner ruling, 2026-08-12): the identity is ours to mint, always. A supplied id may
+    // ADDRESS an existing record — the update path above — but it never becomes a new record's identity.
+    // It used to: a supplied id that named nothing was adopted, which made the caller a co-author of our
+    // primary key and, across a sync, let two instances deriving ids from the same key collide by design.
+    // A caller wanting to carry their own reference puts it in `name` or `description`, which are for that.
+    _id: uuidv4(),
     spaceId,
     name,
     type,

--- a/server/src/brain/memory.ts
+++ b/server/src/brain/memory.ts
@@ -169,7 +169,12 @@ export async function remember(
 
   const doc: MemoryDoc = {
     // A supplied id that named nothing becomes the record's identity, so the caller's retry finds it next time.
-    _id: id ?? uuidv4(),
+    // ID IS ID (owner ruling, 2026-08-12): the identity is ours to mint, always. A supplied id may
+    // ADDRESS an existing record — the update path above — but it never becomes a new record's identity.
+    // It used to: a supplied id that named nothing was adopted, which made the caller a co-author of our
+    // primary key and, across a sync, let two instances deriving ids from the same key collide by design.
+    // A caller wanting to carry their own reference puts it in `name` or `description`, which are for that.
+    _id: uuidv4(),
     spaceId,
     fact,
     tags,

--- a/server/src/mcp/tools/bulk.ts
+++ b/server/src/mcp/tools/bulk.ts
@@ -52,7 +52,7 @@ export const bulk_writeTool: ToolHandler = {
                 type: 'object',
                 additionalProperties: false,
                 properties: {
-                  id:          uuidSchema('Optional UUID v4 — if provided, updates the entity with this ID (or inserts with this ID). If omitted, a new entity is always inserted.'),
+                  id:          uuidSchema('UUID v4 of an EXISTING entity to update. It is not a way to choose an id: identity is server-generated, so an id that names nothing is ignored rather than adopted. To carry your own reference, use `name` or `description`.'),
                   name:        { type: 'string', description: 'Entity name.' },
                   type:        { type: 'string', description: 'Entity type.' },
                   tags:        { type: 'array', items: { type: 'string' } },

--- a/server/src/mcp/tools/chrono.ts
+++ b/server/src/mcp/tools/chrono.ts
@@ -19,7 +19,7 @@ export const create_chronoTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            id: uuidSchema('Optional UUID v4. Supply one to make this call IDEMPOTENT: retrying with the same id converges on the same entry instead of creating a second one. Generate it before your first attempt and reuse it on every retry. Omit it and each call creates a new entry.'),
+            id: uuidSchema('UUID v4 of an EXISTING record to update. It is not a way to choose an id: identity is server-generated, so an id that names nothing is ignored rather than adopted. To carry your own reference, use `name` or `description`.'),
             title: { type: 'string', minLength: 1, description: 'Entry title.' },
             type: { type: 'string', minLength: 1, description: 'Entry type. Rejected unless it is one of the space\'s allowed chrono types: the defaults are event, deadline, plan, prediction, milestone, or the custom set declared in the space\'s typeSchemas.chrono.' },
             startsAt: { type: 'string', minLength: 1, description: 'ISO 8601 start date/time.' },

--- a/server/src/mcp/tools/entity.ts
+++ b/server/src/mcp/tools/entity.ts
@@ -19,7 +19,7 @@ export const upsert_entityTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            id: uuidSchema('Optional UUID v4 — if provided, updates the entity with this ID (or inserts with this ID if it does not exist). If omitted, a new entity is always inserted.'),
+            id: uuidSchema('UUID v4 of an EXISTING record to update. It is not a way to choose an id: identity is server-generated, so an id that names nothing is ignored rather than adopted. To carry your own reference, use `name` or `description`.'),
             name: { type: 'string', minLength: 1, description: 'Entity name.' },
             type: { type: 'string', minLength: 1, description: 'Entity type (person, place, concept, …).' },
             tags: { type: 'array', items: { type: 'string' } },

--- a/server/src/mcp/tools/memory.ts
+++ b/server/src/mcp/tools/memory.ts
@@ -29,7 +29,7 @@ export const rememberTool: ToolHandler = {
   inputSchema: (s: ToolSchemas) => ({
           type: 'object',
           properties: {
-            id: uuidSchema('Optional UUID v4. Supply one to make this call IDEMPOTENT: retrying with the same id converges on the same record instead of creating a second one. Generate it before your first attempt and reuse it on every retry. Omit it and each call creates a new record.'),
+            id: uuidSchema('UUID v4 of an EXISTING record to update. It is not a way to choose an id: identity is server-generated, so an id that names nothing is ignored rather than adopted. To carry your own reference, use `name` or `description`.'),
             space: s.requiredSpace,
             fact: { type: 'string', minLength: 1, maxLength: 50000, description: 'The fact, observation, or memory to store (1–50 000 characters).' },
             entityIds: {

--- a/testing/integration/brain.test.js
+++ b/testing/integration/brain.test.js
@@ -2073,11 +2073,18 @@ describe('Brain — PATCH chrono by ID', () => {
   });
 });
 
-// ── Entity creation with explicit UUID id ────────────────────────────────────
+// ── A supplied id does NOT become a new record's identity ────────────────────────
 
-describe('Brain — entity creation with explicit UUID id', () => {
+/**
+ * Reversed by the owner's 2026-08-12 ruling: "id is id". This block used to assert the opposite — that a
+ * supplied UUID became the created entity's `_id` — which was the documented idempotency contract.
+ *
+ * It is rewritten rather than deleted. The behaviour it covers still needs a database to observe, and deleting
+ * it would leave the new rule checked only by a source-reading gate: nothing would prove the SERVER honours it.
+ */
+describe('Brain — a supplied id does not become a new entity id', () => {
   const RUN = Date.now();
-  const validUuid = `550e8400-e29b-41d4-a716-${String(RUN).padStart(12, '0').slice(0, 12)}`;
+  const unusedUuid = `550e8400-e29b-41d4-a716-${String(RUN).padStart(12, '0').slice(0, 12)}`;
   const createdIds = [];
 
   before(() => {
@@ -2090,61 +2097,50 @@ describe('Brain — entity creation with explicit UUID id', () => {
     }
   });
 
-  it('Create entity with valid UUID id uses that id', async () => {
+  it('a create with an id that names nothing IGNORES it and mints a fresh one', async () => {
     const r = await post(INSTANCES.a, token(), '/api/brain/spaces/general/entities', {
-      id: validUuid,
-      name: `ExplicitId-${RUN}`,
+      id: unusedUuid,
+      name: `IgnoredId-${RUN}`,
       type: 'concept',
     });
     assert.equal(r.status, 201, JSON.stringify(r.body));
-    assert.equal(r.body._id, validUuid, 'Entity _id must match supplied UUID');
-    createdIds.push(validUuid);
+    assert.notEqual(r.body._id, unusedUuid,
+      'a supplied id must not become the identity — that made the caller a co-author of the primary key');
+    assert.match(r.body._id, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+      'the server must have minted a UUID v4 of its own');
+    createdIds.push(r.body._id);
   });
 
-  it('Retrieve entity by explicit UUID id', async () => {
-    const r = await get(INSTANCES.a, token(), `/api/brain/spaces/general/entities/${validUuid}`);
-    assert.equal(r.status, 200, JSON.stringify(r.body));
-    assert.equal(r.body._id, validUuid);
-    assert.equal(r.body.name, `ExplicitId-${RUN}`);
+  it('the ignored id addresses nothing afterwards', async () => {
+    // The other half: if the id had been quietly adopted anyway, this would return the record.
+    const r = await get(INSTANCES.a, token(), `/api/brain/spaces/general/entities/${unusedUuid}`);
+    assert.equal(r.status, 404, `expected the supplied id to name nothing, got ${r.status}`);
   });
 
-  it('Second POST with same UUID id updates (upserts) the entity', async () => {
+  it('a create with the SAME unused id again produces a SECOND record', async () => {
+    // This is the cost of the ruling, asserted rather than described: retry-by-reused-id no longer converges.
+    // A caller relying on it duplicates, which is why `checkDuplicates` returning `similar` is the replacement.
     const r = await post(INSTANCES.a, token(), '/api/brain/spaces/general/entities', {
-      id: validUuid,
-      name: `ExplicitId-${RUN}`,
+      id: unusedUuid,
+      name: `IgnoredIdTwice-${RUN}`,
       type: 'concept',
-      description: 'updated via id-based upsert',
     });
     assert.equal(r.status, 201, JSON.stringify(r.body));
-    assert.equal(r.body._id, validUuid, 'Same UUID must be reused');
-    assert.equal(r.body.description, 'updated via id-based upsert');
+    assert.notEqual(r.body._id, createdIds[0], 'the second create must be its own record');
+    createdIds.push(r.body._id);
   });
 
-  it('Rejects invalid UUID (ObjectId format) with 400', async () => {
+  it('but an id that DOES name a record still updates it', async () => {
+    // The half that must survive: an id addresses an existing record. Losing this would make every update a
+    // create, which is a far worse bug than the one the ruling removes.
+    const existing = createdIds[0];
     const r = await post(INSTANCES.a, token(), '/api/brain/spaces/general/entities', {
-      id: '507f1f77bcf86cd799439011',
-      name: `BadId-${RUN}`,
+      id: existing,
+      name: `IgnoredId-${RUN}-renamed`,
       type: 'concept',
     });
-    assert.equal(r.status, 400, `Expected 400 for ObjectId, got ${r.status}: ${JSON.stringify(r.body)}`);
-  });
-
-  it('Rejects UUID v1 with 400', async () => {
-    const r = await post(INSTANCES.a, token(), '/api/brain/spaces/general/entities', {
-      id: '550e8400-e29b-11d4-a716-446655440000',
-      name: `V1Id-${RUN}`,
-      type: 'concept',
-    });
-    assert.equal(r.status, 400, `Expected 400 for UUID v1, got ${r.status}`);
-  });
-
-  it('Rejects empty string id with 400', async () => {
-    const r = await post(INSTANCES.a, token(), '/api/brain/spaces/general/entities', {
-      id: '',
-      name: `EmptyId-${RUN}`,
-      type: 'concept',
-    });
-    assert.equal(r.status, 400, `Expected 400 for empty id, got ${r.status}`);
+    assert.ok([200, 201].includes(r.status), JSON.stringify(r.body));
+    assert.equal(r.body._id, existing, 'an id naming a real record must land on that record');
   });
 });
 

--- a/testing/integration/idempotent-writes.test.js
+++ b/testing/integration/idempotent-writes.test.js
@@ -42,7 +42,7 @@ let tok;
 before(() => { tok = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim(); });
 
 /** A fresh UUID v4 per test, so one test's id can never make another's assertion pass. */
-const uuid = () => crypto.randomUUID();
+const uuid = () => crypto.uuid();
 
 /**
  * Identity, not count.
@@ -58,125 +58,79 @@ const uuid = () => crypto.randomUUID();
  */
 const idOf = (r) => r.body?._id ?? r.body?.entity?._id ?? r.body?.edge?._id;
 
-describe('memories: a retry with the same id converges', () => {
-  it('two identical creates with one id produce ONE record', async () => {
-    const id = uuid();
-    const fact = `idempotency probe ${id}`;
-
-    const first = await post(INSTANCES.a, tok, '/api/brain/spaces/general/memories', { id, fact });
-    assert.equal(first.status, 201, `first create failed: ${JSON.stringify(first.body)}`);
-    assert.equal(first.body._id, id, 'the supplied id did not become the record id, so a retry cannot find it');
-
-    // The retry. Byte-identical payload, which is what a client resending after a timeout actually sends.
-    const second = await post(INSTANCES.a, tok, '/api/brain/spaces/general/memories', { id, fact });
-    assert.equal(second.status, 201, `retry failed: ${JSON.stringify(second.body)}`);
-    assert.equal(second.body._id, id, 'the retry produced a different id');
-
-    assert.equal(idOf(second), idOf(first),
-      `the retry produced a DIFFERENT record (${idOf(first)} then ${idOf(second)}). This is the bug: an agent `
-      + 'whose request timed out and retried used to double every record it wrote.');
+/**
+ * ── Reversed by the "id is id" ruling, 2026-08-12 ────────────────────────────────────────────────
+ *
+ * Every describe in this file used to assert that a retry with the same id CONVERGES: two creates, one record.
+ * That was the documented contract and it is gone — identity is server-minted, and a supplied id that names
+ * nothing is ignored rather than adopted.
+ *
+ * The file is rewritten rather than deleted, for the reason it existed in the first place: "how many records are
+ * in the collection after the second call" is a database question, and only a real instance can answer it. A
+ * source-reading gate can prove the code says `_id: uuidv4()`; only this can prove the server behaves that way.
+ *
+ * What is asserted now is the COST as well as the rule, because the cost is the part callers have to plan for:
+ * a retried create really does duplicate, and the duplicate-check is what makes that visible.
+ */
+describe('memories: a supplied id is not adopted', () => {
+  it('a create with an unused id mints a server id instead', async () => {
+    const unused = uuid();
+    const r = await post(INSTANCES.a, tok, `/api/brain/spaces/general/memories`,
+      { id: unused, fact: `unadopted-${Date.now()}` });
+    assert.equal(r.status, 201, JSON.stringify(r.body));
+    assert.notEqual(idOf(r), unused, 'the caller must not choose the identity');
+    assert.match(idOf(r), /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
   });
 
-  it('the retry moves seq and updatedAt — it converges, it is not a no-op', async () => {
-    // Stated in the docs and asserted here, because "idempotent" is often read as "no effect" and that would be
-    // wrong: the second write really happens, it just lands on the same record.
-    const id = uuid();
-    const fact = `seq probe ${id}`;
-    const first = await post(INSTANCES.a, tok, '/api/brain/spaces/general/memories', { id, fact });
-    const second = await post(INSTANCES.a, tok, '/api/brain/spaces/general/memories', { id, fact });
-
-    assert.ok(second.body.seq > first.body.seq,
-      `seq did not advance (${first.body.seq} -> ${second.body.seq}); the second write did not happen at all, which `
-      + 'is a different behaviour from the one documented');
+  it('two creates with the SAME unused id produce TWO records', async () => {
+    // The cost of the ruling, stated as a fact rather than a caveat. A caller still reusing an id across a
+    // retry gets duplicates, which is exactly why the release note calls this breaking.
+    const unused = uuid();
+    const fact = `duplicating-${Date.now()}`;
+    const a = await post(INSTANCES.a, tok, `/api/brain/spaces/general/memories`, { id: unused, fact });
+    const b = await post(INSTANCES.a, tok, `/api/brain/spaces/general/memories`, { id: unused, fact });
+    assert.equal(a.status, 201);
+    assert.equal(b.status, 201);
+    assert.notEqual(idOf(a), idOf(b), 'these are two records now, and that is the documented consequence');
   });
 
-  it('tags and properties MERGE on convergence, matching the entity path', async () => {
-    const id = uuid();
-    const fact = `merge probe ${id}`;
-    await post(INSTANCES.a, tok, '/api/brain/spaces/general/memories',
-      { id, fact, tags: ['first'], properties: { a: '1' } });
-    const second = await post(INSTANCES.a, tok, '/api/brain/spaces/general/memories',
-      { id, fact, tags: ['second'], properties: { b: '2' } });
+  it('an id that NAMES a record still updates it', async () => {
+    // The surviving half. If this broke, every update would silently become a create — worse than the bug the
+    // ruling removes, and invisible until a collection doubled.
+    const created = await post(INSTANCES.a, tok, `/api/brain/spaces/general/memories`,
+      { fact: `addressable-${Date.now()}` });
+    assert.equal(created.status, 201);
+    const id = idOf(created);
 
-    assert.deepEqual([...second.body.tags].sort(), ['first', 'second'],
-      'tags replaced rather than merged — entities merge, and one rule across four record types is the point');
-    assert.deepEqual(second.body.properties, { a: '1', b: '2' }, 'properties did not shallow-merge');
+    const again = await post(INSTANCES.a, tok, `/api/brain/spaces/general/memories`,
+      { id, fact: `addressable-${Date.now()}-v2` });
+    assert.ok([200, 201].includes(again.status), JSON.stringify(again.body));
+    assert.equal(idOf(again), id, 'an id naming a real record must land on it');
   });
 
-  it('omitting the id still creates a new record every time', async () => {
-    // The default must not change. Every existing client omits the id and relies on this.
-    const fact = `no-id probe ${uuid()}`;
-    const a = await post(INSTANCES.a, tok, '/api/brain/spaces/general/memories', { fact });
-    const b = await post(INSTANCES.a, tok, '/api/brain/spaces/general/memories', { fact });
-    assert.ok(idOf(a) && idOf(b), `both creates must return an id (${idOf(a)}, ${idOf(b)})`);
-    assert.notEqual(idOf(b), idOf(a),
-      'omitting the id silently deduplicated, which would break every existing caller');
-  });
-
-  it('a malformed id is refused with 400, not stored', async () => {
-    // A caller-supplied id becomes the sync identity of a record that replicates across networks.
-    for (const bad of ['not-a-uuid', '', '../../etc/passwd', '12345']) {
-      const r = await post(INSTANCES.a, tok, '/api/brain/spaces/general/memories',
-        { id: bad, fact: `bad id ${bad}` });
-      assert.equal(r.status, 400, `id "${bad}" was accepted (status ${r.status}) and became a record identity`);
-    }
+  it('a malformed id is still refused with 400, not stored', async () => {
+    // Unchanged, and worth keeping: the format check is what stops a corrupted id being stored at all, which
+    // is the defect that started this whole audit.
+    const r = await post(INSTANCES.a, tok, `/api/brain/spaces/general/memories`,
+      { id: 'not-a-uuid', fact: `malformed-${Date.now()}` });
+    assert.equal(r.status, 400, JSON.stringify(r.body));
   });
 });
 
-describe('chrono: the same contract', () => {
-  it('two identical creates with one id produce ONE entry', async () => {
-    const id = uuid();
-    const title = `chrono idempotency ${id}`;
-    const body = { id, title, type: 'event', startsAt: '2026-01-01T00:00:00.000Z' };
+describe('edges: the one thing that IS still idempotent', () => {
+  it('an edge retry converges on its natural key, with no id involved', async () => {
+    // Deliberately kept: edges are unaffected by the ruling because `(from, to, label)` is their identity.
+    // A caller told "retries duplicate now" needs the exception stated, or they will work around a problem
+    // they do not have.
+    const from = (await post(INSTANCES.a, tok, `/api/brain/spaces/general/entities`,
+      { name: `EdgeFrom-${Date.now()}`, type: 'concept' })).body._id;
+    const to = (await post(INSTANCES.a, tok, `/api/brain/spaces/general/entities`,
+      { name: `EdgeTo-${Date.now()}`, type: 'concept' })).body._id;
 
-    const first = await post(INSTANCES.a, tok, '/api/brain/spaces/general/chrono', body);
-    assert.equal(first.status, 201, `first create failed: ${JSON.stringify(first.body)}`);
-    assert.equal(first.body._id, id, 'the supplied id did not become the entry id');
-
-    const second = await post(INSTANCES.a, tok, '/api/brain/spaces/general/chrono', body);
-    assert.equal(second.status, 201, `retry failed: ${JSON.stringify(second.body)}`);
-
-    assert.equal(idOf(second), idOf(first),
-      `the retry produced a different chrono entry (${idOf(first)} then ${idOf(second)})`);
-  });
-
-  it('a malformed id is refused with 400', async () => {
-    const r = await post(INSTANCES.a, tok, '/api/brain/spaces/general/chrono',
-      { id: 'nope', title: 'bad', type: 'event', startsAt: '2026-01-01T00:00:00.000Z' });
-    assert.equal(r.status, 400, `a malformed chrono id was accepted (status ${r.status})`);
-  });
-});
-
-describe('entities and edges: the behaviour that already existed still holds', () => {
-  it('an entity retry with the same id converges', async () => {
-    // Regression cover for the path the new ones were modelled on — if this changes, the "one rule across four
-    // types" claim in the docs stops being true and nothing else would notice.
-    const id = uuid();
-    const name = `idem entity ${id}`;
-    const first = await post(INSTANCES.a, tok, '/api/brain/spaces/general/entities', { id, name, type: 'person' });
-    assert.equal(first.status, 201, `entity create failed: ${JSON.stringify(first.body)}`);
-    const second = await post(INSTANCES.a, tok, '/api/brain/spaces/general/entities', { id, name, type: 'person' });
-    assert.ok(second.status === 200 || second.status === 201, `entity retry failed: ${second.status}`);
-    assert.equal(idOf(second), id, 'the entity retry did not converge on the same id');
-  });
-
-  it('an edge retry converges on its natural key without any id', async () => {
-    // `from`/`to` are entity IDs, not names — the API says so explicitly: "a name is not a reference". The first
-    // version passed names and got a 400 that had nothing to do with idempotency.
-    const suffix = uuid().slice(0, 8);
-    const ids = [];
-    for (const n of [`edge-from-${suffix}`, `edge-to-${suffix}`]) {
-      const e = await post(INSTANCES.a, tok, '/api/brain/spaces/general/entities', { name: n, type: 'person' });
-      assert.ok(idOf(e), `entity ${n} was not created: ${JSON.stringify(e.body)}`);
-      ids.push(idOf(e));
-    }
-    const body = { from: ids[0], to: ids[1], label: 'knows' };
-    const first = await post(INSTANCES.a, tok, '/api/brain/spaces/general/edges', body);
-    assert.ok(first.status === 200 || first.status === 201, `edge create failed: ${JSON.stringify(first.body)}`);
-    const second = await post(INSTANCES.a, tok, '/api/brain/spaces/general/edges', body);
-    assert.ok(second.status === 200 || second.status === 201, `edge retry failed: ${second.status}`);
-    assert.ok(idOf(first), `the edge create returned no id: ${JSON.stringify(first.body)}`);
-    assert.equal(idOf(second), idOf(first),
-      'the edge retry created a second edge — the (from, to, label) natural key stopped being idempotent');
+    const a = await post(INSTANCES.a, tok, `/api/brain/spaces/general/edges`, { from, to, label: 'relates_to' });
+    const b = await post(INSTANCES.a, tok, `/api/brain/spaces/general/edges`, { from, to, label: 'relates_to' });
+    assert.ok([200, 201].includes(a.status), JSON.stringify(a.body));
+    assert.ok([200, 201].includes(b.status), JSON.stringify(b.body));
+    assert.equal(idOf(a), idOf(b), 'the natural key must still converge');
   });
 });

--- a/testing/integration/idempotent-writes.test.js
+++ b/testing/integration/idempotent-writes.test.js
@@ -42,7 +42,7 @@ let tok;
 before(() => { tok = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim(); });
 
 /** A fresh UUID v4 per test, so one test's id can never make another's assertion pass. */
-const uuid = () => crypto.uuid();
+const uuid = () => crypto.randomUUID();
 
 /**
  * Identity, not count.

--- a/testing/standalone/idempotent-writes-contract.test.js
+++ b/testing/standalone/idempotent-writes-contract.test.js
@@ -1,151 +1,97 @@
 /**
- * The retry-safety contract, in the parts that can be checked without a database.
+ * ID IS ID: a record's identity is minted by the server, never supplied by the caller.
  *
- * The behaviour itself — "how many records are in the collection after the second call" — is a database question
- * and lives in `testing/integration/idempotent-writes.test.js`. This file holds everything else, because the
- * integration suite needs Docker and therefore only runs in CI, while the contract is the part somebody breaks
- * accidentally while editing a route.
+ * Owner ruling, 2026-08-12: *"we do not accept custom ids. on write time one is mongodb-generated … they can use
+ * name or description for descriptive fields. id is id."*
  *
- * ## What it defends
+ * ## What it used to do
  *
- *  1. **All four record types are documented**, with their different mechanisms. Two of them (entity by id, edge
- *     by natural key) were already idempotent and nobody was told — the only mention of supplying an id was inside
- *     a *warning string* about updating an existing entity. Documented capability is the whole point of this work.
- *  2. **A caller-supplied id is validated as a UUID v4** on the new paths. It becomes the `_id` of a record that
- *     replicates across every peer in every network the space belongs to, so an arbitrary string must not reach it.
- *  3. **The MCP tools advertise it.** An MCP agent is precisely the "external caller that retries" this exists for;
- *     leaving it REST-only would have fixed the case that matters least.
- *  4. **The convergence emits `*.updated`, not `*.created`.** A subscriber has to be able to tell a converged
- *     retry from a new record, and getting this backwards would be invisible to any count-based test.
+ * `create_chrono`, `remember`, `upsert_entity` and `bulk_write` all adopted a supplied id when it named nothing:
+ *
+ *     _id: fields.id ?? uuidv4()
+ *
+ * documented as an idempotency feature — retry with the same id and converge on the same record. That made the
+ * caller a co-author of our primary key, and it has a sharp edge across a network: the natural way to get a
+ * stable id is to DERIVE it from a stable key, so two instances following one convention collide **by design**.
+ * Inbound sync resolves a collision purely by `seq` (`api/sync/docs.ts` — replaceOne when the incoming seq is
+ * higher), with no author comparison, so the loser is overwritten silently. The link-violation machinery cannot
+ * see it either: both records are internally valid and every reference still resolves, to whichever survived.
+ *
+ * A supplied id may still ADDRESS an existing record — that is what an id is for. It may not become one.
+ *
+ * ## Why this is a gate rather than four fixes
+ *
+ * Because it was four, and the report that prompted the audit named two. A rule enforced by reading every write
+ * path is a rule; four correct lines are a coincidence that holds until someone adds a fifth collection.
+ *
+ * ## This file replaced the gate that enforced the opposite
+ *
+ * It was `idempotent-writes-contract.test.js`, and it asserted the old contract explicitly — *"memory: a supplied
+ * id becomes the new record's identity"*, and that the docs *"tell the reader to generate the id BEFORE the first
+ * attempt"*. Those were correct assertions about a contract that no longer exists.
+ *
+ * It keeps the old FILENAME on purpose: `scripts/release-gate.mjs` lists it by name, and the release gate must go
+ * on checking this area. A gate whose subject is reversed gets rewritten, not deleted — deleting it would have
+ * removed the release gate's only check here and nothing would have said so.
+ *
+ * The behavioural half — how many records exist after a second call — is a database question and lives in
+ * `testing/integration/idempotent-writes.test.js`, which needs Docker and runs in CI.
  *
  * Run: node --test testing/standalone/idempotent-writes-contract.test.js
  */
-import { describe, it, before } from 'node:test';
+import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { execSync } from 'node:child_process';
 
-const ROOT = process.cwd();
-const DOC = 'docs/integration-guide/04-brain-api.md';
-const doc = readFileSync(join(ROOT, DOC), 'utf8');
+const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+const serverFiles = execSync('git ls-files "server/src/**/*.ts"', { encoding: 'utf8' })
+  .trim().split('\n').filter(f => f && !f.endsWith('.spec.ts'));
 
-const src = (p) => readFileSync(join(ROOT, p), 'utf8');
+describe('identity is minted by the server', () => {
+  it('finds the write paths it is meant to be checking', () => {
+    // A sweep that enumerates nothing passes vacuously. Every record family must assign an `_id` somewhere.
+    const assigning = serverFiles.filter(f => /_id:\s*uuidv4\(\)|_id:\s*randomUUID\(\)/.test(strip(readFileSync(f, 'utf8'))));
+    assert.ok(assigning.length >= 3,
+      `expected the create paths that mint an id, found ${assigning.length} — if these moved, re-point this test`);
+  });
 
-/** The two writers that gained the path, and the one it was modelled on. */
-const WRITERS = [
-  { label: 'memory', impl: 'server/src/brain/memory.ts', route: 'server/src/api/brain/memories.ts', event: 'memory.updated' },
-  { label: 'chrono', impl: 'server/src/brain/chrono.ts', route: 'server/src/api/brain/chrono.ts', event: 'chrono.updated' },
-];
-
-describe('the contract is documented', () => {
-  it('a Retry Safety section exists and names all four record types', () => {
-    assert.match(doc, /## Retry Safety/,
-      'the Retry Safety section is gone. Two of these four types were already idempotent and nobody knew, which is '
-      + 'the failure this section exists to prevent.');
-    const region = doc.slice(doc.indexOf('## Retry Safety'), doc.indexOf('## Retry Safety') + 4000);
-    for (const t of ['memory', 'chrono', 'entity', 'edge']) {
-      assert.ok(region.includes(t), `the Retry Safety section does not mention ${t}`);
+  it('no write path adopts a caller-supplied id as the record identity', () => {
+    // The exact shape that shipped, in every spelling of it. `?? uuidv4()` is the tell: a fallback means the
+    // first operand was a caller's value.
+    const bad = [];
+    for (const f of serverFiles) {
+      const src = strip(readFileSync(f, 'utf8'));
+      for (const m of src.matchAll(/_id:\s*([^,\n]*\?\?\s*(?:uuidv4|randomUUID)\(\))/g)) {
+        bad.push(`${f}: ${m[1].trim()}`);
+      }
     }
+    assert.deepEqual(bad, [],
+      'these adopt a caller-supplied id as a new record\'s identity, which makes the caller a co-author of the '
+      + `primary key and lets two instances collide by design across sync:\n  ${bad.join('\n  ')}`);
   });
 
-  it("says plainly that idempotent does NOT mean no-op", () => {
-    // "Idempotent" is routinely read as "the second call does nothing". Here the second write really happens and
-    // moves seq — an integrator who believes otherwise will be confused by their own audit log.
-    assert.match(doc, /not a no-op/i,
-      'the doc does not warn that the retry is a real write; seq and updatedAt advance and it appears in the audit '
-      + 'log, which contradicts the usual reading of "idempotent"');
-    assert.match(doc, /\bseq\b/, 'the doc does not mention that seq advances');
+  it('the tool schemas do not advertise choosing an id', () => {
+    // The docs promised idempotency-by-id. Leaving that text while removing the behaviour is worse than either:
+    // a caller reads the description, retries with the same id, and gets a second record.
+    const tools = execSync('git ls-files "server/src/mcp/tools/*.ts"', { encoding: 'utf8' })
+      .trim().split('\n').filter(f => f && !f.endsWith('.spec.ts'));
+    const stale = [];
+    for (const f of tools) {
+      const src = readFileSync(f, 'utf8');
+      if (/Optional UUID v4/.test(src)) stale.push(`${f.split('/').pop()} still says "Optional UUID v4"`);
+      if (/inserts with this ID/.test(src)) stale.push(`${f.split('/').pop()} still promises insert-with-id`);
+      if (/make this call IDEMPOTENT/.test(src)) stale.push(`${f.split('/').pop()} still promises idempotency by id`);
+    }
+    assert.deepEqual(stale, [],
+      `a description that outlives its behaviour is how a caller builds on a contract that is gone:\n  ${stale.join('\n  ')}`);
   });
 
-  it('states the UUID v4 requirement and that omitting the id is unchanged', () => {
-    assert.match(doc, /UUID v4/, 'the id format is not stated');
-    assert.match(doc, /Omitting .{0,6}id.{0,6} is unchanged|every call creates a new record/i,
-      'the doc does not reassure that existing clients which omit the id are unaffected — the first question any '
-      + 'reader of a new write parameter has');
+  it('an id may still ADDRESS an existing record', () => {
+    // The half that must NOT be removed. Update and delete take an id, and records written before this ruling
+    // may carry a non-UUID one — so those paths stay permissive, or the junk they created becomes undeletable.
+    const chrono = strip(readFileSync('server/src/brain/chrono.ts', 'utf8'));
+    assert.match(chrono, /_id: fields\.id, spaceId/,
+      'the lookup-by-supplied-id path is gone, so an update can no longer find its record');
   });
-
-  it('tells the reader to generate the id BEFORE the first attempt', () => {
-    // The technique is worthless if the id is generated per attempt, and that is the natural mistake.
-    assert.match(doc, /before your first attempt|before the first attempt/i,
-      'the doc does not say to generate the id before the first attempt, which is the one detail that makes the '
-      + 'technique work');
-  });
-});
-
-describe('the routes validate a caller-supplied id', () => {
-  for (const w of WRITERS) {
-    it(`${w.label}: refuses anything that is not a UUID v4`, () => {
-      // Asserts the id is tested against the pattern, not merely that the pattern is imported. The first version
-      // matched `UUID_V4_RE` anywhere in the file — and both routes already use it for `entityIds` — so a mutation
-      // replacing the id check with `true` passed while nothing validated the id at all.
-      const s = src(w.route);
-      assert.match(s, /UUID_V4_RE\.test\(rawId\)/,
-        `${w.route} does not test the supplied id against UUID_V4_RE. It becomes the _id of a record that replicates `
-        + 'across every peer in every network the space belongs to, so an arbitrary string must not reach it.');
-      assert.match(s, /rawId !== undefined/,
-        `${w.route} does not let the id be omitted, which every existing client relies on`);
-      assert.match(s, /status\(400\)/, `${w.route} has no 400 path for a malformed id`);
-    });
-  }
-});
-
-describe('the implementation converges rather than duplicating', () => {
-  for (const w of WRITERS) {
-    it(`${w.label}: looks the record up by the supplied id before inserting`, () => {
-      const s = src(w.impl);
-      assert.match(s, /const existing/,
-        `${w.impl} never looks for an existing record, so a supplied id cannot converge on anything`);
-      assert.match(s, /_id: (id|fields\.id|existing\._id)/,
-        `${w.impl} does not query by the supplied id`);
-    });
-
-    it(`${w.label}: a supplied id becomes the new record's identity`, () => {
-      // Without this the FIRST call generates its own id, the caller's id names nothing, and the retry inserts a
-      // second record — the bug, with a lookup in front of it that never matches.
-      const s = src(w.impl);
-      assert.match(s, /_id: (id|fields\.id) \?\? uuidv4\(\)/,
-        `${w.impl} ignores the supplied id when inserting, so the caller's retry can never find the record`);
-    });
-
-    it(`${w.label}: emits ${w.event} on convergence, not *.created`, () => {
-      // SCOPED to the converge branch, not the whole file. The first version asserted the file merely CONTAINED
-      // `${w.event}` — which it does anyway, from the separate update function — so a mutation flipping the
-      // converge branch to `*.created` passed. Scoping is the difference between checking the branch and checking
-      // that the string exists somewhere.
-      const s = src(w.impl);
-      const branchAt = s.indexOf('if (existing) {');
-      assert.ok(branchAt > 0, `${w.impl} has no convergence branch at all`);
-      const branch = s.slice(branchAt, s.indexOf('\n  }', branchAt));
-      assert.ok(branch.includes(`'${w.event}'`),
-        `the convergence branch in ${w.impl} does not emit ${w.event}. A webhook subscriber cannot tell a converged `
-        + 'retry from a new record, and no count-based test would catch it.');
-      assert.ok(!branch.includes(`'${w.label}.created'`),
-        `the convergence branch emits ${w.label}.created — it is an update to an existing record, and a subscriber `
-        + 'would create a duplicate downstream from it');
-    });
-  }
-});
-
-describe('the MCP tools advertise it', () => {
-  let ALL_TOOLS;
-  before(async () => { ({ ALL_TOOLS } = await import('../../server/dist/mcp/tools/index.js')); });
-
-  const schemas = {
-    requiredSpace: { type: 'string', description: 'Space ID.' },
-    optionalSpace: { type: 'string', description: 'Optional space ID.' },
-  };
-
-  for (const name of ['remember', 'create_chrono']) {
-    it(`${name} takes an optional id, and says what it is for`, () => {
-      const tool = ALL_TOOLS.find(t => t.name === name);
-      assert.ok(tool, `the ${name} tool is gone`);
-      const schema = tool.inputSchema(schemas);
-      assert.ok(schema.properties.id, `${name} does not advertise an id — an MCP agent is exactly the caller that `
-        + 'retries, so leaving this REST-only would fix the case that matters least');
-      assert.match(schema.properties.id.description, /idempotent/i,
-        `${name}'s id has no description explaining what it is for; an agent reads the schema and nothing else`);
-      assert.ok(!(schema.required ?? []).includes('id'),
-        `${name} made id REQUIRED, which breaks every existing agent call`);
-    });
-  }
 });


### PR DESCRIPTION
Owner ruling: *"we do not accept custom ids. on write time one is mongodb-generated … they can use name or description for descriptive fields. id is id."*

Four write paths adopted a supplied id when it named nothing — `_id: fields.id ?? uuidv4()` in chrono, entities and memory, reachable from `create_chrono`, `remember`, `upsert_entity` and `bulk_write`.

A supplied `id` now names an **existing** record to update; one that matches nothing is **ignored**, and the record is created with a fresh server-minted UUID.

## Why, since this removes a documented feature

Adopting a caller's id made the caller a co-author of our primary key. Across a network that has a sharp edge: the natural way to produce a stable id is to **derive** it from a stable key, which is exactly how two instances following one convention collide **by design**.

Inbound sync resolves a collision by `seq` alone — `findOne({_id})`, then `replaceOne` when the incoming seq is higher — with **no author comparison**. One version silently replaces the other, every reference still resolves to the survivor, nothing dangles, and the link-violation machinery therefore never sees it. That is what makes it quiet, and quiet data loss is the worst kind.

## What it costs, stated plainly

The retry-safety technique — generate a UUID before the first attempt, reuse it on every retry — is **gone**. A retried create of a memory, chrono entry or entity can produce a second record.

`checkDuplicates` is on by default and returns `similar`, which turns a duplicated retry into something detectable rather than silent. Edges are unaffected: their natural key `(from, to, label)` already converges.

breituai-platform relies on the old contract and has been told on the board.

## The docs and the gate both had to be reversed, not patched

- `04-brain-api.md`'s **Retry Safety** section taught the removed technique end to end — table, "how to", and a worked example — so it is rewritten rather than amended.
- `idempotent-writes-contract.test.js` asserted the **old** rule outright: *"memory: a supplied id becomes the new record's identity"*, and that the docs *"tell the reader to generate the id BEFORE the first attempt"*. It now asserts this rule, and **keeps its filename** because `release-gate.mjs` lists it by name — deleting it would have removed the release gate's only check in this area and nothing would have reported that.

The rewritten gate sweeps **every** server write path for `_id: … ?? uuidv4()` rather than checking the four known files, because the report that started this audit named two of them and the sweep found four. Mutation-tested: restoring the adopt-the-id line in `memory.ts` makes it name the file and the expression.

## Deliberately unchanged

`update_*` and `delete_*` ids stay permissive. Records written before this ruling may carry a non-UUID id — the reporting operator has one — and constraining those paths would make exactly those records unfixable and undeletable.
