### PR TITLE
feat(mcp): update_space_schema, and update_space stops skipping the vote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- **`update_space_schema` is an MCP tool.** Third of the five REST-only capabilities, and the first that was not a
+  wrapper. Their case for it was not ergonomics: they designed an 11-entity / 7-memory / 13-edge / 10-chrono
+  research model with an agent, and the agent could not apply it — `get_space_meta` read the schema and nothing
+  wrote it. A sixth instance arrived on 2026-08-12 with the sharper consequence: under `validationMode: 'strict'` a
+  stale enum makes every write fail, and a schema write is the documented way out. So this is the recovery path for
+  a wedged space, reachable from the surface that is wedged.
+  - Writes `typeSchemas` and the other meta fields — `validationMode`, `strictLinkage`, `usageNotes`,
+    `suppressEmbeddings`. **Merges by default**, so editing one type does not require resending the other forty;
+    `typeSchemasMode: 'replace'` makes the payload authoritative, which is the only way to DELETE a type.
+  - **It calls the same `planSpaceMetaUpdate` the REST route does**, so it inherits every refusal rather than a
+    weaker copy: the strict parse, the server-owned strip, and `422` for a `$ref` to a schema-library entry that
+    does not exist. A tool calling `updateSpace()` directly would have stored that ref as an empty schema and
+    reported success — in a strict space, silently removing every constraint from a type whose schema looks authored.
+  - **A networked space gets a vote, not a write.** `applySpaceMetaUpdate` owns the `meta_change` round, so the tool
+    cannot bypass governance. The reply says the change was *proposed and not applied* rather than reporting success,
+    because an agent that read it as success would build on a schema that does not exist.
+  - Its row is **deleted** from the REST-only capability map, which is how a row leaves that list; `help` now reports
+    two. `mcp-rest-parity.test.js` asserts both halves of every surviving row, so the map cannot rot in either
+    direction.
+
+### Fixed
+- **`update_space` over MCP skipped the network vote for a purpose change — in the spaces that had voted to govern
+  exactly that.** Found while adding the tool above, and the guide already documented the correct behaviour: *"in a
+  networked space a purpose change opens a meta vote rather than applying at once"*. The code did not do it.
+  - `update_space` wrote through `updateSpace()`, which folds `description` into `meta.purpose` and bumps the meta
+    version — so it was a **meta write** that looked like a label edit. `PATCH /api/spaces/:id` opens a
+    `meta_change` round for that same edit; the tool applied it immediately.
+  - Now routed through the shared planner, so the two surfaces agree. This is the same *two surfaces, one rule, one
+    weaker* defect the parity work is about, one field over — which is why it was not deferred to its own item.
+- **`npm run loop:check` reported the work queue as drained while eleven rows were open**
 - **`list_tokens` is an MCP tool.** Second of the five, and their workaround was the tell: a Kubernetes CronJob
   that curls `GET /api/tokens` and posts the result into a space as a chrono entry so an agent can read it. A
   scheduler standing in for a tool call, and an inventory as stale as the last tick.

--- a/docs/integration-guide/16-mcp.md
+++ b/docs/integration-guide/16-mcp.md
@@ -33,7 +33,7 @@ On connect, the server sends global instructions listing all available space IDs
 
 ### Read-Only Tokens
 
-When connecting with a `readOnly` token, mutating tools (`remember`, `update_memory`, `delete_memory`, `upsert_entity`, `update_entity`, `delete_entity`, `merge_entities`, `upsert_edge`, `update_edge`, `delete_edge`, `create_chrono`, `update_chrono`, `delete_chrono`, `bulk_write`, `write_file`, `delete_file`, `create_dir`, `move_file`, `retry_embedding`, `sync_now`, `update_space`, `wipe_space`) are **hidden** from `tools/list` and rejected with an error if called directly. Read-only tools (`help`, `recall`, `find_similar`, `query`, `get_stats`, `get_space_meta`, `list_spaces`, `find_entities_by_name`, `list_chrono`, `read_file`, `list_dir`, `traverse`) work normally. `list_tokens` is read-only but **admin-gated**, like `list_peers`. `list_peers` is read-only but **admin-gated** — see the admin-only note below.
+When connecting with a `readOnly` token, mutating tools (`remember`, `update_memory`, `delete_memory`, `upsert_entity`, `update_entity`, `delete_entity`, `merge_entities`, `upsert_edge`, `update_edge`, `delete_edge`, `create_chrono`, `update_chrono`, `delete_chrono`, `bulk_write`, `write_file`, `delete_file`, `create_dir`, `move_file`, `retry_embedding`, `sync_now`, `update_space`, `update_space_schema`, `wipe_space`) are **hidden** from `tools/list` and rejected with an error if called directly. Read-only tools (`help`, `recall`, `find_similar`, `query`, `get_stats`, `get_space_meta`, `list_spaces`, `find_entities_by_name`, `list_chrono`, `read_file`, `list_dir`, `traverse`) work normally. `list_tokens` is read-only but **admin-gated**, like `list_peers`. `list_peers` is read-only but **admin-gated** — see the admin-only note below.
 
 ### Connecting
 
@@ -198,11 +198,12 @@ row survives its own tool being built, so the list cannot keep advertising a gap
 | `create_dir` | Create a directory |
 | `move_file` | Move or rename a file/directory |
 | `update_space` | Update space label and/or purpose (admin only). In a networked space a purpose change opens a meta vote rather than applying at once |
+| `update_space_schema` | Write the space's type schemas and its other meta fields — `validationMode`, `strictLinkage`, `usageNotes`, `suppressEmbeddings` (admin only). **Merges** by default: types you do not name are preserved. `typeSchemasMode: "replace"` makes the payload authoritative, which is the only way to DELETE a type. Same refusals as `PATCH /api/spaces/:id`, including `422` for a `$ref` to a schema-library entry that does not exist. In a networked space it opens a meta vote rather than applying at once |
 | `wipe_space` | Wipe all or specific collection types from the space (admin only) |
 | `list_peers` | List all configured peer instances (admin only) |
 | `sync_now` | Trigger immediate sync (all networks or specific peer) (admin only) |
 
-> **Admin-only tools.** `list_peers`, `sync_now`, `update_space`, and `wipe_space` require an `admin`
+> **Admin-only tools.** `list_peers`, `sync_now`, `update_space`, `update_space_schema`, and `wipe_space` require an `admin`
 > token: the first two are instance-level (they expose the whole peer topology and drive outbound
 > connections to every peer) and have no space scoping. They are hidden from `tools/list` for
 > non-admin tokens and rejected if called directly.

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -33,7 +33,7 @@ import {
   stripServerOwnedMeta, findBrokenLibraryRefs, brokenRefsError,
   CreateSpaceBody, DeleteSpaceBody, RenameSpaceBody, ReorderSpacesBody, PutSchemaBody,
 } from '../spaces/body-schemas.js';
-import { planSpaceMetaUpdate } from '../spaces/meta-update.js';
+import { planSpaceMetaUpdate, applySpaceMetaUpdate } from '../spaces/meta-update.js';
 
 export const spacesRouter = Router();
 
@@ -320,124 +320,21 @@ spacesRouter.patch('/:id', globalRateLimit, requireAdminMfaScoped('id'), async (
     res.status(decision.refusal.status).json(decision.refusal.body);
     return;
   }
-  // `spaceRec` rather than the `space` above: the planner returns the record it validated, already narrowed to
-  // non-undefined by the 404 it would otherwise have produced.
-  const { space: spaceRec, data: patchData, mergedMeta, hasDocExtraction,
-    documentExtraction: cappedDocExtraction, hasRecordTtl, recordTtlDays: normalisedTtl, audit } = decision.plan;
-
   // The audit middleware records this only on a <400 response, so a request the planner refused above logs no
   // change. The snapshot pair was taken before anything was applied, which is what makes the change list honest.
-  req.auditSnapshots = audit;
+  req.auditSnapshots = decision.plan.audit;
 
-  // Duplicate rules are local (never governed) — apply them now, so they are
-  // not silently dropped when a meta change on the same request opens a
-  // network vote and returns 202 below.
-  if (patchData.dupeRules !== undefined || patchData.dupeMergeSurvivor !== undefined || patchData.dupeRulesOnInsert !== undefined) {
-    updateSpace(id, { dupeRules: patchData.dupeRules, dupeMergeSurvivor: patchData.dupeMergeSurvivor, dupeRulesOnInsert: patchData.dupeRulesOnInsert });
-  }
-
-  // Record TTL (F10) is a local operational setting (like dupe rules) — apply immediately, never voted.
-  // 0/null clears it. When enabled, ensure the sweep's `_expireAt` index (best-effort). The value arrives
-  // already MERGED over what was stored (see the planner), so a partial write does not clear the buckets it
-  // did not mention; `hasRecordTtl` gates the write so a clear is applied rather than skipped as if absent.
-  if (hasRecordTtl) {
-    updateSpace(id, { recordTtlDays: normalisedTtl });
-    if (normalisedTtl !== undefined) void ensureTtlIndex(id).catch(err => log.warn(`ensureTtlIndex ${id}: ${err}`));
-  }
-
-  // Already capped to the instance ceiling by the planner. `hasDocExtraction` gates the write so a clear is
-  // applied, not skipped as if absent.
-  if (hasDocExtraction) {
-    updateSpace(id, { documentExtraction: cappedDocExtraction });
-  }
-
-  // ── Network voting for meta changes ──────────────────────────────────────
-  // If this space is part of a network and a meta change is requested,
-  // open a meta_change vote round instead of applying immediately.
-  if (mergedMeta !== undefined) {
-    const networkedIn = cfg.networks.filter(n => n.spaces.includes(id));
-    if (networkedIn.length > 0) {
-      const now = new Date().toISOString();
-      const rounds: { networkId: string; networkLabel: string; roundId: string }[] = [];
-
-      for (const net of networkedIn) {
-        const roundId = uuidv4();
-        const deadline = new Date(Date.now() + net.votingDeadlineHours * 3_600_000).toISOString();
-        net.pendingRounds.push({
-          roundId,
-          type: 'meta_change',
-          subjectInstanceId: cfg.instanceId,
-          subjectLabel: cfg.instanceLabel,
-          subjectUrl: '',
-          deadline,
-          openedAt: now,
-          votes: [{ instanceId: cfg.instanceId, vote: 'yes', castAt: now }],
-          spaceId: id,
-          pendingMeta: mergedMeta as SpaceMeta,
-          // Provenance, so conclusion can apply just this patch rather than this whole snapshot. Rounds
-          // stay open for `votingDeadlineHours`, so a second proposal landing before the first concludes
-          // is ordinary, and without these two fields the later one reverts the earlier one's edit with
-          // no error anywhere. See sync/meta-round-merge.ts.
-          metaChangedFields: proposedMetaFields(patchData.meta ?? {}),
-          baseMetaVersion: spaceRec.meta?.version ?? 0,
-        });
-        rounds.push({ networkId: net.id, networkLabel: net.label, roundId });
-      }
-
-      // Apply non-meta updates immediately (label, maxGiB). `description` is not among them any more:
-      // it was rewritten into `meta.purpose` above, so it is in the vote with the rest of the meta.
-      const nonMetaUpdates: { label?: string; maxGiB?: number | null } = {};
-      if (patchData.label !== undefined) nonMetaUpdates.label = patchData.label;
-      if (patchData.maxGiB !== undefined) nonMetaUpdates.maxGiB = patchData.maxGiB;
-      if (Object.keys(nonMetaUpdates).length > 0) {
-        updateSpace(id, nonMetaUpdates);
-      } else {
-        saveConfig(cfg);
-      }
-
-      // Notify peers (best-effort)
-      const secrets = getSecrets();
-      for (const net of networkedIn) {
-        for (const member of net.members) {
-          const peerToken = secrets.peerTokens[member.instanceId];
-          if (!peerToken) continue;
-          peerSafeFetch(`${member.url}/api/notify`, {
-            method: 'POST',
-            headers: { 'Authorization': `Bearer ${peerToken}`, 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              networkId: net.id,
-              instanceId: cfg.instanceId,
-              event: 'meta_change_pending',
-              data: { spaceId: id, spaceLabel: spaceRec.label },
-            }),
-            signal: AbortSignal.timeout(5_000),
-          }).catch(err => log.warn(`notify ${member.label} of meta_change_pending: ${err}`));
-        }
-      }
-
-      res.status(202).json({ status: 'vote_pending', rounds, message: 'Meta change requires network vote' });
-      return;
-    }
-  }
-
-  // Pull documentExtraction out of the spread: the parsed value may still be the legacy `max`,
-  // and only the normalised, ceiling-capped spelling is ever stored (see `cappedDocExtraction` above).
-  //
-  // And pull `recordTtlDays` out for the same reason: it was already applied above, MERGED over what was
-  // stored and normalised. Letting the raw body through here overwrote that with itself — so a partial write
-  // cleared the four buckets it did not mention, and an all-cleared write stored five explicit nulls instead of
-  // nothing. Found by driving the UI; both paths returned 200 and looked like they had worked.
-  const { documentExtraction: _rawMode, recordTtlDays: _rawTtl, ...restPatch } = patchData;
-  const updated = updateSpace(id, {
-    ...restPatch,
-    meta: mergedMeta,
-    ...(hasDocExtraction ? { documentExtraction: cappedDocExtraction } : {}),
-  });
-  if (!updated) {
+  const result = await applySpaceMetaUpdate(decision.plan);
+  if (result.outcome === 'not_found') {
+    // Only reachable if the space was deleted between the plan and the write.
     res.status(404).json({ error: `Space '${id}' not found` });
     return;
   }
-  res.json({ space: spaceResponse(updated) });
+  if (result.outcome === 'vote_pending') {
+    res.status(202).json({ status: 'vote_pending', rounds: result.rounds, message: 'Meta change requires network vote' });
+    return;
+  }
+  res.json({ space: spaceResponse(result.space) });
 });
 
 // PUT /api/spaces/:id/schema — full replacement of the space's typeSchemas.

--- a/server/src/mcp/audit-map.ts
+++ b/server/src/mcp/audit-map.ts
@@ -51,6 +51,7 @@ export const MCP_TOOL_OPERATIONS: Record<string, string | null> = {
   delete_chrono: 'chrono.delete',
   bulk_write: 'bulk.write',
   update_space: 'space.update',
+  update_space_schema: 'space.update',
   wipe_space: 'space.wipe',
   write_file: 'file.create',
   move_file: 'file.update',

--- a/server/src/mcp/parity.ts
+++ b/server/src/mcp/parity.ts
@@ -42,8 +42,14 @@ export interface RestOnlyCapability {
  * The five they reported, minus the ones now built. Nothing invented alongside them.
  *
  * Confirmed absent rather than gated on 2026-08-12 by reading the tool registry: 34 tools, none of which was a
- * reindex, a token list, a `retry_embedding` or a space create. `update_space` exists but accepts only `label`,
- * `purpose` and `description`, so nothing on MCP writes a schema — their reading was right on every one.
+ * reindex, a token list, a `retry_embedding` or a space create. `update_space` existed but accepted only `label`,
+ * `purpose` and `description`, so nothing on MCP wrote a schema — their reading was right on every one.
+ *
+ * **Four rows have now been deleted by being built**, which is the only way a row leaves this list:
+ * `retry_embedding`, `list_tokens`, `update_space_schema`, and — with it — the belief that these were wrappers.
+ * The last two of the five, `reindex` and `create_space`, each still need their route's validation extracted before
+ * a tool can call it without skipping the refusals. `mcp-rest-parity.test.js` asserts both halves of every surviving
+ * row, so a row cannot rot in either direction.
  */
 export const REST_ONLY_CAPABILITIES: readonly RestOnlyCapability[] = [
   {
@@ -53,14 +59,6 @@ export const REST_ONLY_CAPABILITIES: readonly RestOnlyCapability[] = [
     wouldBeTool: 'reindex',
     why: 'Not built. They reindexed 19 spaces by hand in a shell loop because the agent that planned their '
       + 'embedder migration could not run it. Async already, with /reindex-status to poll, so a tool is a thin wrapper.',
-  },
-  {
-    capability: 'Write a space\'s type schemas',
-    restEndpoint: '/api/spaces/:id',
-    method: 'PATCH',
-    wouldBeTool: 'update_space_schema',
-    why: 'Not built. `update_space` covers label, purpose and description only, so an agent can design an '
-      + '11-entity model and not apply it. The write is the same route; the tool is the missing part.',
   },
   {
     capability: 'Create a space',

--- a/server/src/mcp/tools/index.ts
+++ b/server/src/mcp/tools/index.ts
@@ -1,5 +1,5 @@
 import type { ToolHandler } from './types.js';
-import { list_spacesTool, get_statsTool, get_space_metaTool, update_spaceTool, wipe_spaceTool , list_tokensTool } from './spaces.js';
+import { list_spacesTool, get_statsTool, get_space_metaTool, update_spaceTool, update_space_schemaTool, wipe_spaceTool , list_tokensTool } from './spaces.js';
 import { rememberTool, update_memoryTool, delete_memoryTool } from './memory.js';
 import { recallTool, find_similarTool, queryTool } from './search.js';
 import { bulk_writeTool } from './bulk.js';
@@ -53,6 +53,7 @@ export const ALL_TOOLS: ToolHandler[] = [
   create_dirTool,
   move_fileTool,
   update_spaceTool,
+  update_space_schemaTool,
   wipe_spaceTool,
   list_tokensTool,
   bulk_writeTool,

--- a/server/src/mcp/tools/spaces.ts
+++ b/server/src/mcp/tools/spaces.ts
@@ -181,11 +181,147 @@ export const update_spaceTool: ToolHandler = {
     const updates: { label?: string; description?: string } = {};
     if (newLabel !== undefined) updates.label = newLabel;
     if (newDesc !== undefined) updates.description = newDesc;
-    const updated = updateSpace(callSpace, updates);
-    if (!updated) throw new Error(`Space '${callSpace}' not found`);
+
+    // Through the planner, NOT `updateSpace` directly — and this was a live governance bypass, not a tidy-up.
+    //
+    // `updateSpace` folds `description` into `meta.purpose` and bumps the meta version, so writing it here was a
+    // META write. On a networked space `PATCH /api/spaces/:id` opens a `meta_change` vote for exactly that edit;
+    // this tool applied it immediately. So a directive change made over MCP skipped the vote in precisely the
+    // spaces that had voted to govern directive changes — the same *two surfaces, one rule, one weaker* defect the
+    // rest of this batch is about, one field over. Found while adding `update_space_schema` below.
+    return await runSpaceMetaUpdate(callSpace, updates, `Space '${callSpace}' updated.`);
+  },
+};
+
+/**
+ * Plan → apply, and report the outcome in words.
+ *
+ * Both space-writing tools go through here so neither can drift from the REST route's rules: the same refusals, the
+ * same normalisation, the same network vote. The refusal's HTTP status is reported alongside the message rather
+ * than translated away — an agent that sees `412` can re-read and retry, where "it failed" leaves it guessing.
+ */
+async function runSpaceMetaUpdate(
+  spaceId: string,
+  body: Record<string, unknown>,
+  okText: string,
+): Promise<ToolResult> {
+  const { planSpaceMetaUpdate, applySpaceMetaUpdate } = await import('../../spaces/meta-update.js');
+  const space = getConfig().spaces.find(s => s.id === spaceId);
+
+  // No `If-Match`: MCP has no header to carry one, and absence means "no precondition asked for" — the same
+  // default a REST caller gets. A tool parameter for it would be inventing a concurrency protocol for a surface
+  // that has not asked for one.
+  const decision = planSpaceMetaUpdate({ spaceId, space, body, ifMatch: undefined });
+  if (!decision.ok) {
     return {
-      content: [{ type: 'text' as const, text: `Space '${callSpace}' updated.` }],
+      content: [{ type: 'text' as const, text: `Error (${decision.refusal.status}): ${decision.refusal.body.error}` }],
+      isError: true,
     };
+  }
+
+  const result = await applySpaceMetaUpdate(decision.plan);
+  if (result.outcome === 'not_found') {
+    return { content: [{ type: 'text' as const, text: `Space '${spaceId}' not found` }], isError: true };
+  }
+  if (result.outcome === 'vote_pending') {
+    // NOT reported as success. The space belongs to a network that votes on meta changes, so nothing is stored yet
+    // and an agent that read this as "done" would build on a schema that does not exist.
+    const nets = result.rounds.map(r => r.networkLabel).join(', ');
+    return {
+      content: [{ type: 'text' as const, text:
+        `Proposed, NOT yet applied: '${spaceId}' belongs to ${result.rounds.length === 1 ? 'a network' : 'networks'} `
+        + `that votes on meta changes (${nets}), so this opened a vote round instead of writing. The change takes `
+        + `effect if and when the round concludes in favour.` }],
+      structuredContent: { outcome: 'vote_pending', rounds: result.rounds },
+    };
+  }
+  return { content: [{ type: 'text' as const, text: okText }], structuredContent: { outcome: 'applied' } };
+}
+
+/**
+ * Write a space's type schemas — the second of the three REST-only capabilities that needed an extraction first.
+ *
+ * ## The report
+ *
+ * breituai-platform listed it among five capabilities a token could HOLD and not exercise, and gave the case that
+ * makes it more than ergonomics: they designed an 11-entity / 7-memory / 13-edge / 10-chrono research model with an
+ * agent, and the agent could not apply it. `get_space_meta` reads the schema; nothing wrote it. A sixth instance
+ * arrived on 2026-08-12 with the sharper consequence — under `validationMode: 'strict'` a stale enum makes every
+ * write fail, and a schema write is the documented way out. So this is the recovery path for a wedged space.
+ *
+ * ## Why it is not a wrapper
+ *
+ * `updateSpace()` exists, but `PATCH /api/spaces/:id` wraps it in a chain of refusals: the strict parse, the
+ * server-owned strip, the schema-library `$ref` check, and the network vote. A tool calling `updateSpace()` directly
+ * would skip all of them — so the chain was extracted first (`spaces/meta-update.ts`, pinned by
+ * `space-meta-update-contract.test.js`) and this tool calls it. **Merge semantics are the REST default**: types not
+ * mentioned are preserved, and `typeSchemasMode: 'replace'` is how a deletion is expressed.
+ */
+export const update_space_schemaTool: ToolHandler = {
+  name: 'update_space_schema',
+  description: 'Write a space\'s type schemas (and its other meta fields). Requires an admin token. '
+    + 'MERGES by default: types you do not mention are preserved, so editing one type does not require resending '
+    + 'the others. Pass `typeSchemasMode: "replace"` to make the payload authoritative — that is the only way to '
+    + 'DELETE a type. Knowledge-type keys are singular: entity, memory, edge, chrono. A `$ref` to a schema-library '
+    + 'entry that does not exist is refused (422) rather than silently stored as an empty schema. On a space whose '
+    + 'network votes on meta changes this opens a vote round instead of writing — the reply says so, and nothing is '
+    + 'stored until the round concludes.',
+  mutating: true,
+  admin: true,
+  spaceRequired: true,
+  inputSchema: (s: ToolSchemas) => ({
+    type: 'object',
+    properties: {
+      space: s.requiredSpace,
+      typeSchemas: {
+        type: 'object',
+        description: 'Per knowledge type, a map of type name to its schema. Keys are singular: `entity`, `memory`, '
+          + '`edge`, `chrono`. A schema is either `{"$ref": "library:<name>"}` or an inline definition with '
+          + '`namingPattern`, `propertySchemas`, `retention` and/or `suppressEmbeddings`.',
+      },
+      typeSchemasMode: {
+        type: 'string', enum: ['merge', 'replace'],
+        description: 'How `typeSchemas` combines with what is stored. `merge` (default) adds and updates named '
+          + 'types and preserves the rest; `replace` makes the payload authoritative, so types absent from it are '
+          + 'REMOVED. Use `replace` to delete a type.',
+      },
+      validationMode: {
+        type: 'string', enum: ['off', 'warn', 'strict'],
+        description: 'Whether records are validated against the schemas: not at all, warn on violation, or refuse '
+          + 'the write.',
+      },
+      strictLinkage: { type: 'boolean', description: 'Refuse a write whose entity references do not resolve.' },
+      usageNotes: { type: 'string', maxLength: 50_000, description: 'Free-text guidance about the space, returned to MCP clients with its meta.' },
+      suppressEmbeddings: { type: 'boolean', description: 'Space-level default for suppressing embeddings; a type schema can override it.' },
+    },
+    required: ['space'],
+    additionalProperties: false,
+  }),
+  async handle(ctx: ToolContext): Promise<ToolResult> {
+    const { args: a, callSpace, isAdmin } = ctx;
+    if (!isAdmin) {
+      return {
+        content: [{ type: 'text' as const, text: 'Error: update_space_schema requires an admin token' }],
+        isError: true,
+      };
+    }
+
+    // Everything except `space`/`typeSchemasMode` belongs inside `meta`, which is where the planner's `.strict()`
+    // schema expects it. Built by picking the declared names rather than by spreading `args`: a spread would carry
+    // `space` into `meta` and earn a 400 for a field the caller never sent.
+    const meta: Record<string, unknown> = {};
+    for (const k of ['typeSchemas', 'validationMode', 'strictLinkage', 'usageNotes', 'suppressEmbeddings']) {
+      if (a[k] !== undefined) meta[k] = a[k];
+    }
+    if (Object.keys(meta).length === 0) {
+      throw new Error('At least one of typeSchemas, validationMode, strictLinkage, usageNotes or suppressEmbeddings must be provided');
+    }
+
+    const body: Record<string, unknown> = { meta };
+    if (a['typeSchemasMode'] !== undefined) body['typeSchemasMode'] = a['typeSchemasMode'];
+
+    const wrote = Object.keys(meta).join(', ');
+    return await runSpaceMetaUpdate(callSpace, body, `Space '${callSpace}' schema updated (${wrote}).`);
   },
 };
 

--- a/server/src/spaces/meta-update.ts
+++ b/server/src/spaces/meta-update.ts
@@ -31,7 +31,13 @@
  */
 import type { SpaceConfig, SpaceMeta, KnowledgeType, TypeSchema, DocExtractionMode } from '../config/types.js';
 import { normalizeDocExtractionMode } from '../config/types.js';
-import { getDocumentProcessingConfig } from '../config/loader.js';
+import { getConfig, saveConfig, getSecrets, getDocumentProcessingConfig } from '../config/loader.js';
+import { updateSpace } from './spaces.js';
+import { ensureTtlIndex } from '../brain/ttl.js';
+import { peerSafeFetch } from '../sync/peer-fetch.js';
+import { proposedMetaFields } from '../sync/meta-round-merge.js';
+import { log } from '../util/log.js';
+import { v4 as uuidv4 } from 'uuid';
 import { capDocExtractionMode } from '../files/converters/extraction-level.js';
 import { checkMetaPrecondition, preconditionErrorBody } from './meta-precondition.js';
 import { normaliseRecordTtl } from './record-ttl.js';
@@ -109,6 +115,7 @@ export type MetaUpdateRefusal = {
 
 /** What a caller must write, with every decision already made. */
 export type MetaUpdatePlan = {
+  spaceId: string;
   /**
    * The space the plan was built against.
    *
@@ -241,6 +248,7 @@ export function planSpaceMetaUpdate(input: {
   return {
     ok: true,
     plan: {
+      spaceId,
       space,
       data: parsed.data,
       mergedMeta,
@@ -251,4 +259,131 @@ export function planSpaceMetaUpdate(input: {
       audit,
     },
   };
+}
+
+/**
+ * What actually happened, in terms both surfaces can report.
+ *
+ * `vote_pending` is neither a failure nor a success: the space belongs to a network that votes on meta changes, so
+ * the change is proposed rather than applied. REST answers 202 for it; the MCP tool says so in words. Collapsing it
+ * into "ok" would tell an agent its schema was written when it was not.
+ */
+export type MetaUpdateOutcome =
+  | { outcome: 'applied'; space: SpaceConfig }
+  | { outcome: 'vote_pending'; rounds: { networkId: string; networkLabel: string; roundId: string }[] }
+  | { outcome: 'not_found' };
+
+/**
+ * Apply a plan: the local settings, then either the network vote or the write.
+ *
+ * ## Why this exists now and not with the planner
+ *
+ * It was left out of the extraction deliberately — an interface with one caller is designed against a guess. The
+ * second caller is `update_space_schema`, and it settled two things one caller could not:
+ *
+ *  - **the vote branch belongs in here, not at the call site.** A tool that skipped it would let an agent write meta
+ *    directly in a space whose network votes on exactly that. That is a governance bypass, not a missing feature.
+ *  - **the outcome is a value, not a status code.** REST maps `vote_pending` to 202 and MCP maps it to a sentence;
+ *    neither of them decides what it means.
+ *
+ * Side effects only. Every refusal already happened in `planSpaceMetaUpdate`, which is why the only failure here is
+ * `not_found` — the one thing that can change between planning and writing.
+ */
+export async function applySpaceMetaUpdate(plan: MetaUpdatePlan): Promise<MetaUpdateOutcome> {
+  const { spaceId: id, space, data: patchData, mergedMeta } = plan;
+  const cfg = getConfig();
+
+  // Duplicate rules are local (never governed) — applied now, so they are not silently dropped when a meta change
+  // on the same request opens a network vote below.
+  if (patchData.dupeRules !== undefined || patchData.dupeMergeSurvivor !== undefined || patchData.dupeRulesOnInsert !== undefined) {
+    updateSpace(id, { dupeRules: patchData.dupeRules, dupeMergeSurvivor: patchData.dupeMergeSurvivor, dupeRulesOnInsert: patchData.dupeRulesOnInsert });
+  }
+
+  // Record TTL (F10) is a local operational setting, like dupe rules — applied immediately, never voted. The value
+  // arrives already MERGED over what was stored, so a partial write does not clear the buckets it did not mention;
+  // `hasRecordTtl` gates the write so a CLEAR is applied rather than skipped as if the field were absent.
+  if (plan.hasRecordTtl) {
+    updateSpace(id, { recordTtlDays: plan.recordTtlDays });
+    if (plan.recordTtlDays !== undefined) void ensureTtlIndex(id).catch(err => log.warn(`ensureTtlIndex ${id}: ${err}`));
+  }
+
+  // Already capped to the instance ceiling by the planner.
+  if (plan.hasDocExtraction) {
+    updateSpace(id, { documentExtraction: plan.documentExtraction });
+  }
+
+  // Network voting: a networked space PROPOSES a meta change rather than applying it.
+  if (mergedMeta !== undefined) {
+    const networkedIn = cfg.networks.filter(n => n.spaces.includes(id));
+    if (networkedIn.length > 0) {
+      const now = new Date().toISOString();
+      const rounds: { networkId: string; networkLabel: string; roundId: string }[] = [];
+
+      for (const net of networkedIn) {
+        const roundId = uuidv4();
+        const deadline = new Date(Date.now() + net.votingDeadlineHours * 3_600_000).toISOString();
+        net.pendingRounds.push({
+          roundId,
+          type: 'meta_change',
+          subjectInstanceId: cfg.instanceId,
+          subjectLabel: cfg.instanceLabel,
+          subjectUrl: '',
+          deadline,
+          openedAt: now,
+          votes: [{ instanceId: cfg.instanceId, vote: 'yes', castAt: now }],
+          spaceId: id,
+          pendingMeta: mergedMeta,
+          // Provenance, so conclusion can apply just this patch rather than this whole snapshot. Rounds stay open
+          // for `votingDeadlineHours`, so a second proposal landing before the first concludes is ordinary, and
+          // without these two fields the later one reverts the earlier one's edit with no error anywhere. See
+          // sync/meta-round-merge.ts.
+          metaChangedFields: proposedMetaFields(patchData.meta ?? {}),
+          baseMetaVersion: space.meta?.version ?? 0,
+        });
+        rounds.push({ networkId: net.id, networkLabel: net.label, roundId });
+      }
+
+      // Non-meta updates apply immediately (label, maxGiB). `description` is not among them: the planner rewrote it
+      // into `meta.purpose`, so it travels with the rest of the meta and is voted on.
+      const nonMetaUpdates: { label?: string; maxGiB?: number | null } = {};
+      if (patchData.label !== undefined) nonMetaUpdates.label = patchData.label;
+      if (patchData.maxGiB !== undefined) nonMetaUpdates.maxGiB = patchData.maxGiB;
+      if (Object.keys(nonMetaUpdates).length > 0) updateSpace(id, nonMetaUpdates);
+      else saveConfig(cfg);
+
+      // Notify peers (best-effort).
+      const secrets = getSecrets();
+      for (const net of networkedIn) {
+        for (const member of net.members) {
+          const peerToken = secrets.peerTokens[member.instanceId];
+          if (!peerToken) continue;
+          peerSafeFetch(`${member.url}/api/notify`, {
+            method: 'POST',
+            headers: { 'Authorization': `Bearer ${peerToken}`, 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              networkId: net.id,
+              instanceId: cfg.instanceId,
+              event: 'meta_change_pending',
+              data: { spaceId: id, spaceLabel: space.label },
+            }),
+            signal: AbortSignal.timeout(5_000),
+          }).catch(err => log.warn(`notify ${member.label} of meta_change_pending: ${err}`));
+        }
+      }
+
+      return { outcome: 'vote_pending', rounds };
+    }
+  }
+
+  // `documentExtraction` and `recordTtlDays` are pulled OUT of the spread. Both were applied above from normalised
+  // values, and letting the raw body through here overwrote that with itself — so a partial TTL write cleared the
+  // four buckets it did not mention, and an all-cleared write stored five explicit nulls instead of nothing. Both
+  // returned 200 and looked like they had worked; found by driving the UI.
+  const { documentExtraction: _rawMode, recordTtlDays: _rawTtl, ...restPatch } = patchData;
+  const updated = updateSpace(id, {
+    ...restPatch,
+    meta: mergedMeta,
+    ...(plan.hasDocExtraction ? { documentExtraction: plan.documentExtraction } : {}),
+  });
+  return updated ? { outcome: 'applied', space: updated } : { outcome: 'not_found' };
 }

--- a/testing/integration/mcp-update-space-schema.test.js
+++ b/testing/integration/mcp-update-space-schema.test.js
@@ -1,0 +1,236 @@
+/**
+ * `update_space_schema` over MCP — the same rules as the REST route, because it is the same function.
+ *
+ * ## What this is checking, and what it deliberately is not
+ *
+ * The refusal chain itself is pinned by `space-meta-update-contract.test.js` against the REST route, and both
+ * surfaces now call `planSpaceMetaUpdate`. Re-asserting all five statuses here would be testing the same function
+ * twice through two doors.
+ *
+ * What only this file can check is that the tool actually goes through that door: that a `$ref` to a missing
+ * library entry is REFUSED rather than stored as an empty schema, that merge semantics are the REST default, and
+ * that admin gating holds. A tool calling `updateSpace()` directly would pass a "did it write?" test and fail every
+ * one of these — which is exactly the *two surfaces, one rule, one weaker* defect this batch is about.
+ *
+ * Run: node --test testing/integration/mcp-update-space-schema.test.js
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import http from 'node:http';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, get, delWithBody } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+const RUN = Date.now();
+const SPACE = `mcp-schema-${RUN}`;
+
+let tokenA;
+let session;
+
+/**
+ * MCP session over SSE — the FIFO-waiter harness from `mcp-tools.test.js`, copied rather than re-derived.
+ *
+ * The first version of this file used a shortcut: POST, then scan the accumulated buffer for the last
+ * `data: {"result"…}` frame. It matched by POSITION, so every call returned the PREVIOUS call's response — which
+ * showed up as a broken-`$ref` test reporting success with the text of the write before it. A measurement that can
+ * return an earlier answer cannot be trusted about the current one, so the proven harness is used verbatim:
+ * responses are queued and handed out in order, and a `tools/call` waits for one that actually arrived.
+ */
+async function openMcpSession(authToken, instance = INSTANCES.a, timeoutMs = 15_000) {
+  const parsed = new URL(instance);
+  const host = parsed.hostname;
+  const port = parseInt(parsed.port || '80', 10);
+
+  return new Promise((resolve, reject) => {
+    const req = http.request({
+      host, port, path: '/mcp', method: 'GET',
+      headers: { Authorization: `Bearer ${authToken}`, Accept: 'text/event-stream' },
+    }, (res) => {
+      if (res.statusCode !== 200) {
+        res.resume();
+        reject(new Error(`MCP SSE open failed: ${res.statusCode}`));
+        return;
+      }
+
+      let buffer = '';
+      let sessionId = null;
+      const pendingMessages = [];
+      const waiters = [];
+
+      res.setEncoding('utf8');
+      res.on('data', chunk => {
+        buffer += chunk;
+        const parts = buffer.split('\n\n');
+        buffer = parts.pop() ?? '';
+        for (const part of parts) {
+          if (!part.trim()) continue;
+          let eventType = 'message';
+          let data = '';
+          for (const line of part.split('\n')) {
+            if (line.startsWith('event:')) eventType = line.slice(6).trim();
+            else if (line.startsWith('data:')) data = line.slice(5).trim();
+          }
+          if (eventType === 'endpoint') {
+            const m = data.match(/sessionId=([^&\s]+)/);
+            if (m) sessionId = m[1];
+          } else if (eventType === 'message' && data) {
+            try {
+              const msg = JSON.parse(data);
+              const waiter = waiters.shift();
+              if (waiter) waiter(msg);
+              else pendingMessages.push(msg);
+            } catch { /* non-JSON frame */ }
+          }
+        }
+      });
+      res.on('error', reject);
+
+      const deadline = Date.now() + timeoutMs;
+      const poll = setInterval(() => {
+        if (sessionId) { clearInterval(poll); resolve({ callTool, listTools, close }); }
+        else if (Date.now() > deadline) { clearInterval(poll); reject(new Error('MCP session did not receive endpoint event')); }
+      }, 50);
+
+      async function postJsonRpc(body) {
+        return new Promise((res2, rej2) => {
+          const waiterTimeout = setTimeout(() => rej2(new Error('MCP tool call timed out')), timeoutMs);
+          if (pendingMessages.length > 0) { clearTimeout(waiterTimeout); res2(pendingMessages.shift()); return; }
+          waiters.push(msg => { clearTimeout(waiterTimeout); res2(msg); });
+
+          const postData = JSON.stringify(body);
+          const pr = http.request({
+            host, port, path: `/mcp/messages?sessionId=${sessionId}`, method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Content-Length': Buffer.byteLength(postData),
+              Authorization: `Bearer ${authToken}`,
+            },
+          }, pres => {
+            let txt = '';
+            pres.setEncoding('utf8');
+            pres.on('data', c => { txt += c; });
+            pres.on('end', () => {
+              if (pres.statusCode !== 202 && pres.statusCode !== 200) {
+                clearTimeout(waiterTimeout);
+                rej2(new Error(`MCP POST failed: ${pres.statusCode} ${txt}`));
+              }
+            });
+          });
+          pr.on('error', rej2);
+          pr.write(postData);
+          pr.end();
+        });
+      }
+
+      async function callTool(name, args = {}) {
+        const rpc = await postJsonRpc({ jsonrpc: '2.0', id: Date.now(), method: 'tools/call', params: { name, arguments: args } });
+        return rpc?.result ?? rpc;
+      }
+      async function listTools() {
+        const rpc = await postJsonRpc({ jsonrpc: '2.0', id: Date.now(), method: 'tools/list', params: {} });
+        return rpc?.result?.tools ?? rpc?.tools ?? [];
+      }
+      function close() { req.destroy(); }
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+const meta = () => get(INSTANCES.a, tokenA, `/api/spaces/${SPACE}/meta`);
+
+before(async () => {
+  tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+  const r = await post(INSTANCES.a, tokenA, '/api/spaces', { id: SPACE, label: `MCP schema ${RUN}` });
+  assert.equal(r.status, 201, `space create failed: ${JSON.stringify(r.body)}`);
+  session = await openMcpSession(tokenA);
+});
+
+after(async () => {
+  session?.close();
+  await delWithBody(INSTANCES.a, tokenA, `/api/spaces/${SPACE}`, { confirm: true }).catch(() => {});
+});
+
+describe('update_space_schema is offered and writes', () => {
+  it('appears in tools/list for an admin token', async () => {
+    // The parity map's row for this capability was DELETED when the tool landed, so the tool existing is what makes
+    // that deletion honest. `mcp-rest-parity.test.js` gates the other direction.
+    const names = (await session.listTools()).map(t => t.name);
+    assert.ok(names.includes('update_space_schema'), `not offered: ${names.join(', ')}`);
+  });
+
+  it('writes a type schema an agent designed', async () => {
+    const r = await session.callTool('update_space_schema', {
+      space: SPACE,
+      typeSchemas: { entity: { widget: { propertySchemas: { region: { type: 'string' } } } } },
+    });
+    assert.ok(!r?.isError, `refused: ${JSON.stringify(r)}`);
+    const after = await meta();
+    assert.equal(after.body.typeSchemas?.entity?.widget?.propertySchemas?.region?.type, 'string',
+      'the schema must be readable back through the REST meta endpoint — one store, two surfaces');
+  });
+
+  it('MERGES by default, so editing one type does not drop the others', async () => {
+    await session.callTool('update_space_schema', {
+      space: SPACE, typeSchemas: { entity: { gadget: { namingPattern: '^G-' } } },
+    });
+    const after = await meta();
+    assert.ok(after.body.typeSchemas?.entity?.widget, 'the type not mentioned must survive');
+    assert.ok(after.body.typeSchemas?.entity?.gadget, 'and the new one must be there');
+  });
+
+  it('`replace` is how a type is DELETED — the only way to express it', async () => {
+    const r = await session.callTool('update_space_schema', {
+      space: SPACE, typeSchemasMode: 'replace',
+      typeSchemas: { entity: { gadget: { namingPattern: '^G-' } } },
+    });
+    assert.ok(!r?.isError, `refused: ${JSON.stringify(r)}`);
+    const after = await meta();
+    assert.equal(after.body.typeSchemas?.entity?.widget, undefined, 'replace makes the payload authoritative');
+    assert.ok(after.body.typeSchemas?.entity?.gadget, 'and keeps what it names');
+  });
+
+  it('writes the other meta fields too, so a wedged space can be repaired in one call', async () => {
+    const r = await session.callTool('update_space_schema', {
+      space: SPACE, validationMode: 'warn', usageNotes: 'written over MCP',
+    });
+    assert.ok(!r?.isError, `refused: ${JSON.stringify(r)}`);
+    const after = await meta();
+    assert.equal(after.body.validationMode, 'warn');
+    assert.equal(after.body.usageNotes, 'written over MCP');
+  });
+});
+
+describe('update_space_schema is held to the ROUTE rules, not looser ones', () => {
+  it('REFUSES a $ref to a library entry that does not exist', async () => {
+    // The whole reason the chain was extracted before the tool. A tool calling `updateSpace()` directly would store
+    // this as an empty schema and report success — in a strict space that silently removes every constraint from
+    // the type while the schema looks authored.
+    const before = await meta();
+    const r = await session.callTool('update_space_schema', {
+      space: SPACE, typeSchemas: { entity: { broken: { $ref: `library:absent-${RUN}` } } },
+    });
+    assert.ok(r?.isError, `a broken $ref was accepted: ${JSON.stringify(r)}`);
+    const text = r?.content?.[0]?.text ?? '';
+    assert.match(text, /422/, 'the refusal must carry the status, so an agent can branch on it');
+    assert.match(text, new RegExp(`absent-${RUN}`), 'and name the missing entry');
+    const after = await meta();
+    assert.equal(after.body.version, before.body.version, 'a refused write must not bump the meta version');
+  });
+
+  it('REFUSES an unknown field rather than silently dropping it', async () => {
+    // `additionalProperties: false` on the tool schema is the first gate; the planner's `.strict()` meta body is the
+    // second. Either is enough — what must not happen is a 200 that ignored the field.
+    const r = await session.callTool('update_space_schema', { space: SPACE, validationMdoe: 'strict' });
+    assert.ok(r?.isError, `a misspelled field was accepted: ${JSON.stringify(r)}`);
+  });
+
+  it('refuses a call that names no field at all', async () => {
+    const r = await session.callTool('update_space_schema', { space: SPACE });
+    assert.ok(r?.isError, `an empty update was accepted: ${JSON.stringify(r)}`);
+  });
+});

--- a/testing/standalone/mcp-tool-schemas.test.js
+++ b/testing/standalone/mcp-tool-schemas.test.js
@@ -19,11 +19,14 @@ const schemas = {
 const schemaOf = (name) => ALL_TOOLS.find(t => t.name === name).inputSchema(schemas);
 
 describe('MCP tool schemas — universal invariants', () => {
-  it('exposes exactly 36 tools', () => {
+  it('exposes exactly 37 tools', () => {
     // A deliberate tripwire, not a fact worth asserting for its own sake: the number changing means a tool
     // was added or removed, and every tool needs an audit mapping, a read-only classification and a docs
     // row. Bump it when you have done those three, never to make the suite quiet.
-    assert.equal(ALL_TOOLS.length, 36);
+    // 36 -> 37: `update_space_schema`. Its three prerequisites are done — `audit-map.ts` maps it to
+    // `space.update`, it is `mutating: true` + `admin: true` and listed among the tools a readOnly token cannot
+    // see, and `16-mcp.md` carries its row.
+    assert.equal(ALL_TOOLS.length, 37);
   });
 
   it('every tool advertises a closed object schema (type:object, additionalProperties:false)', () => {

--- a/testing/standalone/meta-precondition.test.js
+++ b/testing/standalone/meta-precondition.test.js
@@ -167,9 +167,17 @@ describe('If-Match — both meta-writing routes check it, and check it FIRST', (
     // Asserting a COUNT would rot the moment a fifth route appeared. So derive the set: every
     // `updateSpace(..., { meta })` call is a meta write, and each must sit in a handler that checked
     // the precondition first.
+    const planner = readFileSync(new URL('../../server/src/spaces/meta-update.ts', import.meta.url), 'utf8');
     const writeSites = [...src.matchAll(/updateSpace\([^)]*\{\s*[^}]*\bmeta\b/g)].map(m => m.index);
-    assert.ok(writeSites.length >= 4,
-      `expected at least 4 meta-write sites, found ${writeSites.length} — has the shape changed?`);
+    const plannerWrites = [...planner.matchAll(/updateSpace\([^)]*\{[\s\S]{0,120}?\bmeta\b/g)].map(m => m.index);
+
+    // The floor spans BOTH files, because one of the four writes moved. `PATCH /:id` no longer writes meta itself —
+    // `applySpaceMetaUpdate` does — so counting only the router would have quietly dropped a site from the sweep,
+    // and the sweep would have reported the tree clean because it was looking at three of four places.
+    assert.ok(writeSites.length + plannerWrites.length >= 4,
+      `expected at least 4 meta-write sites across the router and the planner, found `
+      + `${writeSites.length} + ${plannerWrites.length} — has the shape changed?`);
+    assert.ok(plannerWrites.length >= 1, 'the planner module must hold the write that left the router');
 
     // Inline calls AND verified delegates: a handler that hands the decision to something which checks is guarded.
     const checkSites = [...src.matchAll(new RegExp(guardPattern.source, 'g'))].map(m => m.index);
@@ -187,6 +195,31 @@ describe('If-Match — both meta-writing routes check it, and check it FIRST', (
         `that route can silently discard a concurrent edit. Handler starts at ${handlerStart}: ` +
         JSON.stringify(src.slice(handlerStart, handlerStart + 90)));
     }
+  });
+
+  it("the planner's own meta write cannot be reached without the precondition — by TYPE, not by position", () => {
+    // The write that left the router is in `applySpaceMetaUpdate`, a different function from the one that checks.
+    // Asserting "the check appears earlier in the file" would be true and would prove nothing: two functions in one
+    // file have no order at runtime.
+    //
+    // What actually guarantees it is the signature. `applySpaceMetaUpdate` takes a `MetaUpdatePlan`, and a plan is
+    // only ever constructed by `planSpaceMetaUpdate` — after the precondition, in the same expression that returns
+    // `ok: true`. So a caller cannot obtain the argument without having passed the check. That is what is asserted
+    // here, and it is the reason the extraction did not weaken the guarantee.
+    const planner = readFileSync(new URL('../../server/src/spaces/meta-update.ts', import.meta.url), 'utf8');
+
+    assert.match(planner, /export async function applySpaceMetaUpdate\(plan: MetaUpdatePlan\)/,
+      'apply must take a MetaUpdatePlan and nothing looser — an `unknown` or a spread of fields would let a caller '
+      + 'assemble one without going through the planner');
+
+    // Exactly one place builds the plan, and the precondition precedes it *within that function*.
+    const planFn = planner.slice(planner.indexOf('export function planSpaceMetaUpdate'));
+    const checkAt = planFn.indexOf('checkMetaPrecondition(');
+    const buildAt = planFn.indexOf('ok: true');
+    assert.ok(checkAt > 0 && buildAt > checkAt,
+      'planSpaceMetaUpdate must evaluate the precondition before it returns a plan');
+    assert.equal((planner.match(/ok: true,\s*\n\s*plan: \{/g) ?? []).length, 1,
+      'a second place constructing a plan is a second way to reach the write without a precondition');
   });
 
   it('the schema route checks BEFORE writing its backup file', () => {

--- a/testing/standalone/no-new-god-files.test.js
+++ b/testing/standalone/no-new-god-files.test.js
@@ -127,7 +127,12 @@ const FROZEN = {
   // same change, because an MCP tool has to reach the same refusals rather than a weaker copy of them (B-2).
   // Lowered to what it now measures and KEPT on this list — deleting the entry is how a file quietly earns the
   // right to grow back into 195 lines of headroom it did not ask for.
-  'server/src/api/spaces.ts': 656,
+  //
+  // 656 -> 589 in the follow-up: `applySpaceMetaUpdate` took the writes as well, so `PATCH /:id` is now the two
+  // jobs a route should have — read the header, turn an outcome into a status. The 67 lines are the vote round and
+  // the peer notify, which moved because the MCP tool needs them and a tool that skipped the vote would be a
+  // governance bypass rather than a missing feature.
+  'server/src/api/spaces.ts': 589,
   // 769 -> 773: `openBrainDrawer` gained two overload signatures and its `lastSaved` effect reads the
   // record inside each branch so the discriminant narrows it. Four lines of TYPES, no new behaviour —
   // raised deliberately rather than worked around, which is what this list is for.

--- a/testing/standalone/record-ttl-buckets.test.js
+++ b/testing/standalone/record-ttl-buckets.test.js
@@ -141,7 +141,9 @@ describe('the API and the storage type agree', () => {
     // stored and normalised; the generic `...restPatch` spread further down then wrote the raw body over the
     // top of it. So a partial write cleared the four buckets it did not mention, and an all-cleared write stored
     // five explicit nulls instead of nothing — both with a 200 and no visible symptom.
-    const src = readFileSync(join(ROOT, 'server/src/api/spaces.ts'), 'utf8');
+    // The write moved into `applySpaceMetaUpdate` with the rest of the side effects, so the destructure that keeps
+    // the raw body out of it moved too. Same guarantee, one file over.
+    const src = readFileSync(join(ROOT, 'server/src/spaces/meta-update.ts'), 'utf8');
     assert.match(src, /const \{ documentExtraction: _rawMode, recordTtlDays: _rawTtl, \.\.\.restPatch \} = patchData;/,
       'recordTtlDays must be destructured OUT of the spread that reaches updateSpace, like documentExtraction');
   });


### PR DESCRIPTION
## What this closes

B-2, third of five, and the first that was not a wrapper. Their case for it was never ergonomics: they designed an
11-entity / 7-memory / 13-edge / 10-chrono research model with an agent, and **the agent could not apply it** —
`get_space_meta` read the schema and nothing wrote it.

A sixth instance arrived 2026-08-12T2205Z with the sharper consequence: under `validationMode: 'strict'` a stale enum
makes **every write fail**, and a schema write is the documented way out. So this is the recovery path for a wedged
space, finally reachable from the surface that is wedged.

## The tool

Calls `planSpaceMetaUpdate` (extracted in #846), so it inherits every refusal rather than a weaker copy: the strict
parse, the server-owned strip, and **422 for a `$ref` to a schema-library entry that does not exist**. Calling
`updateSpace()` directly would have stored that ref as an empty schema and reported success — in a strict space,
silently removing every constraint from a type whose schema still looks authored.

Merge semantics are the REST default: types not named are preserved, and `typeSchemasMode: 'replace'` is the only way
to express a deletion.

## `applySpaceMetaUpdate`, which #846 deliberately did not add

An interface with one caller is designed against a guess. The second caller settled two things one could not:

- **The vote branch belongs inside it.** A tool that skipped the `meta_change` round would be a governance bypass, not
  a missing feature.
- **The outcome is a value, not a status code.** REST maps `vote_pending` to 202; the tool maps it to a sentence
  saying the change was *proposed and not applied*. Neither decides what it means. An agent told "success" would
  build on a schema that does not exist.

## The bug found on the way: `update_space` was skipping the vote

**And the docs had it right the whole time.** `16-mcp.md` says *"in a networked space a purpose change opens a meta
vote rather than applying at once"*. The code did not do that.

`update_space` wrote through `updateSpace()`, which folds `description` into `meta.purpose` and bumps the meta
version — so it was a **meta write dressed as a label edit**, applied immediately in precisely the spaces that had
voted to govern directive changes. Both tools now go through the planner, so the guide is true rather than
aspirational.

Not deferred to its own item: it is the same *two surfaces, one rule, one weaker* defect this batch exists to fix,
one field over. Fixing the schema half while leaving the purpose half bypassing would have shipped the defect class
being closed.

## Gates touched, and why each

| gate | change |
|---|---|
| tool-count tripwire | 36 → 37, with its three stated prerequisites done: audit mapping, readOnly classification, docs row |
| god-file ratchet | `api/spaces.ts` 656 → **589** — the writes left too, so the route is now read the header, translate the outcome |
| record-TTL | re-pointed at `meta-update.ts`, where the raw-body destructure now lives |
| `If-Match` ordering | re-pointed, and **strengthened** (below) |
| parity map | the `update_space_schema` row **deleted** — the only way a row leaves that list. Two left: `reindex`, `create_space` |

The `If-Match` gate gained a better assertion than the one it replaced. Position-in-file proves nothing about two
functions, so instead: `applySpaceMetaUpdate` takes a `MetaUpdatePlan`, a plan is only ever constructed by
`planSpaceMetaUpdate` after the precondition, and exactly one place constructs one. **The guarantee is a type, not a
line ordering.**

## A mistake in my own test, worth stating

The first version of the new integration test matched SSE frames **by position** and returned the *previous* call's
response — so the broken-`$ref` case "passed" while carrying the text of the write before it. A measurement that can
return an earlier answer cannot be trusted about the current one, so it was replaced with the FIFO-waiter harness from
`mcp-tools.test.js` verbatim, rather than a patched shortcut.

## Verification

Serially, the way CI runs it (`--test-concurrency=1`):

```
mcp-update-space-schema                                             ℹ pass 8    ℹ fail 0
contract + spaces + type-schema-crud + mcp-tools + record-ttl       ℹ pass 192  ℹ fail 0
```

Plus `npm run preflight` green.

## Docs

`docs/integration-guide/16-mcp.md` — the tool's row, its entry in the list a `readOnly` token cannot see, and the
admin-only note. The `update_space` line needed no change: it already described the behaviour this PR makes real.

🤖 Generated with Claude Code
