### PR TITLE
fix(loop): the stop gate counted a row prefix that no longer exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     nothing would have said so.
 
 ### Fixed
+- **`npm run loop:check` reported the work queue as drained while eleven rows were open** — a development gate, so
+  nothing shipped wrong because of it, but the one gate whose whole job is refusing that exact claim.
+  - It counted rows whose ID began `Q-`, from a period when every row did. The queue was later re-keyed per domain
+    — `B-` architecture, `U-` UX, `T-` sync — and a prefix filter that matches nothing returns nothing, so the
+    count was zero and the verdict was printed in green.
+  - **A row's tier is now the section it sits under, not the letter in its ID.** Sections are what is maintained by
+    hand, and one row proves the ID cannot stand in for a tier: `W-8` is open work carrying a watch-tier ID because
+    its home tracker keyed it that way. The rule defaults to *work* for any heading it does not recognise —
+    over-counting says "keep working", under-counting drains the queue silently.
+  - **A second under-count, on healthy rows:** a status was read as finished if `done`, `shipped` or `merged`
+    appeared anywhere in it, so `2 wrappers shipped (#842, #843)` — three fifths remaining — dropped out of the
+    queue. The marker now has to be the entire cell.
 - **A token stored with `spaces: null` came out of the 2.6 rights migration reaching NOTHING.** Reported from a
   live instance (aigents, 2026-08-12T1620Z) with the evidence attached: an unscoped persona token kept answering
   reads and was refused every write, so nothing alerted and it lost writes quietly for two days.

--- a/scripts/loop-check.mjs
+++ b/scripts/loop-check.mjs
@@ -21,7 +21,8 @@
  *
  *  - **In flight** — an open PR I authored. Then "Running" is a fact with a number attached, which is what the
  *    reply format's last slot is supposed to carry.
- *  - **Drained** — no open `Q-` rows. That is the release boundary the loop is designed to stop at.
+ *  - **Drained** — no open rows in the queue's work section. That is the release boundary the loop is designed to
+ *    stop at. Work sections are identified by heading, not by row ID; see `parseRows`.
  *
  * Anything else means work is available and nothing is executing, so the turn must continue. It prints the next
  * row, so the verdict is "keep going, on this" rather than just "keep going".
@@ -60,25 +61,51 @@ const sh = (cmd) => {
 };
 
 /**
+ * Sections that are listed in the ordered file but are NOT the queue.
+ *
+ * `W-` (watching), `P-` (parked) and the release section are exactly why the file can be drained while still
+ * listing things; counting them would make "the queue is empty" unreachable, which is the defect the retired
+ * *behind the tag* tier had.
+ *
+ * Matched on the HEADING rather than on the row ID, and the direction of the rule is deliberate: everything is
+ * work unless its section says otherwise. A new non-work section nobody taught this script about gets COUNTED,
+ * so the gate says "keep working" — an annoyance. The reverse default drains the queue silently, which is the
+ * failure this file exists to prevent and the one it shipped with for two weeks.
+ */
+const NOT_WORK_HEADING = /watch|parked|not work|release|reference|note/i;
+
+/** A done marker and nothing else: `shipped`, `merged (#812)`, `done 2026-08-04`. */
+const DONE_ONLY = /^(?:done|shipped|merged)\b[^a-z]*$/i;
+
+/**
  * Open rows in the ordered queue.
  *
  * The file is a table, one task per line (owner, 2026-08-09), so a row is a `|`-delimited line whose first cell
- * is an ID like `Q-2`. Anything else — headers, the `|---|` separator, prose between tables — is not a task.
+ * is an ID like `B-2`. Anything else — headers, the `|---|` separator, prose between tables — is not a task.
  *
- * Only the `Q-` tier counts. `W-` (watching) and `P-` (parked) rows are exactly why the file can be drained
- * while still listing things; counting them would make "the queue is empty" unreachable, which is the defect the
- * retired *behind the tag* tier had. A row whose status says it shipped is not open either — the queue is what
- * is left, not what was listed.
+ * **A row's tier is the section it sits under, never the letter in its ID.** The first version keyed on
+ * `id.startsWith('Q-')`, from a period when every row was a `Q-`. The queue was later re-keyed per domain — `B-`
+ * architecture, `U-` UX, `T-` sync — and this went on counting a prefix that no longer existed: it reported *the
+ * queue is drained* with eleven rows open, in green. Sections are what the owner maintains by hand, and `W-8`
+ * proves the ID cannot stand in for one — it is open work carrying a watch-tier ID because its home tracker keyed
+ * it that way.
+ *
+ * A row whose status is *only* a done marker is not open either — the queue is what is left, not what was listed.
+ * That test used to match `done|shipped|merged` anywhere in the cell, which read `2 wrappers shipped (#842,
+ * #843)` as finished when it means three fifths remain. Partial progress is the most common status in this file,
+ * so the marker now has to be the whole cell.
  */
 export function parseRows(text) {
   const rows = [];
+  let inWork = true; // Rows above the first heading are work; an unlabelled table is the file's oldest shape.
   for (const line of text.split('\n')) {
-    if (!line.trim().startsWith('|')) continue;
+    const heading = /^#{1,6}\s+(.*)$/.exec(line.trim());
+    if (heading) { inWork = !NOT_WORK_HEADING.test(heading[1]); continue; }
+    if (!inWork || !line.trim().startsWith('|')) continue;
     const cells = line.split('|').map((c) => c.trim()).filter((_, i, a) => i > 0 && i < a.length - 1);
     const id = cells[0];
     if (!id || !/^[A-Z]-\d+$/.test(id)) continue;
-    if (!id.startsWith('Q-')) continue;
-    if (/\b(done|shipped|merged)\b/.test((cells[3] ?? '').toLowerCase())) continue;
+    if (DONE_ONLY.test(cells[3] ?? '')) continue;
     rows.push({ id, what: cells[1] ?? '', status: cells[3] ?? '' });
   }
   return rows;
@@ -135,7 +162,8 @@ function main() {
   }
 
   const inFlight = prs !== null && prs.length > 0;
-  console.log(`  open Q- rows in ${ORDERED}: ${rows.length}`);
+  console.log(`  open work rows in ${ORDERED}: ${rows.length}` +
+    (rows.length ? ` ${C.dim}-> ${rows.slice(0, 4).map((r) => r.id).join(', ')}${rows.length > 4 ? ', …' : ''}${C.off}` : ''));
   console.log(`  open PRs authored by me:    ${prs === null ? '(gh unavailable)' : prs.length}` +
     (inFlight ? ` ${C.dim}-> #${prs.map((p) => p.number).join(', #')}${C.off}` : ''));
   console.log(`  uncommitted source files:   ${dirty.length}` +
@@ -156,7 +184,7 @@ function main() {
     if (/owner|decision|your move|sign.?off|approval/i.test(reason)) {
       const parkedOpen = existsSync(PARKED) && !/^\s*##\s+Nothing open\s*$/mi.test(readFileSync(PARKED, 'utf8'));
       if (rows.length > 0) {
-        console.log(`${C.red}NOT A STOP${C.off} — an owner decision is claimed, but ${rows.length} Q- row(s) are open.`);
+        console.log(`${C.red}NOT A STOP${C.off} — an owner decision is claimed, but ${rows.length} work row(s) are open.`);
         console.log('Parked never blocks while other work exists. Go build the next row and batch the decision.');
         console.log(`${C.bold}Next: ${rows[0].id} — ${rows[0].what}${C.off}`);
         process.exit(1);

--- a/testing/standalone/loop-check.test.js
+++ b/testing/standalone/loop-check.test.js
@@ -17,31 +17,65 @@ import { parseRows, sourceFiles } from '../../scripts/loop-check.mjs';
 
 const TABLE = `# Ordered queue
 
-| # | What | Home | Status | Remark |
+## 1 · Open work, in shipping order
+
+| # | Task | Home | Status | Remark |
 |---|------|------|--------|--------|
 | Q-2 | suppressEmbeddings per type | QA | in progress | tier resolver merged |
-| Q-3 | Split config/types.ts | ARCH | open | |
-| Q-4 | Authenticate CI compose pull | ARCH | open | measure first |
+| B-3 | Split config/types.ts | ARCH | open | |
+| U-9 | token rights: admin edit tier | UX | tiers 1+3 done, #840 shipped the self-view | own PR |
+| W-8 | Dockerfile still fetches CUDA | QA | fixed in CI, owner call on the image | 3x npm ci |
 
-## Watching
+## 2 · Watch items — NOT work
 
-| # | What | Home | Status | Remark |
+| # | Watch item | Home | Status | Remark |
 |---|------|------|--------|--------|
 | W-1 | Mongo boot race | QA | watching | |
 
-## Parked
+## 3 · Parked — an owner decision is missing
 
 | # | What | Home | Status | Remark |
 |---|------|------|--------|--------|
 | P-1 | F11-b assist model | FEAT | parked | owner decision |
+
+## 4 · The release
+
+| # | What | Home | Status | Remark |
+|---|------|------|--------|--------|
+| R-1 | Cut the tag | LOOP | after the drain | |
 `;
 
 describe('the queue rows', () => {
-  it('counts the Q- tier and nothing else', () => {
-    // W- and P- rows are why the file can be "drained" while still listing things. Counting them would make
-    // the queue permanently non-empty, and "cut the tag when the queue is empty" unreachable — the same defect
-    // the retired `behind the tag` tier had.
-    assert.deepEqual(parseRows(TABLE).map((r) => r.id), ['Q-2', 'Q-3', 'Q-4']);
+  it('counts every ID prefix the open section uses', () => {
+    // The bug this replaced: the filter was `id.startsWith('Q-')`, from a period when every row was a `Q-`. The
+    // queue was later re-keyed per domain — `B-` architecture, `U-` UX, `T-` sync — and the gate went on counting
+    // a prefix that no longer existed. It reported "the queue is drained" with eleven rows open, which is the
+    // exact state it was written to refuse, and it reported it in green.
+    assert.deepEqual(parseRows(TABLE).map((r) => r.id), ['Q-2', 'B-3', 'U-9', 'W-8']);
+  });
+
+  it('reads the SECTION, not the prefix — so a W- row of real work counts', () => {
+    // `W-8` is open work that happens to carry a watch-tier ID, because its home tracker keyed it that way. Under
+    // the old prefix rule it was invisible; under the section rule it counts, and `W-1` two headings down does not.
+    // Membership is where a row was filed, which is the thing the owner actually maintains.
+    const ids = parseRows(TABLE).map((r) => r.id);
+    assert.ok(ids.includes('W-8'), 'a W- row inside the open section is work');
+    assert.ok(!ids.includes('W-1'), 'a W- row under Watch items is not');
+  });
+
+  it('excludes the watch, parked and release sections', () => {
+    // These are why the file can be "drained" while still listing things. Counting them would make the queue
+    // permanently non-empty, and "cut the tag when the queue is empty" unreachable — the same defect the retired
+    // `behind the tag` tier had.
+    const ids = parseRows(TABLE).map((r) => r.id);
+    assert.ok(!ids.includes('P-1'));
+    assert.ok(!ids.includes('R-1'));
+  });
+
+  it('counts rows that appear before any heading', () => {
+    // A bare table with no `##` above it is the shape every earlier version of this file had, and the shape a
+    // hand-written fixture takes. Defaulting an unlabelled section to CLOSED would silently drain the queue.
+    assert.deepEqual(parseRows('| B-1 | a thing | ARCH | open | |\n').map((r) => r.id), ['B-1']);
   });
 
   it('keeps what the next row IS, so the refusal can name it', () => {
@@ -57,8 +91,26 @@ describe('the queue rows', () => {
   it('a row marked done is not open', () => {
     // The queue is what is left, not what was listed. `todo/` is supposed to hold open items only, but a status
     // cell is the one place a shipped row can linger before the tracker reconcile catches it.
-    const done = TABLE.replace('| Q-3 | Split config/types.ts | ARCH | open |', '| Q-3 | Split config/types.ts | ARCH | shipped |');
-    assert.deepEqual(parseRows(done).map((r) => r.id), ['Q-2', 'Q-4']);
+    const done = TABLE.replace('| B-3 | Split config/types.ts | ARCH | open |', '| B-3 | Split config/types.ts | ARCH | shipped (#812) |');
+    assert.deepEqual(parseRows(done).map((r) => r.id), ['Q-2', 'U-9', 'W-8']);
+  });
+
+  it('a status reporting PARTIAL progress is still open', () => {
+    // The second under-count, and the more dangerous one because it fires on healthy rows. The test was
+    // `/\b(done|shipped|merged)\b/` anywhere in the cell, so `2 wrappers shipped (#842, #843)` — a row three
+    // fifths finished — read as finished, as did `tiers 1+3 done, #840 shipped the self-view`. A partially
+    // shipped row is the most common status in this file.
+    const partial = TABLE.replace('| B-3 | Split config/types.ts | ARCH | open |', '| B-3 | Split config/types.ts | ARCH | 2 wrappers shipped (#842, #843) |');
+    assert.ok(parseRows(partial).map((r) => r.id).includes('B-3'));
+    assert.ok(parseRows(TABLE).map((r) => r.id).includes('U-9'), 'tiers 1+3 done, #840 shipped ... is open work');
+  });
+
+  it('treats a done marker with prose after it as open', () => {
+    // Deliberately conservative: over-counting makes the gate say "keep working", under-counting makes it say
+    // "drained" on a queue that is not. Only one of those two failures is survivable, so anything the rule cannot
+    // read as unambiguously finished stays in the queue.
+    const hedged = TABLE.replace('| B-3 | Split config/types.ts | ARCH | open |', '| B-3 | Split config/types.ts | ARCH | done except the migration |');
+    assert.ok(parseRows(hedged).map((r) => r.id).includes('B-3'));
   });
 
   it('an empty file is a drained queue, not a parse failure', () => {


### PR DESCRIPTION
## What was wrong

`npm run loop:check` reported **`MAY STOP` — the queue is drained**, in green, with **eleven rows open** in
section 1 of the ordered queue. It is the one gate whose entire job is to refuse that claim.

The filter was `id.startsWith('Q-')`, correct when every queue row was a `Q-`. The queue was later re-keyed per
domain — `B-` architecture, `U-` UX, `T-` sync — and a prefix filter that matches nothing returns nothing. Zero
rows, no open PR, clean tree: every input to the verdict agreed the queue was empty.

A development gate, so nothing shipped wrong because of it. But it is load-bearing for the loop's stop decision,
and it had been wrong since the re-key.

## The fix

**A row's tier is the section it sits under, not the letter in its ID.** Sections are what is maintained by hand,
and one row proves the ID cannot stand in for a tier: `W-8` is open work carrying a watch-tier ID because its home
tracker keyed it that way. Under the prefix rule it was invisible. `W-1`, two headings down, is a real watch item
and is excluded by both rules.

The default direction is deliberate and documented at the constant: **everything is work unless its heading says
watch / parked / release.** A non-work section nobody taught the script about gets counted, so the gate says "keep
working" — an annoyance. The reverse default drains the queue silently, which is the bug being fixed.

**A second under-count, found while writing the tests, and worse because it fires on healthy rows.** A status
counted as finished if `done`, `shipped` or `merged` appeared *anywhere* in the cell, so
`2 wrappers shipped (#842, #843)` — three fifths remaining — dropped out of the queue, as did
`tiers 1+3 done, #840 shipped the self-view`. Partial progress is the most common status this file carries. A done
marker now has to be the entire cell; a hedge like `done except the migration` stays open.

## Evidence

- **Six of the new assertions fail against the previous script.** Written first and run against it, because a
  gate-fix with tests that pass both ways is not evidence of anything.
- **After:** `open work rows in todo/_TODO-ORDERED.md: 11 -> B-2, U-9, U-6, B-3, …` · verdict `DO NOT STOP`.
- The verdict line now names the first four IDs, so a wrong count is visible rather than inferred from a total.

## Docs

None. `loop:check` is a development gate over a gitignored input and appears nowhere under `docs/`
(`grep` confirms). Nothing user-facing or integration-relevant changed — stated here rather than left to be
inferred, per section 0 of the queue.

🤖 Generated with Claude Code
