### PR TITLE
refactor(spaces): the create chain is a function, not a route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,6 +290,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     worse than the bug being fixed.
 
 ### Internal
+- **The space CREATE chain is now a function both surfaces can call.** Last of the three extractions B-2 needs, and
+  the reason it was needed: `createSpace()` already exists in `lifecycle.ts`, so a tool could call it today — and
+  would skip the two proxy refusals, the schema-library `$ref` check, and the strict-posture seeding. A token holding
+  `createSpaces` would have got a materially weaker create over MCP than over REST.
+  - `spaces/space-create.ts`: `planSpaceCreate` decides (parse → proxy member existence → proxy nesting → `$ref` →
+    seed the strict flags) and `applySpaceCreate` writes. It reads config and writes nothing, so the refusals are
+    reachable without a request.
+  - **`conflict` and `failed` are separate outcomes**, not one error. A taken id means *pick another, or you already
+    have it* — often a successful retry whose response was lost — while a failure means *retry, or read the log*.
+    REST maps them to 409 and 500; a tool can say which.
+  - **The ordering guarantee is now a type.** `applySpaceCreate` takes a `SpaceCreatePlan`, a plan is only
+    constructed by `planSpaceCreate` after the `$ref` check, and exactly one place constructs one — so `createSpace`
+    cannot be reached without having passed the checks. The gate that used to compare two line positions inside one
+    handler now asserts that, which is a stronger claim than the one it replaced.
+  - Behaviour-preserving by construction: the code moved verbatim, and the 11-assertion contract suite that landed
+    against the unmoved route passes unchanged against the extracted one.
 - **The space update's refusal chain is now a function both surfaces can call, and the router lost 195 lines.**
   Three of the five REST-only capabilities breituai-platform reported are not wrappers: `updateSpace()` exists, but
   `PATCH /api/spaces/:id` wrapped it in a chain of refusals, and a tool calling `updateSpace()` directly would skip

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -34,6 +34,7 @@ import {
   CreateSpaceBody, DeleteSpaceBody, RenameSpaceBody, ReorderSpacesBody, PutSchemaBody,
 } from '../spaces/body-schemas.js';
 import { planSpaceMetaUpdate, applySpaceMetaUpdate } from '../spaces/meta-update.js';
+import { planSpaceCreate, applySpaceCreate } from '../spaces/space-create.js';
 
 export const spacesRouter = Router();
 
@@ -231,75 +232,29 @@ spacesRouter.get('/', globalRateLimit, requireAuth, async (req, res) => {
 });
 
 // POST /api/spaces
+// Every refusal — the parse, the two proxy checks, the schema-library `$ref` — and the strict-posture seeding are
+// decided by `planSpaceCreate`, so an MCP `create_space` reaches the same rules instead of a weaker copy of them
+// (B-2). What stays here is turning an outcome into a status.
+//
+// `space-create-contract.test.js` pins that chain, including that a refusal leaves NO SPACE BEHIND, and it was proven
+// against this handler before the move.
 spacesRouter.post('/', globalRateLimit, requireAdminMfa, async (req, res) => {
-  const parsed = CreateSpaceBody.safeParse(req.body);
-  if (!parsed.success) {
-    res.status(400).json({ error: parsed.error.message });
+  const decision = planSpaceCreate(req.body);
+  if (!decision.ok) {
+    res.status(decision.refusal.status).json(decision.refusal.body);
     return;
   }
-  const { id: rawId, label, description, folders, maxGiB, proxyFor, meta, faceDescriptorDims } = parsed.data;
-  const id = rawId ?? slugify(label);
 
-  // Validate proxy members exist and are not themselves proxies
-  // '*' is the wildcard sentinel — skip per-member validation
-  if (proxyFor && !(proxyFor.length === 1 && proxyFor[0] === '*')) {
-    const cfg = getConfig();
-    for (const memberId of proxyFor) {
-      const member = cfg.spaces.find(s => s.id === memberId);
-      if (!member) {
-        res.status(400).json({ error: `Proxy member space '${memberId}' not found` });
-        return;
-      }
-      if (member.proxyFor) {
-        res.status(400).json({ error: `Proxy member '${memberId}' is itself a proxy space (nesting not allowed)` });
-        return;
-      }
-    }
+  const result = await applySpaceCreate(decision.plan);
+  if (result.outcome === 'conflict') {
+    res.status(409).json({ error: result.error });
+    return;
   }
-
-  // New user-created spaces default to a fully-strict schema posture (owner decision 2026-07-25):
-  // validationMode:'strict' + strictLinkage:true, so a space enforces its schema and referential
-  // integrity from day one. An explicit value in the request wins (spread last). Proxy spaces hold no
-  // data of their own, so they are left un-defaulted. The federation-join path (networks/join) calls
-  // createSpace directly and is intentionally NOT affected — defaulting strict there would reject
-  // incoming off-schema federated records on ingest. With no typeSchemas yet defined, 'strict' still
-  // accepts every type/label (nothing to violate), so this never blocks a brand-new empty space.
-  const requestMeta = meta as SpaceMeta | undefined;
-
-  // Same broken-`$ref` refusal the three UPDATE routes make, which this one did not.
-  //
-  // Reported by an operator setting up a NEW space: a type declared `{"$ref": "library:…"}` came back as an
-  // empty schema, and the create reported success. Every path that EDITS meta — `PATCH /:id`,
-  // `PUT /:id/schema`, `PUT /:id/meta/typeSchemas/…` — already answers 422 here; only creation did not, so
-  // the identical mistake was loud on one route and silent on another.
-  //
-  // It matters most in a `strict` space, which is the default this very handler seeds two lines below: one
-  // mistyped ref leaves that type with no constraints at all, and the space then accepts anything for it
-  // while its schema looks authored. A refusal naming the missing entry costs one call to fix; a silent
-  // empty schema costs however long it takes someone to notice their rules are not being applied.
-  if (requestMeta?.typeSchemas) {
-    const brokenRefs = findBrokenLibraryRefs(requestMeta.typeSchemas as z.infer<typeof TypeSchemasZ>);
-    if (brokenRefs.length > 0) {
-      res.status(422).json({ error: `Schema library ${brokenRefs.length === 1 ? 'entry' : 'entries'} not found: ${brokenRefs.join(', ')}. Create ${brokenRefs.length === 1 ? 'it' : 'them'} via POST /api/schema-library before referencing.` });
-      return;
-    }
+  if (result.outcome === 'failed') {
+    res.status(500).json({ error: result.error });
+    return;
   }
-
-  const seededMeta: SpaceMeta | undefined = proxyFor
-    ? requestMeta
-    : { validationMode: 'strict', strictLinkage: true, ...(requestMeta ?? {}) };
-
-  try {
-    const space = await createSpace({ id, label, description, folders, maxGiB, proxyFor, meta: seededMeta, faceDescriptorDims });
-    res.status(201).json({ space: spaceResponse(space) });
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (msg.includes('already exists')) {
-      res.status(409).json({ error: msg });
-    } else {
-      res.status(500).json({ error: 'Failed to create space' });
-    }
-  }
+  res.status(201).json({ space: spaceResponse(result.space) });
 });
 
 // PATCH /api/spaces/:id

--- a/server/src/spaces/space-create.ts
+++ b/server/src/spaces/space-create.ts
@@ -1,0 +1,140 @@
+/**
+ * The decision half of creating a space: every refusal, and the arguments `createSpace()` must be called with.
+ *
+ * ## Why this is a function and not a route
+ *
+ * B-2's last two capabilities are `create_space` and `reindex`. `createSpace()` already exists in `lifecycle.ts`, so
+ * a tool could call it today — and that is the problem. `POST /api/spaces` wraps it in checks that would all be
+ * skipped: the two proxy refusals, the schema-library `$ref`, and the strict-flag seeding. A token holding
+ * `createSpaces` would then get a *weaker* create over MCP than over REST, which is the *two surfaces, one rule, one
+ * weaker* defect this whole item exists to close, reintroduced by the fix for it.
+ *
+ * So the chain lives here and both surfaces call it. Same split as `meta-update.ts`: decisions here, side effects at
+ * the caller, and the refusal carries its HTTP status because the status IS the contract —
+ * `space-create-contract.test.js` pins five of them and an MCP tool maps them rather than re-deriving them.
+ *
+ * ## The ordering that is part of the contract
+ *
+ * Parse, then the proxy checks, then the `$ref` check, and **only then** the create. Every refusal happens before
+ * anything is written, which is what makes "a refused create leaves no space behind" true — asserted on every
+ * refusal in the contract suite, because the natural way to get this wrong is to create first and validate after,
+ * which returns the right status while stranding a space the caller has to clean up.
+ */
+import type { SpaceConfig, SpaceMeta } from '../config/types.js';
+import type { z } from 'zod';
+import { getConfig } from '../config/loader.js';
+import { slugify } from './_shared.js';
+import { createSpace } from './lifecycle.js';
+import { CreateSpaceBody, TypeSchemasZ, findBrokenLibraryRefs, brokenRefsError } from './body-schemas.js';
+
+/** A refusal, carrying the status the contract suite pins. */
+export type SpaceCreateRefusal = {
+  status: 400 | 422;
+  body: { error: string };
+};
+
+/** Exactly the arguments `createSpace()` takes, with the id resolved and the meta seeded. */
+export type SpaceCreatePlan = {
+  args: Parameters<typeof createSpace>[0];
+};
+
+export type SpaceCreateDecision =
+  | { ok: false; refusal: SpaceCreateRefusal }
+  | { ok: true; plan: SpaceCreatePlan };
+
+/**
+ * Decide a space creation: refuse it, or return the call that makes it.
+ *
+ * Reads config (the space list, the schema library) and writes nothing, so the refusal chain is reachable without a
+ * request and testable without standing up Docker.
+ */
+export function planSpaceCreate(body: unknown): SpaceCreateDecision {
+  const parsed = CreateSpaceBody.safeParse(body);
+  if (!parsed.success) {
+    return { ok: false, refusal: { status: 400, body: { error: parsed.error.message } } };
+  }
+  const { id: rawId, label, description, folders, maxGiB, proxyFor, meta, faceDescriptorDims } = parsed.data;
+  const id = rawId ?? slugify(label);
+
+  // Validate proxy members exist and are not themselves proxies.
+  //
+  // `['*']` is the wildcard SENTINEL, not a member list, so per-member validation is skipped for it. Treating it as
+  // an id would refuse every wildcard proxy space with "space '*' not found" — pinned in the contract suite for
+  // exactly that reason.
+  if (proxyFor && !(proxyFor.length === 1 && proxyFor[0] === '*')) {
+    const cfg = getConfig();
+    for (const memberId of proxyFor) {
+      const member = cfg.spaces.find(s => s.id === memberId);
+      if (!member) {
+        return { ok: false, refusal: { status: 400, body: { error: `Proxy member space '${memberId}' not found` } } };
+      }
+      if (member.proxyFor) {
+        return {
+          ok: false,
+          refusal: { status: 400, body: { error: `Proxy member '${memberId}' is itself a proxy space (nesting not allowed)` } },
+        };
+      }
+    }
+  }
+
+  const requestMeta = meta as SpaceMeta | undefined;
+
+  // The same broken-`$ref` refusal the three UPDATE routes make, which creation once did not.
+  //
+  // Reported by an operator setting up a NEW space: a type declared `{"$ref": "library:…"}` came back as an empty
+  // schema and the create reported success. It matters most in a `strict` space — which is the posture seeded a few
+  // lines below — because one mistyped ref leaves that type with no constraints at all while its schema looks
+  // authored. The check must stay AHEAD of the create, or a rejected schema leaves a space behind.
+  if (requestMeta?.typeSchemas) {
+    const brokenRefs = findBrokenLibraryRefs(requestMeta.typeSchemas as z.infer<typeof TypeSchemasZ>);
+    if (brokenRefs.length > 0) {
+      return { ok: false, refusal: { status: 422, body: { error: brokenRefsError(brokenRefs) } } };
+    }
+  }
+
+  // New user-created spaces default to a fully-strict schema posture (owner decision 2026-07-25):
+  // `validationMode: 'strict'` + `strictLinkage: true`, so a space enforces its schema and referential integrity
+  // from day one. An explicit value in the request wins (spread last). Proxy spaces hold no data of their own, so
+  // they are left un-defaulted. The federation-join path calls `createSpace` directly and is intentionally NOT
+  // affected — defaulting strict there would reject incoming off-schema federated records on ingest. With no
+  // typeSchemas yet defined, 'strict' still accepts every type/label, so this never blocks a brand-new empty space.
+  const seededMeta: SpaceMeta | undefined = proxyFor
+    ? requestMeta
+    : { validationMode: 'strict', strictLinkage: true, ...(requestMeta ?? {}) };
+
+  return {
+    ok: true,
+    plan: { args: { id, label, description, folders, maxGiB, proxyFor, meta: seededMeta, faceDescriptorDims } },
+  };
+}
+
+/**
+ * What happened, in terms both surfaces can report.
+ *
+ * `conflict` is separated from `failed` because they mean opposite things to a caller: the id is taken (pick another,
+ * or you already have it), versus something broke (retry, or read the log). REST maps them to 409 and 500; a tool
+ * says which one. Collapsing them would make "already exists" indistinguishable from a storage failure, and the
+ * first is often a successful retry of a request whose response was lost.
+ */
+export type SpaceCreateOutcome =
+  | { outcome: 'created'; space: SpaceConfig }
+  | { outcome: 'conflict'; error: string }
+  | { outcome: 'failed'; error: string };
+
+/**
+ * Apply a plan. The only failures here are the ones that can only be discovered by attempting the write.
+ *
+ * `createSpace` signals a taken id by throwing with `already exists` in the message, which is matched rather than
+ * typed — that is how the route did it, and changing it in an extraction would be changing behaviour under cover of
+ * moving it. Worth a typed error eventually; not in a PR whose value is being provably behaviour-preserving.
+ */
+export async function applySpaceCreate(plan: SpaceCreatePlan): Promise<SpaceCreateOutcome> {
+  try {
+    const space = await createSpace(plan.args);
+    return { outcome: 'created', space };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes('already exists')) return { outcome: 'conflict', error: msg };
+    return { outcome: 'failed', error: 'Failed to create space' };
+  }
+}

--- a/testing/standalone/broken-library-ref-refused-everywhere.test.js
+++ b/testing/standalone/broken-library-ref-refused-everywhere.test.js
@@ -133,13 +133,28 @@ describe('a broken schema-library $ref is refused on every route that accepts on
   });
 
   it('the create route refuses BEFORE the space exists', () => {
-    // Ordering is the guarantee: a check after `createSpace` would leave a space behind whose schema is the
-    // thing being rejected, and the caller would have to clean it up.
+    // Ordering is the guarantee: a check after `createSpace` would leave a space behind whose schema is the thing
+    // being rejected, and the caller would have to clean it up.
+    //
+    // The route delegates now, and the two halves live in different functions of `spaces/space-create.ts` — so a
+    // position test would be comparing two things that have no order at runtime. What actually holds the ordering is
+    // the signature: `applySpaceCreate` takes a `SpaceCreatePlan`, and a plan is only ever constructed by
+    // `planSpaceCreate`, after the `$ref` check, in the expression that returns `ok: true`. A caller cannot reach
+    // `createSpace` without having passed the check, which is stronger than what this assertion used to say.
     const create = all.find(r => r.verb === 'post' && r.path === '/');
-    const check = create.body.indexOf('findBrokenLibraryRefs(');
-    const write = create.body.indexOf('await createSpace(');
-    assert.ok(check > 0, 'the create route must call the checker');
-    assert.ok(write > check, 'the ref check must run before the space is created');
+    assert.ok(effectiveChecker(create.body), 'the create route must reach the checker, directly or by delegation');
+
+    const planner = readFileSync(join(ROOT, 'server/src/spaces/space-create.ts'), 'utf8');
+    assert.match(planner, /export async function applySpaceCreate\(plan: SpaceCreatePlan\)/,
+      'apply must take a SpaceCreatePlan and nothing looser, or a caller could assemble one without the checks');
+    assert.match(planner, /await createSpace\(plan\.args\)/, 'and it must create from the PLAN, not from a body');
+
+    const planFn = planner.slice(planner.indexOf('export function planSpaceCreate'));
+    const check = planFn.indexOf('findBrokenLibraryRefs(');
+    const built = planFn.indexOf('ok: true');
+    assert.ok(check > 0 && built > check, 'the ref check must run before a plan is returned');
+    assert.equal((planner.match(/ok: true,\s*\n\s*plan: \{/g) ?? []).length, 1,
+      'a second place constructing a plan is a second way to reach createSpace without the check');
   });
 
   it('all four answer with the same status and a message naming what is missing', () => {

--- a/testing/standalone/doc-cited-constants.test.js
+++ b/testing/standalone/doc-cited-constants.test.js
@@ -180,7 +180,9 @@ describe('numbers quoted in the docs match the constants they quote', () => {
 });
 
 describe('the defaults a new space is seeded with are documented as such', () => {
-  const spacesSrc = read('server/src/api/spaces.ts');
+  // The seeding moved to `spaces/space-create.ts` with the rest of the create chain, so both surfaces seed the same
+  // posture rather than the route seeding it and a tool not. The pairing is unchanged; only where the code lives is.
+  const spacesSrc = read('server/src/spaces/space-create.ts');
   const guide = read('docs/integration-guide.md');
 
   for (const row of SEEDED_SPACE_DEFAULTS) {


### PR DESCRIPTION
## What this is

Last of the three extractions B-2 needs, and the reason it is needed: **`createSpace()` already exists**, so a tool
could call it today — and would skip the two proxy refusals, the schema-library `$ref` check, and the strict-posture
seeding. A token holding `createSpaces` would have got a materially weaker create over MCP than over REST.

**No behaviour change.** The 11-assertion contract suite from #849, written against the unmoved route, passes unchanged
against the extracted one.

## The split

`server/src/spaces/space-create.ts`:

- **`planSpaceCreate`** — parse → proxy member existence → proxy nesting → schema-library `$ref` → seed the strict
  flags. Reads config, writes nothing, returns a refusal carrying its HTTP status or a plan.
- **`applySpaceCreate`** — the one call that can only fail by being attempted.

The route keeps one job: turn an outcome into a status.

**`conflict` and `failed` are separate outcomes, not one error.** A taken id means *pick another, or you already have
it* — often a successful retry whose response was lost. A failure means *retry, or read the log*. REST maps them to 409
and 500; a tool can say which. Collapsing them would make "already exists" indistinguishable from a storage failure.

## The gate got stronger from the move, not weaker

`broken-library-ref-refused-everywhere.test.js` asserted that `findBrokenLibraryRefs(` appeared **before**
`await createSpace(` inside one handler. Those halves are now separate functions, where a line position proves nothing
about runtime order — so re-pointing the old assertion would have kept a check that no longer checked anything.

It now asserts what actually holds the ordering:

- `applySpaceCreate` takes a `SpaceCreatePlan` and nothing looser, and creates from `plan.args` rather than a body;
- exactly **one** place constructs a plan, and it does so after the `$ref` check.

So `createSpace` cannot be reached without having passed the checks — a stronger claim than the one it replaced, and
the same pattern the `If-Match` gate took in #848.

Two gates re-pointed at where the code now lives: the delegation-aware `$ref` sweep, and the doc-cited seeded defaults
(`validationMode: 'strict'` + `strictLinkage: true`), now paired against `space-create.ts`.

## Verification

Serially, on a rebuilt image:

```
space-create-contract + spaces + proxy-spaces   ℹ tests 71   ℹ pass 71   ℹ fail 0
```

Plus `npm run preflight` green.

## Docs

None. No endpoint, status code, error message or default changed — the strict-posture defaults are still documented in
`integration-guide.md`, and the gate that pairs them with the code now reads the file they live in.

## What follows

The `create_space` tool, in its own PR, which deletes its row from `REST_ONLY_CAPABILITIES`. Mixing a new surface into
an extraction makes *"did behaviour change?"* harder to answer, which is the one question this diff exists to make easy.

🤖 Generated with Claude Code
