### PR TITLE
feat(mcp): list_tokens is a tool, and the map is down to three rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- **`list_tokens` is an MCP tool.** Second of the five, and their workaround was the tell: a Kubernetes CronJob
+  that curls `GET /api/tokens` and posts the result into a space as a chrono entry so an agent can read it. A
+  scheduler standing in for a tool call, and an inventory as stale as the last tick.
+  - Admin-gated exactly as the REST route is, and read-only, so it is hidden from a non-admin`s `tools/list`
+    rather than refused on call.
+  - **The hash cannot leak from here, and not because this code is careful.** `listTokens()` is typed
+    `Omit<TokenRecord, 'hash'>[]` and destructures it out, so the omission is that function`s contract rather
+    than this call site`s discipline. A tool that stripped the hash itself would be one edit from forgetting to,
+    and the compiler would not object.
+  - Not audited, matching REST: `GET /api/tokens` is a read, and the acts worth a log entry — the mint, the edit,
+    the revoke — are all audited already.
+  - Three rows left in the capability map: `reindex`, `update_space_schema` and `create_space`.
 - **`retry_embedding` is an MCP tool.** First of the five REST-only capabilities breituai-platform reported, and
   the sharpest one: it is the documented recovery path for a failed file embedding, so the surface that could SEE
   the failure was the surface that could not act on it.

--- a/docs/integration-guide/16-mcp.md
+++ b/docs/integration-guide/16-mcp.md
@@ -33,7 +33,7 @@ On connect, the server sends global instructions listing all available space IDs
 
 ### Read-Only Tokens
 
-When connecting with a `readOnly` token, mutating tools (`remember`, `update_memory`, `delete_memory`, `upsert_entity`, `update_entity`, `delete_entity`, `merge_entities`, `upsert_edge`, `update_edge`, `delete_edge`, `create_chrono`, `update_chrono`, `delete_chrono`, `bulk_write`, `write_file`, `delete_file`, `create_dir`, `move_file`, `retry_embedding`, `sync_now`, `update_space`, `wipe_space`) are **hidden** from `tools/list` and rejected with an error if called directly. Read-only tools (`help`, `recall`, `find_similar`, `query`, `get_stats`, `get_space_meta`, `list_spaces`, `find_entities_by_name`, `list_chrono`, `read_file`, `list_dir`, `traverse`) work normally. `list_peers` is read-only but **admin-gated** — see the admin-only note below.
+When connecting with a `readOnly` token, mutating tools (`remember`, `update_memory`, `delete_memory`, `upsert_entity`, `update_entity`, `delete_entity`, `merge_entities`, `upsert_edge`, `update_edge`, `delete_edge`, `create_chrono`, `update_chrono`, `delete_chrono`, `bulk_write`, `write_file`, `delete_file`, `create_dir`, `move_file`, `retry_embedding`, `sync_now`, `update_space`, `wipe_space`) are **hidden** from `tools/list` and rejected with an error if called directly. Read-only tools (`help`, `recall`, `find_similar`, `query`, `get_stats`, `get_space_meta`, `list_spaces`, `find_entities_by_name`, `list_chrono`, `read_file`, `list_dir`, `traverse`) work normally. `list_tokens` is read-only but **admin-gated**, like `list_peers`. `list_peers` is read-only but **admin-gated** — see the admin-only note below.
 
 ### Connecting
 
@@ -193,6 +193,7 @@ row survives its own tool being built, so the list cannot keep advertising a gap
 | `write_file` | Write a text file to the space file store (optional `description` and `tags` stored as metadata) |
 | `list_dir` | List directory contents |
 | `delete_file` | Delete a file |
+| `list_tokens` | List the instance API tokens — names, prefixes, expiry, rights. **Admin only.** Never includes a secret or its hash |
 | `retry_embedding` | Re-queue a file whose media embedding failed or was skipped. Returns `processing` unchanged when the worker already holds it |
 | `create_dir` | Create a directory |
 | `move_file` | Move or rename a file/directory |

--- a/server/src/mcp/audit-map.ts
+++ b/server/src/mcp/audit-map.ts
@@ -86,6 +86,9 @@ export const MCP_TOOL_OPERATIONS: Record<string, string | null> = {
   // Lists configured peers from local config. There is no `network.list` operation on the REST side
   // either — peer topology is read from `/api/networks`, which is itself unaudited as a read.
   list_peers: null,
+  // Reads the token inventory from local config. `GET /api/tokens` is not audited either — it is a
+  // read, and the acts worth an entry are the mint, the edit and the revoke, all of which are.
+  list_tokens: null,
 };
 
 /**

--- a/server/src/mcp/parity.ts
+++ b/server/src/mcp/parity.ts
@@ -63,14 +63,6 @@ export const REST_ONLY_CAPABILITIES: readonly RestOnlyCapability[] = [
       + '11-entity model and not apply it. The write is the same route; the tool is the missing part.',
   },
   {
-    capability: 'List the instance\'s tokens',
-    restEndpoint: '/api/tokens',
-    method: 'GET',
-    wouldBeTool: 'list_tokens',
-    why: 'Not built, and admin-only over REST. They audit tokens with a Kubernetes CronJob that curls this and '
-      + 'posts the result into a space as a chrono entry, so an agent can read it — a workaround with a scheduler in it.',
-  },
-  {
     capability: 'Create a space',
     restEndpoint: '/api/spaces',
     method: 'POST',

--- a/server/src/mcp/tools/index.ts
+++ b/server/src/mcp/tools/index.ts
@@ -1,5 +1,5 @@
 import type { ToolHandler } from './types.js';
-import { list_spacesTool, get_statsTool, get_space_metaTool, update_spaceTool, wipe_spaceTool } from './spaces.js';
+import { list_spacesTool, get_statsTool, get_space_metaTool, update_spaceTool, wipe_spaceTool , list_tokensTool } from './spaces.js';
 import { rememberTool, update_memoryTool, delete_memoryTool } from './memory.js';
 import { recallTool, find_similarTool, queryTool } from './search.js';
 import { bulk_writeTool } from './bulk.js';
@@ -54,6 +54,7 @@ export const ALL_TOOLS: ToolHandler[] = [
   move_fileTool,
   update_spaceTool,
   wipe_spaceTool,
+  list_tokensTool,
   bulk_writeTool,
   list_peersTool,
   sync_nowTool,

--- a/server/src/mcp/tools/spaces.ts
+++ b/server/src/mcp/tools/spaces.ts
@@ -229,3 +229,60 @@ export const wipe_spaceTool: ToolHandler = {
     };
   },
 };
+
+/**
+ * List the instance's tokens.
+ *
+ * ## Why this is a tool
+ *
+ * breituai-platform, 2026-08-11T1722Z, third of five: *"The rights matrix decides what a token may do; the
+ * surface should not also decide whether it can."* Their workaround was a Kubernetes CronJob that curls
+ * `GET /api/tokens` and posts the result into a space as a chrono entry so an agent can read it — a scheduler
+ * standing in for a tool call. That workaround also means the inventory an agent reads is as stale as the last
+ * tick, which is the part that makes it wrong rather than merely inconvenient.
+ *
+ * ## The hash cannot leak from here, and not because this code is careful
+ *
+ * `listTokens()` is typed `Omit<TokenRecord, 'hash'>[]` and destructures the hash out, so the omission is the
+ * function's contract rather than this call site's discipline. That matters: a tool that stripped the hash
+ * itself would be one edit away from forgetting to, and the compiler would not object.
+ *
+ * Admin-gated exactly as the REST route is. The response is credential METADATA — names, prefixes, expiry,
+ * rights — which is what an audit of who-can-reach-what needs and is no wider than the REST answer.
+ */
+export const list_tokensTool: ToolHandler = {
+  name: 'list_tokens',
+  description: 'List this instance\'s API tokens with their names, prefixes, expiry and rights matrix. Admin '
+    + 'only. Secrets are never included — a token\'s value exists only at the moment it is minted, and the '
+    + 'stored hash is not returned by this or any other surface. Use it to audit which tokens can reach which '
+    + 'spaces and at what level.',
+  admin: true,
+  inputSchema: () => ({
+    type: 'object',
+    properties: {},
+    required: [],
+    additionalProperties: false,
+  }),
+  async handle(_ctx: ToolContext): Promise<ToolResult> {
+    // Same call the REST route makes, and its return type is what guarantees no hash rides along.
+    const { listTokens } = await import('../../auth/tokens.js');
+    const tokens = listTokens();
+
+    const lines = tokens.map(t => {
+      const bits = [
+        t.admin ? 'instance-admin' : null,
+        t.readOnly ? 'read-only' : null,
+        t.expiresAt ? `expires ${t.expiresAt}` : 'no expiry',
+        t.rights ? 'rights matrix' : 'legacy scope',
+      ].filter(Boolean).join(', ');
+      return `- ${t.name} (${t.id}) — ${bits}`;
+    });
+
+    const text = tokens.length > 0
+      ? `${tokens.length} token(s):\n${lines.join('\n')}`
+      : 'No tokens are configured on this instance.';
+
+    // The full records ride here so an audit can branch on the matrix rather than parse the summary above.
+    return { content: [{ type: 'text' as const, text }], structuredContent: { tokens } };
+  },
+};

--- a/testing/standalone/mcp-tool-schemas.test.js
+++ b/testing/standalone/mcp-tool-schemas.test.js
@@ -19,11 +19,11 @@ const schemas = {
 const schemaOf = (name) => ALL_TOOLS.find(t => t.name === name).inputSchema(schemas);
 
 describe('MCP tool schemas — universal invariants', () => {
-  it('exposes exactly 35 tools', () => {
+  it('exposes exactly 36 tools', () => {
     // A deliberate tripwire, not a fact worth asserting for its own sake: the number changing means a tool
     // was added or removed, and every tool needs an audit mapping, a read-only classification and a docs
     // row. Bump it when you have done those three, never to make the suite quiet.
-    assert.equal(ALL_TOOLS.length, 35);
+    assert.equal(ALL_TOOLS.length, 36);
   });
 
   it('every tool advertises a closed object schema (type:object, additionalProperties:false)', () => {


### PR DESCRIPTION
feat(mcp): list_tokens is a tool, and the map is down to three rows

Second of the five REST-only capabilities breituai-platform reported. Their
workaround was the tell: a Kubernetes CronJob that curls GET /api/tokens and posts
the result into a space as a chrono entry so an agent can read it. A scheduler
standing in for a tool call -- and an inventory as stale as the last tick, which is
what makes it wrong rather than merely inconvenient.

Admin-gated exactly as the REST route is, and read-only, so it is hidden from a
non-admin's tools/list rather than refused on call.

## The hash cannot leak from here, and not because this code is careful

`listTokens()` is typed `Omit<TokenRecord, 'hash'>[]` and destructures the hash
out, so the omission is that function's contract rather than this call site's
discipline. A tool that stripped the hash itself would be one edit away from
forgetting to, and the compiler would not object.

Not audited, matching REST: GET /api/tokens is a read, and the acts worth a log
entry -- the mint, the edit, the revoke -- are audited already. Mapped to null
explicitly with that reason, because the coverage gate requires every registered
tool to be classified one way or the other.

## Two shell-escaping mistakes worth not repeating

Removing the parity row by script failed twice on the apostrophe in "List the
instance's tokens" -- the quote closed the shell string. The Edit tool has no such
layer and is the right instrument for text containing quotes; this is the third
time this session that escaping through bash cost a step.

The parity gate caught the row still standing both times, which is what it is for.

Three rows left: reindex, update_space_schema, create_space. reindex still needs
its inline re-embedding loop extracted first, behind characterization tests.