### PR TITLE
feat(mcp): help reports which capabilities are REST-only, and why

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,23 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
+      # ONNXRUNTIME_NODE_INSTALL_CUDA=skip is not an optimisation, it is what makes this step hermetic.
+      #
+      # onnxruntime-node ships its CUDA execution-provider binaries OUTSIDE npm (too large for the registry) and
+      # its postinstall downloads them from a GitHub release. On a runner with no nvcc the script logs
+      # "`nvcc` not found. Assuming CUDA 12" and downloads the GPU tarball anyway - so every build depended on a
+      # GitHub release fetch succeeding, for binaries no runner here can use.
+      #
+      # It failed twice in 35 minutes on 2026-08-12 with ECONNRESET / socket hang up, killing the job in ~37
+      # seconds. Reading it as a test failure wastes the diagnosis; a job that dies that fast died before the
+      # tests. `skip` is the flag the install script documents for exactly this.
+      #
+      # NOT a retry. A retry around a network fetch hides the non-hermeticity and still fails when the release
+      # host is down; removing the fetch removes the dependency.
       - name: Install dependencies
         run: npm ci
+        env:
+          ONNXRUNTIME_NODE_INSTALL_CUDA: skip
 
       # A change to shipped code needs a CHANGELOG entry under [Unreleased].
       #

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,8 +41,23 @@ jobs:
           node-version: 24
           cache: npm
 
+      # ONNXRUNTIME_NODE_INSTALL_CUDA=skip is not an optimisation, it is what makes this step hermetic.
+      #
+      # onnxruntime-node ships its CUDA execution-provider binaries OUTSIDE npm (too large for the registry) and
+      # its postinstall downloads them from a GitHub release. On a runner with no nvcc the script logs
+      # "`nvcc` not found. Assuming CUDA 12" and downloads the GPU tarball anyway - so every build depended on a
+      # GitHub release fetch succeeding, for binaries no runner here can use.
+      #
+      # It failed twice in 35 minutes on 2026-08-12 with ECONNRESET / socket hang up, killing the job in ~37
+      # seconds. Reading it as a test failure wastes the diagnosis; a job that dies that fast died before the
+      # tests. `skip` is the flag the install script documents for exactly this.
+      #
+      # NOT a retry. A retry around a network fetch hides the non-hermeticity and still fails when the release
+      # host is down; removing the fetch removes the dependency.
       - name: Install
         run: npm ci
+        env:
+          ONNXRUNTIME_NODE_INSTALL_CUDA: skip
 
       - name: Build (the doc gates read server/dist)
         run: npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- **`help` now reports which capabilities exist over REST and not over MCP, and why.** breituai-platform,
+  2026-08-11T1722Z, whose principle is the right one: *"The rights matrix decides what a token may do; the
+  surface should not also decide whether it can."*
+  - The sharp part of their report was not the five capabilities they hit. It was that they **could not tell
+    absent from gated** — a tool hidden because their token lacks a right and a tool that was never built look
+    identical from outside, and one is a documentation fix while the other is an afternoon. So they had to ask.
+  - `help` returns `structuredContent.restOnly`: every REST-only capability with its route, method and the
+    reason it is not a tool yet. Machine-readable because their agents branch on it. A client reading only
+    `content` loses nothing.
+  - The five are confirmed **absent, not gated**, read from the registry: 34 tools, none of them a reindex, a
+    token list, a `retry_embedding` or a space create. `update_space` exists but takes only label, purpose and
+    description, so nothing on MCP writes a schema.
+  - `mcp-rest-parity.test.js` checks each row in **both** directions: the REST route must exist, and no tool of
+    that name may exist. The second is the one that matters — the day somebody builds `reindex`, the gate fails
+    until the row is deleted, so the map cannot go on advertising a gap that has closed. That is the direction a
+    hand-maintained list always rots in, because closing a gap feels like the end of the job.
+  - A row must also carry a real reason: mutation testing showed a length check alone passed a `TODO` with a long
+    sentence after it, so placeholders are refused by name.
+  - Parity itself is not done — this ships the map first, because it makes the remaining work legible to the
+    people waiting on it.
 - **You can see the rights your own token holds, without being an administrator.** Owner: *"everyone else at
   least view their own"*.
   - `GET /api/tokens/me` has always returned the caller`s whole record, `rights` included. The typed client

--- a/docs/integration-guide/16-mcp.md
+++ b/docs/integration-guide/16-mcp.md
@@ -114,6 +114,38 @@ Authorization: Bearer <token>
 Content-Type: application/json
 ```
 
+### Telling "absent" from "your token cannot see it"
+
+Two different situations look identical from outside: a tool that was never built, and a tool hidden from your
+`tools/list` because your token is read-only or non-admin. One is a gap in the product; the other is a
+permission. You should not have to ask which.
+
+**Hidden by scope:** a mutating tool is omitted for a `readOnly` token, and an admin tool for a non-admin. The
+`help` tool's prose says outright when tools are being hidden from you and how many.
+
+**Never built:** `help` returns a `structuredContent.restOnly` block listing every capability that exists over
+REST and not yet over MCP — each with the route, the method, and *why* it is not a tool yet:
+
+```json
+{
+  "restOnly": {
+    "note": "These capabilities exist over REST and are NOT yet on MCP. Each row is a confirmed absence, not a permission you lack …",
+    "capabilities": [
+      {
+        "capability": "Rebuild a space's vector indexes",
+        "mcpTool": null,
+        "restEndpoint": "/api/brain/spaces/:spaceId/reindex",
+        "method": "POST",
+        "why": "Not built. …"
+      }
+    ]
+  }
+}
+```
+
+`mcpTool` is `null` on every row by definition. A row disappearing means the tool now exists — a gate fails if a
+row survives its own tool being built, so the list cannot keep advertising a gap that has closed.
+
 ### Available Tools
 
 > **After an instance upgrade, reconnect before concluding a tool is missing.** MCP negotiates the tool list

--- a/server/src/mcp/parity.ts
+++ b/server/src/mcp/parity.ts
@@ -1,0 +1,111 @@
+/**
+ * Capabilities that exist over REST and not over MCP, declared rather than discovered.
+ *
+ * ## Why this file exists
+ *
+ * breituai-platform, 2026-08-11T1722Z, and the principle is theirs: *"The rights matrix decides what a token may
+ * do; the surface should not also decide whether it can."* They hit five of these in one day of ordinary work —
+ * none from auditing the API — and the worst part of the report is not the five. It is that they could not tell
+ * **absent** from **gated**: a capability hidden behind a right they lacked and a capability that was never
+ * built look identical from outside, and one is a documentation fix while the other is an afternoon.
+ *
+ * So the gap is written down, machine-readable, with the reason beside it. A hole becomes a row with a blank
+ * rather than a discovery. Their own smaller ask was exactly this, and it is worth shipping ahead of parity
+ * itself because it makes the remaining work legible to the people waiting on it.
+ *
+ * ## The rule this file is under
+ *
+ * A row here is a PROMISE THAT SOMETHING IS MISSING. `mcp-rest-parity.test.js` asserts both halves of every row:
+ * the REST route named actually exists, and no MCP tool by that name exists. So a row cannot rot in either
+ * direction — the day someone builds `reindex` as a tool, the gate fails until the row is deleted, and the day
+ * someone renames the REST route, the gate fails until the row is corrected.
+ *
+ * That is deliberate. A hand-maintained list is what produced five gaps; a hand-maintained list of the gaps
+ * would produce the same problem one level up.
+ */
+
+/** One capability reachable over REST and not over MCP. */
+export interface RestOnlyCapability {
+  /** What an operator would call it. */
+  capability: string;
+  /** The REST route, exactly as the router declares it. Asserted to exist. */
+  restEndpoint: string;
+  /** HTTP method, for a caller building the request. */
+  method: 'GET' | 'POST' | 'PATCH' | 'DELETE';
+  /** The tool name it WOULD have, asserted NOT to exist while this row stands. */
+  wouldBeTool: string;
+  /** Why it is not on MCP yet — never "no reason", because that is what a blank invites. */
+  why: string;
+}
+
+/**
+ * The five they reported, and nothing invented alongside them.
+ *
+ * Confirmed absent rather than gated on 2026-08-12 by reading the tool registry: 34 tools, none of which is a
+ * reindex, a token list, a `retry_embedding` or a space create. `update_space` exists but accepts only `label`,
+ * `purpose` and `description`, so nothing on MCP writes a schema — their reading was right on every one.
+ */
+export const REST_ONLY_CAPABILITIES: readonly RestOnlyCapability[] = [
+  {
+    capability: 'Rebuild a space\'s vector indexes',
+    restEndpoint: '/api/brain/spaces/:spaceId/reindex',
+    method: 'POST',
+    wouldBeTool: 'reindex',
+    why: 'Not built. They reindexed 19 spaces by hand in a shell loop because the agent that planned their '
+      + 'embedder migration could not run it. Async already, with /reindex-status to poll, so a tool is a thin wrapper.',
+  },
+  {
+    capability: 'Write a space\'s type schemas',
+    restEndpoint: '/api/spaces/:id',
+    method: 'PATCH',
+    wouldBeTool: 'update_space_schema',
+    why: 'Not built. `update_space` covers label, purpose and description only, so an agent can design an '
+      + '11-entity model and not apply it. The write is the same route; the tool is the missing part.',
+  },
+  {
+    capability: 'List the instance\'s tokens',
+    restEndpoint: '/api/tokens',
+    method: 'GET',
+    wouldBeTool: 'list_tokens',
+    why: 'Not built, and admin-only over REST. They audit tokens with a Kubernetes CronJob that curls this and '
+      + 'posts the result into a space as a chrono entry, so an agent can read it — a workaround with a scheduler in it.',
+  },
+  {
+    capability: 'Re-queue a failed file embedding',
+    restEndpoint: '/api/files/:spaceId/retry_embedding',
+    method: 'POST',
+    wouldBeTool: 'retry_embedding',
+    why: 'Not built. This is the documented recovery path for a failed embedding, so the surface that cannot '
+      + 'reach it cannot recover from a failure it can see.',
+  },
+  {
+    capability: 'Create a space',
+    restEndpoint: '/api/spaces',
+    method: 'POST',
+    wouldBeTool: 'create_space',
+    why: 'Not built, including the descriptor-width parameter. A token holding `createSpaces` in the rights '
+      + 'matrix cannot exercise it over MCP, which is the exact shape of their complaint.',
+  },
+] as const;
+
+/**
+ * The capability map `help()` reports, so a caller can see the gap without asking anyone.
+ *
+ * Shaped as rows rather than prose because they asked for something machine-readable: their agents branch on it.
+ */
+export function restOnlyCapabilityMap(): {
+  note: string;
+  capabilities: { capability: string; mcpTool: null; restEndpoint: string; method: string; why: string }[];
+} {
+  return {
+    note: 'These capabilities exist over REST and are NOT yet on MCP. Each row is a confirmed absence, not a '
+      + 'permission you lack — a tool you cannot see because of your token is hidden from tools/list instead.',
+    capabilities: REST_ONLY_CAPABILITIES.map(c => ({
+      capability: c.capability,
+      mcpTool: null,
+      restEndpoint: c.restEndpoint,
+      method: c.method,
+      why: c.why,
+    })),
+  };
+}

--- a/server/src/mcp/tools/help.ts
+++ b/server/src/mcp/tools/help.ts
@@ -1,4 +1,5 @@
 import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.js';
+import { restOnlyCapabilityMap } from '../parity.js';
 
 /**
  * `help` — self-documenting system guide (F1).
@@ -150,6 +151,12 @@ ${toolLines}
 
 ${REST_SUMMARY}`;
 
-    return { content: [{ type: 'text' as const, text }] };
+    // The gap, machine-readable, beside the prose. breituai-platform asked for a capability map because their
+    // agents BRANCH on it, and because a hole they can read is an afternoon they do not spend discovering it.
+    // `structuredContent` rather than more text: a client that reads only `content` loses nothing.
+    return {
+      content: [{ type: 'text' as const, text }],
+      structuredContent: { restOnly: restOnlyCapabilityMap() },
+    };
   },
 };

--- a/testing/standalone/mcp-rest-parity.test.js
+++ b/testing/standalone/mcp-rest-parity.test.js
@@ -1,0 +1,143 @@
+/**
+ * The MCP/REST gap is declared, and every declaration is checked in BOTH directions.
+ *
+ * ## The report
+ *
+ * breituai-platform, 2026-08-11T1722Z: *"The rights matrix decides what a token may do; the surface should not
+ * also decide whether it can."* They hit five REST-only capabilities in one day of ordinary work, none of them
+ * from auditing the API — reindex, schema write, token listing, `retry_embedding`, space creation.
+ *
+ * The sharpest part of the report was not the five. It was that they **could not tell absent from gated**: a
+ * tool hidden by a right they lack and a tool that was never built look identical from outside, and one is a
+ * documentation fix while the other is an afternoon of work. So they had to ask.
+ *
+ * ## What this gate protects
+ *
+ * `REST_ONLY_CAPABILITIES` is a list of promises that things are MISSING, which is an unusual thing to assert
+ * and needs both halves checked or it rots silently:
+ *
+ *  1. **The REST route named must exist.** Otherwise the map sends an integrator at a 404 while telling them
+ *     it is the supported path.
+ *  2. **No MCP tool of that name may exist.** The day somebody builds `reindex`, this gate fails until the row
+ *     is deleted — so the map cannot keep advertising a gap that has been closed. That is the direction a
+ *     hand-maintained list always rots in, and the one nobody notices, because closing a gap feels like the end
+ *     of the job.
+ *
+ * A hand-maintained list is what produced the five gaps. A hand-maintained list OF the gaps would reproduce the
+ * problem one level up, which is why neither half is taken on trust.
+ *
+ * Run: node --test testing/standalone/mcp-rest-parity.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+let REST_ONLY_CAPABILITIES, restOnlyCapabilityMap;
+
+before(async () => {
+  ({ REST_ONLY_CAPABILITIES, restOnlyCapabilityMap } = await import('../../server/dist/mcp/parity.js'));
+});
+
+/** Every route string declared anywhere under server/src/api, with its router prefix resolved. */
+function declaredRoutes() {
+  const files = execFileSync('git', ['ls-files', 'server/src/api'], { encoding: 'utf8' })
+    .split('\n').map(f => f.trim()).filter(f => f.endsWith('.ts'));
+  const paths = new Set();
+  for (const f of files) {
+    const src = readFileSync(f, 'utf8');
+    for (const m of src.matchAll(/\.(get|post|patch|put|delete)\(\s*'([^']+)'/g)) paths.add(m[2]);
+  }
+  // Router mount prefixes, read from app.ts so a remount cannot invalidate this quietly.
+  const app = readFileSync('server/src/app.ts', 'utf8');
+  const mounts = [...app.matchAll(/app\.use\('(\/api\/[a-z-]+)'/g)].map(m => m[1]);
+  return { paths, mounts };
+}
+
+/** The MCP tool names the registry actually exposes. */
+function toolNames() {
+  const files = execFileSync('git', ['ls-files', 'server/src/mcp/tools'], { encoding: 'utf8' })
+    .split('\n').map(f => f.trim()).filter(f => f.endsWith('.ts'));
+  const names = new Set();
+  for (const f of files) {
+    for (const m of readFileSync(f, 'utf8').matchAll(/^\s*name: '([a-z_]+)',/gm)) names.add(m[1]);
+  }
+  assert.ok(names.size >= 30, `parsed only ${names.size} tool names — the parser is stale`);
+  return names;
+}
+
+describe('the declared MCP/REST gap is real in both directions', () => {
+  it('the list is not empty, and every row is fully specified', () => {
+    // An empty list would pass every assertion below while saying nothing. If parity is ever complete, delete
+    // this gate rather than leaving it green and vacuous.
+    assert.ok(REST_ONLY_CAPABILITIES.length > 0, 'no rows — if the gap is closed, remove this gate deliberately');
+    for (const c of REST_ONLY_CAPABILITIES) {
+      for (const field of ['capability', 'restEndpoint', 'method', 'wouldBeTool', 'why']) {
+        assert.ok(typeof c[field] === 'string' && c[field].trim().length > 0,
+          `${c.capability ?? '(unnamed)'} is missing \`${field}\``);
+      }
+      assert.ok(c.why.length > 40,
+        `\`why\` for ${c.capability} is too short to be a reason — a blank is what invites the next gap`);
+      // Length alone is a weak proxy, and mutation testing proved it: a placeholder with a long sentence after
+      // it passed the length check. A reason that defers is not a reason, and this map is read by the people
+      // waiting on the work.
+      assert.doesNotMatch(c.why, /\b(TODO|TBD|FIXME|N\/?A|later|somebody|eventually|no reason)\b/i,
+        `\`why\` for ${c.capability} defers instead of explaining. Say what is missing and why, or delete the row`);
+    }
+  });
+
+  it('every REST route it names EXISTS', () => {
+    const { paths, mounts } = declaredRoutes();
+    const missing = [];
+    for (const c of REST_ONLY_CAPABILITIES) {
+      // The declared endpoint is absolute; a router declares it relative to its mount. Strip each known mount
+      // and see whether what remains was declared. `/api/spaces` with a router path of `/` is the awkward case,
+      // so an empty remainder is normalised back to `/`.
+      const hit = [...mounts].some(m => {
+        if (!c.restEndpoint.startsWith(m)) return false;
+        const rel = c.restEndpoint.slice(m.length) || '/';
+        return paths.has(rel);
+      }) || paths.has(c.restEndpoint);
+      if (!hit) missing.push(`${c.capability}: ${c.method} ${c.restEndpoint}`);
+    }
+    assert.deepEqual(missing, [],
+      'the capability map names a REST route that does not exist, so it would send an integrator at a 404 while '
+      + 'calling it the supported path:\n  ' + missing.join('\n  '));
+  });
+
+  it('no MCP tool exists for any row — a closed gap must be DELETED, not left advertised', () => {
+    const tools = toolNames();
+    const built = REST_ONLY_CAPABILITIES.filter(c => tools.has(c.wouldBeTool));
+    assert.deepEqual(built.map(c => c.wouldBeTool), [],
+      `these tools now EXIST, so the rows claiming they are missing are wrong. Delete the row (and tell the `
+      + `partner who asked): ${built.map(c => c.wouldBeTool).join(', ')}`);
+  });
+
+  it('the five reported capabilities are all still accounted for', () => {
+    // Named outright rather than counted: these are the ones an integrator was told about, and a refactor that
+    // dropped one from the map would quietly un-answer their report.
+    const covered = new Set(REST_ONLY_CAPABILITIES.map(c => c.wouldBeTool));
+    for (const t of ['reindex', 'update_space_schema', 'list_tokens', 'retry_embedding', 'create_space']) {
+      assert.ok(covered.has(t), `\`${t}\` was reported as a gap and is no longer in the map`);
+    }
+  });
+
+  it('help() reports the map, with mcpTool null on every row', () => {
+    const map = restOnlyCapabilityMap();
+    assert.equal(map.capabilities.length, REST_ONLY_CAPABILITIES.length);
+    for (const row of map.capabilities) {
+      assert.equal(row.mcpTool, null, 'a row in the REST-only map must not claim an MCP tool');
+      assert.ok(row.why && row.restEndpoint && row.method, 'each row must carry its reason and its route');
+    }
+    // The distinction they said they could not make from outside must be stated where they will read it.
+    assert.match(map.note, /absent|not a permission/i,
+      'the note must say these are absences rather than rights the caller lacks — that is the whole ask');
+  });
+
+  it('help() actually emits it, rather than only being able to', () => {
+    const src = readFileSync('server/src/mcp/tools/help.ts', 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    assert.match(src, /restOnlyCapabilityMap\(\)/, 'help must call the map');
+    assert.match(src, /structuredContent/, 'the map must ride in structuredContent, not only in prose');
+  });
+});


### PR DESCRIPTION
feat(mcp): help reports which capabilities are REST-only, and why

breituai-platform, 2026-08-11T1722Z. Their principle is the right one: "The
rights matrix decides what a token may do; the surface should not also decide
whether it can."

The sharp part of their report was not the five capabilities they hit in one day
of ordinary work. It was that they COULD NOT TELL ABSENT FROM GATED. A tool
hidden from tools/list because their token is read-only or non-admin, and a tool
that was never built, look identical from outside -- and one is a documentation
fix while the other is an afternoon. So they had to ask, and asking is the cost
this closes.

`help` now returns `structuredContent.restOnly`: every capability that exists
over REST and not over MCP, with its route, its method, and why it is not a tool
yet. Machine-readable because their agents branch on it; a client that reads only
`content` loses nothing.

The five are confirmed ABSENT rather than gated, read from the registry on
2026-08-12: 34 tools, none of which is a reindex, a token list, a
`retry_embedding` or a space create. `update_space` exists but accepts only
label, purpose and description, so nothing on MCP writes a schema. Their reading
was right on every one.

## The gate is the point

A hand-maintained list is what produced five gaps. A hand-maintained list OF the
gaps would reproduce that one level up, so mcp-rest-parity.test.js checks each row
in BOTH directions:

- the REST route named must exist, or the map sends an integrator at a 404 while
  calling it the supported path;
- no MCP tool of that name may exist. This is the one that matters. The day
  somebody builds `reindex`, the gate fails until the row is deleted -- so the map
  cannot go on advertising a gap that has closed. That is the direction a list
  always rots in, because closing a gap feels like the end of the job.

A row must also carry a real reason. Mutation testing earned that assertion: a
length check alone passed a `TODO` with a long sentence after it, so placeholders
are now refused by name. Five mutations, all caught -- an invented route, a
closed-but-still-advertised gap, a dropped capability, a deferring reason, and
help quietly stopping emitting the map.

## What this is not

Parity itself. The five tools are still to build, and this ships ahead of them on
purpose: the people waiting on the work can now read exactly what is missing and
why, instead of discovering it one 403 at a time.
