### PR TITLE
fix(brain): deleteFields could never remove a whole field, and answered 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     nothing would have said so.
 
 ### Fixed
+- **`deleteFields` could never remove a whole field from an entity or an edge — it answered 500.** Reported by
+  breituai-platform (2026-08-12T2140Z) against `deleteFields: ["tags"]`, which the integration guide documents.
+  Confirmed by reading the write paths, because the cause is total rather than conditional.
+  - The guard meant to suppress the `$set` was `!$unset['tags']`, and `$unset` entries are written as
+    `$unset['tags'] = ''` — Mongo's own convention. **The empty string is falsy**, so the test was always true, the
+    `$set` was always written, and the update reached Mongo naming one path in both `$set` and `$unset`. Mongo
+    rejects that outright: *"Updating the path 'tags' would create a conflict at 'tags'"*.
+  - **Eight sites, two files** (`brain/entities.ts`, `brain/edges.ts`), covering `description`, `tags`, `properties`
+    and an edge's `weight`.
+  - **Nested paths were never affected, which is why it survived.** Deleting `properties.region` leaves `properties`
+    present, so no `$unset` is written for it and the guard never mattered — and every documented example, plus the
+    only prior integration coverage, used a nested path. The working half looked like proof the feature worked.
+  - **`brain/memory.ts` was already correct**, by a different route: it writes the `$set` first and then
+    `delete $set[field]` beside the `$unset`. Both broken files also used the right idiom a few lines away for a
+    different field (`'_expireAt' in $unset`). Three surfaces, one correct, two wrong, and the correct test spelled
+    out twice inside each wrong file — so this was a slip, not a convention.
+  - Replaced by one `setUnlessDeleted` helper in `brain/delete-fields.ts`, the module that owns the feature, rather
+    than seven corrected copies of a four-line guard. **`$unset` wins over a `$set` of the same field**, which makes
+    "update it and delete it in one request" resolve as documented instead of being rejected — now stated explicitly
+    in the integration guide.
+  - **A gate now refuses reading any `$unset` entry as a boolean**, with comments stripped so the doc comment that
+    quotes the defect does not trip it, and with the real shipped line asserted as a positive match so the pattern
+    cannot rot. Mutation-tested: restoring the old guard makes it fail and name the file.
 - **`npm run loop:check` reported the work queue as drained while eleven rows were open** — a development gate, so
   nothing shipped wrong because of it, but the one gate whose whole job is refusing that exact claim.
   - It counted rows whose ID began `Q-`, from a period when every row did. The queue was later re-keyed per domain

--- a/docs/integration-guide/04-brain-api.md
+++ b/docs/integration-guide/04-brain-api.md
@@ -669,6 +669,7 @@ PATCH /api/brain/spaces/:spaceId/memories/:id
 **Rules:**
 
 - `deleteFields` is applied **after** the normal merge — so you can add new properties and delete stale ones in the same request.
+- **Naming the same field in both halves is allowed, and the deletion wins.** `{"tags": ["a"], "deleteFields": ["tags"]}` stores no tags, because the delete is the later instruction. This follows from the rule above rather than being a separate one, but it is the case worth stating: it used to be rejected.
 - Paths targeting non-existent keys are silently ignored (no error).
 - System fields (`id`, `_id`, `name`, `type`, `spaceId`, `createdAt`, `updatedAt`) **cannot** be deleted. Attempting to do so returns `400`.
 - Paths with empty segments (e.g. `"properties..key"`) are rejected with `400`.

--- a/server/src/brain/delete-fields.ts
+++ b/server/src/brain/delete-fields.ts
@@ -93,6 +93,52 @@ export function applyDeleteFields(
 }
 
 /**
+ * Write `field` into `$set` — unless the same update is REMOVING it, in which case `$unset` wins.
+ *
+ * ## Why this is a function and not four lines at each call site
+ *
+ * It was four lines at each call site, and seven of the eight were wrong in the same way. `entities.ts` and
+ * `edges.ts` each guarded with
+ *
+ *     if (updates.tags !== undefined || (deleteFieldsPaths && !$unset['tags'])) $set['tags'] = newTags;
+ *
+ * and `$unset` entries are written as `$unset['tags'] = ''`, which is Mongo's convention and also FALSY. So
+ * `!$unset['tags']` was always true, `$set['tags']` was always written, and the update reached Mongo naming one
+ * path in both `$set` and `$unset`. Mongo rejects that outright — *"Updating the path 'tags' would create a
+ * conflict at 'tags'"* — so `deleteFields` on a whole field could never work on either record type. Reported by
+ * breituai-platform 2026-08-12 against `deleteFields: ["tags"]`, which returned a 500.
+ *
+ * **Nested paths were unaffected**, which is why it survived: deleting `properties.region` leaves `properties`
+ * present, so no `$unset` is written for it and the guard never mattered. Every documented example used a nested
+ * path.
+ *
+ * ## The precedence, and why `$unset` wins
+ *
+ * `deleteFields` is documented as applying AFTER the normal merge, so a request that both updates a field and
+ * deletes it has asked for the deletion last. The `in` test is what makes that expressible at all: with the old
+ * guard, that combination did not resolve one way or the other — it produced a rejected write.
+ *
+ * `memory.ts` had this right by a different route (it writes the `$set` first, then `delete $set[field]` beside the
+ * `$unset`), and both broken files used the correct idiom a few lines away for a different field: `'_expireAt' in
+ * $unset`. The test that was missing is the one that drives the real write path; `delete-fields.test.js` covered
+ * the pure helper above, which was never the broken part.
+ */
+export function setUnlessDeleted(
+  $set: Record<string, unknown>,
+  $unset: Record<string, unknown>,
+  field: string,
+  value: unknown,
+  requested: boolean,
+): void {
+  if (field in $unset) {
+    // Defensive: the caller may have written the `$set` before deciding on the `$unset`, as `memory.ts` does.
+    delete $set[field];
+    return;
+  }
+  if (requested) $set[field] = value;
+}
+
+/**
  * Recursively apply a single deleteFields path starting at `depth`.
  * Handles `*` wildcard segments by iterating over array elements.
  */

--- a/server/src/brain/edges.ts
+++ b/server/src/brain/edges.ts
@@ -10,7 +10,7 @@ import { embed } from './embedding.js';
 import { edgeEmbedText } from './embed-text.js';
 import { getConfig } from '../config/loader.js';
 import { stampExpiryOnCreate, applyExpiryToUpdate } from './ttl.js';
-import { applyDeleteFields } from './delete-fields.js';
+import { applyDeleteFields, setUnlessDeleted } from './delete-fields.js';
 import { mergePropertiesOrKeep, mergeTagsOrKeep } from './merge-fields.js';
 import { enqueueEmbedJob } from './embed-queue.js';
 import { getEntityById } from './entities.js';
@@ -318,11 +318,13 @@ export async function updateEdgeById(
   }
 
   if (updates.label !== undefined) $set['label'] = newLabel;
-  if (updates.description !== undefined || (deleteFieldsPaths && !$unset['description'])) $set['description'] = newDesc;
-  if (updates.tags !== undefined || (deleteFieldsPaths && !$unset['tags'])) $set['tags'] = newTags;
-  if (updates.properties !== undefined || (deleteFieldsPaths && !$unset['properties'])) $set['properties'] = newProps;
+  // `setUnlessDeleted` rather than a guard on `$unset['x']`: that value is the empty string, so the old test was
+  // always true and every whole-field `deleteFields` produced a rejected write. See its doc comment.
+  setUnlessDeleted($set, $unset, 'description', newDesc, updates.description !== undefined || !!deleteFieldsPaths);
+  setUnlessDeleted($set, $unset, 'tags', newTags, updates.tags !== undefined || !!deleteFieldsPaths);
+  setUnlessDeleted($set, $unset, 'properties', newProps, updates.properties !== undefined || !!deleteFieldsPaths);
   if (updates.type !== undefined) $set['type'] = newType;
-  if (updates.weight !== undefined || (deleteFieldsPaths && !$unset['weight'])) $set['weight'] = newWeight;
+  setUnlessDeleted($set, $unset, 'weight', newWeight, updates.weight !== undefined || !!deleteFieldsPaths);
 
   // The re-embed is ENQUEUED after the write — see `embedStoredRecord`. Computing it here would build the
   // text from this function's stale read, which is how a record's vector ends up describing a record that
@@ -355,7 +357,10 @@ export async function updateEdgeById(
     updatedAt: now,
     seq,
     ...(updates.description !== undefined ? { description: newDesc } : {}),
-    ...(updates.properties !== undefined || (deleteFieldsPaths && !$unset['properties']) ? { properties: newProps } : {}),
+    // Same `in` test as the write above. `applyDeleteFields` runs over this object a few lines down and would have
+    // removed the key anyway, so this was right by accident rather than by decision — and an accident that agrees
+    // with the write only while both stay wrong the same way.
+    ...(!('properties' in $unset) && (updates.properties !== undefined || deleteFieldsPaths) ? { properties: newProps } : {}),
     ...(updates.type !== undefined ? { type: newType } : {}),
     ...(updates.weight !== undefined ? { weight: newWeight } : {}),
   } as EdgeDoc;

--- a/server/src/brain/entities.ts
+++ b/server/src/brain/entities.ts
@@ -11,7 +11,7 @@ import { entityEmbedText } from './embed-text.js';
 import { getConfig } from '../config/loader.js';
 import { stampExpiryOnCreate, applyExpiryToUpdate } from './ttl.js';
 import { writeFilterFor, writeOutcome } from './write-precondition.js';
-import { applyDeleteFields } from './delete-fields.js';
+import { applyDeleteFields, setUnlessDeleted } from './delete-fields.js';
 import { mergeTagsAndProperties, mergePropertiesOrKeep, mergeTagsOrKeep } from './merge-fields.js';
 import { enqueueEmbedJob } from './embed-queue.js';
 import { checkDuplicates, type SimilarMatch, type DupeCheckOpts } from './recall.js';
@@ -312,9 +312,11 @@ export async function updateEntityById(
   if (updates.excludeFromVectorSearch !== undefined) $set['excludeFromVectorSearch'] = updates.excludeFromVectorSearch;
   if (updates.name !== undefined) $set['name'] = newName;
   if (updates.type !== undefined) $set['type'] = newType;
-  if (updates.description !== undefined || (deleteFieldsPaths && !$unset['description'])) $set['description'] = newDesc;
-  if (updates.tags !== undefined || (deleteFieldsPaths && !$unset['tags'])) $set['tags'] = newTags;
-  if (updates.properties !== undefined || (deleteFieldsPaths && !$unset['properties'])) $set['properties'] = newProps;
+  // `setUnlessDeleted` rather than a guard on `$unset['x']`: that value is the empty string, so the old test was
+  // always true and every whole-field `deleteFields` produced a rejected write. See its doc comment.
+  setUnlessDeleted($set, $unset, 'description', newDesc, updates.description !== undefined || !!deleteFieldsPaths);
+  setUnlessDeleted($set, $unset, 'tags', newTags, updates.tags !== undefined || !!deleteFieldsPaths);
+  setUnlessDeleted($set, $unset, 'properties', newProps, updates.properties !== undefined || !!deleteFieldsPaths);
 
   // The re-embed is ENQUEUED after the write, not computed here. See `embedStoredRecord` for why computing
   // it inline was wrong rather than merely slow: the text would come from this function's stale read.

--- a/testing/integration/delete-fields-write-path.test.js
+++ b/testing/integration/delete-fields-write-path.test.js
@@ -1,0 +1,153 @@
+/**
+ * `deleteFields` against the real write path, for whole fields as well as nested keys.
+ *
+ * ## The report, and why it was believed on sight
+ *
+ * breituai-platform, 2026-08-12T2140Z: `deleteFields: ["tags"]` is documented and fails with a Mongo path
+ * conflict. Confirmed by reading `entities.ts` and `edges.ts` rather than by reproducing, because the cause is
+ * total: the guard meant to suppress the `$set` was
+ *
+ *     if (updates.tags !== undefined || (deleteFieldsPaths && !$unset['tags'])) $set['tags'] = newTags;
+ *
+ * and `$unset` entries are written as `$unset['tags'] = ''` — Mongo's own convention. The empty string is FALSY,
+ * so `!$unset['tags']` was always true, the `$set` was always applied, and the update reached Mongo with one path
+ * in both `$set` and `$unset`. Mongo rejects the whole write.
+ *
+ * ## Why it survived this long, which is the part worth keeping
+ *
+ * **Nested paths were fine.** `deleteFields: ["properties.region"]` leaves `properties` present in the merged
+ * view, so no `$unset` is written for it and the guard never mattered. Every example in the docs and the only
+ * existing integration coverage (`schema-library.test.js`) used a nested path. So the broken half was the one
+ * nobody had a test for, and the working half looked like proof the feature worked.
+ *
+ * That is why this file asserts BOTH shapes on BOTH record types. A test for the reported case alone would have
+ * left the next person to discover that the two shapes go down different branches.
+ *
+ * ## The comparison that made the fix obvious
+ *
+ * `memory.ts` was already correct, and not by writing a better guard: it writes `$unset[field] = ''` and then
+ * `delete $set[field]`, so the deletion is expressed by removing the `$set` rather than by testing the `$unset`
+ * for truth. Both broken files also used the right idiom a few lines away for a different field — `'_expireAt' in
+ * $unset`. Three surfaces, one correct, two wrong, and the correct test spelled out twice inside each wrong file.
+ *
+ * Run: node --test testing/integration/delete-fields-write-path.test.js
+ */
+
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, get, patch } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+const RUN = Date.now();
+const SPACE = 'general';
+
+let token;
+
+before(() => {
+  token = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+});
+
+async function newEntity(extra = {}) {
+  const r = await post(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/entities`, {
+    name: `DeleteFields-${RUN}-${Math.floor(performance.now() * 1000)}`,
+    type: 'concept',
+    description: 'to be removed',
+    tags: ['keep-me', 'and-me'],
+    properties: { region: 'eu', tier: 'core' },
+    ...extra,
+  });
+  assert.equal(r.status, 201, `entity create failed: ${JSON.stringify(r.body)}`);
+  return r.body._id;
+}
+
+async function newEdge() {
+  const [a, b] = [await newEntity(), await newEntity()];
+  const r = await post(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/edges`, {
+    from: a, to: b, label: `df-edge-${RUN}-${Math.floor(performance.now() * 1000)}`,
+    description: 'to be removed',
+    tags: ['keep-me', 'and-me'],
+    properties: { region: 'eu', tier: 'core' },
+    weight: 0.75,
+  });
+  assert.equal(r.status, 201, `edge create failed: ${JSON.stringify(r.body)}`);
+  return r.body._id;
+}
+
+const patchEntity = (id, body) => patch(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/entities/${id}`, body);
+const patchEdge = (id, body) => patch(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/edges/${id}`, body);
+const getEntity = (id) => get(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/entities/${id}`);
+const getEdge = (id) => get(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/edges/${id}`);
+
+describe('deleteFields removes a WHOLE field — the reported failure', () => {
+  it('an entity loses `tags`, and the write is not refused', async () => {
+    const id = await newEntity();
+    const r = await patchEntity(id, { deleteFields: ['tags'] });
+    // The failure mode being pinned is a REFUSED WRITE, not a wrong value: Mongo answers "Updating the path
+    // 'tags' would create a conflict at 'tags'" and nothing is applied. So the status is the assertion that
+    // matters, and it is asserted before the value.
+    assert.equal(r.status, 200, `deleteFields:["tags"] was refused: ${JSON.stringify(r.body)}`);
+    const after = await getEntity(id);
+    assert.equal(after.body.tags, undefined, 'tags must be gone from the stored record, not merely absent from the response');
+    assert.equal(after.body.properties?.region, 'eu', 'deleting one field must not disturb the others');
+  });
+
+  it('an entity loses `description` and `properties` in one request', async () => {
+    const id = await newEntity();
+    const r = await patchEntity(id, { deleteFields: ['description', 'properties'] });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    const after = await getEntity(id);
+    assert.equal(after.body.description, undefined);
+    assert.equal(after.body.properties, undefined);
+    assert.deepEqual(after.body.tags, ['keep-me', 'and-me'], 'the field NOT named must survive');
+  });
+
+  it('an edge loses `tags`, and `weight` too — four guards, all of them the same shape', async () => {
+    const id = await newEdge();
+    const r = await patchEdge(id, { deleteFields: ['tags', 'weight'] });
+    assert.equal(r.status, 200, `deleteFields on an edge was refused: ${JSON.stringify(r.body)}`);
+    const after = await getEdge(id);
+    assert.equal(after.body.tags, undefined);
+    assert.equal(after.body.weight, undefined);
+  });
+});
+
+describe('deleteFields removes a NESTED key — the half that always worked', () => {
+  // Kept because it is the branch the docs and the only prior coverage exercised. If a fix made whole-field
+  // deletion work by writing `$unset` unconditionally, this is what would break: `properties` would vanish
+  // entirely instead of losing one key, and the reported bug would be traded for a worse one.
+  it('an entity loses one property and keeps the rest', async () => {
+    const id = await newEntity();
+    const r = await patchEntity(id, { deleteFields: ['properties.region'] });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    const after = await getEntity(id);
+    assert.equal(after.body.properties?.region, undefined, 'the named key is gone');
+    assert.equal(after.body.properties?.tier, 'core', 'and the sibling is not');
+  });
+
+  it('an edge loses one property and keeps the rest', async () => {
+    const id = await newEdge();
+    const r = await patchEdge(id, { deleteFields: ['properties.region'] });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    const after = await getEdge(id);
+    assert.equal(after.body.properties?.region, undefined);
+    assert.equal(after.body.properties?.tier, 'core');
+  });
+});
+
+describe('deleteFields alongside an update of the same field', () => {
+  it('the deletion wins, and the request is not refused', async () => {
+    // The one case where a conflict is genuinely easy to produce: the caller sends `tags` AND asks for `tags` to
+    // be deleted. `deleteFields` is documented as applying AFTER the normal merge, so the delete is the later
+    // instruction and wins. What must NOT happen is the write being rejected — which is what happens when both
+    // `$set` and `$unset` name the path.
+    const id = await newEntity();
+    const r = await patchEntity(id, { tags: ['replacement'], deleteFields: ['tags'] });
+    assert.equal(r.status, 200, `a same-field update + delete was refused: ${JSON.stringify(r.body)}`);
+    const after = await getEntity(id);
+    assert.equal(after.body.tags, undefined, 'deleteFields applies after the merge, so it wins');
+  });
+});

--- a/testing/standalone/unset-presence-uses-in.test.js
+++ b/testing/standalone/unset-presence-uses-in.test.js
@@ -1,0 +1,111 @@
+/**
+ * A `$unset` entry is never tested for TRUTH — only for presence.
+ *
+ * ## The bug this exists for
+ *
+ * Mongo's convention for removing a field is `{ $unset: { tags: '' } }`, so an entry's value is the empty string.
+ * `entities.ts` and `edges.ts` guarded a `$set` with
+ *
+ *     if (updates.tags !== undefined || (deleteFieldsPaths && !$unset['tags'])) $set['tags'] = newTags;
+ *
+ * which reads as "unless we are removing it" and means nothing of the kind: `!''` is `true`, always. So the `$set`
+ * was always written, the update named one path in both `$set` and `$unset`, and Mongo rejected the whole write
+ * with *"Updating the path 'tags' would create a conflict"*. `deleteFields` on a whole field could not work on
+ * either record type, and the failure was a 500. Reported by breituai-platform 2026-08-12.
+ *
+ * Nested paths were unaffected — deleting `properties.region` leaves `properties` present, so no `$unset` is
+ * written for it — which is why every documented example worked and the feature looked fine.
+ *
+ * ## Why a gate rather than trusting the fix
+ *
+ * The value being falsy is a property of Mongo's API, not of this codebase, so the mistake is available to anyone
+ * writing the next record type — and it is invisible on inspection, because the broken guard reads correctly. The
+ * correct spellings all already appear in the same files: `'_expireAt' in $unset`, `delete $set[field]`, and now
+ * `setUnlessDeleted`.
+ *
+ * **Comments are stripped before matching.** Without that, this gate would fire on the doc comment in
+ * `delete-fields.ts` that quotes the broken line to explain it — a source-reading gate that cannot tell code from
+ * the prose describing it fails on the fix and passes on the bug.
+ *
+ * Run: node --test testing/standalone/unset-presence-uses-in.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+
+/** Tracked `.ts` files under server/src — `git ls-files`, never a directory walk that picks up build output. */
+function serverSources() {
+  return execSync('git ls-files server/src', { encoding: 'utf8' })
+    .split('\n').map(s => s.trim()).filter(f => f.endsWith('.ts'));
+}
+
+/** Block and line comments out, string literals left alone (a `$unset` inside a string is not a test). */
+function stripComments(text) {
+  return text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+/**
+ * A `$unset[...]` read in a boolean position.
+ *
+ * Three shapes, which is every way the mistake has appeared or could: negated (`!$unset['x']`), as an operand of
+ * `&&`/`||`, and as a whole condition (`if ($unset['x'])`). A comparison — `$unset['x'] === undefined` — is fine
+ * and deliberately not matched: it is explicit about what it is asking.
+ */
+const TRUTH_TESTS = [
+  { name: 'negated', re: /!\s*\$unset\s*\[/ },
+  { name: 'as an && / || operand', re: /(?:&&|\|\|)\s*\$unset\s*\[[^\]]+\]\s*(?:\)|&&|\|\||\?)/ },
+  { name: 'as a whole condition', re: /if\s*\(\s*\$unset\s*\[[^\]]+\]\s*\)/ },
+];
+
+describe('$unset entries are tested for presence, not truth', () => {
+  const files = serverSources();
+
+  it('found the sources to scan', () => {
+    // Floors the enumeration: a broken glob would make every check below vacuous.
+    assert.ok(files.length > 50, `only ${files.length} server sources found — is this running from the repo root?`);
+    assert.ok(files.includes('server/src/brain/entities.ts'), 'the file this gate was written for must be in scope');
+  });
+
+  it('no file reads a $unset entry as a boolean', () => {
+    const offenders = [];
+    for (const f of files) {
+      const code = stripComments(readFileSync(f, 'utf8'));
+      for (const line of code.split('\n')) {
+        for (const { name, re } of TRUTH_TESTS) {
+          if (re.test(line)) offenders.push(`${f}: ${name} — ${line.trim().slice(0, 100)}`);
+        }
+      }
+    }
+    assert.deepEqual(offenders, [],
+      'a $unset entry is the empty string, so testing it for truth is always the same answer. Use '
+      + "`'field' in $unset`, or `setUnlessDeleted` from brain/delete-fields.ts:\n  " + offenders.join('\n  '));
+  });
+
+  it('the checker sees the shape it is looking for — proven on the real broken line', () => {
+    // Mutation check, inline, so the gate cannot rot into one that passes on everything. This is the exact line
+    // that shipped in entities.ts and edges.ts.
+    const broken = "  if (updates.tags !== undefined || (deleteFieldsPaths && !$unset['tags'])) $set['tags'] = newTags;";
+    assert.ok(TRUTH_TESTS.some(t => t.re.test(broken)), 'the pattern no longer matches the defect it was written for');
+
+    // And the two correct spellings must NOT match, or the gate would demand its own fix be reverted.
+    for (const ok of [
+      "  if ('_expireAt' in $unset) delete (result as { _expireAt?: unknown })._expireAt;",
+      "  setUnlessDeleted($set, $unset, 'tags', newTags, updates.tags !== undefined || !!deleteFieldsPaths);",
+      "  if (Object.keys($unset).length > 0) updateOp['$unset'] = $unset;",
+      "  if ($unset['tags'] === undefined) $set['tags'] = newTags;",
+    ]) {
+      assert.ok(!TRUTH_TESTS.some(t => t.re.test(ok)), `false positive on a correct line: ${ok.trim()}`);
+    }
+  });
+
+  it('strips comments, so quoting the defect to explain it is allowed', () => {
+    // `delete-fields.ts` documents the broken line verbatim. A gate that fired on that would be a gate whose
+    // only fix is deleting the explanation of the bug.
+    const doc = stripComments(readFileSync('server/src/brain/delete-fields.ts', 'utf8'));
+    assert.ok(!TRUTH_TESTS.some(t => t.re.test(doc)),
+      'the broken pattern survived comment-stripping in delete-fields.ts — the stripper is the thing to fix');
+    assert.match(readFileSync('server/src/brain/delete-fields.ts', 'utf8'), /!\$unset\['tags'\]/,
+      'the doc comment should still quote the defect; if it stopped, this assertion is what noticed');
+  });
+});


### PR DESCRIPTION
## The report, and what it actually was

breituai-platform, 2026-08-12T2140Z: `deleteFields: ["tags"]` is documented and fails with a Mongo path conflict.
It returned **500**.

Confirmed by reading the write paths rather than reproducing first, because the cause is total:

```ts
if (updates.tags !== undefined || (deleteFieldsPaths && !$unset['tags'])) $set['tags'] = newTags;
```

`$unset` entries are written `$unset['tags'] = ''` — Mongo's own convention. **The empty string is falsy**, so
`!$unset['tags']` was always true, the `$set` was always written, and the update reached Mongo naming one path in
both `$set` and `$unset`. Mongo refuses that outright: *"Updating the path 'tags' would create a conflict at
'tags'"*. The documented operation could not succeed at all on entities or edges.

**Eight sites, two files** — `brain/entities.ts` and `brain/edges.ts` — covering `description`, `tags`, `properties`
and an edge's `weight`.

## Why it survived, which is the part worth keeping

**Nested paths were never affected.** Deleting `properties.region` leaves `properties` present in the merged view,
so no `$unset` is written for it and the guard never mattered. Every example in the integration guide and the only
prior integration coverage (`schema-library.test.js`, a different route entirely) used a nested path — so the half
nobody had a test for was broken, and the working half read as proof the feature worked.

The new suite asserts **both shapes on both record types**. Against unfixed code that is exactly:

```
✖ an entity loses `tags`                      → {"error":"Internal server error"}
✖ an entity loses `description` + `properties` → 500
✖ an edge loses `tags` and `weight`            → 500
✖ update `tags` and delete `tags` together     → 500
✔ an entity loses one property, keeps the rest
✔ an edge loses one property, keeps the rest
```

## The fix

`brain/memory.ts` was **already correct**, by a different route: it writes the `$set` first, then
`delete $set[field]` beside the `$unset`. Both broken files also used the right idiom a few lines away for another
field — `'_expireAt' in $unset`. Three surfaces, one correct, two wrong, and the correct test spelled out twice
inside each wrong file. That is a slip, not a convention.

So: one `setUnlessDeleted` in `brain/delete-fields.ts` — the module that owns the feature — instead of seven
corrected copies of a four-line guard. **`$unset` wins over a `$set` of the same field**, which makes "update it and
delete it in one request" resolve the way the docs' *applied after the normal merge* rule already implied, instead
of being rejected. That case is now stated outright in the guide rather than left to be inferred.

## The gate

Reading any `$unset` entry as a boolean is now refused across `server/src`. Three details, each load-bearing:

- **Comments are stripped.** `delete-fields.ts` quotes the broken line to explain it, and a gate that fired on that
  would be a gate whose only fix is deleting the explanation — it would fail on the fix and pass on the bug.
- **The real shipped line is asserted as a positive match**, so the pattern cannot rot into one that matches nothing.
- **Four correct spellings are asserted as non-matches**, so it cannot demand its own fix be reverted.
- **Mutation-tested:** restoring the old guard in `entities.ts` makes it fail and name the file.

## Verification

On a rebuilt image (the fix is server-side, so a stale `ythril-test:latest` would have proven nothing):

```
delete-fields-write-path                      ℹ pass 6    ℹ fail 0
brain + entity-refs + entity-merge            ℹ pass 200  ℹ fail 0
```

Plus `npm run preflight` green, including the new gate.

## Docs

`docs/integration-guide/04-brain-api.md` — the path-semantics table already promised top-level `description`,
`properties` and `weight` deletes, so the docs were right and the code was wrong; nothing there needed correcting.
Added the one rule they left implicit: naming the same field as both an update and a deletion is allowed, and the
deletion wins.

🤖 Generated with Claude Code
