### PR TITLE
refactor(spaces): the update's refusal chain is a function, not a route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     records unfixable and undeletable. Being unable to delete the junk record you were warned not to create is
     worse than the bug being fixed.
 
+### Internal
+- **The space update's refusal chain is now a function both surfaces can call, and the router lost 195 lines.**
+  Three of the five REST-only capabilities breituai-platform reported are not wrappers: `updateSpace()` exists, but
+  `PATCH /api/spaces/:id` wrapped it in a chain of refusals, and a tool calling `updateSpace()` directly would skip
+  every one. That is *two surfaces, one rule, one weaker* — the defect being reintroduced by the fix for it.
+  - `spaces/meta-update.ts` owns the decisions: existence, the `If-Match` precondition, the strict parse, the
+    server-owned strip, the schema-library `$ref` check, the `description` → `meta.purpose` fold, the extraction-mode
+    cap, the record-TTL merge, and the audit snapshot. It returns a refusal carrying its HTTP status, or a plan. It
+    writes nothing — no config, no vote, no peer call — so the chain is testable without standing up Docker.
+  - `spaces/body-schemas.ts` holds the request bodies. Four of the router's five god-file ratchet raises were single
+    Zod lines, because `SpaceMetaBody` and `TypeSchemaZ` are `.strict()` and a field the API must accept has nowhere
+    smaller to go. The ratchet entry is **lowered 851 → 656** rather than deleted: dropping it is how a file quietly
+    earns back headroom it did not ask for.
+  - **No `apply` function yet, deliberately.** The writes stay in the route until the MCP tool needs them — an
+    interface extracted with one caller is designed against a guess.
+  - **Two gates could not simply be re-pointed, and that is the interesting part.** The broken-`$ref` sweep and the
+    `If-Match` ordering gate both required an INLINE call, which a delegating route does not have. Rather than
+    weaken them per route, each now resolves the delegate from the import list and requires the delegate's own
+    source to do the checking — so "the handler calls a function" is not an escape hatch. Both were mutation-tested
+    by removing the planner's check and confirming they still name `PATCH /:id`.
+  - Behaviour-preserving by construction: the code moved verbatim, and the ten-assertion contract suite that landed
+    against the unmoved handler passes unchanged against the extracted one.
+
 ### Testing
 - **The `PATCH /api/spaces/:id` refusal chain is pinned before it moves.** Three of the five REST-only
   capabilities need route-level validation extracted into something both MCP and REST call, and this route is the

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -28,291 +28,14 @@ import { proposedMetaFields } from '../sync/meta-round-merge.js';
 import type { SpaceMeta, KnowledgeType, TypeSchema } from '../config/types.js';
 import { DOC_EXTRACTION_MODES_IN, IMAGE_LEVELS, AUDIO_LEVELS, VIDEO_LEVELS, TEXT_LEVELS, normalizeDocExtractionMode } from '../config/types.js';
 import { writeFile as writeSpaceFile } from '../files/files.js';
-import { normaliseRecordTtl } from '../spaces/record-ttl.js';
+import {
+  TypeSchemaZ, TypeSchemasZ, SpaceMetaBody, SERVER_OWNED_META_FIELDS,
+  stripServerOwnedMeta, findBrokenLibraryRefs, brokenRefsError,
+  CreateSpaceBody, DeleteSpaceBody, RenameSpaceBody, ReorderSpacesBody, PutSchemaBody,
+} from '../spaces/body-schemas.js';
+import { planSpaceMetaUpdate } from '../spaces/meta-update.js';
 
 export const spacesRouter = Router();
-
-// ── Zod schema for PropertySchema ──────────────────────────────────────────
-/**
- * Exported for the standalone tests, which used to keep a hand-copy of this schema and drifted:
- * the copy was missing `required`, `default` and `type: "date"`, so it REJECTED bodies this accepts —
- * including every property the Schema tab sends, since `required` is an inline flag on the property.
- */
-export const PropertySchemaZ = z.object({
-  type: z.enum(['string', 'number', 'boolean', 'date']).optional(),
-  enum: z.array(z.union([z.string(), z.number(), z.boolean()])).optional(),
-  minimum: z.number().optional(),
-  maximum: z.number().optional(),
-  pattern: z.string().max(500).optional(),
-  mergeFn: z.enum(['avg', 'min', 'max', 'sum', 'and', 'or', 'xor']).optional(),
-  required: z.boolean().optional(),
-  default: z.union([z.string(), z.number(), z.boolean()]).optional(),
-}).strict().refine(data => {
-  if (!data.mergeFn) return true;
-  const numericFns = new Set(['avg', 'min', 'max', 'sum']);
-  const booleanFns = new Set(['and', 'or', 'xor']);
-  if (data.type === 'number') return numericFns.has(data.mergeFn);
-  if (data.type === 'boolean') return booleanFns.has(data.mergeFn);
-  // mergeFn requires a compatible type declaration
-  if (data.type === 'string' || data.type === 'date') return false;
-  // No type declared but mergeFn given — allow if the fn could be valid for some type
-  return numericFns.has(data.mergeFn) || booleanFns.has(data.mergeFn);
-}, {
-  message: 'mergeFn is incompatible with the declared type (numeric fns require type "number", boolean fns require type "boolean")',
-});
-
-const TypeSchemaZ = z.union([
-  // Reference to a schema library entry
-  z.object({
-    $ref: z.string().regex(/^library:[a-zA-Z0-9][a-zA-Z0-9._-]{0,199}$/, '$ref must be in format "library:<name>"'),
-  }).strict(),
-  // Inline schema definition
-  z.object({
-    namingPattern: z.string().max(500).optional(),
-    tagSuggestions: z.array(z.string().min(1).max(200)).max(200).optional(),
-    propertySchemas: z.record(z.string().min(1).max(200), PropertySchemaZ).optional(),
-    // The schema tier of record > schema > space. `.strict()` above means an unlisted key is REJECTED, so
-    // without this the field would be stripped from every PATCH and the feature would silently not exist.
-    retention: z.object({
-      days: z.number().int().positive().max(36500).optional(),
-      contentDays: z.number().int().positive().max(36500).optional(),
-    }).strict().refine(v => v.days !== undefined || v.contentDays !== undefined, {
-      message: 'retention needs days, contentDays, or both',
-    }).optional(),
-    // Same reasoning as `retention` above, and the same tier. Absent means NOT STATED and falls through to the
-    // space setting — which is why this is a plain optional boolean and not defaulted to `false` here. A default
-    // would turn "said nothing" into "said no" at the edge, and the tier resolver would never see the space.
-    suppressEmbeddings: z.boolean().optional(),
-  }).strict(),
-]);
-
-const TypeSchemasZ = z.object({
-  entity: z.record(z.string().min(1).max(200), TypeSchemaZ).optional(),
-  memory: z.record(z.string().min(1).max(200), TypeSchemaZ).optional(),
-  edge:   z.record(z.string().min(1).max(200), TypeSchemaZ).optional(),
-  chrono: z.record(z.string().min(1).max(200), TypeSchemaZ).optional(),
-}).strict();
-
-/**
- * Return names of any `$ref` library entries referenced in typeSchemas that do not
- * exist in the instance schema library.  Used to reject PATCH/PUT early with 422.
- */
-function findBrokenLibraryRefs(typeSchemas: z.infer<typeof TypeSchemasZ> | undefined): string[] {
-  if (!typeSchemas) return [];
-  const library = getSchemaLibrary();
-  const broken: string[] = [];
-  for (const ktMap of Object.values(typeSchemas)) {
-    if (!ktMap) continue;
-    for (const schema of Object.values(ktMap)) {
-      if (typeof schema === 'object' && schema !== null && '$ref' in schema) {
-        const ref = (schema as { $ref: string }).$ref;
-        const name = ref.startsWith('library:') ? ref.slice('library:'.length) : ref;
-        if (!library.some(e => e.name === name) && !broken.includes(name)) {
-          broken.push(name);
-        }
-      }
-    }
-  }
-  return broken;
-}
-
-const SpaceMetaBody = z.object({
-  purpose: z.string().max(SPACE_PURPOSE_MAX).optional(),
-  usageNotes: z.string().max(50_000).optional(),
-  validationMode: z.enum(['off', 'warn', 'strict']).optional(),
-  typeSchemas: TypeSchemasZ.optional(),
-  tagSuggestions: z.array(z.string().min(1).max(200)).max(200).optional(),
-  strictLinkage: z.boolean().optional(),
-  // The lowest of the three suppression tiers. `.strict()` above is why this has to be listed at all: without
-  // it the field would be REJECTED as unknown, not silently ignored — which is the right failure, but still a
-  // failure for a field the type now declares.
-  suppressEmbeddings: z.boolean().optional(),
-}).strict();
-
-/**
- * The three fields the server OWNS: it writes them, `GET` returns them, and a caller may not set them.
- *
- * They are stripped from an incoming `meta` rather than rejected by `.strict()`. Reported by an integrator
- * doing the obvious thing — `GET` a space, edit one field of `meta.typeSchemas`, `PATCH` it back — and getting
- * `unrecognized_keys` for three fields they never wrote and cannot omit without knowing to. Their ask was
- * *"either merge, or do not return what you will not accept"*, and this is the second half; the merge half
- * already shipped as `mergeSpaceMeta`.
- *
- * **Only these three, and `.strict()` still rejects everything else.** That distinction is the whole design:
- * a key the server itself emitted is echo-back noise and dropping it costs the caller nothing, while an
- * unknown key is a typo — and silently ignoring `validationMdoe` would let someone believe they had turned
- * validation on. Stripping everything would trade a real diagnostic for a convenience.
- *
- * The dry-run endpoint at the bottom of this file has stripped exactly these three since it was written, so
- * before this the two endpoints disagreed about whether a round-tripped body was acceptable. One of them had
- * to be wrong; the one that accepted it was right.
- */
-const SERVER_OWNED_META_FIELDS = ['version', 'updatedAt', 'previousVersions'] as const;
-
-/** Drop the server-owned housekeeping fields from an incoming `meta`, leaving everything else to Zod. */
-function stripServerOwnedMeta(meta: unknown): unknown {
-  if (meta == null || typeof meta !== 'object' || Array.isArray(meta)) return meta;
-  const copy: Record<string, unknown> = { ...(meta as Record<string, unknown>) };
-  for (const f of SERVER_OWNED_META_FIELDS) delete copy[f];
-  return copy;
-}
-
-// proxyFor accepts either the wildcard sentinel ['*'] or a list of specific space IDs
-const ProxyForZ = z.union([
-  z.tuple([z.literal('*')]),
-  z.array(z.string().min(1).max(40)).min(1),
-]);
-
-const CreateSpaceBody = z.object({
-  id: z.string().min(1).max(40).regex(/^[a-z0-9-]+$/).optional(),
-  label: z.string().min(1).max(200),
-  description: z.string().max(SPACE_PURPOSE_MAX).optional(),
-  folders: z.array(z.string()).optional(),
-  maxGiB: z.number().positive().optional(),
-  // Create-only, and deliberately absent from the update body: a populated gallery cannot be re-dimensioned,
-  // so offering the field on PATCH would be offering a change the index build then refuses.
-  // Bounds rather than an enum — 128 (MobileFaceNet class) and 512 (ArcFace, AdaFace, FaceNet, EdgeFace) are
-  // today's answers, and pinning an enum would make the next model a code change.
-  faceDescriptorDims: z.number().int().min(64).max(4096).optional(),
-  proxyFor: ProxyForZ.optional(),
-  meta: SpaceMetaBody.optional(),
-});
-
-const DeleteSpaceBody = z.object({
-  confirm: z.literal(true),
-});
-
-const RenameSpaceBody = z.object({
-  newId: z.string().min(1).max(40).regex(/^[a-z0-9-]+$/),
-});
-
-const DupeActionRuleBody = z.object({
-  minScore: z.number().min(0).max(1),
-  action: z.enum(['flag', 'automerge', 'notify']),
-  types: z.array(z.enum(['memory', 'entity', 'edge', 'chrono', 'file'])).optional(),
-  webhookUrl: z.string().url().refine(isSsrfSafeUrl, { message: SSRF_SAFE_MESSAGE }).optional(),
-}).strict();
-
-/** One bucket's window: a positive day count, or 0/null to clear it. Same bounds as the legacy scalar. */
-const TtlWindowZ = z.number().int().nonnegative().max(36500).nullable().optional();
-
-const UpdateSpaceBody = z.object({
-  label: z.string().min(1).max(200).optional(),
-  description: z.string().max(SPACE_PURPOSE_MAX).optional(),
-  maxGiB: z.number().positive().nullable().optional(),
-  meta: SpaceMetaBody.optional(),
-  /**
-   * How `meta.typeSchemas` combines with what is already stored. Default `merge`, which is the behaviour
-   * this endpoint has always had and which an integrator specifically asked for — a caller that edits one
-   * type must not have to resend the other forty.
-   *
-   * `replace` makes the payload authoritative: types absent from it are REMOVED. It exists because there
-   * was otherwise no way to delete a type at all. The settings UI deleted one, sent a payload that simply
-   * did not mention it, and `mergeSpaceMeta` faithfully preserved it — so a deletion could be performed,
-   * saved, and silently not happen. Reported by an integrator whose space had 21 foreign types they could
-   * not remove by any sequence of UI actions.
-   *
-   * Deliberately NOT a new endpoint. `PUT /:id/schema` already replaces wholesale, but it calls
-   * `updateSpace()` directly and so bypasses the network vote that a meta change on a networked space
-   * has to go through. Routing the UI's Save there would have traded a silent no-op for a silent
-   * consensus bypass.
-   */
-  typeSchemasMode: z.enum(['merge', 'replace']).optional(),
-  dupeRules: z.array(DupeActionRuleBody).max(20).optional(),
-  dupeMergeSurvivor: z.enum(['older', 'newer']).optional(),
-  dupeRulesOnInsert: z.boolean().optional(),
-  // F10: auto-TTL in days — the SPACE tier of record > schema > space. 0/null clears it; a positive value
-  // stamps every new/updated record with no closer window.
-  //
-  // TWO shapes. The scalar came first and is accepted forever, because a space that set one keeps working and
-  // this is local config a read-side widening can absorb. The object is per BUCKET, five of them: a space does
-  // not hold one kind of thing, and files share this tier while having no type for the schema tier to reach.
-  //
-  // A bucket set to 0 or null clears that bucket. `{}` is rejected: it says nothing, and accepting it would make
-  // "clear everything" and "change nothing" the same request.
-  recordTtlDays: z.union([
-    z.number().int().nonnegative().max(36500),
-    z.object({
-      entity: TtlWindowZ, memory: TtlWindowZ, edge: TtlWindowZ, chrono: TtlWindowZ, file: TtlWindowZ,
-    }).strict().refine(v => Object.values(v).some(x => x !== undefined), {
-      message: 'recordTtlDays needs at least one of entity, memory, edge, chrono or file',
-    }),
-  ]).nullable().optional(),
-  // F11-c: per-space document-extraction mode override. null clears it (inherit the instance default).
-  // `max` is accepted as the legacy spelling of `repair` and normalised on the way in.
-  documentExtraction: z.enum(DOC_EXTRACTION_MODES_IN).nullable().optional(),
-  // Per-space analysis level for the other media classes, capped by the instance ceiling.
-  // null clears the override so the space follows the instance again.
-  imageAnalysis: z.enum(IMAGE_LEVELS).nullable().optional(),
-  audioAnalysis: z.enum(AUDIO_LEVELS).nullable().optional(),
-  videoAnalysis: z.enum(VIDEO_LEVELS).nullable().optional(),
-  textAnalysis: z.enum(TEXT_LEVELS).nullable().optional(),
-}).refine(d => d.label !== undefined || d.description !== undefined || d.meta !== undefined || d.maxGiB !== undefined || d.dupeRules !== undefined || d.dupeMergeSurvivor !== undefined || d.dupeRulesOnInsert !== undefined || d.recordTtlDays !== undefined || d.documentExtraction !== undefined || d.imageAnalysis !== undefined || d.audioAnalysis !== undefined || d.videoAnalysis !== undefined || d.textAnalysis !== undefined, {
-  message: 'At least one of label, description, maxGiB, meta, dupeRules, dupeMergeSurvivor, dupeRulesOnInsert, recordTtlDays, documentExtraction, imageAnalysis, audioAnalysis, videoAnalysis, or textAnalysis must be provided',
-});
-
-const ReorderSpacesBody = z.object({
-  ids: z.array(z.string().min(1).max(40)).min(1),
-});
-
-const PutSchemaBody = z.object({
-  typeSchemas: TypeSchemasZ,
-});
-
-/**
- * Deep-merge an incoming PATCH `meta` payload into the existing SpaceMeta.
- *
- * - Scalar fields (purpose, usageNotes, validationMode, tagSuggestions,
- *   strictLinkage) overwrite the existing value when present in `incoming`.
- * - `typeSchemas` is merged per-knowledge-type, then per-type-name:
- *   types present in `incoming` are added or updated; types *not* mentioned
- *   in the request body are left untouched.
- *
- * The `version`, `updatedAt`, and `previousVersions` housekeeping fields are
- * intentionally omitted from the return value — `updateSpace()` re-adds them.
- */
-// Exported for testing only. The merge/replace decision is pure and is where a deletion was silently lost
-// for as long as it was; a unit test that reaches it directly is worth more than one that has to stand up
-// Docker and a network to observe the same branch.
-export function mergeSpaceMeta(
-  existing: SpaceMeta,
-  incoming: Partial<SpaceMeta>,
-  typeSchemasMode: 'merge' | 'replace' = 'merge',
-): Omit<SpaceMeta, 'version' | 'updatedAt' | 'previousVersions'> {
-  // Spread the existing base (drop housekeeping fields that updateSpace re-adds)
-  const { version: _v, updatedAt: _u, previousVersions: _pv, ...existingBase } = existing;
-  const merged: Omit<SpaceMeta, 'version' | 'updatedAt' | 'previousVersions'> = { ...existingBase };
-
-  // Scalar fields — replace if present in incoming
-  if (incoming.purpose !== undefined) merged.purpose = incoming.purpose;
-  if (incoming.usageNotes !== undefined) merged.usageNotes = incoming.usageNotes;
-  if (incoming.validationMode !== undefined) merged.validationMode = incoming.validationMode;
-  if (incoming.tagSuggestions !== undefined) merged.tagSuggestions = incoming.tagSuggestions;
-  if (incoming.strictLinkage !== undefined) merged.strictLinkage = incoming.strictLinkage;
-  // Guarded on `!== undefined`, not on truthiness. `suppressEmbeddings: false` is how an operator turns
-  // suppression back OFF, and a truthy guard would drop that patch and leave the space suppressed while
-  // answering 200 — the flag reporting one thing and the write path doing another.
-  if (incoming.suppressEmbeddings !== undefined) merged.suppressEmbeddings = incoming.suppressEmbeddings;
-
-  // typeSchemas — merge per-KT, per-type: incoming types add/update, existing untouched types preserved.
-  // Under `replace` the payload is authoritative instead, so a type absent from it is deleted. Note the
-  // guard is on `!== undefined`, so `replace` with `typeSchemas: {}` clears every type — which is the only
-  // way to express "this space declares nothing" and has to be reachable.
-  if (incoming.typeSchemas !== undefined && typeSchemasMode === 'replace') {
-    merged.typeSchemas = incoming.typeSchemas;
-  } else if (incoming.typeSchemas !== undefined) {
-    const existingTs = existingBase.typeSchemas ?? {};
-    const mergedTs: Partial<Record<KnowledgeType, Record<string, TypeSchema>>> = { ...existingTs };
-    for (const [kt, ktMap] of Object.entries(incoming.typeSchemas) as
-        [KnowledgeType, Record<string, TypeSchema> | undefined][]) {
-      if (!ktMap) continue;
-      mergedTs[kt] = { ...(existingTs[kt] ?? {}), ...ktMap };
-    }
-    merged.typeSchemas = mergedTs;
-  }
-
-  return merged;
-}
 
 // POST /api/spaces/:id/rebuild-indexes
 //
@@ -580,115 +303,53 @@ spacesRouter.post('/', globalRateLimit, requireAdminMfa, async (req, res) => {
 });
 
 // PATCH /api/spaces/:id
+//
+// Every refusal, and every value that has to be normalised before it is stored, is decided by
+// `planSpaceMetaUpdate` — so an MCP tool can reach the same rules instead of a weaker copy of them (B-2). What
+// stays here is the WRITE and how it is reported: the local settings, the network vote's 202, the peer notify.
+//
+// `space-meta-update-contract.test.js` pins the chain the planner now owns, including its ORDER, and it was proven
+// against this handler before the move.
 spacesRouter.patch('/:id', globalRateLimit, requireAdminMfaScoped('id'), async (req, res) => {
   const id = req.params['id'] as string;
   const cfg = getConfig();
-
   const space = cfg.spaces.find(s => s.id === id);
-  if (!space) {
-    res.status(404).json({ error: `Space '${id}' not found` });
+
+  const decision = planSpaceMetaUpdate({ spaceId: id, space, body: req.body, ifMatch: req.get('If-Match') });
+  if (!decision.ok) {
+    res.status(decision.refusal.status).json(decision.refusal.body);
     return;
   }
+  // `spaceRec` rather than the `space` above: the planner returns the record it validated, already narrowed to
+  // non-undefined by the 404 it would otherwise have produced.
+  const { space: spaceRec, data: patchData, mergedMeta, hasDocExtraction,
+    documentExtraction: cappedDocExtraction, hasRecordTtl, recordTtlDays: normalisedTtl, audit } = decision.plan;
 
-  // Optimistic concurrency: honour If-Match against the current meta version, if the client sent one.
-  // Runs before validation, the audit snapshot and every side effect — a rejected write must change
-  // nothing and record nothing.
-  const precondition = checkMetaPrecondition(req.get('If-Match'), space.meta?.version ?? 0);
-  if (!precondition.ok) {
-    res.status(precondition.status).json(preconditionErrorBody(precondition));
-    return;
-  }
-
-  // Accept what we emit: a caller who GETs a space, edits one field and PATCHes it back is doing the obvious
-  // thing, and `version`/`updatedAt`/`previousVersions` come straight out of our own response. Stripped, not
-  // rejected — and ONLY these three, so `.strict()` still catches a typo like `validationMdoe`, which someone
-  // would otherwise believe had turned validation on. See SERVER_OWNED_META_FIELDS.
-  const bodyForParse = req.body != null && typeof req.body === 'object' && !Array.isArray(req.body)
-    ? { ...(req.body as Record<string, unknown>), ...('meta' in (req.body as object) ? { meta: stripServerOwnedMeta((req.body as { meta?: unknown }).meta) } : {}) }
-    : req.body;
-
-  const parsed = UpdateSpaceBody.safeParse(bodyForParse);
-  if (!parsed.success) {
-    res.status(400).json({ error: parsed.error.message });
-    return;
-  }
-
-  // `description` is the deprecated spelling of `meta.purpose`. Rewrite it into meta HERE, before any
-  // branching, so it travels the meta path in full: the $ref check, the merge, the version bump, and —
-  // the one that matters — the network vote. Applying it further down as a "non-meta update" would let a
-  // directive change skip governance in exactly the spaces that voted to govern it.
-  // `meta.purpose` wins when both are sent; it is the current name.
-  if (parsed.data.description !== undefined) {
-    const legacy = parsed.data.description.trim();
-    parsed.data.meta = { ...(parsed.data.meta ?? {}), ...(parsed.data.meta?.purpose === undefined ? { purpose: legacy } : {}) };
-    delete parsed.data.description;
-  }
-
-  // Snapshot for the audit log's change list, taken BEFORE anything is applied. Handing the whole record
-  // over is safe: `audit-changes.ts` reads only the fields allowlisted for `space.update` and never
-  // touches the rest, so this cannot publish something by carrying it. The middleware only records it on
-  // a <400 response, so a request rejected below logs no change.
-  req.auditSnapshots = {
-    before: { ...space, ...space.meta },
-    after: { ...space, ...space.meta, ...parsed.data, ...(parsed.data.meta ?? {}) },
-  };
-
-  // Validate any $ref values in the incoming meta against the instance schema library
-  if (parsed.data.meta?.typeSchemas) {
-    const brokenRefs = findBrokenLibraryRefs(parsed.data.meta.typeSchemas as z.infer<typeof TypeSchemasZ>);
-    if (brokenRefs.length > 0) {
-      res.status(422).json({ error: `Schema library ${brokenRefs.length === 1 ? 'entry' : 'entries'} not found: ${brokenRefs.join(', ')}. Create ${brokenRefs.length === 1 ? 'it' : 'them'} via POST /api/schema-library before referencing.` });
-      return;
-    }
-  }
+  // The audit middleware records this only on a <400 response, so a request the planner refused above logs no
+  // change. The snapshot pair was taken before anything was applied, which is what makes the change list honest.
+  req.auditSnapshots = audit;
 
   // Duplicate rules are local (never governed) — apply them now, so they are
   // not silently dropped when a meta change on the same request opens a
   // network vote and returns 202 below.
-  if (parsed.data.dupeRules !== undefined || parsed.data.dupeMergeSurvivor !== undefined || parsed.data.dupeRulesOnInsert !== undefined) {
-    updateSpace(id, { dupeRules: parsed.data.dupeRules, dupeMergeSurvivor: parsed.data.dupeMergeSurvivor, dupeRulesOnInsert: parsed.data.dupeRulesOnInsert });
+  if (patchData.dupeRules !== undefined || patchData.dupeMergeSurvivor !== undefined || patchData.dupeRulesOnInsert !== undefined) {
+    updateSpace(id, { dupeRules: patchData.dupeRules, dupeMergeSurvivor: patchData.dupeMergeSurvivor, dupeRulesOnInsert: patchData.dupeRulesOnInsert });
   }
 
   // Record TTL (F10) is a local operational setting (like dupe rules) — apply immediately, never voted.
-  // 0/null clears it. When enabled, ensure the sweep's `_expireAt` index (best-effort).
-  //
-  // A PARTIAL object MERGES over the stored windows, so `{"chrono":90}` does not silently clear the other four.
-  // That is the opposite of the `typeSchemas` rule one level down, and deliberately so: there a named type is a
-  // whole definition the caller holds, here each bucket is one independent number.
-  if (parsed.data.recordTtlDays !== undefined) {
-    const ttl = normaliseRecordTtl(space.recordTtlDays, parsed.data.recordTtlDays);
-    updateSpace(id, { recordTtlDays: ttl });
-    if (ttl !== undefined) void ensureTtlIndex(id).catch(err => log.warn(`ensureTtlIndex ${id}: ${err}`));
+  // 0/null clears it. When enabled, ensure the sweep's `_expireAt` index (best-effort). The value arrives
+  // already MERGED over what was stored (see the planner), so a partial write does not clear the buckets it
+  // did not mention; `hasRecordTtl` gates the write so a clear is applied rather than skipped as if absent.
+  if (hasRecordTtl) {
+    updateSpace(id, { recordTtlDays: normalisedTtl });
+    if (normalisedTtl !== undefined) void ensureTtlIndex(id).catch(err => log.warn(`ensureTtlIndex ${id}: ${err}`));
   }
 
-
-  // A space may pick any extraction mode up to the instance ceiling and nothing beyond. The client only
-  // offers valid options, but an API caller (or a space whose stored value predates a lowered ceiling)
-  // could still send more — so cap it here rather than store a value the runtime would only clamp later
-  // anyway. Distinguish field ABSENT (leave the override alone) from an explicit value: `null`/legacy
-  // clears it (stored as undefined), `auto` follows the ceiling, a concrete mode is capped to the
-  // ceiling. `hasDocExtraction` gates the write so a clear is applied, not skipped as if absent.
-  const hasDocExtraction = parsed.data.documentExtraction !== undefined;
-  const cappedDocExtraction = !hasDocExtraction
-    ? undefined
-    : (() => {
-        const requested = normalizeDocExtractionMode(parsed.data.documentExtraction);
-        if (!requested || requested === 'auto') return requested;  // null (clear → undefined) / auto pass through
-        return capDocExtractionMode(getDocumentProcessingConfig().mode ?? 'auto', requested);
-      })();
-
+  // Already capped to the instance ceiling by the planner. `hasDocExtraction` gates the write so a clear is
+  // applied, not skipped as if absent.
   if (hasDocExtraction) {
     updateSpace(id, { documentExtraction: cappedDocExtraction });
   }
-
-  // Merge the incoming meta with the existing meta so that PATCH has true
-  // RFC-7396 semantics: scalar fields overwrite, typeSchemas entries are
-  // added/updated, and types *not* mentioned in the body are preserved.
-  // `typeSchemasMode: 'replace'` opts out of that last clause so a deletion can be expressed at all.
-  const mergedMeta: SpaceMeta | undefined =
-    parsed.data.meta !== undefined
-      ? mergeSpaceMeta(space.meta ?? {}, parsed.data.meta, parsed.data.typeSchemasMode ?? 'merge')
-      : undefined;
 
   // ── Network voting for meta changes ──────────────────────────────────────
   // If this space is part of a network and a meta change is requested,
@@ -717,8 +378,8 @@ spacesRouter.patch('/:id', globalRateLimit, requireAdminMfaScoped('id'), async (
           // stay open for `votingDeadlineHours`, so a second proposal landing before the first concludes
           // is ordinary, and without these two fields the later one reverts the earlier one's edit with
           // no error anywhere. See sync/meta-round-merge.ts.
-          metaChangedFields: proposedMetaFields(parsed.data.meta ?? {}),
-          baseMetaVersion: space.meta?.version ?? 0,
+          metaChangedFields: proposedMetaFields(patchData.meta ?? {}),
+          baseMetaVersion: spaceRec.meta?.version ?? 0,
         });
         rounds.push({ networkId: net.id, networkLabel: net.label, roundId });
       }
@@ -726,8 +387,8 @@ spacesRouter.patch('/:id', globalRateLimit, requireAdminMfaScoped('id'), async (
       // Apply non-meta updates immediately (label, maxGiB). `description` is not among them any more:
       // it was rewritten into `meta.purpose` above, so it is in the vote with the rest of the meta.
       const nonMetaUpdates: { label?: string; maxGiB?: number | null } = {};
-      if (parsed.data.label !== undefined) nonMetaUpdates.label = parsed.data.label;
-      if (parsed.data.maxGiB !== undefined) nonMetaUpdates.maxGiB = parsed.data.maxGiB;
+      if (patchData.label !== undefined) nonMetaUpdates.label = patchData.label;
+      if (patchData.maxGiB !== undefined) nonMetaUpdates.maxGiB = patchData.maxGiB;
       if (Object.keys(nonMetaUpdates).length > 0) {
         updateSpace(id, nonMetaUpdates);
       } else {
@@ -747,7 +408,7 @@ spacesRouter.patch('/:id', globalRateLimit, requireAdminMfaScoped('id'), async (
               networkId: net.id,
               instanceId: cfg.instanceId,
               event: 'meta_change_pending',
-              data: { spaceId: id, spaceLabel: space.label },
+              data: { spaceId: id, spaceLabel: spaceRec.label },
             }),
             signal: AbortSignal.timeout(5_000),
           }).catch(err => log.warn(`notify ${member.label} of meta_change_pending: ${err}`));
@@ -766,7 +427,7 @@ spacesRouter.patch('/:id', globalRateLimit, requireAdminMfaScoped('id'), async (
   // stored and normalised. Letting the raw body through here overwrote that with itself — so a partial write
   // cleared the four buckets it did not mention, and an all-cleared write stored five explicit nulls instead of
   // nothing. Found by driving the UI; both paths returned 200 and looked like they had worked.
-  const { documentExtraction: _rawMode, recordTtlDays: _rawTtl, ...restPatch } = parsed.data;
+  const { documentExtraction: _rawMode, recordTtlDays: _rawTtl, ...restPatch } = patchData;
   const updated = updateSpace(id, {
     ...restPatch,
     meta: mergedMeta,

--- a/server/src/spaces/body-schemas.ts
+++ b/server/src/spaces/body-schemas.ts
@@ -1,0 +1,263 @@
+/**
+ * The request-body schemas for the space routes, and the two helpers that read them.
+ *
+ * ## Why they are here and not in the router
+ *
+ * They were all in `api/spaces.ts`, which is the file the god-file ratchet has raised four times with the note
+ * *"a fourth raise of one file is the signal to split it instead of raising a fifth time"*. Two of those raises
+ * were single Zod lines, because both `SpaceMetaBody` and `TypeSchemaZ` are `.strict()` — an unlisted field is
+ * REJECTED, not ignored, so there is no "put it beside the feature" for a field the API must accept. The schemas
+ * are what keeps pulling that file upward, so the schemas are what moved.
+ *
+ * The immediate reason is a cycle. `planSpaceMetaUpdate` in `meta-update.ts` needs `UpdateSpaceBody`, and the
+ * router imports the planner — so leaving the schema in the router would be `spaces.ts -> meta-update.ts ->
+ * spaces.ts`. Moving them here is what makes both surfaces able to reach one copy of the validation, which is the
+ * whole point of B-2: the rights matrix decides what a token may do, and the surface must not also decide whether
+ * the same rules apply.
+ *
+ * ## What is deliberate in here
+ *
+ * **`.strict()` where it is, and where it is not.** `SpaceMetaBody`, `TypeSchemasZ`, `PropertySchemaZ` and
+ * `DupeActionRuleBody` refuse an unknown key; the top-level bodies drop one. That asymmetry is NOT a decision made
+ * here — it is inherited verbatim from the router, it is a real defect (a typo in `faceDescriptorDims` creates a
+ * space at the default width and reports 201), and it is filed as its own item because making them strict is a
+ * breaking change for any caller currently sending a key we ignore. Moved unchanged on purpose: an extraction that
+ * also alters behaviour is an extraction nobody can verify.
+ */
+import { z } from 'zod';
+import { getSchemaLibrary } from '../config/loader.js';
+import { isSsrfSafeUrl, SSRF_SAFE_MESSAGE } from '../util/ssrf.js';
+import { SPACE_PURPOSE_MAX } from './_shared.js';
+import { DOC_EXTRACTION_MODES_IN, IMAGE_LEVELS, AUDIO_LEVELS, VIDEO_LEVELS, TEXT_LEVELS } from '../config/types.js';
+
+// ── Zod schema for PropertySchema ──────────────────────────────────────────
+/**
+ * One property's constraints, as a space's type schema declares them.
+ *
+ * `mergeFn` is refined against `type` rather than accepted freely: an `avg` on a string is not a merge strategy,
+ * it is a silent no-op at merge time.
+ */
+export const PropertySchemaZ = z.object({
+  type: z.enum(['string', 'number', 'boolean', 'date']).optional(),
+  enum: z.array(z.union([z.string(), z.number(), z.boolean()])).optional(),
+  minimum: z.number().optional(),
+  maximum: z.number().optional(),
+  pattern: z.string().max(500).optional(),
+  mergeFn: z.enum(['avg', 'min', 'max', 'sum', 'and', 'or', 'xor']).optional(),
+  required: z.boolean().optional(),
+  default: z.union([z.string(), z.number(), z.boolean()]).optional(),
+}).strict().refine(data => {
+  if (!data.mergeFn) return true;
+  const numericFns = new Set(['avg', 'min', 'max', 'sum']);
+  const booleanFns = new Set(['and', 'or', 'xor']);
+  if (data.type === 'number') return numericFns.has(data.mergeFn);
+  if (data.type === 'boolean') return booleanFns.has(data.mergeFn);
+  // mergeFn requires a compatible type declaration
+  if (data.type === 'string' || data.type === 'date') return false;
+  // No type declared but mergeFn given — allow if the fn could be valid for some type
+  return numericFns.has(data.mergeFn) || booleanFns.has(data.mergeFn);
+}, {
+  message: 'mergeFn is incompatible with the declared type (numeric fns require type "number", boolean fns require type "boolean")',
+});
+
+export const TypeSchemaZ = z.union([
+  // Reference to a schema library entry
+  z.object({
+    $ref: z.string().regex(/^library:[a-zA-Z0-9][a-zA-Z0-9._-]{0,199}$/, '$ref must be in format "library:<name>"'),
+  }).strict(),
+  // Inline schema definition
+  z.object({
+    namingPattern: z.string().max(500).optional(),
+    tagSuggestions: z.array(z.string().min(1).max(200)).max(200).optional(),
+    propertySchemas: z.record(z.string().min(1).max(200), PropertySchemaZ).optional(),
+    // The schema tier of record > schema > space. `.strict()` above means an unlisted key is REJECTED, so
+    // without this the field would be stripped from every PATCH and the feature would silently not exist.
+    retention: z.object({
+      days: z.number().int().positive().max(36500).optional(),
+      contentDays: z.number().int().positive().max(36500).optional(),
+    }).strict().refine(v => v.days !== undefined || v.contentDays !== undefined, {
+      message: 'retention needs days, contentDays, or both',
+    }).optional(),
+    // Same reasoning as `retention` above, and the same tier. Absent means NOT STATED and falls through to the
+    // space setting — which is why this is a plain optional boolean and not defaulted to `false` here. A default
+    // would turn "said nothing" into "said no" at the edge, and the tier resolver would never see the space.
+    suppressEmbeddings: z.boolean().optional(),
+  }).strict(),
+]);
+
+/** The knowledge-type keys are SINGULAR, and `.strict()` means the plural spelling is a 400 rather than a no-op. */
+export const TypeSchemasZ = z.object({
+  entity: z.record(z.string().min(1).max(200), TypeSchemaZ).optional(),
+  memory: z.record(z.string().min(1).max(200), TypeSchemaZ).optional(),
+  edge:   z.record(z.string().min(1).max(200), TypeSchemaZ).optional(),
+  chrono: z.record(z.string().min(1).max(200), TypeSchemaZ).optional(),
+}).strict();
+
+/**
+ * Return names of any `$ref` library entries referenced in typeSchemas that do not
+ * exist in the instance schema library.  Used to reject PATCH/PUT early with 422.
+ */
+export function findBrokenLibraryRefs(typeSchemas: z.infer<typeof TypeSchemasZ> | undefined): string[] {
+  if (!typeSchemas) return [];
+  const library = getSchemaLibrary();
+  const broken: string[] = [];
+  for (const ktMap of Object.values(typeSchemas)) {
+    if (!ktMap) continue;
+    for (const schema of Object.values(ktMap)) {
+      if (typeof schema === 'object' && schema !== null && '$ref' in schema) {
+        const ref = (schema as { $ref: string }).$ref;
+        const name = ref.startsWith('library:') ? ref.slice('library:'.length) : ref;
+        if (!library.some(e => e.name === name) && !broken.includes(name)) {
+          broken.push(name);
+        }
+      }
+    }
+  }
+  return broken;
+}
+
+/** The 422 body for a broken `$ref`, naming what is missing — "invalid schema" sends the caller to the wrong file. */
+export function brokenRefsError(brokenRefs: string[]): string {
+  return `Schema library ${brokenRefs.length === 1 ? 'entry' : 'entries'} not found: ${brokenRefs.join(', ')}. `
+    + `Create ${brokenRefs.length === 1 ? 'it' : 'them'} via POST /api/schema-library before referencing.`;
+}
+
+export const SpaceMetaBody = z.object({
+  purpose: z.string().max(SPACE_PURPOSE_MAX).optional(),
+  usageNotes: z.string().max(50_000).optional(),
+  validationMode: z.enum(['off', 'warn', 'strict']).optional(),
+  typeSchemas: TypeSchemasZ.optional(),
+  tagSuggestions: z.array(z.string().min(1).max(200)).max(200).optional(),
+  strictLinkage: z.boolean().optional(),
+  // The lowest of the three suppression tiers. `.strict()` above is why this has to be listed at all: without
+  // it the field would be REJECTED as unknown, not silently ignored — which is the right failure, but still a
+  // failure for a field the type now declares.
+  suppressEmbeddings: z.boolean().optional(),
+}).strict();
+
+/**
+ * The three fields the server OWNS: it writes them, `GET` returns them, and a caller may not set them.
+ *
+ * They are stripped from an incoming `meta` rather than rejected by `.strict()`. Reported by an integrator
+ * doing the obvious thing — `GET` a space, edit one field of `meta.typeSchemas`, `PATCH` it back — and getting
+ * `unrecognized_keys` for three fields they never wrote and cannot omit without knowing to. Their ask was
+ * *"either merge, or do not return what you will not accept"*, and this is the second half; the merge half
+ * already shipped as `mergeSpaceMeta`.
+ *
+ * **Only these three, and `.strict()` still rejects everything else.** That distinction is the whole design:
+ * a key the server itself emitted is echo-back noise and dropping it costs the caller nothing, while an
+ * unknown key is a typo — and silently ignoring `validationMdoe` would let someone believe they had turned
+ * validation on. Stripping everything would trade a real diagnostic for a convenience.
+ *
+ * The dry-run endpoint has stripped exactly these three since it was written, so before this the two endpoints
+ * disagreed about whether a round-tripped body was acceptable. One of them had to be wrong; the one that
+ * accepted it was right.
+ */
+export const SERVER_OWNED_META_FIELDS = ['version', 'updatedAt', 'previousVersions'] as const;
+
+/** Drop the server-owned housekeeping fields from an incoming `meta`, leaving everything else to Zod. */
+export function stripServerOwnedMeta(meta: unknown): unknown {
+  if (meta == null || typeof meta !== 'object' || Array.isArray(meta)) return meta;
+  const copy: Record<string, unknown> = { ...(meta as Record<string, unknown>) };
+  for (const f of SERVER_OWNED_META_FIELDS) delete copy[f];
+  return copy;
+}
+
+// proxyFor accepts either the wildcard sentinel ['*'] or a list of specific space IDs
+export const ProxyForZ = z.union([
+  z.tuple([z.literal('*')]),
+  z.array(z.string().min(1).max(40)).min(1),
+]);
+
+export const CreateSpaceBody = z.object({
+  id: z.string().min(1).max(40).regex(/^[a-z0-9-]+$/).optional(),
+  label: z.string().min(1).max(200),
+  description: z.string().max(SPACE_PURPOSE_MAX).optional(),
+  folders: z.array(z.string()).optional(),
+  maxGiB: z.number().positive().optional(),
+  // Create-only, and deliberately absent from the update body: a populated gallery cannot be re-dimensioned,
+  // so offering the field on PATCH would be offering a change the index build then refuses.
+  // Bounds rather than an enum — 128 (MobileFaceNet class) and 512 (ArcFace, AdaFace, FaceNet, EdgeFace) are
+  // today's answers, and pinning an enum would make the next model a code change.
+  faceDescriptorDims: z.number().int().min(64).max(4096).optional(),
+  proxyFor: ProxyForZ.optional(),
+  meta: SpaceMetaBody.optional(),
+});
+
+export const DeleteSpaceBody = z.object({
+  confirm: z.literal(true),
+});
+
+export const RenameSpaceBody = z.object({
+  newId: z.string().min(1).max(40).regex(/^[a-z0-9-]+$/),
+});
+
+export const DupeActionRuleBody = z.object({
+  minScore: z.number().min(0).max(1),
+  action: z.enum(['flag', 'automerge', 'notify']),
+  types: z.array(z.enum(['memory', 'entity', 'edge', 'chrono', 'file'])).optional(),
+  webhookUrl: z.string().url().refine(isSsrfSafeUrl, { message: SSRF_SAFE_MESSAGE }).optional(),
+}).strict();
+
+/** One bucket's window: a positive day count, or 0/null to clear it. Same bounds as the legacy scalar. */
+const TtlWindowZ = z.number().int().nonnegative().max(36500).nullable().optional();
+
+export const UpdateSpaceBody = z.object({
+  label: z.string().min(1).max(200).optional(),
+  description: z.string().max(SPACE_PURPOSE_MAX).optional(),
+  maxGiB: z.number().positive().nullable().optional(),
+  meta: SpaceMetaBody.optional(),
+  /**
+   * How `meta.typeSchemas` combines with what is already stored. Default `merge`, which is the behaviour
+   * this endpoint has always had and which an integrator specifically asked for — a caller that edits one
+   * type must not have to resend the other forty.
+   *
+   * `replace` makes the payload authoritative: types absent from it are REMOVED. It exists because there
+   * was otherwise no way to delete a type at all. The settings UI deleted one, sent a payload that simply
+   * did not mention it, and `mergeSpaceMeta` faithfully preserved it — so a deletion could be performed,
+   * saved, and silently not happen. Reported by an integrator whose space had 21 foreign types they could
+   * not remove by any sequence of UI actions.
+   *
+   * Deliberately NOT a new endpoint. `PUT :id/schema` already replaces wholesale, but it calls
+   * `updateSpace()` directly and so bypasses the network vote that a meta change on a networked space
+   * has to go through. Routing the UI's Save there would have traded a silent no-op for a silent
+   * consensus bypass.
+   */
+  typeSchemasMode: z.enum(['merge', 'replace']).optional(),
+  dupeRules: z.array(DupeActionRuleBody).max(20).optional(),
+  dupeMergeSurvivor: z.enum(['older', 'newer']).optional(),
+  dupeRulesOnInsert: z.boolean().optional(),
+  // F10: auto-TTL in days — the SPACE tier of record > schema > space. 0/null clears it; a positive value
+  // stamps every new/updated record with no closer window.
+  //
+  // TWO shapes. The scalar came first and is accepted forever, because a space that set one keeps working and
+  // this is local config a read-side widening can absorb. The object is per BUCKET, five of them: a space does
+  // not hold one kind of thing, and files share this tier while having no type for the schema tier to reach.
+  recordTtlDays: z.union([
+    TtlWindowZ,
+    z.object({
+      entity: TtlWindowZ, memory: TtlWindowZ, edge: TtlWindowZ, chrono: TtlWindowZ, file: TtlWindowZ,
+    }).strict().refine(v => Object.values(v).some(x => x !== undefined), {
+      message: 'recordTtlDays needs at least one of entity, memory, edge, chrono or file',
+    }),
+  ]).nullable().optional(),
+  // F11-c: per-space document-extraction mode override. null clears it (inherit the instance default).
+  // `max` is accepted as the legacy spelling of `repair` and normalised on the way in.
+  documentExtraction: z.enum(DOC_EXTRACTION_MODES_IN).nullable().optional(),
+  // Per-space analysis level for the other media classes, capped by the instance ceiling.
+  // null clears the override so the space follows the instance again.
+  imageAnalysis: z.enum(IMAGE_LEVELS).nullable().optional(),
+  audioAnalysis: z.enum(AUDIO_LEVELS).nullable().optional(),
+  videoAnalysis: z.enum(VIDEO_LEVELS).nullable().optional(),
+  textAnalysis: z.enum(TEXT_LEVELS).nullable().optional(),
+}).refine(d => d.label !== undefined || d.description !== undefined || d.meta !== undefined || d.maxGiB !== undefined || d.dupeRules !== undefined || d.dupeMergeSurvivor !== undefined || d.dupeRulesOnInsert !== undefined || d.recordTtlDays !== undefined || d.documentExtraction !== undefined || d.imageAnalysis !== undefined || d.audioAnalysis !== undefined || d.videoAnalysis !== undefined || d.textAnalysis !== undefined, {
+  message: 'At least one of label, description, maxGiB, meta, dupeRules, dupeMergeSurvivor, dupeRulesOnInsert, recordTtlDays, documentExtraction, imageAnalysis, audioAnalysis, videoAnalysis, or textAnalysis must be provided',
+});
+
+export const ReorderSpacesBody = z.object({
+  ids: z.array(z.string().min(1).max(40)).min(1),
+});
+
+export const PutSchemaBody = z.object({
+  typeSchemas: TypeSchemasZ,
+});

--- a/server/src/spaces/meta-update.ts
+++ b/server/src/spaces/meta-update.ts
@@ -1,0 +1,254 @@
+/**
+ * The decision half of a space update: every refusal, and the values a caller must end up writing.
+ *
+ * ## Why this is a function and not a route
+ *
+ * Five capabilities were reachable over REST and not over MCP, and the principle behind the report is the one this
+ * file serves: *"the rights matrix decides what a token may do; the surface should not also decide whether it
+ * can."* Two of the five were thin wrappers over an existing function. This one is not — `updateSpace()` exists,
+ * but `PATCH /api/spaces/:id` wraps it in a chain of refusals, and a tool that called `updateSpace()` directly
+ * would skip all of them. That is the *two surfaces, one rule, one weaker* defect being reintroduced by the fix
+ * for it.
+ *
+ * So the chain lives here, and both surfaces call it. What a caller still owns is the WRITE — `updateSpace`, the
+ * network vote, the peer notify — because those differ in how they are reported, not in whether they are allowed.
+ *
+ * ## The split: decisions here, side effects at the caller
+ *
+ * Nothing in this file writes config, opens a vote or touches a peer. It reads config (the extraction ceiling, the
+ * schema library) and returns either a refusal or a plan. That is what makes the refusal chain testable without
+ * standing up Docker, and it is why the plan carries `recordTtlDays` and `documentExtraction` already normalised:
+ * those are decisions with config reads in them, and leaving them at the call site is how the second surface ends
+ * up storing a value the first one would have capped.
+ *
+ * ## The ORDER is part of the contract, not an implementation detail
+ *
+ * `space-meta-update-contract.test.js` pins it, because a refactor loses it silently. Existence, then the
+ * precondition, then the body, then the schema-library refs. A precondition evaluated after validation is not a
+ * precondition — it reports a body problem for a write that was never allowed to be applied, and the caller hits
+ * the real conflict on their second attempt instead of their first. And a rejected write must change NOTHING,
+ * which is why the audit snapshot is returned in the plan rather than taken as we go.
+ */
+import type { SpaceConfig, SpaceMeta, KnowledgeType, TypeSchema, DocExtractionMode } from '../config/types.js';
+import { normalizeDocExtractionMode } from '../config/types.js';
+import { getDocumentProcessingConfig } from '../config/loader.js';
+import { capDocExtractionMode } from '../files/converters/extraction-level.js';
+import { checkMetaPrecondition, preconditionErrorBody } from './meta-precondition.js';
+import { normaliseRecordTtl } from './record-ttl.js';
+import { UpdateSpaceBody, findBrokenLibraryRefs, brokenRefsError, stripServerOwnedMeta } from './body-schemas.js';
+import type { TypeSchemasZ } from './body-schemas.js';
+import type { z } from 'zod';
+
+/**
+ * Deep-merge an incoming PATCH `meta` payload into the existing SpaceMeta.
+ *
+ * - Scalar fields (purpose, usageNotes, validationMode, tagSuggestions,
+ *   strictLinkage) overwrite the existing value when present in `incoming`.
+ * - `typeSchemas` is merged per-knowledge-type, then per-type-name:
+ *   types present in `incoming` are added or updated; types *not* mentioned
+ *   in the request body are left untouched.
+ *
+ * The `version`, `updatedAt`, and `previousVersions` housekeeping fields are
+ * intentionally omitted from the return value — `updateSpace()` re-adds them.
+ *
+ * Exported for testing as well as for the planner. The merge/replace decision is pure and is where a deletion was
+ * silently lost for as long as it was; a unit test that reaches it directly is worth more than one that has to
+ * stand up Docker and a network to observe the same branch.
+ */
+export function mergeSpaceMeta(
+  existing: SpaceMeta,
+  incoming: Partial<SpaceMeta>,
+  typeSchemasMode: 'merge' | 'replace' = 'merge',
+): Omit<SpaceMeta, 'version' | 'updatedAt' | 'previousVersions'> {
+  // Spread the existing base (drop housekeeping fields that updateSpace re-adds)
+  const { version: _v, updatedAt: _u, previousVersions: _pv, ...existingBase } = existing;
+  const merged: Omit<SpaceMeta, 'version' | 'updatedAt' | 'previousVersions'> = { ...existingBase };
+
+  // Scalar fields — replace if present in incoming
+  if (incoming.purpose !== undefined) merged.purpose = incoming.purpose;
+  if (incoming.usageNotes !== undefined) merged.usageNotes = incoming.usageNotes;
+  if (incoming.validationMode !== undefined) merged.validationMode = incoming.validationMode;
+  if (incoming.tagSuggestions !== undefined) merged.tagSuggestions = incoming.tagSuggestions;
+  if (incoming.strictLinkage !== undefined) merged.strictLinkage = incoming.strictLinkage;
+  // Guarded on `!== undefined`, not on truthiness. `suppressEmbeddings: false` is how an operator turns
+  // suppression back OFF, and a truthy guard would drop that patch and leave the space suppressed while
+  // answering 200 — the flag reporting one thing and the write path doing another.
+  if (incoming.suppressEmbeddings !== undefined) merged.suppressEmbeddings = incoming.suppressEmbeddings;
+
+  // typeSchemas — merge per-KT, per-type: incoming types add/update, existing untouched types preserved.
+  // Under `replace` the payload is authoritative instead, so a type absent from it is deleted. Note the
+  // guard is on `!== undefined`, so `replace` with `typeSchemas: {}` clears every type — which is the only
+  // way to express "this space declares nothing" and has to be reachable.
+  if (incoming.typeSchemas !== undefined && typeSchemasMode === 'replace') {
+    merged.typeSchemas = incoming.typeSchemas;
+  } else if (incoming.typeSchemas !== undefined) {
+    const existingTs = existingBase.typeSchemas ?? {};
+    const mergedTs: Partial<Record<KnowledgeType, Record<string, TypeSchema>>> = { ...existingTs };
+    for (const [kt, ktMap] of Object.entries(incoming.typeSchemas) as
+        [KnowledgeType, Record<string, TypeSchema> | undefined][]) {
+      if (!ktMap) continue;
+      mergedTs[kt] = { ...(existingTs[kt] ?? {}), ...ktMap };
+    }
+    merged.typeSchemas = mergedTs;
+  }
+
+  return merged;
+}
+
+/**
+ * A refusal, carrying the HTTP status.
+ *
+ * The status is part of the contract rather than something each surface re-derives: five distinct numbers, and a
+ * caller branching on them cannot tell a stale precondition from a malformed one if two collapse into one. An MCP
+ * tool maps these to its own error shape; it does not decide them.
+ */
+export type MetaUpdateRefusal = {
+  status: 400 | 404 | 412 | 422;
+  body: { error: string; expectedVersion?: number; currentVersion?: number };
+};
+
+/** What a caller must write, with every decision already made. */
+export type MetaUpdatePlan = {
+  /**
+   * The space the plan was built against.
+   *
+   * Returned rather than left to the caller to re-narrow: the caller looked it up as possibly-undefined, the 404
+   * above is what rules that out, and handing back the record is how the type says so. A caller re-asserting
+   * non-undefined with `!` would be claiming exactly what this function decided.
+   */
+  space: SpaceConfig;
+  /** The parsed body, with `description` already rewritten into `meta.purpose`. */
+  data: z.infer<typeof UpdateSpaceBody>;
+  /** The merged meta to store, or `undefined` when the request touches no meta at all. */
+  mergedMeta: SpaceMeta | undefined;
+  /** Present only when `documentExtraction` was in the body; already capped to the instance ceiling. */
+  documentExtraction: DocExtractionMode | undefined;
+  hasDocExtraction: boolean;
+  /** Present only when `recordTtlDays` was in the body; already merged over what was stored. */
+  recordTtlDays: SpaceConfig['recordTtlDays'];
+  hasRecordTtl: boolean;
+  /** The audit change-list snapshot, taken before anything is applied. */
+  audit: { before: Record<string, unknown>; after: Record<string, unknown> };
+};
+
+export type MetaUpdateDecision =
+  | { ok: false; refusal: MetaUpdateRefusal }
+  | { ok: true; plan: MetaUpdatePlan };
+
+/**
+ * Decide a space update: refuse it, or return everything needed to apply it.
+ *
+ * `space` is passed in rather than looked up so the caller keeps ownership of how it resolves a space id — the MCP
+ * side already holds a resolved space, and a second lookup here would be a second place for the two surfaces to
+ * disagree about what "not found" means.
+ */
+export function planSpaceMetaUpdate(input: {
+  spaceId: string;
+  space: SpaceConfig | undefined;
+  body: unknown;
+  ifMatch: string | undefined;
+}): MetaUpdateDecision {
+  const { spaceId, space, body, ifMatch } = input;
+
+  if (!space) {
+    return { ok: false, refusal: { status: 404, body: { error: `Space '${spaceId}' not found` } } };
+  }
+
+  // Optimistic concurrency: honour If-Match against the current meta version, if the client sent one.
+  // Runs before validation, the audit snapshot and every side effect — a rejected write must change
+  // nothing and record nothing.
+  const precondition = checkMetaPrecondition(ifMatch, space.meta?.version ?? 0);
+  if (!precondition.ok) {
+    return { ok: false, refusal: { status: precondition.status, body: preconditionErrorBody(precondition) } };
+  }
+
+  // Accept what we emit: a caller who GETs a space, edits one field and PATCHes it back is doing the obvious
+  // thing, and `version`/`updatedAt`/`previousVersions` come straight out of our own response. Stripped, not
+  // rejected — and ONLY these three, so `.strict()` still catches a typo like `validationMdoe`, which someone
+  // would otherwise believe had turned validation on. See SERVER_OWNED_META_FIELDS.
+  const bodyForParse = body != null && typeof body === 'object' && !Array.isArray(body)
+    ? { ...(body as Record<string, unknown>), ...('meta' in (body as object) ? { meta: stripServerOwnedMeta((body as { meta?: unknown }).meta) } : {}) }
+    : body;
+
+  const parsed = UpdateSpaceBody.safeParse(bodyForParse);
+  if (!parsed.success) {
+    return { ok: false, refusal: { status: 400, body: { error: parsed.error.message } } };
+  }
+
+  // `description` is the deprecated spelling of `meta.purpose`. Rewrite it HERE, before any branching, so it
+  // travels the meta path in full: the $ref check, the merge, the version bump, and — the one that matters — the
+  // network vote. Applying it further down as a "non-meta update" would let a directive change skip governance in
+  // exactly the spaces that voted to govern it. That is also why the rewrite is in the PLAN and not at the write:
+  // a caller that applied it after the vote branch would reintroduce the bypass without touching this file.
+  // `meta.purpose` wins when both are sent; it is the current name.
+  if (parsed.data.description !== undefined) {
+    const legacy = parsed.data.description.trim();
+    parsed.data.meta = { ...(parsed.data.meta ?? {}), ...(parsed.data.meta?.purpose === undefined ? { purpose: legacy } : {}) };
+    delete parsed.data.description;
+  }
+
+  // Validate any $ref values in the incoming meta against the instance schema library
+  if (parsed.data.meta?.typeSchemas) {
+    const brokenRefs = findBrokenLibraryRefs(parsed.data.meta.typeSchemas as z.infer<typeof TypeSchemasZ>);
+    if (brokenRefs.length > 0) {
+      return { ok: false, refusal: { status: 422, body: { error: brokenRefsError(brokenRefs) } } };
+    }
+  }
+
+  // Snapshot for the audit log's change list, taken BEFORE anything is applied. Handing the whole record
+  // over is safe: `audit-changes.ts` reads only the fields allowlisted for `space.update` and never
+  // touches the rest, so this cannot publish something by carrying it. The middleware only records it on
+  // a <400 response, so a request rejected above logs no change — which is why every refusal returns before here.
+  const audit = {
+    before: { ...space, ...space.meta } as Record<string, unknown>,
+    after: { ...space, ...space.meta, ...parsed.data, ...(parsed.data.meta ?? {}) } as Record<string, unknown>,
+  };
+
+  // Record TTL (F10): a PARTIAL object MERGES over the stored windows, so `{"chrono":90}` does not silently clear
+  // the other four. That is the opposite of the `typeSchemas` rule, and deliberately so: there a named type is a
+  // whole definition the caller holds, here each bucket is one independent number. `hasRecordTtl` gates the write
+  // so a CLEAR is applied rather than skipped as if the field were absent.
+  //
+  // The guard is written as the `!== undefined` comparison rather than as `hasRecordTtl ? …`, because only the
+  // comparison NARROWS the type — a boolean const does not, and `normaliseRecordTtl` does not accept `undefined`.
+  const hasRecordTtl = parsed.data.recordTtlDays !== undefined;
+  const recordTtlDays = parsed.data.recordTtlDays !== undefined
+    ? normaliseRecordTtl(space.recordTtlDays, parsed.data.recordTtlDays)
+    : undefined;
+
+  // A space may pick any extraction mode up to the instance ceiling and nothing beyond. The client only
+  // offers valid options, but an API caller (or a space whose stored value predates a lowered ceiling)
+  // could still send more — so cap it here rather than store a value the runtime would only clamp later
+  // anyway. Distinguish field ABSENT (leave the override alone) from an explicit value: `null`/legacy
+  // clears it (stored as undefined), `auto` follows the ceiling, a concrete mode is capped to the ceiling.
+  const hasDocExtraction = parsed.data.documentExtraction !== undefined;
+  const documentExtraction: DocExtractionMode | undefined = !hasDocExtraction
+    ? undefined
+    : (() => {
+        const requested = normalizeDocExtractionMode(parsed.data.documentExtraction);
+        if (!requested || requested === 'auto') return requested;  // null (clear → undefined) / auto pass through
+        return capDocExtractionMode(getDocumentProcessingConfig().mode ?? 'auto', requested);
+      })();
+
+  // Merge the incoming meta with the existing meta so that PATCH has true RFC-7396 semantics: scalar fields
+  // overwrite, typeSchemas entries are added/updated, and types *not* mentioned in the body are preserved.
+  // `typeSchemasMode: 'replace'` opts out of that last clause so a deletion can be expressed at all.
+  const mergedMeta: SpaceMeta | undefined =
+    parsed.data.meta !== undefined
+      ? mergeSpaceMeta(space.meta ?? {}, parsed.data.meta, parsed.data.typeSchemasMode ?? 'merge') as SpaceMeta
+      : undefined;
+
+  return {
+    ok: true,
+    plan: {
+      space,
+      data: parsed.data,
+      mergedMeta,
+      documentExtraction,
+      hasDocExtraction,
+      recordTtlDays,
+      hasRecordTtl,
+      audit,
+    },
+  };
+}

--- a/testing/standalone/broken-library-ref-refused-everywhere.test.js
+++ b/testing/standalone/broken-library-ref-refused-everywhere.test.js
@@ -28,7 +28,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
 
 const ROOT = process.cwd();
 const SRC = 'server/src/api/spaces.ts';
@@ -44,6 +44,59 @@ function routes() {
     ...s,
     body: src.slice(s.at, i + 1 < starts.length ? starts[i + 1].at : src.length),
   }));
+}
+
+/**
+ * Local name → source text, for every module this router imports from `../…`.
+ *
+ * Needed because a handler is allowed to DELEGATE the check. `PATCH /:id` now calls `planSpaceMetaUpdate`, which
+ * owns the whole refusal chain so an MCP tool can reach the same rules — and a gate that only accepted an inline
+ * call would have to be weakened for every such extraction, one route at a time.
+ *
+ * The delegate is RESOLVED and READ rather than named in an allowlist. That is the difference between following
+ * the check and taking a route's word for it: `effectiveChecker` below only accepts a delegate whose own source
+ * calls the checker, so "I call a function" is not an escape hatch — the function has to do the work.
+ */
+function resolveImports(text, fromDir) {
+  const byName = new Map();
+  const re = /import\s+(?:type\s+)?\{([^}]+)\}\s+from\s+'(\.\.?\/[^']+)\.js'/g;
+  let m;
+  while ((m = re.exec(text)) !== null) {
+    const file = join(fromDir, `${m[2]}.ts`);
+    let body;
+    try { body = readFileSync(file, 'utf8'); } catch { continue; }
+    for (const raw of m[1].split(',')) {
+      const name = raw.trim().split(/\s+as\s+/).pop().trim();
+      if (name) byName.set(name, { text: body, dir: dirname(file) });
+    }
+  }
+  return byName;
+}
+
+const ROUTER_IMPORTS = resolveImports(src, join(ROOT, 'server/src/api'));
+
+/**
+ * The source that actually performs the ref check for a handler: its own body, plus — when it delegates — the
+ * delegate's source and the source of whatever the delegate calls to build the message.
+ *
+ * **Two hops, and no more.** The check and its wording are allowed to live one module apart: `planSpaceMetaUpdate`
+ * calls `findBrokenLibraryRefs` and answers with `brokenRefsError`, which is declared beside the schema it reads.
+ * A third hop would mean this gate no longer reads as "this route refuses"; at that distance it is asserting the
+ * shape of a call graph rather than a guarantee, and it would start passing for reasons nobody intended.
+ *
+ * `null` means nothing in reach checks, which is the defect this file exists to catch.
+ */
+function effectiveChecker(handlerBody) {
+  if (/findBrokenLibraryRefs\(/.test(handlerBody)) return handlerBody;
+  for (const [name, mod] of ROUTER_IMPORTS) {
+    if (!new RegExp(`\\b${name}\\s*\\(`).test(handlerBody)) continue;
+    if (!/findBrokenLibraryRefs\(/.test(mod.text)) continue;
+    // Second hop: whatever this delegate calls, so the 422 and its message count wherever they are declared.
+    let bundle = mod.text;
+    for (const [, dep] of resolveImports(mod.text, mod.dir)) bundle += `\n${dep.text}`;
+    return bundle;
+  }
+  return null;
 }
 
 describe('a broken schema-library $ref is refused on every route that accepts one', () => {
@@ -65,14 +118,18 @@ describe('a broken schema-library $ref is refused on every route that accepts on
       // from the body and never named `typeSchemas` at all — a detector keyed on that word would have
       // reported the tree clean on the day the bug was live, which is the one day it needed to speak.
       const takesSchemas = /typeSchemas/.test(r.body)
-        || /const \{[^}]*\bmeta\b[^}]*\} = parsed\.data/.test(r.body);
+        || /const \{[^}]*\bmeta\b[^}]*\} = parsed\.data/.test(r.body)
+        // A handler that hands the whole body to a planner names neither `typeSchemas` nor `meta`. It still
+        // accepts schemas — via `req.body` — so it is in scope, and the delegate is what has to check.
+        || /planSpaceMetaUpdate\(/.test(r.body);
       if (!takesSchemas) continue;
-      if (!/findBrokenLibraryRefs\(/.test(r.body)) offenders.push(`${r.verb.toUpperCase()} ${r.path}`);
+      if (!effectiveChecker(r.body)) offenders.push(`${r.verb.toUpperCase()} ${r.path}`);
     }
     assert.deepEqual(offenders, [],
-      'these accept `typeSchemas` from a request without checking its library refs. An unresolvable ref '
-      + 'degrades to an empty schema, so in a strict space the type silently loses every constraint while '
-      + 'the call reports success — and the other routes answer 422 for the same input.');
+      'these accept `typeSchemas` from a request without checking its library refs — directly or through a '
+      + 'delegate that checks. An unresolvable ref degrades to an empty schema, so in a strict space the type '
+      + 'silently loses every constraint while the call reports success — and the other routes answer 422 for '
+      + 'the same input.');
   });
 
   it('the create route refuses BEFORE the space exists', () => {
@@ -86,11 +143,14 @@ describe('a broken schema-library $ref is refused on every route that accepts on
   });
 
   it('all four answer with the same status and a message naming what is missing', () => {
-    const checking = all.filter(r => /findBrokenLibraryRefs\(/.test(r.body));
+    // Read from the EFFECTIVE checker, so a route that delegates is held to the same two requirements as one that
+    // checks inline. A delegate reports the status in its refusal rather than by calling `res`, which is why 422
+    // is matched as a bare status here rather than as `res.status(422)`.
+    const checking = all.map(r => ({ r, src: effectiveChecker(r.body) })).filter(x => x.src);
     assert.ok(checking.length >= 4, `only ${checking.length} routes check refs; expected the create route plus three editors`);
-    for (const r of checking) {
-      assert.match(r.body, /res\.status\(422\)/, `${r.verb.toUpperCase()} ${r.path} must answer 422`);
-      assert.match(r.body, /Schema library[^\n]*not found/,
+    for (const { r, src: checker } of checking) {
+      assert.match(checker, /422/, `${r.verb.toUpperCase()} ${r.path} must answer 422`);
+      assert.match(checker, /Schema library[^\n]*not found/,
         `${r.verb.toUpperCase()} ${r.path} must name the missing entry — "invalid schema" sends the caller looking in the wrong place`);
     }
   });

--- a/testing/standalone/chrono-retention.test.js
+++ b/testing/standalone/chrono-retention.test.js
@@ -235,7 +235,8 @@ describe('the feature is reachable and wired', () => {
   it('the space PATCH accepts retention inside a type schema', () => {
     // `TypeSchemaZ` is `.strict()`, so an unlisted key is REJECTED — without this the field would be stripped
     // from every request and the whole tier would silently not exist.
-    const src = readFileSync(join(ROOT, 'server/src/api/spaces.ts'), 'utf8');
+    // `TypeSchemaZ` moved to `spaces/body-schemas.ts` with the rest of the space request bodies.
+    const src = readFileSync(join(ROOT, 'server/src/spaces/body-schemas.ts'), 'utf8');
     assert.match(src, /retention: z\.object\(\{[\s\S]{0,200}contentDays: z\.number\(\)/);
   });
 

--- a/testing/standalone/face-width-is-create-only.test.js
+++ b/testing/standalone/face-width-is-create-only.test.js
@@ -29,7 +29,11 @@ const read = (p) => readFileSync(join(ROOT, p), 'utf8');
 const withoutComments = (text) =>
   text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
 
-const api = withoutComments(read('server/src/api/spaces.ts'));
+// The space request bodies live in `spaces/body-schemas.ts`, not in the router. They moved there because four of
+// the router's five ratchet raises were single Zod lines — both `SpaceMetaBody` and `TypeSchemaZ` are `.strict()`,
+// so a field the API must accept has nowhere smaller to go. The "finds the two body schemas" assertion below is
+// what turns a move like that into a failure to re-point rather than three tests quietly passing on nothing.
+const api = withoutComments(read('server/src/spaces/body-schemas.ts'));
 const idx = withoutComments(read('server/src/spaces/vector-index.ts'));
 const life = withoutComments(read('server/src/spaces/lifecycle.ts'));
 

--- a/testing/standalone/mergefn-schema.test.js
+++ b/testing/standalone/mergefn-schema.test.js
@@ -24,7 +24,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-const { PropertySchemaZ } = await import('../../server/dist/api/spaces.js');
+const { PropertySchemaZ } = await import('../../server/dist/spaces/body-schemas.js');
 
 const accepts = (input, why = '') => assert.ok(
   PropertySchemaZ.safeParse(input).success,

--- a/testing/standalone/meta-precondition.test.js
+++ b/testing/standalone/meta-precondition.test.js
@@ -113,8 +113,49 @@ describe('If-Match — the error tells the caller what to do', () => {
 describe('If-Match — both meta-writing routes check it, and check it FIRST', () => {
   const src = readFileSync(new URL('../../server/src/api/spaces.ts', import.meta.url), 'utf8');
 
-  it('PATCH /:id consults the precondition', () => {
-    assert.match(src, /checkMetaPrecondition\(req\.get\('If-Match'\)/);
+  /**
+   * Imported functions that consult the precondition THEMSELVES — a guard may be delegated, not only inline.
+   *
+   * `PATCH /:id` hands its whole decision to `planSpaceMetaUpdate`, which owns the refusal chain so an MCP tool
+   * reaches the same rules instead of a weaker copy (B-2). Each candidate's module is read and required to call
+   * `checkMetaPrecondition` itself, so "the handler calls a function" is not an escape hatch: the function has to
+   * do the checking. A delegate that stopped checking drops out of this set and every write it guards fails below.
+   */
+  const DELEGATES = (() => {
+    const names = [];
+    const re = /import\s+\{([^}]+)\}\s+from\s+'(\.\.?\/[^']+)\.js'/g;
+    let m;
+    while ((m = re.exec(src)) !== null) {
+      let text;
+      try { text = readFileSync(new URL(`../../server/src/api/${m[2]}.ts`, import.meta.url), 'utf8'); } catch { continue; }
+      if (!/checkMetaPrecondition\(/.test(text)) continue;
+      for (const raw of m[1].split(',')) {
+        const name = raw.trim().split(/\s+as\s+/).pop().trim();
+        if (name) names.push(name);
+      }
+    }
+    return names;
+  })();
+
+  /** Every place a handler consults the precondition, inline or through a verified delegate. */
+  const guardPattern = new RegExp(
+    ['checkMetaPrecondition\\(', ...DELEGATES.map(n => `\\b${n}\\s*\\(`)].join('|'), 'g');
+
+  it('the delegate that owns the chain was found — or every check below is vacuous', () => {
+    assert.ok(DELEGATES.includes('planSpaceMetaUpdate'),
+      `no imported module checks the precondition; found ${JSON.stringify(DELEGATES)}. If the planner was `
+      + 're-pointed or stopped checking, fix that rather than this list.');
+  });
+
+  it('PATCH /:id consults the precondition, and hands it the header', () => {
+    // Two halves, and the second is the one a delegation can quietly lose: the planner treats an absent header as
+    // "no precondition asked for", so a route that stopped passing `If-Match` would keep answering 200 and the
+    // guarantee would be gone with no call site missing.
+    const patchStart = src.indexOf("spacesRouter.patch('/:id',");
+    const patchBody = src.slice(patchStart, src.indexOf('spacesRouter.', patchStart + 20));
+    assert.match(patchBody, guardPattern, 'PATCH /:id neither checks the precondition nor delegates to something that does');
+    assert.match(patchBody, /ifMatch:\s*req\.get\('If-Match'\)|checkMetaPrecondition\(req\.get\('If-Match'\)/,
+      'PATCH /:id must pass the If-Match header on; an absent header means NO precondition');
   });
 
   it('EVERY route that writes meta consults it — derived, not counted', () => {
@@ -130,7 +171,8 @@ describe('If-Match — both meta-writing routes check it, and check it FIRST', (
     assert.ok(writeSites.length >= 4,
       `expected at least 4 meta-write sites, found ${writeSites.length} — has the shape changed?`);
 
-    const checkSites = [...src.matchAll(/checkMetaPrecondition\(/g)].map(m => m.index);
+    // Inline calls AND verified delegates: a handler that hands the decision to something which checks is guarded.
+    const checkSites = [...src.matchAll(new RegExp(guardPattern.source, 'g'))].map(m => m.index);
 
     for (const write of writeSites) {
       // The handler containing this write starts at the nearest preceding `spacesRouter.<verb>(`.
@@ -160,12 +202,26 @@ describe('If-Match — both meta-writing routes check it, and check it FIRST', (
   });
 
   it('PATCH checks before taking the audit snapshot', () => {
-    // The audit middleware records on any <400 response. A precondition checked after the snapshot
-    // would still be correct, but this keeps the ordering explicit: rejected writes record nothing.
-    const patchAt = src.indexOf("spacesRouter.patch('/:id'");
-    const checkAt = src.indexOf('checkMetaPrecondition(', patchAt);
+    // The audit middleware records on any <400 response. A precondition checked after the snapshot would still be
+    // correct, but this keeps the ordering explicit: rejected writes record nothing.
+    //
+    // Both halves are asserted where each now lives. In the ROUTE: the plan is obtained and the refusal returned
+    // before `req.auditSnapshots` is set, so a refused request cannot have left a snapshot behind. In the PLANNER:
+    // the precondition is evaluated before the snapshot is built at all. Splitting the assertion this way is the
+    // point — a delegation that reordered either half would fail here rather than in whichever suite noticed the
+    // audit log had grown an entry for a write that never happened.
+    const patchAt = src.indexOf("spacesRouter.patch('/:id',");
+    const planAt = src.indexOf('planSpaceMetaUpdate(', patchAt);
+    const refusalAt = src.indexOf('decision.refusal.status', patchAt);
     const snapshotAt = src.indexOf('req.auditSnapshots', patchAt);
-    assert.ok(checkAt > 0 && snapshotAt > 0);
-    assert.ok(checkAt < snapshotAt, 'the precondition must be evaluated before the audit snapshot');
+    assert.ok(planAt > 0 && refusalAt > 0 && snapshotAt > 0, 'the PATCH handler no longer has the shape this reads');
+    assert.ok(planAt < refusalAt && refusalAt < snapshotAt,
+      'the refusal must be returned before the audit snapshot is set, or a rejected write records a change');
+
+    const planner = readFileSync(new URL('../../server/src/spaces/meta-update.ts', import.meta.url), 'utf8');
+    const checkAt = planner.indexOf('checkMetaPrecondition(');
+    const auditAt = planner.indexOf('const audit = {');
+    assert.ok(checkAt > 0 && auditAt > 0, 'the planner no longer has the shape this reads');
+    assert.ok(checkAt < auditAt, 'the precondition must be evaluated before the audit snapshot is built');
   });
 });

--- a/testing/standalone/no-new-god-files.test.js
+++ b/testing/standalone/no-new-god-files.test.js
@@ -119,7 +119,15 @@ const FROZEN = {
   // body itself is +47 lines and lives in `api/spaces-activity.ts`, the same shape `spaces-reembed.ts` took and
   // for the reason written above it — this file has been raised four times, and the answer to the fifth is to
   // put the route beside its mount point rather than inside it.
-  'server/src/api/spaces.ts': 851,
+  //
+  // 851 -> 656, and this is the raise being PAID rather than taken. Four of the five raises above were Zod lines,
+  // because `SpaceMetaBody` and `TypeSchemaZ` are `.strict()` and an unlisted field is REJECTED — so there was no
+  // "put it beside the feature" for a field the API must accept. The schemas were what kept pulling this file up,
+  // so the schemas left: `spaces/body-schemas.ts`. The PATCH decision chain went to `spaces/meta-update.ts` in the
+  // same change, because an MCP tool has to reach the same refusals rather than a weaker copy of them (B-2).
+  // Lowered to what it now measures and KEPT on this list — deleting the entry is how a file quietly earns the
+  // right to grow back into 195 lines of headroom it did not ask for.
+  'server/src/api/spaces.ts': 656,
   // 769 -> 773: `openBrainDrawer` gained two overload signatures and its `lastSaved` effect reads the
   // record inside each branch so the discriminant narrows it. Four lines of TYPES, no new behaviour —
   // raised deliberately rather than worked around, which is what this list is for.

--- a/testing/standalone/record-ttl-buckets.test.js
+++ b/testing/standalone/record-ttl-buckets.test.js
@@ -116,7 +116,8 @@ describe('normaliseRecordTtl — what a write stores', () => {
 
 describe('the API and the storage type agree', () => {
   it('the route accepts both shapes and refuses an empty object', () => {
-    const src = readFileSync(join(ROOT, 'server/src/api/spaces.ts'), 'utf8');
+    // `UpdateSpaceBody` lives in `spaces/body-schemas.ts` with the rest of the space request bodies.
+    const src = readFileSync(join(ROOT, 'server/src/spaces/body-schemas.ts'), 'utf8');
     assert.match(src, /recordTtlDays: z\.union\(\[/, 'recordTtlDays must accept a union of both shapes');
     assert.match(src, /entity: TtlWindowZ, memory: TtlWindowZ, edge: TtlWindowZ, chrono: TtlWindowZ, file: TtlWindowZ/,
       'all five buckets must be accepted');
@@ -125,7 +126,9 @@ describe('the API and the storage type agree', () => {
   });
 
   it('the route normalises through the shared helper rather than deciding again', () => {
-    const src = readFileSync(join(ROOT, 'server/src/api/spaces.ts'), 'utf8');
+    // The normalisation is a DECISION, so it moved into the planner both surfaces call — a second surface that
+    // normalised for itself is exactly how the two would drift.
+    const src = readFileSync(join(ROOT, 'server/src/spaces/meta-update.ts'), 'utf8');
     assert.match(src, /normaliseRecordTtl\(space\.recordTtlDays, parsed\.data\.recordTtlDays\)/,
       'the merge must read what is stored, or a partial write clears the buckets it did not mention');
     const store = readFileSync(join(ROOT, 'server/src/spaces/spaces.ts'), 'utf8');
@@ -139,7 +142,7 @@ describe('the API and the storage type agree', () => {
     // top of it. So a partial write cleared the four buckets it did not mention, and an all-cleared write stored
     // five explicit nulls instead of nothing — both with a 200 and no visible symptom.
     const src = readFileSync(join(ROOT, 'server/src/api/spaces.ts'), 'utf8');
-    assert.match(src, /const \{ documentExtraction: _rawMode, recordTtlDays: _rawTtl, \.\.\.restPatch \} = parsed\.data;/,
+    assert.match(src, /const \{ documentExtraction: _rawMode, recordTtlDays: _rawTtl, \.\.\.restPatch \} = patchData;/,
       'recordTtlDays must be destructured OUT of the spread that reaches updateSpace, like documentExtraction');
   });
 

--- a/testing/standalone/schema-type-deletion-persists.test.js
+++ b/testing/standalone/schema-type-deletion-persists.test.js
@@ -32,7 +32,7 @@ import assert from 'node:assert/strict';
 let mergeSpaceMeta;
 
 before(async () => {
-  ({ mergeSpaceMeta } = await import('../../server/dist/api/spaces.js'));
+  ({ mergeSpaceMeta } = await import('../../server/dist/spaces/meta-update.js'));
 });
 
 /** A space declaring two entity types and one edge label. */

--- a/testing/standalone/space-id-prefix-safety.test.js
+++ b/testing/standalone/space-id-prefix-safety.test.js
@@ -30,7 +30,7 @@ const read = (rel) => readFileSync(new URL(`../../${rel}`, import.meta.url), 'ut
 
 /** Every place a caller-supplied space id is validated. */
 const VALIDATION_SITES = [
-  { file: 'server/src/api/spaces.ts', what: 'create + rename' },
+  { file: 'server/src/spaces/body-schemas.ts', what: 'create + rename' },
   { file: 'server/src/api/networks/join.ts', what: 'peer space map' },
   { file: 'server/src/spaces/lifecycle.ts', what: 'wipe guard' },
 ];

--- a/testing/standalone/space-purpose-one-field.test.js
+++ b/testing/standalone/space-purpose-one-field.test.js
@@ -151,7 +151,9 @@ describe('space purpose is one field', () => {
       // The one that would be silent: a governed space votes on meta changes. If `description` were
       // still applied as a non-meta update, a directive change would skip the vote in exactly the
       // spaces that voted to govern it.
-      assert.ok(has('server/src/api/spaces.ts', /parsed\.data\.meta = \{[\s\S]{0,300}?purpose: legacy/),
+      // The fold happens in the planner now, which is still BEFORE the router's vote branch — and further from
+      // it than before, since a caller cannot reach the branch without going through the plan.
+      assert.ok(has('server/src/spaces/meta-update.ts', /parsed\.data\.meta = \{[\s\S]{0,300}?purpose: legacy/),
         'description must become meta.purpose before the networked branch is reached');
       assert.ok(!has('server/src/api/spaces.ts', /nonMetaUpdates\.description/),
         'applying it as a non-meta update is the bypass this test exists to prevent');

--- a/testing/standalone/suppress-embeddings-wiring.test.js
+++ b/testing/standalone/suppress-embeddings-wiring.test.js
@@ -94,7 +94,11 @@ describe('the field exists on both tiers of the type', () => {
 
 describe('both write surfaces accept it', () => {
   it('the space meta body lists it, or .strict() would reject the field', () => {
-    const spaces = readFileSync(new URL('../../server/src/api/spaces.ts', import.meta.url), 'utf8');
+    // Two files now: the field is declared with the space request bodies, and the merge guard is in the planner
+    // both write surfaces call. Read together, because the pair IS the guarantee — a field the body accepts and
+    // the merge drops is the same silent failure as one the body rejects.
+    const spaces = ['server/src/spaces/body-schemas.ts', 'server/src/spaces/meta-update.ts']
+      .map(p => readFileSync(new URL(`../../${p}`, import.meta.url), 'utf8')).join('\n');
     assert.match(spaces, /suppressEmbeddings: z\.boolean\(\)\.optional\(\)/);
     // Guarded on `!== undefined`: `false` is how suppression is turned back OFF, and a truthy guard would drop
     // that patch while answering 200.

--- a/testing/standalone/type-schema-editable.test.js
+++ b/testing/standalone/type-schema-editable.test.js
@@ -29,7 +29,8 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const ROOT = process.cwd();
-const API    = 'server/src/api/spaces.ts';
+// `TypeSchemaZ` moved out of the router into `spaces/body-schemas.ts`; this gate reads the schema, not the route.
+const API    = 'server/src/spaces/body-schemas.ts';
 const LIB    = 'server/src/api/schema-library.ts';
 const EDITOR = 'client/src/app/pages/settings/space-settings-state.service.ts';
 const TAB    = 'client/src/app/pages/settings/space-schema-tab.component.ts';

--- a/testing/standalone/ui-maxlength-matches-api.test.js
+++ b/testing/standalone/ui-maxlength-matches-api.test.js
@@ -129,7 +129,7 @@ describe('no UI field truncates below the API limit', () => {
   });
 
   it('the API really does allow 50 000 there — or the fix is aimed at nothing', () => {
-    const src = readFileSync(join(ROOT, 'server/src/api/spaces.ts'), 'utf8');
+    const src = readFileSync(join(ROOT, 'server/src/spaces/body-schemas.ts'), 'utf8');
     assert.match(src, /usageNotes:\s*z\.string\(\)\.max\(50_000\)/,
       'the server cap moved; update the UI constant and this gate together');
   });


### PR DESCRIPTION
## What this is

B-2, third of five. Two of the reported capabilities were thin wrappers and shipped as such. `update_space_schema`
is not: `updateSpace()` exists, but `PATCH /api/spaces/:id` wraps it in a chain of refusals, and a tool calling
`updateSpace()` directly would skip every one — *two surfaces, one rule, one weaker*, reintroduced by the fix for it.

This PR moves the chain. **No tool yet, and no behaviour change** — the contract suite from #845, written against the
unmoved handler, passes unchanged against the extracted one.

## The split

**`server/src/spaces/meta-update.ts` — decisions.** Existence · the `If-Match` precondition · the strict parse · the
server-owned strip · the schema-library `$ref` check · the `description` → `meta.purpose` fold · the extraction-mode
cap · the record-TTL merge · the audit snapshot. Returns a refusal carrying its HTTP status, or a plan.

It writes nothing — no config, no vote, no peer call. That is what makes the refusal chain reachable without a
request and testable without Docker, and it is why the plan carries `recordTtlDays` and `documentExtraction` already
normalised: those are decisions with config reads in them, and leaving them at the call site is how the second
surface ends up storing a value the first would have capped.

**`server/src/spaces/body-schemas.ts` — the request bodies.** Forced rather than tidy: the planner needs
`UpdateSpaceBody`, the router imports the planner, so leaving the schema in the router is a cycle. It also pays a
debt — four of this router's five ratchet raises were single Zod lines, because `SpaceMetaBody` and `TypeSchemaZ` are
`.strict()` and a field the API must accept has nowhere smaller to go.

**The route keeps the writes and how they are reported**: the local settings, the vote round's 202, the peer notify.

| | before | after |
|---|---|---|
| `server/src/api/spaces.ts` code lines | 851 (frozen, raised 4×) | **656** |

Lowered on the ratchet rather than deleted from it — dropping the entry is how a file quietly earns back headroom it
did not ask for.

**No `applySpaceMetaUpdate` in this PR, deliberately.** The writes stay in the route until the MCP tool needs them.
An interface extracted with one caller is designed against a guess; the tool PR is where the second caller shows up
and the shape becomes answerable.

## The part worth reviewing: two gates that could not be re-pointed

Nine source-reading gates read the router for schemas that are no longer in it. Seven were a path change. Two were
not, and they are the interesting ones — the broken-`$ref` sweep and the `If-Match` ordering gate both required an
**inline** call, which a delegating route does not have.

Weakening them per route would turn *"this route refuses"* into *"this route used to"*. Instead each now resolves
the delegate from the import list and **requires the delegate's own source to do the checking** — so "the handler
calls a function" is not an escape hatch, and any future extraction is covered on the day it is written.

**Both were mutation-tested.** With `findBrokenLibraryRefs` removed from the planner, the sweep still reports
`PATCH /:id` as an offender; restored, it passes. Same for the precondition gate.

The ordering gate also **split in two**, which states the guarantee more precisely than the single check it replaced:

- in the route — plan, then refusal, then `req.auditSnapshots`, so a refused request cannot leave a snapshot behind;
- in the planner — the precondition is evaluated before the snapshot is built at all.

## Verification

On a freshly built image (not the three-week-old `ythril-test:latest`):

```
space-meta-update-contract · spaces · type-schema-crud · record-ttl
ℹ tests 77   ℹ pass 77   ℹ fail 0
```

Plus `npm run preflight` green, including the god-file ratchet at its new number and all nine re-pointed gates.

## Docs

None. No endpoint, parameter, status code, error message, default, config key or UI control changed — the statuses
are the ones `docs/` already documents, and this PR is where they moved to, not what they are. Stated rather than
left to be inferred, per section 0 of the queue.

🤖 Generated with Claude Code
