### PR TITLE
feat(mcp): retry_embedding is a tool, and the map lost a row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- **`retry_embedding` is an MCP tool.** First of the five REST-only capabilities breituai-platform reported, and
+  the sharpest one: it is the documented recovery path for a failed file embedding, so the surface that could SEE
+  the failure was the surface that could not act on it.
+  - A wrapper over the same `retryJob` the REST route calls. Reimplementing the reset — status, attempts,
+    lastError, claim fields — would be a second copy of a state machine, and the copy that drifts is the one
+    nobody watches.
+  - The three outcomes are reported verbatim rather than collapsed into success/failure. `processing` means the
+    worker already holds the file: not an error, and not something to retry, because resetting it would take the
+    job away from a run in progress.
+  - Audited under `file.retry_embedding`, the same operation string the REST route uses, so one query finds a
+    retry however it arrived.
+  - **It landed by DELETING its row from the capability map**, which is the lifecycle that map is built around:
+    `help` now lists four REST-only capabilities instead of five, with no separate changelog needed to say so.
 - **`help` now reports which capabilities exist over REST and not over MCP, and why.** breituai-platform,
   2026-08-11T1722Z, whose principle is the right one: *"The rights matrix decides what a token may do; the
   surface should not also decide whether it can."*

--- a/docs/integration-guide/16-mcp.md
+++ b/docs/integration-guide/16-mcp.md
@@ -33,7 +33,7 @@ On connect, the server sends global instructions listing all available space IDs
 
 ### Read-Only Tokens
 
-When connecting with a `readOnly` token, mutating tools (`remember`, `update_memory`, `delete_memory`, `upsert_entity`, `update_entity`, `delete_entity`, `merge_entities`, `upsert_edge`, `update_edge`, `delete_edge`, `create_chrono`, `update_chrono`, `delete_chrono`, `bulk_write`, `write_file`, `delete_file`, `create_dir`, `move_file`, `sync_now`, `update_space`, `wipe_space`) are **hidden** from `tools/list` and rejected with an error if called directly. Read-only tools (`help`, `recall`, `find_similar`, `query`, `get_stats`, `get_space_meta`, `list_spaces`, `find_entities_by_name`, `list_chrono`, `read_file`, `list_dir`, `traverse`) work normally. `list_peers` is read-only but **admin-gated** — see the admin-only note below.
+When connecting with a `readOnly` token, mutating tools (`remember`, `update_memory`, `delete_memory`, `upsert_entity`, `update_entity`, `delete_entity`, `merge_entities`, `upsert_edge`, `update_edge`, `delete_edge`, `create_chrono`, `update_chrono`, `delete_chrono`, `bulk_write`, `write_file`, `delete_file`, `create_dir`, `move_file`, `retry_embedding`, `sync_now`, `update_space`, `wipe_space`) are **hidden** from `tools/list` and rejected with an error if called directly. Read-only tools (`help`, `recall`, `find_similar`, `query`, `get_stats`, `get_space_meta`, `list_spaces`, `find_entities_by_name`, `list_chrono`, `read_file`, `list_dir`, `traverse`) work normally. `list_peers` is read-only but **admin-gated** — see the admin-only note below.
 
 ### Connecting
 
@@ -193,6 +193,7 @@ row survives its own tool being built, so the list cannot keep advertising a gap
 | `write_file` | Write a text file to the space file store (optional `description` and `tags` stored as metadata) |
 | `list_dir` | List directory contents |
 | `delete_file` | Delete a file |
+| `retry_embedding` | Re-queue a file whose media embedding failed or was skipped. Returns `processing` unchanged when the worker already holds it |
 | `create_dir` | Create a directory |
 | `move_file` | Move or rename a file/directory |
 | `update_space` | Update space label and/or purpose (admin only). In a networked space a purpose change opens a meta vote rather than applying at once |

--- a/server/src/mcp/audit-map.ts
+++ b/server/src/mcp/audit-map.ts
@@ -55,6 +55,8 @@ export const MCP_TOOL_OPERATIONS: Record<string, string | null> = {
   write_file: 'file.create',
   move_file: 'file.update',
   delete_file: 'file.delete',
+  // Same operation string the REST route audits under, so one query finds a retry however it arrived.
+  retry_embedding: 'file.retry_embedding',
   create_dir: 'file.mkdir',
   // The tool registry flags this `mutating: true`, and it is right: a sync cycle pulls records from
   // peers and writes them locally, so "who started the run that brought in these records" is a fair

--- a/server/src/mcp/parity.ts
+++ b/server/src/mcp/parity.ts
@@ -39,9 +39,9 @@ export interface RestOnlyCapability {
 }
 
 /**
- * The five they reported, and nothing invented alongside them.
+ * The five they reported, minus the ones now built. Nothing invented alongside them.
  *
- * Confirmed absent rather than gated on 2026-08-12 by reading the tool registry: 34 tools, none of which is a
+ * Confirmed absent rather than gated on 2026-08-12 by reading the tool registry: 34 tools, none of which was a
  * reindex, a token list, a `retry_embedding` or a space create. `update_space` exists but accepts only `label`,
  * `purpose` and `description`, so nothing on MCP writes a schema — their reading was right on every one.
  */
@@ -69,14 +69,6 @@ export const REST_ONLY_CAPABILITIES: readonly RestOnlyCapability[] = [
     wouldBeTool: 'list_tokens',
     why: 'Not built, and admin-only over REST. They audit tokens with a Kubernetes CronJob that curls this and '
       + 'posts the result into a space as a chrono entry, so an agent can read it — a workaround with a scheduler in it.',
-  },
-  {
-    capability: 'Re-queue a failed file embedding',
-    restEndpoint: '/api/files/:spaceId/retry_embedding',
-    method: 'POST',
-    wouldBeTool: 'retry_embedding',
-    why: 'Not built. This is the documented recovery path for a failed embedding, so the surface that cannot '
-      + 'reach it cannot recover from a failure it can see.',
   },
   {
     capability: 'Create a space',

--- a/server/src/mcp/tools/file.ts
+++ b/server/src/mcp/tools/file.ts
@@ -246,3 +246,69 @@ export const move_fileTool: ToolHandler = {
     return { content: [{ type: 'text' as const, text: `Moved '${src}' → '${dst}'.` }] };
   },
 };
+
+/**
+ * Re-queue a failed file embedding.
+ *
+ * ## Why this is a tool now
+ *
+ * breituai-platform, 2026-08-11T1722Z, listed it among five capabilities a token could HOLD and not exercise:
+ * *"The rights matrix decides what a token may do; the surface should not also decide whether it can."* This one
+ * is the sharpest of the five, because it is the documented recovery path for a failed embedding — so the surface
+ * that could see the failure was the surface that could not act on it.
+ *
+ * ## A wrapper, deliberately
+ *
+ * `retryJob` is the same function `POST /api/files/:spaceId/retry_embedding` calls. Reimplementing the reset
+ * (status, attempts, lastError, claim fields) here would be a second copy of a state machine, and the copy that
+ * drifts is the one nobody is watching. The three outcomes are reported verbatim rather than collapsed into
+ * success/failure: `processing` means someone else already has it, which is not an error and not a retry.
+ */
+export const retry_embeddingTool: ToolHandler = {
+  name: 'retry_embedding',
+  description: 'Re-queue a file whose media embedding failed or was skipped, so the worker picks it up again. '
+    + 'Resets the job to pending and clears its attempt count and last error. Returns `processing` unchanged if '
+    + 'the worker already holds it — that is not a failure, and retrying it would take the job away from a run in '
+    + 'progress. Use the file path as it appears in list_dir.',
+  mutating: true,
+  spaceRequired: true,
+  inputSchema: (s: ToolSchemas) => ({
+    type: 'object',
+    properties: {
+      space: s.requiredSpace,
+      path: { type: 'string', minLength: 1, description: 'File path relative to the space root.' },
+      targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
+    },
+    required: ['space', 'path'],
+    additionalProperties: false,
+  }),
+  async handle(ctx: ToolContext): Promise<ToolResult> {
+    const { args: a, callSpace } = ctx;
+    const filePath = String(a['path'] ?? '');
+    if (!filePath.trim()) throw new Error('path must not be empty');
+    const wt = resolveWriteTarget(callSpace, a['targetSpace'] as string | undefined);
+    if (!wt.ok) throw new Error(wt.error);
+
+    // Normalised the same way the REST route does it, so a path that works there works here. A raw path would
+    // miss the job whose id is the normalised form, and report `not_found` for a file that exists.
+    const { toDocId } = await import('../../util/paths.js');
+    let docId: string;
+    try {
+      docId = toDocId(filePath);
+    } catch (err: unknown) {
+      throw new Error(err instanceof Error ? err.message : `Invalid path '${filePath}'`);
+    }
+
+    const { retryJob } = await import('../../files/media/job-queue.js');
+    const result = await retryJob(wt.target, docId);
+
+    const text = result === 'ok'
+      ? `Re-queued '${filePath}' for embedding.`
+      : result === 'processing'
+        ? `'${filePath}' is being processed right now — left alone rather than reset, so the run in progress is not interrupted.`
+        : `No embedding job exists for '${filePath}'. Either it was never queued, or the path does not match a stored file.`;
+
+    // The outcome verbatim, so a caller can branch without reading English.
+    return { content: [{ type: 'text' as const, text }], structuredContent: { result, path: filePath } };
+  },
+};

--- a/server/src/mcp/tools/index.ts
+++ b/server/src/mcp/tools/index.ts
@@ -6,7 +6,7 @@ import { bulk_writeTool } from './bulk.js';
 import { merge_entitiesTool, upsert_entityTool, find_entities_by_nameTool, update_entityTool, delete_entityTool } from './entity.js';
 import { upsert_edgeTool, traverseTool, update_edgeTool, delete_edgeTool } from './edge.js';
 import { create_chronoTool, update_chronoTool, list_chronoTool, delete_chronoTool } from './chrono.js';
-import { read_fileTool, write_fileTool, list_dirTool, delete_fileTool, create_dirTool, move_fileTool } from './file.js';
+import { read_fileTool, write_fileTool, list_dirTool, delete_fileTool, create_dirTool, move_fileTool, retry_embeddingTool } from './file.js';
 import { list_peersTool, sync_nowTool } from './sync.js';
 import { helpTool } from './help.js';
 
@@ -49,6 +49,7 @@ export const ALL_TOOLS: ToolHandler[] = [
   write_fileTool,
   list_dirTool,
   delete_fileTool,
+  retry_embeddingTool,
   create_dirTool,
   move_fileTool,
   update_spaceTool,

--- a/testing/standalone/mcp-audit-coverage.test.js
+++ b/testing/standalone/mcp-audit-coverage.test.js
@@ -80,9 +80,17 @@ describe('MCP audit coverage', () => {
   it('every operation it names is one the REST surface already uses', () => {
     // The point of reusing the vocabulary: the same act through two transports must read the same in the
     // log. An operation that exists only for MCP would split every compliance query in two.
+    // `_` is in the character class because operation names contain it — `file.retry_embedding` and
+    // `file.retry_embedding_all` are both real REST operations. Without it this regex captured `file.retry`,
+    // so the set of "operations REST uses" held a name nothing uses and lacked the two that exist. It went
+    // unnoticed because no MCP tool had mapped to an underscored operation yet: a comparison that cannot
+    // express part of its own vocabulary reports a mismatch the moment something legitimate arrives.
     const restOperations = new Set(
-      [...readFileSync(MIDDLEWARE, 'utf8').matchAll(/operation: '([a-z][a-zA-Z.]+)'/g)].map(m => m[1]),
+      [...readFileSync(MIDDLEWARE, 'utf8').matchAll(/operation: '([a-z][a-zA-Z._]+)'/g)].map(m => m[1]),
     );
+    // Proof the parse works, rather than trusting a green result: an operation known to exist must be found.
+    assert.ok(restOperations.has('file.retry_embedding'),
+      'the REST operation parse is broken — it cannot see an operation that is plainly there');
     const invented = [...new Set(Object.values(MCP_TOOL_OPERATIONS))]
       .filter(op => op && !restOperations.has(op));
     assert.deepEqual(invented, [],

--- a/testing/standalone/mcp-rest-parity.test.js
+++ b/testing/standalone/mcp-rest-parity.test.js
@@ -113,13 +113,23 @@ describe('the declared MCP/REST gap is real in both directions', () => {
       + `partner who asked): ${built.map(c => c.wouldBeTool).join(', ')}`);
   });
 
-  it('the five reported capabilities are all still accounted for', () => {
+  it('the five reported capabilities are each either still mapped or now BUILT', () => {
     // Named outright rather than counted: these are the ones an integrator was told about, and a refactor that
-    // dropped one from the map would quietly un-answer their report.
-    const covered = new Set(REST_ONLY_CAPABILITIES.map(c => c.wouldBeTool));
+    // dropped one would quietly un-answer their report.
+    //
+    // "Still in the map" is the wrong invariant on its own, and using the gate is what showed it: a row LEAVES
+    // the map when its tool ships, which is the whole lifecycle this file enforces. So the requirement is that
+    // each reported capability is accounted for one way or the other — mapped as missing, or present as a tool.
+    // Neither is the failure worth catching, and that is what this now catches.
+    const mapped = new Set(REST_ONLY_CAPABILITIES.map(c => c.wouldBeTool));
+    const built = toolNames();
+    const lost = [];
     for (const t of ['reindex', 'update_space_schema', 'list_tokens', 'retry_embedding', 'create_space']) {
-      assert.ok(covered.has(t), `\`${t}\` was reported as a gap and is no longer in the map`);
+      if (!mapped.has(t) && !built.has(t)) lost.push(t);
     }
+    assert.deepEqual(lost, [],
+      `reported as a gap, and now neither in the map nor built as a tool — the report has been silently `
+      + `un-answered: ${lost.join(', ')}`);
   });
 
   it('help() reports the map, with mcpTool null on every row', () => {

--- a/testing/standalone/mcp-tool-schemas.test.js
+++ b/testing/standalone/mcp-tool-schemas.test.js
@@ -19,11 +19,11 @@ const schemas = {
 const schemaOf = (name) => ALL_TOOLS.find(t => t.name === name).inputSchema(schemas);
 
 describe('MCP tool schemas — universal invariants', () => {
-  it('exposes exactly 34 tools', () => {
+  it('exposes exactly 35 tools', () => {
     // A deliberate tripwire, not a fact worth asserting for its own sake: the number changing means a tool
     // was added or removed, and every tool needs an audit mapping, a read-only classification and a docs
     // row. Bump it when you have done those three, never to make the suite quiet.
-    assert.equal(ALL_TOOLS.length, 34);
+    assert.equal(ALL_TOOLS.length, 35);
   });
 
   it('every tool advertises a closed object schema (type:object, additionalProperties:false)', () => {


### PR DESCRIPTION
feat(mcp): retry_embedding is a tool, and the map lost a row

First of the five REST-only capabilities breituai-platform reported, and the
sharpest one: retry_embedding is the documented recovery path for a failed file
embedding, so the surface that could SEE the failure was the surface that could
not act on it.

A wrapper over the same `retryJob` the REST route calls. Reimplementing the reset
-- status, attempts, lastError, claim fields -- would be a second copy of a state
machine, and the copy that drifts is the one nobody watches.

The three outcomes are reported verbatim rather than collapsed into
success/failure. `processing` means the worker already holds the file: not an
error, and not something to retry, because resetting it would take the job away
from a run in progress. It rides in structuredContent so a caller can branch
without reading English.

It landed by DELETING its row from the capability map, which is the lifecycle that
map exists for -- help now lists four REST-only capabilities instead of five, and
no separate note was needed to say so.

## Three gates fired, which is the checklist working

Adding a tool is not one edit here, and the gates said so: the audit map needed an
operation (`file.retry_embedding`, the same string REST audits under, so one query
finds a retry however it arrived), the docs needed it in the mutating-tools list
and the tool table, and the count assertion went 34 -> 35.

## And one of those gates was itself broken

`mcp-audit-coverage` compares MCP operation names against the REST vocabulary with
`/operation: '([a-z][a-zA-Z.]+)'/` -- no underscore in the class. So it captured
`file.retry` and its set of "operations REST uses" held a name nothing uses while
lacking the two that do (`file.retry_embedding`, `file.retry_embedding_all`).

It went unnoticed because no MCP tool had mapped to an underscored operation
before: a comparison that cannot express part of its own vocabulary reports a
mismatch the moment something legitimate arrives. Fixed, and it now asserts the
parse can see a known operation rather than trusting a green result.

## The parity gate also had the wrong invariant, and using it showed that

It required every reported capability to still be IN the map. But a row leaves the
map when its tool ships -- that is the lifecycle. Now each reported capability must
be either mapped as missing or present as a tool; neither is the failure worth
catching, and that is what it catches.