### PR TITLE
test(spaces): pin the POST /api/spaces refusals before that chain moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -313,6 +313,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     against the unmoved handler passes unchanged against the extracted one.
 
 ### Testing
+- **`POST /api/spaces` refusals are pinned before that chain moves too.** `create_space` is the 9-refusal member of
+  the REST-only set, and the checks a tool calling `createSpace()` directly would skip are the ones nothing tested.
+  Its own PR against the unmoved route, same reason as the `PATCH` pair.
+  - **The two proxy refusals** — member existence and nesting — are the only checks whose input is the rest of the
+    config rather than the request body, which makes them the likeliest to be dropped. The wildcard `['*']` is
+    asserted as a *sentinel*: an extraction that validated it as a member id would refuse every wildcard proxy space
+    and report *"space '*' not found"*.
+  - **`422` for a broken schema-library `$ref`, at RUNTIME.** `broken-library-ref-refused-everywhere.test.js` reads
+    source to assert the call site exists; nothing asserted the route answers 422. A source gate and a runtime test
+    fail for different reasons, and this is the route that shipped the defect — a create that reported success and
+    stored an empty schema, in the posture this handler itself seeds as `strict`.
+  - **Every refusal now asserts the space was NOT created.** That ordering is what a plan/apply split loses most
+    easily: validate, create, then check returns the right status while stranding a space the caller must clean up.
+  - **`faceDescriptorDims` bounds at runtime**, because the field is create-only by design and a width cannot be
+    changed afterwards — a value that slips through is unfixable without deleting the space. Both widths real
+    recognisers use (128, 512) are asserted accepted, so the bounds test cannot pass by refusing everything.
 - **The `PATCH /api/spaces/:id` refusal chain is pinned before it moves.** Three of the five REST-only
   capabilities need route-level validation extracted into something both MCP and REST call, and this route is the
   first of them. Its own PR, against the unmoved handler, because a characterization test written in the same

--- a/testing/integration/space-create-contract.test.js
+++ b/testing/integration/space-create-contract.test.js
@@ -1,0 +1,194 @@
+/**
+ * The refusal contract of `POST /api/spaces` — characterization, ahead of an extraction.
+ *
+ * ## Why this lands before the code moves
+ *
+ * B-2's last two capabilities are `create_space` and `reindex`, and `create_space` is the 9-refusal one:
+ * `createSpace()` exists in `spaces/lifecycle.ts`, but this route wraps it in checks that an MCP tool calling
+ * `createSpace()` directly would skip — proxy member existence, proxy nesting, the schema-library `$ref`, and the
+ * strict-flag seeding. That is the *two surfaces, one rule, one weaker* defect the whole item is about, and it would
+ * be reintroduced by the fix for it.
+ *
+ * So the chain moves into something both surfaces call, and this is the net under it. Its own PR against the unmoved
+ * route, for the reason the `PATCH` pair had: a characterization test written in the same commit as the change it
+ * guards cannot show which behaviour it was describing.
+ *
+ * ## What is pinned here, and what is already pinned elsewhere
+ *
+ * `spaces.test.js` already covers the happy paths and two refusals — auto-slug and explicit id, the strict-posture
+ * defaults, an explicit `meta` overriding them, the extraction-mode cap, `409` on a duplicate id, and `400` on
+ * invalid slug characters. None of that is repeated.
+ *
+ * What is NOT covered anywhere, and is exactly what an extraction can drop:
+ *
+ *  - **the two proxy refusals**, which are the only checks that read OTHER spaces to validate this one;
+ *  - **`422` for a broken schema-library `$ref` at CREATE time.** `broken-library-ref-refused-everywhere.test.js`
+ *    asserts the call site exists by reading source; nothing asserted the route actually answers 422. A source gate
+ *    and a runtime test fail for different reasons, and this route is the one that had the defect;
+ *  - **that a refused create leaves NO SPACE BEHIND.** This is the ordering guarantee, and it is the one a
+ *    plan/apply split is most likely to lose: validate, create, then check would return the right status while
+ *    stranding a space the caller has to clean up. Every refusal below asserts a `404` from the follow-up `GET`.
+ *  - **`faceDescriptorDims` bounds**, because a space's descriptor width cannot be changed after creation. A value
+ *    that slips through here is unfixable without deleting the space.
+ *
+ * Run: node --test testing/integration/space-create-contract.test.js
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, get, delWithBody } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+const RUN = Date.now();
+
+let token;
+const created = [];
+
+/** A space id nobody else in this run will use. */
+const idFor = (what) => `create-${what}-${RUN}`;
+
+async function create(body) {
+  const r = await post(INSTANCES.a, token, '/api/spaces', body);
+  if (r.status === 201) created.push(r.body.space?.id ?? body.id);
+  return r;
+}
+
+/** Did the route leave anything behind? A refusal must answer 404 here. */
+async function exists(id) {
+  const r = await get(INSTANCES.a, token, `/api/spaces/${id}/meta`);
+  return r.status !== 404;
+}
+
+before(() => {
+  token = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+});
+
+after(async () => {
+  for (const id of created) {
+    await delWithBody(INSTANCES.a, token, `/api/spaces/${id}`, { confirm: true }).catch(() => {});
+  }
+});
+
+describe('POST /api/spaces — the proxy refusals, which read other spaces to validate this one', () => {
+  it('400 when a proxy member does not exist, and no space is created', async () => {
+    const id = idFor('proxy-missing');
+    const r = await create({ id, label: 'Proxy missing member', proxyFor: [`no-such-space-${RUN}`] });
+    assert.equal(r.status, 400, JSON.stringify(r.body));
+    assert.match(r.body.error, /not found/i);
+    assert.equal(await exists(id), false, 'a refused create must not leave the space behind');
+  });
+
+  it('400 when a proxy member is itself a proxy — nesting is refused, and nothing is created', async () => {
+    // Needs a real member and a real proxy over it, so this is the one case that cannot be checked without
+    // building two spaces first. That is also why it is the refusal most likely to be dropped by an extraction:
+    // it is the only one whose input is the rest of the config rather than the request body.
+    const member = idFor('proxy-base');
+    const firstProxy = idFor('proxy-level1');
+    const nested = idFor('proxy-level2');
+
+    assert.equal((await create({ id: member, label: 'Proxy base' })).status, 201);
+    assert.equal((await create({ id: firstProxy, label: 'Proxy level 1', proxyFor: [member] })).status, 201);
+
+    const r = await create({ id: nested, label: 'Proxy level 2', proxyFor: [firstProxy] });
+    assert.equal(r.status, 400, JSON.stringify(r.body));
+    assert.match(r.body.error, /nesting/i, 'the message must say WHY, not just that it failed');
+    assert.equal(await exists(nested), false);
+  });
+
+  it('the wildcard proxy is accepted — it is a sentinel, not a member list', async () => {
+    // `['*']` must skip per-member validation entirely. An extraction that validated it as a member id would
+    // refuse every wildcard proxy space, and the refusal would read as "space '*' not found".
+    const id = idFor('proxy-wildcard');
+    const r = await create({ id, label: 'Proxy wildcard', proxyFor: ['*'] });
+    assert.equal(r.status, 201, JSON.stringify(r.body));
+  });
+});
+
+describe('POST /api/spaces — the schema-library $ref, at create time', () => {
+  it('422 for a $ref to an entry that does not exist, naming it, and no space is created', async () => {
+    // The reported defect this route once had: the create reported success and stored an EMPTY schema, so in a
+    // strict space — which is the posture this very handler seeds — one mistyped ref left the type with no
+    // constraints while its schema looked authored. The three editing routes answered 422 already; only this one
+    // did not, and it is the one people make the mistake on, because the space and its schema arrive together.
+    const id = idFor('broken-ref');
+    const r = await create({
+      id, label: 'Broken ref',
+      meta: { typeSchemas: { entity: { widget: { $ref: `library:absent-${RUN}` } } } },
+    });
+    assert.equal(r.status, 422, JSON.stringify(r.body));
+    assert.match(r.body.error, /Schema library[\s\S]*not found/);
+    assert.match(r.body.error, new RegExp(`absent-${RUN}`));
+    assert.equal(await exists(id), false, 'the ref check must run BEFORE the space is created');
+  });
+
+  it('the check does not fire on an inline schema that merely looks like one', async () => {
+    // Non-vacuity: the same shape WITHOUT a `$ref` must be accepted, or the test above would pass on a route that
+    // refused every typeSchemas payload.
+    const id = idFor('inline-schema');
+    const r = await create({
+      id, label: 'Inline schema',
+      meta: { typeSchemas: { entity: { widget: { propertySchemas: { region: { type: 'string' } } } } } },
+    });
+    assert.equal(r.status, 201, JSON.stringify(r.body));
+  });
+});
+
+describe('POST /api/spaces — faceDescriptorDims, which cannot be changed afterwards', () => {
+  // Create-only by design (`face-width-is-create-only.test.js` gates its absence from the update body), so a value
+  // accepted here is permanent for the life of the space. That asymmetry is why the bounds are pinned at runtime and
+  // not just in the schema: there is no second chance to refuse it.
+  for (const [what, dims] of [['too small', 32], ['too large', 8192], ['fractional', 128.5]]) {
+    it(`400 for a ${what} descriptor width, and no space is created`, async () => {
+      const id = idFor(`dims-${dims}`.replace('.', '-'));
+      const r = await create({ id, label: `Dims ${dims}`, faceDescriptorDims: dims });
+      assert.equal(r.status, 400, JSON.stringify(r.body));
+      assert.equal(await exists(id), false);
+    });
+  }
+
+  it('accepts the two widths today’s recognisers actually use', async () => {
+    // 128 (MobileFaceNet class) and 512 (ArcFace, AdaFace, FaceNet, EdgeFace). Bounds rather than an enum was a
+    // deliberate call — pinning an enum would make the next model a code change — so the test names the real values
+    // without asserting they are the only legal ones.
+    for (const dims of [128, 512]) {
+      const id = idFor(`dims-ok-${dims}`);
+      const r = await create({ id, label: `Dims ok ${dims}`, faceDescriptorDims: dims });
+      assert.equal(r.status, 201, `${dims} should be accepted: ${JSON.stringify(r.body)}`);
+    }
+  });
+});
+
+describe('POST /api/spaces — a refusal is complete, never partial', () => {
+  it('a body carrying TWO faults answers for the parse first', async () => {
+    // Ordering, the part a refactor loses silently. `validationMdoe` inside `meta` fails the strict parse; the
+    // `$ref` would fail the library check. The parse runs first, so an unknown key is never reported as a
+    // schema-library problem — the two failures send the caller to different files.
+    const id = idFor('two-faults');
+    const r = await create({
+      id, label: 'Two faults',
+      meta: { validationMdoe: 'strict', typeSchemas: { entity: { w: { $ref: 'library:also-absent' } } } },
+    });
+    assert.equal(r.status, 400, `expected the strict parse to win, got ${r.status}: ${JSON.stringify(r.body)}`);
+    assert.equal(await exists(id), false);
+  });
+
+  it('a proxy space is left un-seeded, while a normal one gets the strict posture', async () => {
+    // The seeding decision is a REFUSAL's mirror image and belongs in the same extracted function: a proxy space
+    // holds no data of its own, so defaulting it to strict would be enforcing a schema on records it never stores.
+    const plain = idFor('seed-plain');
+    const proxy = idFor('seed-proxy');
+    assert.equal((await create({ id: plain, label: 'Seed plain' })).status, 201);
+    assert.equal((await create({ id: proxy, label: 'Seed proxy', proxyFor: ['*'] })).status, 201);
+
+    const plainMeta = await get(INSTANCES.a, token, `/api/spaces/${plain}/meta`);
+    assert.equal(plainMeta.body.validationMode, 'strict', 'a new space enforces its schema from day one');
+    assert.equal(plainMeta.body.strictLinkage, true);
+
+    const proxyMeta = await get(INSTANCES.a, token, `/api/spaces/${proxy}/meta`);
+    assert.equal(proxyMeta.body.validationMode, undefined, 'a proxy space is not seeded — it stores nothing to validate');
+  });
+});


### PR DESCRIPTION
## Why this is a PR of its own

`create_space` is the 9-refusal member of the REST-only set. `createSpace()` exists in `spaces/lifecycle.ts`, but the
route wraps it in checks a tool calling it directly would skip — and those checks are the ones nothing tested. So they
get pinned first, against the unmoved route, for the same reason the `PATCH` pair had: a characterization test written
in the same commit as the change it guards cannot show which behaviour it was describing.

**No production code in this diff.**

## Not repeated here

`spaces.test.js` already covers the happy paths and two refusals: auto-slug and explicit id, the strict-posture
defaults, an explicit `meta` overriding them, the extraction-mode cap, `409` on a duplicate id, `400` on invalid slug
characters. None of that is duplicated.

## What was uncovered — and is what an extraction can drop

**The two proxy refusals.** Member existence and nesting are the only checks whose input is *the rest of the config*
rather than the request body, which is exactly what makes them likeliest to be lost when the chain moves into a
function that takes a body. The nesting case needs a real member and a real proxy over it, so it is also the only
refusal that cannot be exercised without building two spaces first.

The wildcard is pinned as a **sentinel**, not a member list: an extraction that validated `['*']` as a member id
would refuse every wildcard proxy space, and the refusal would read *"space '*' not found"*.

**`422` for a broken schema-library `$ref`, at runtime.** `broken-library-ref-refused-everywhere.test.js` reads source
to assert the call site exists; nothing asserted the route actually answers 422. A source gate and a runtime test fail
for different reasons — and this is the route that shipped the defect: a create that reported success and stored an
**empty schema**, in the `strict` posture this same handler seeds two lines later.

**Every refusal asserts the space was NOT created.** This is the ordering guarantee, and the one a plan/apply split
loses most easily: validate → create → check returns the right status while stranding a space the caller has to clean
up. Each refusal is followed by a `GET …/meta` that must be `404`.

**`faceDescriptorDims` bounds at runtime.** The field is create-only by design (`face-width-is-create-only.test.js`
gates its absence from the update body), so a width accepted here is permanent for the life of the space — there is
no second chance to refuse it.

## Non-vacuity

Each refusal is paired with an acceptance, so none of them can pass on a route that refuses everything:

| refusal asserted | paired acceptance |
|---|---|
| `422` on a broken `$ref` | the same `typeSchemas` shape **without** a `$ref` → `201` |
| `400` on out-of-range `faceDescriptorDims` | `128` and `512` → `201` |
| `400` on a missing proxy member | `proxyFor: ['*']` → `201` |
| strict posture seeded | a proxy space left **un-seeded**, because it stores nothing to validate |

## Verification

```
space-create-contract   ℹ pass 11   ℹ fail 0
```

Against the unmoved route, plus `npm run preflight` green.

## Docs

None. Test-only, and no documented behaviour changed — these are the refusals `docs/` already describes.

🤖 Generated with Claude Code
