### PR TITLE
feat(mcp): create_space, and the capability map is down to one row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- **`create_space` is an MCP tool.** Fourth of the five, and the one where "just call the existing function" was most
+  tempting and most dangerous: `createSpace()` has existed all along, so a tool could have called it on day one — and
+  produced spaces a REST caller cannot. Un-seeded, with no validation and no strict linkage. Or proxying a space that
+  does not exist. Or nesting a proxy inside a proxy.
+  - Calls `planSpaceCreate` + `applySpaceCreate`, so every refusal is the route's: both proxy checks, `422` for a
+    missing schema-library `$ref`, the `faceDescriptorDims` bounds, and the strict-posture seeding — including that a
+    `proxyFor` space is left un-seeded, because it stores nothing of its own to validate.
+  - **`faceDescriptorDims` is on the tool deliberately.** It is the parameter breituai-platform was blocked on, and it
+    is create-only by design: a populated gallery cannot be re-dimensioned. Leaving it off would have meant an agent
+    could create a space but never one that works with a 512-float recogniser — the exact shape of their complaint.
+  - **A taken id is reported as a `conflict`**, machine-readably, rather than as a generic failure. It is often a
+    successful retry whose response was lost, and an agent that can tell the two apart stops retrying.
+  - Its row is deleted from the capability map, leaving **one**: `reindex`, whose re-embedding loop is inline in its
+    route handler, so there is genuinely no function for a tool to call yet.
 - **`update_space_schema` is an MCP tool.** Third of the five REST-only capabilities, and the first that was not a
   wrapper. Their case for it was not ergonomics: they designed an 11-entity / 7-memory / 13-edge / 10-chrono
   research model with an agent, and the agent could not apply it — `get_space_meta` read the schema and nothing

--- a/docs/integration-guide/16-mcp.md
+++ b/docs/integration-guide/16-mcp.md
@@ -33,7 +33,7 @@ On connect, the server sends global instructions listing all available space IDs
 
 ### Read-Only Tokens
 
-When connecting with a `readOnly` token, mutating tools (`remember`, `update_memory`, `delete_memory`, `upsert_entity`, `update_entity`, `delete_entity`, `merge_entities`, `upsert_edge`, `update_edge`, `delete_edge`, `create_chrono`, `update_chrono`, `delete_chrono`, `bulk_write`, `write_file`, `delete_file`, `create_dir`, `move_file`, `retry_embedding`, `sync_now`, `update_space`, `update_space_schema`, `wipe_space`) are **hidden** from `tools/list` and rejected with an error if called directly. Read-only tools (`help`, `recall`, `find_similar`, `query`, `get_stats`, `get_space_meta`, `list_spaces`, `find_entities_by_name`, `list_chrono`, `read_file`, `list_dir`, `traverse`) work normally. `list_tokens` is read-only but **admin-gated**, like `list_peers`. `list_peers` is read-only but **admin-gated** — see the admin-only note below.
+When connecting with a `readOnly` token, mutating tools (`remember`, `update_memory`, `delete_memory`, `upsert_entity`, `update_entity`, `delete_entity`, `merge_entities`, `upsert_edge`, `update_edge`, `delete_edge`, `create_chrono`, `update_chrono`, `delete_chrono`, `bulk_write`, `write_file`, `delete_file`, `create_dir`, `move_file`, `retry_embedding`, `sync_now`, `update_space`, `update_space_schema`, `create_space`, `wipe_space`) are **hidden** from `tools/list` and rejected with an error if called directly. Read-only tools (`help`, `recall`, `find_similar`, `query`, `get_stats`, `get_space_meta`, `list_spaces`, `find_entities_by_name`, `list_chrono`, `read_file`, `list_dir`, `traverse`) work normally. `list_tokens` is read-only but **admin-gated**, like `list_peers`. `list_peers` is read-only but **admin-gated** — see the admin-only note below.
 
 ### Connecting
 
@@ -198,12 +198,13 @@ row survives its own tool being built, so the list cannot keep advertising a gap
 | `create_dir` | Create a directory |
 | `move_file` | Move or rename a file/directory |
 | `update_space` | Update space label and/or purpose (admin only). In a networked space a purpose change opens a meta vote rather than applying at once |
+| `create_space` | Create a space (admin only). The id is derived from the label when omitted. A new space is seeded `validationMode: strict` + `strictLinkage: true` unless `meta` says otherwise; a `proxyFor` space is left un-seeded because it stores nothing of its own. **`faceDescriptorDims` is create-only and permanent** — 128 for MobileFaceNet-class models, 512 for ArcFace / AdaFace / FaceNet / EdgeFace. Same refusals as `POST /api/spaces`, including `422` for a missing schema-library `$ref` and `409` when the id is taken |
 | `update_space_schema` | Write the space's type schemas and its other meta fields — `validationMode`, `strictLinkage`, `usageNotes`, `suppressEmbeddings` (admin only). **Merges** by default: types you do not name are preserved. `typeSchemasMode: "replace"` makes the payload authoritative, which is the only way to DELETE a type. Same refusals as `PATCH /api/spaces/:id`, including `422` for a `$ref` to a schema-library entry that does not exist. In a networked space it opens a meta vote rather than applying at once |
 | `wipe_space` | Wipe all or specific collection types from the space (admin only) |
 | `list_peers` | List all configured peer instances (admin only) |
 | `sync_now` | Trigger immediate sync (all networks or specific peer) (admin only) |
 
-> **Admin-only tools.** `list_peers`, `sync_now`, `update_space`, `update_space_schema`, and `wipe_space` require an `admin`
+> **Admin-only tools.** `list_peers`, `sync_now`, `update_space`, `update_space_schema`, `create_space`, and `wipe_space` require an `admin`
 > token: the first two are instance-level (they expose the whole peer topology and drive outbound
 > connections to every peer) and have no space scoping. They are hidden from `tools/list` for
 > non-admin tokens and rejected if called directly.

--- a/server/src/mcp/audit-map.ts
+++ b/server/src/mcp/audit-map.ts
@@ -52,6 +52,7 @@ export const MCP_TOOL_OPERATIONS: Record<string, string | null> = {
   bulk_write: 'bulk.write',
   update_space: 'space.update',
   update_space_schema: 'space.update',
+  create_space: 'space.create',
   wipe_space: 'space.wipe',
   write_file: 'file.create',
   move_file: 'file.update',

--- a/server/src/mcp/parity.ts
+++ b/server/src/mcp/parity.ts
@@ -45,11 +45,16 @@ export interface RestOnlyCapability {
  * reindex, a token list, a `retry_embedding` or a space create. `update_space` existed but accepted only `label`,
  * `purpose` and `description`, so nothing on MCP wrote a schema — their reading was right on every one.
  *
- * **Four rows have now been deleted by being built**, which is the only way a row leaves this list:
- * `retry_embedding`, `list_tokens`, `update_space_schema`, and — with it — the belief that these were wrappers.
- * The last two of the five, `reindex` and `create_space`, each still need their route's validation extracted before
- * a tool can call it without skipping the refusals. `mcp-rest-parity.test.js` asserts both halves of every surviving
- * row, so a row cannot rot in either direction.
+ * **Four of the five rows have now been deleted by being built**, which is the only way a row leaves this list:
+ * `retry_embedding`, `list_tokens`, `update_space_schema`, `create_space`. Two of those needed their route's
+ * validation extracted into a shared function first, because `createSpace()` and `updateSpace()` both already
+ * existed — which is what made a "just add a tool" fix dangerous rather than easy.
+ *
+ * **One row left: `reindex`.** Its re-embedding loop is written inline in the route handler, so there is genuinely no
+ * function for a tool to call; that extraction is its own work, behind its own characterization tests.
+ *
+ * `mcp-rest-parity.test.js` asserts both halves of every surviving row — the REST route exists, and no MCP tool by
+ * that name does — so a row cannot rot in either direction.
  */
 export const REST_ONLY_CAPABILITIES: readonly RestOnlyCapability[] = [
   {
@@ -59,14 +64,6 @@ export const REST_ONLY_CAPABILITIES: readonly RestOnlyCapability[] = [
     wouldBeTool: 'reindex',
     why: 'Not built. They reindexed 19 spaces by hand in a shell loop because the agent that planned their '
       + 'embedder migration could not run it. Async already, with /reindex-status to poll, so a tool is a thin wrapper.',
-  },
-  {
-    capability: 'Create a space',
-    restEndpoint: '/api/spaces',
-    method: 'POST',
-    wouldBeTool: 'create_space',
-    why: 'Not built, including the descriptor-width parameter. A token holding `createSpaces` in the rights '
-      + 'matrix cannot exercise it over MCP, which is the exact shape of their complaint.',
   },
 ] as const;
 

--- a/server/src/mcp/tools/index.ts
+++ b/server/src/mcp/tools/index.ts
@@ -1,5 +1,5 @@
 import type { ToolHandler } from './types.js';
-import { list_spacesTool, get_statsTool, get_space_metaTool, update_spaceTool, update_space_schemaTool, wipe_spaceTool , list_tokensTool } from './spaces.js';
+import { list_spacesTool, get_statsTool, get_space_metaTool, update_spaceTool, update_space_schemaTool, create_spaceTool, wipe_spaceTool , list_tokensTool } from './spaces.js';
 import { rememberTool, update_memoryTool, delete_memoryTool } from './memory.js';
 import { recallTool, find_similarTool, queryTool } from './search.js';
 import { bulk_writeTool } from './bulk.js';
@@ -54,6 +54,7 @@ export const ALL_TOOLS: ToolHandler[] = [
   move_fileTool,
   update_spaceTool,
   update_space_schemaTool,
+  create_spaceTool,
   wipe_spaceTool,
   list_tokensTool,
   bulk_writeTool,

--- a/server/src/mcp/tools/spaces.ts
+++ b/server/src/mcp/tools/spaces.ts
@@ -325,6 +325,120 @@ export const update_space_schemaTool: ToolHandler = {
   },
 };
 
+/**
+ * Create a space — the last of the five REST-only capabilities that needed an extraction first.
+ *
+ * ## Why it is not a wrapper over `createSpace()`
+ *
+ * `createSpace()` has existed all along, which is exactly what made this dangerous rather than easy. The REST route
+ * wraps it in checks a direct call skips: proxy member existence, proxy nesting, the schema-library `$ref`, and the
+ * strict-posture seeding. A tool calling it directly would let a token holding `createSpaces` produce spaces that a
+ * REST caller could not — an un-seeded space with no validation, or a proxy pointing at a space that does not exist.
+ * That is the *two surfaces, one rule, one weaker* defect this batch closes, so the chain was extracted first
+ * (`spaces/space-create.ts`, pinned by `space-create-contract.test.js`) and this calls it.
+ *
+ * ## `faceDescriptorDims` is on the tool deliberately
+ *
+ * It is the parameter breituai-platform was blocked on for a week, and it is **create-only by design**: a populated
+ * gallery cannot be re-dimensioned, so `PATCH` does not offer it. Leaving it off the tool would mean an agent could
+ * create a space but never one that works with a 512-float recogniser — the exact shape of their complaint.
+ */
+export const create_spaceTool: ToolHandler = {
+  name: 'create_space',
+  description: 'Create a new space. Requires an admin token. The id is derived from the label when omitted. '
+    + 'A new space is seeded with a fully strict schema posture (validationMode: strict, strictLinkage: true) '
+    + 'unless you pass meta saying otherwise — with no typeSchemas defined yet that accepts every type, so it does '
+    + 'not block an empty space. A proxy space (proxyFor) holds no data of its own and is left un-seeded. '
+    + '`faceDescriptorDims` is CREATE-ONLY: a populated gallery cannot be re-dimensioned, so it cannot be changed '
+    + 'afterwards. Refusals match POST /api/spaces exactly, including 422 for a $ref to a schema-library entry that '
+    + 'does not exist and 409 when the id is taken.',
+  mutating: true,
+  admin: true,
+  inputSchema: (_s: ToolSchemas) => ({
+    type: 'object',
+    properties: {
+      label: { type: 'string', minLength: 1, maxLength: 200, description: 'Display label (1–200 chars). Required.' },
+      id: {
+        type: 'string', minLength: 1, maxLength: 40, pattern: '^[a-z0-9-]+$',
+        description: 'Space id — lowercase letters, digits and hyphens. Derived from the label when omitted.',
+      },
+      purpose: {
+        type: 'string', maxLength: SPACE_PURPOSE_MAX,
+        description: `The space-level directive injected into MCP instructions at handshake (max ${SPACE_PURPOSE_MAX} chars).`,
+      },
+      maxGiB: { type: 'number', exclusiveMinimum: 0, description: 'Storage quota in GiB. Omit for unlimited.' },
+      proxyFor: {
+        type: 'array', items: { type: 'string', minLength: 1, maxLength: 40 }, minItems: 1,
+        description: 'Make this a PROXY space that reads across the listed member spaces, or ["*"] for all of them. '
+          + 'Members must exist and must not themselves be proxies — nesting is refused. A proxy holds no data of '
+          + 'its own.',
+      },
+      faceDescriptorDims: {
+        type: 'integer', minimum: 64, maximum: 4096,
+        description: 'Face-descriptor width for this space. CREATE-ONLY and permanent: 128 for MobileFaceNet-class '
+          + 'models, 512 for ArcFace / AdaFace / FaceNet / EdgeFace. Omit to take the instance default.',
+      },
+      meta: {
+        type: 'object',
+        description: 'Initial meta: typeSchemas, validationMode, strictLinkage, usageNotes, suppressEmbeddings. '
+          + 'An explicit value here wins over the seeded strict defaults.',
+      },
+    },
+    required: ['label'],
+    additionalProperties: false,
+  }),
+  async handle(ctx: ToolContext): Promise<ToolResult> {
+    const { args: a, isAdmin } = ctx;
+    if (!isAdmin) {
+      return {
+        content: [{ type: 'text' as const, text: 'Error: create_space requires an admin token' }],
+        isError: true,
+      };
+    }
+
+    // `purpose` is the current name for what the create body still calls `description`. Translated here rather than
+    // widening the body schema: the REST field is the deprecated spelling, and a tool that took the deprecated name
+    // would be a new surface adopting an old one on the day it is written.
+    const body: Record<string, unknown> = {};
+    for (const k of ['label', 'id', 'maxGiB', 'proxyFor', 'faceDescriptorDims', 'meta']) {
+      if (a[k] !== undefined) body[k] = a[k];
+    }
+    if (a['purpose'] !== undefined) body['description'] = a['purpose'];
+
+    const { planSpaceCreate, applySpaceCreate } = await import('../../spaces/space-create.js');
+    const decision = planSpaceCreate(body);
+    if (!decision.ok) {
+      return {
+        content: [{ type: 'text' as const, text: `Error (${decision.refusal.status}): ${decision.refusal.body.error}` }],
+        isError: true,
+      };
+    }
+
+    const result = await applySpaceCreate(decision.plan);
+    if (result.outcome === 'conflict') {
+      // 409, and reported as its own thing rather than as a generic failure: the id being taken is often a successful
+      // retry of a request whose response was lost, and an agent that can tell the two apart stops retrying.
+      return {
+        content: [{ type: 'text' as const, text: `Error (409): ${result.error}` }],
+        isError: true,
+        structuredContent: { outcome: 'conflict' },
+      };
+    }
+    if (result.outcome === 'failed') {
+      return { content: [{ type: 'text' as const, text: `Error (500): ${result.error}` }], isError: true };
+    }
+
+    const s = result.space;
+    return {
+      content: [{ type: 'text' as const, text:
+        `Created space '${s.id}' (${s.label})`
+        + `${s.proxyFor ? ` as a proxy over ${s.proxyFor.join(', ')}` : ''}`
+        + `${s.meta?.validationMode ? `, validationMode: ${s.meta.validationMode}` : ''}.` }],
+      structuredContent: { outcome: 'created', id: s.id, label: s.label },
+    };
+  },
+};
+
 export const wipe_spaceTool: ToolHandler = {
   name: 'wipe_space',
   description: 'Wipe data from the specified space. By default wipes all collections (memories, entities, edges, chrono, files). Pass `types` to wipe only specific collections. The space itself and its configuration are preserved. Requires an admin token. Idempotent — wiping an empty space returns zero counts.',

--- a/testing/integration/mcp-create-space.test.js
+++ b/testing/integration/mcp-create-space.test.js
@@ -1,0 +1,265 @@
+/**
+ * `create_space` over MCP — the same refusals as the route, because it is the same function.
+ *
+ * ## What only this file can check
+ *
+ * The chain itself is pinned by `space-create-contract.test.js` against `POST /api/spaces`, and both surfaces now call
+ * `planSpaceCreate`. Re-asserting all of it here would be testing one function through two doors.
+ *
+ * What only this file can check is that the tool goes through that door at all — and for this capability that matters
+ * more than for the others, because `createSpace()` has existed all along. A tool calling it directly would pass a
+ * "did it create a space?" test while producing spaces a REST caller could not: un-seeded, no validation, or proxying
+ * a space that does not exist. Every assertion below is one of those.
+ *
+ * Run: node --test testing/integration/mcp-create-space.test.js
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import http from 'node:http';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, get, delWithBody } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+const RUN = Date.now();
+
+let token;
+let session;
+const created = [];
+
+/** The FIFO-waiter SSE harness from `mcp-tools.test.js`. Matching frames by position returns the PREVIOUS answer. */
+async function openMcpSession(authToken, instance = INSTANCES.a, timeoutMs = 15_000) {
+  const parsed = new URL(instance);
+  const host = parsed.hostname;
+  const port = parseInt(parsed.port || '80', 10);
+
+  return new Promise((resolve, reject) => {
+    const req = http.request({
+      host, port, path: '/mcp', method: 'GET',
+      headers: { Authorization: `Bearer ${authToken}`, Accept: 'text/event-stream' },
+    }, (res) => {
+      if (res.statusCode !== 200) { res.resume(); reject(new Error(`MCP SSE open failed: ${res.statusCode}`)); return; }
+
+      let buffer = '';
+      let sessionId = null;
+      const pendingMessages = [];
+      const waiters = [];
+
+      res.setEncoding('utf8');
+      res.on('data', chunk => {
+        buffer += chunk;
+        const parts = buffer.split('\n\n');
+        buffer = parts.pop() ?? '';
+        for (const part of parts) {
+          if (!part.trim()) continue;
+          let eventType = 'message';
+          let data = '';
+          for (const line of part.split('\n')) {
+            if (line.startsWith('event:')) eventType = line.slice(6).trim();
+            else if (line.startsWith('data:')) data = line.slice(5).trim();
+          }
+          if (eventType === 'endpoint') {
+            const m = data.match(/sessionId=([^&\s]+)/);
+            if (m) sessionId = m[1];
+          } else if (eventType === 'message' && data) {
+            try {
+              const msg = JSON.parse(data);
+              const waiter = waiters.shift();
+              if (waiter) waiter(msg);
+              else pendingMessages.push(msg);
+            } catch { /* non-JSON frame */ }
+          }
+        }
+      });
+      res.on('error', reject);
+
+      const deadline = Date.now() + timeoutMs;
+      const poll = setInterval(() => {
+        if (sessionId) { clearInterval(poll); resolve({ callTool, listTools, close }); }
+        else if (Date.now() > deadline) { clearInterval(poll); reject(new Error('MCP session did not receive endpoint event')); }
+      }, 50);
+
+      async function postJsonRpc(body) {
+        return new Promise((res2, rej2) => {
+          const waiterTimeout = setTimeout(() => rej2(new Error('MCP tool call timed out')), timeoutMs);
+          if (pendingMessages.length > 0) { clearTimeout(waiterTimeout); res2(pendingMessages.shift()); return; }
+          waiters.push(msg => { clearTimeout(waiterTimeout); res2(msg); });
+
+          const postData = JSON.stringify(body);
+          const pr = http.request({
+            host, port, path: `/mcp/messages?sessionId=${sessionId}`, method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Content-Length': Buffer.byteLength(postData),
+              Authorization: `Bearer ${authToken}`,
+            },
+          }, pres => {
+            let txt = '';
+            pres.setEncoding('utf8');
+            pres.on('data', c => { txt += c; });
+            pres.on('end', () => {
+              if (pres.statusCode !== 202 && pres.statusCode !== 200) {
+                clearTimeout(waiterTimeout);
+                rej2(new Error(`MCP POST failed: ${pres.statusCode} ${txt}`));
+              }
+            });
+          });
+          pr.on('error', rej2);
+          pr.write(postData);
+          pr.end();
+        });
+      }
+
+      async function callTool(name, args = {}) {
+        const rpc = await postJsonRpc({ jsonrpc: '2.0', id: Date.now(), method: 'tools/call', params: { name, arguments: args } });
+        return rpc?.result ?? rpc;
+      }
+      async function listTools() {
+        const rpc = await postJsonRpc({ jsonrpc: '2.0', id: Date.now(), method: 'tools/list', params: {} });
+        return rpc?.result?.tools ?? rpc?.tools ?? [];
+      }
+      function close() { req.destroy(); }
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+const idFor = (what) => `mcp-create-${what}-${RUN}`;
+const meta = (id) => get(INSTANCES.a, token, `/api/spaces/${id}/meta`);
+
+async function makeSpace(args) {
+  const r = await session.callTool('create_space', args);
+  if (!r?.isError && args.id) created.push(args.id);
+  return r;
+}
+
+before(async () => {
+  token = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+  session = await openMcpSession(token);
+});
+
+after(async () => {
+  session?.close();
+  for (const id of created) {
+    await delWithBody(INSTANCES.a, token, `/api/spaces/${id}`, { confirm: true }).catch(() => {});
+  }
+});
+
+describe('create_space is offered and creates', () => {
+  it('appears in tools/list for an admin token', async () => {
+    const names = (await session.listTools()).map(t => t.name);
+    assert.ok(names.includes('create_space'), `not offered: ${names.join(', ')}`);
+  });
+
+  it('creates a space and SEEDS the strict posture — the check a direct createSpace() call would skip', async () => {
+    // The whole reason the chain was extracted. `createSpace()` has always existed, so a tool could have called it on
+    // day one — and produced a space with no validation and no strict linkage, silently different from every space a
+    // REST caller creates.
+    const id = idFor('seeded');
+    const r = await makeSpace({ id, label: `MCP created ${RUN}` });
+    assert.ok(!r?.isError, `refused: ${JSON.stringify(r)}`);
+
+    const m = await meta(id);
+    assert.equal(m.status, 200, 'the space must be readable over REST — one store, two surfaces');
+    assert.equal(m.body.validationMode, 'strict');
+    assert.equal(m.body.strictLinkage, true);
+  });
+
+  it('derives the id from the label when none is given', async () => {
+    const r = await session.callTool('create_space', { label: `Derived Slug ${RUN}` });
+    assert.ok(!r?.isError, `refused: ${JSON.stringify(r)}`);
+    const derived = r?.structuredContent?.id;
+    assert.ok(derived, `the reply must name the id it chose: ${JSON.stringify(r)}`);
+    created.push(derived);
+    assert.match(derived, /^[a-z0-9-]+$/, 'a derived id must be a valid slug');
+    assert.equal((await meta(derived)).status, 200);
+  });
+
+  it('an explicit meta wins over the seeded defaults', async () => {
+    const id = idFor('explicit-meta');
+    const r = await makeSpace({ id, label: 'Explicit meta', meta: { validationMode: 'off' } });
+    assert.ok(!r?.isError, `refused: ${JSON.stringify(r)}`);
+    assert.equal((await meta(id)).body.validationMode, 'off');
+  });
+
+  it('a proxy space is left UN-seeded, because it stores nothing to validate', async () => {
+    const member = idFor('proxy-member');
+    const proxy = idFor('proxy');
+    assert.ok(!(await makeSpace({ id: member, label: 'Proxy member' }))?.isError);
+    const r = await makeSpace({ id: proxy, label: 'Proxy over member', proxyFor: [member] });
+    assert.ok(!r?.isError, `refused: ${JSON.stringify(r)}`);
+    assert.equal((await meta(proxy)).body.validationMode, undefined);
+  });
+});
+
+describe('create_space is held to the ROUTE rules, not looser ones', () => {
+  it('REFUSES a proxy member that does not exist', async () => {
+    // A direct `createSpace()` call would have accepted this and left a proxy pointing at nothing.
+    const id = idFor('proxy-missing');
+    const r = await makeSpace({ id, label: 'Proxy missing', proxyFor: [`no-such-${RUN}`] });
+    assert.ok(r?.isError, `accepted: ${JSON.stringify(r)}`);
+    assert.match(r.content[0].text, /400/);
+    assert.match(r.content[0].text, /not found/i);
+    assert.equal((await meta(id)).status, 404, 'a refusal must not leave the space behind');
+  });
+
+  it('REFUSES proxy nesting', async () => {
+    const base = idFor('nest-base');
+    const level1 = idFor('nest-1');
+    const level2 = idFor('nest-2');
+    assert.ok(!(await makeSpace({ id: base, label: 'Nest base' }))?.isError);
+    assert.ok(!(await makeSpace({ id: level1, label: 'Nest 1', proxyFor: [base] }))?.isError);
+
+    const r = await makeSpace({ id: level2, label: 'Nest 2', proxyFor: [level1] });
+    assert.ok(r?.isError, `accepted: ${JSON.stringify(r)}`);
+    assert.match(r.content[0].text, /nesting/i);
+    assert.equal((await meta(level2)).status, 404);
+  });
+
+  it('REFUSES a $ref to a schema-library entry that does not exist', async () => {
+    // 422, and the reason this refusal matters most on CREATE: the seeded posture is `strict`, so an unresolvable ref
+    // would leave that type with no constraints at all while its schema looked authored.
+    const id = idFor('broken-ref');
+    const r = await makeSpace({
+      id, label: 'Broken ref',
+      meta: { typeSchemas: { entity: { widget: { $ref: `library:absent-${RUN}` } } } },
+    });
+    assert.ok(r?.isError, `accepted: ${JSON.stringify(r)}`);
+    assert.match(r.content[0].text, /422/);
+    assert.match(r.content[0].text, new RegExp(`absent-${RUN}`));
+    assert.equal((await meta(id)).status, 404);
+  });
+
+  it('reports a taken id as a CONFLICT, distinct from a failure', async () => {
+    // 409 rather than a generic error, because "the id is taken" is often a successful retry whose response was lost.
+    // An agent that can tell the two apart stops retrying; one that cannot keeps going.
+    const id = idFor('conflict');
+    assert.ok(!(await makeSpace({ id, label: 'First' }))?.isError);
+    const r = await session.callTool('create_space', { id, label: 'Second' });
+    assert.ok(r?.isError, `a duplicate id was accepted: ${JSON.stringify(r)}`);
+    assert.match(r.content[0].text, /409/);
+    assert.equal(r?.structuredContent?.outcome, 'conflict', 'the outcome must be machine-readable, not only prose');
+  });
+
+  it('REFUSES a descriptor width outside the bounds — it cannot be changed afterwards', async () => {
+    const id = idFor('dims');
+    const r = await makeSpace({ id, label: 'Bad dims', faceDescriptorDims: 32 });
+    assert.ok(r?.isError, `accepted: ${JSON.stringify(r)}`);
+    assert.equal((await meta(id)).status, 404);
+  });
+
+  it('ACCEPTS the widths real recognisers use, so the bounds test is not vacuous', async () => {
+    const id = idFor('dims-512');
+    const r = await makeSpace({ id, label: 'Good dims', faceDescriptorDims: 512 });
+    assert.ok(!r?.isError, `refused: ${JSON.stringify(r)}`);
+  });
+
+  it('REFUSES an unknown parameter rather than silently dropping it', async () => {
+    const r = await session.callTool('create_space', { label: 'Typo', validationMdoe: 'strict' });
+    assert.ok(r?.isError, `a misspelled parameter was accepted: ${JSON.stringify(r)}`);
+  });
+});

--- a/testing/standalone/caller-supplied-ids-are-uuids.test.js
+++ b/testing/standalone/caller-supplied-ids-are-uuids.test.js
@@ -79,19 +79,50 @@ describe('a caller-supplied id must be a UUID', () => {
     assert.ok(total >= 8, `expected several id declarations across the tools, found ${total}`);
   });
 
+  /**
+   * The SPACE-id slug, which is a different identity from a record id and constrained differently on purpose.
+   *
+   * A record id is server-generated and a caller supplies one only to be idempotent, so anything but a UUID
+   * destroys the field's purpose. A space id is **chosen by a human**, appears in every URL and collection name,
+   * and is documented as a slug — `create_space` would be unusable if it demanded a UUID.
+   *
+   * So this is an allowlist of identity SHAPES, not of tools. That distinction is the whole point: a per-tool
+   * exemption is what let the original defect hide in a fourth tool nobody named, and it would let the next
+   * unconstrained record id in behind a name. Two shapes are recognised, both explicit, and everything else is
+   * still refused.
+   */
+  const SPACE_ID_PATTERN = "'^[a-z0-9-]+$'";
+
   it('every id declaration is constrained, not merely described', () => {
     const open = [];
     for (const f of files) {
       for (const d of idDeclarations(readFileSync(f, 'utf8'))) {
-        if (d.addressesExisting) continue;                       // update/delete — see idDeclarations
-        if (d.helper) continue;                                  // uuidSchema() carries the pattern
-        if (/pattern:\s*UUID_V4_PATTERN/.test(d.blob)) continue;  // spelled out inline is fine too
+        if (d.addressesExisting) continue;                          // update/delete — see idDeclarations
+        if (d.helper) continue;                                     // uuidSchema() carries the pattern
+        if (/pattern:\s*UUID_V4_PATTERN/.test(d.blob)) continue;     // spelled out inline is fine too
+        if (d.blob.includes(`pattern: ${SPACE_ID_PATTERN}`)) continue; // a space id is a slug, not a record id
         open.push(`${f.split('/').pop()}:${d.line}`);
       }
     }
     assert.deepEqual(open, [],
       'these accept any string as an id, so a corrupted one stores silently and the idempotent retry the field '
       + `exists for can never fire:\n  ${open.join('\n  ')}`);
+  });
+
+  it('the space-id slug the exemption recognises is the one the REST body enforces', () => {
+    // This is what keeps the second shape from being a hole. If the tool and the route disagreed about what a space
+    // id may contain, the looser one would decide — and the exemption above would be the reason nobody noticed.
+    // Asserted against the request-body schema rather than against a copy of the regex.
+    const bodies = readFileSync('server/src/spaces/body-schemas.ts', 'utf8');
+    const create = bodies.slice(bodies.indexOf('export const CreateSpaceBody'));
+    assert.match(create.slice(0, 400), /id: z\.string\(\)\.min\(1\)\.max\(40\)\.regex\(\/\^\[a-z0-9-\]\+\$\/\)/,
+      'the REST create body no longer enforces the slug this exemption is written against — reconcile them');
+
+    const tools = readFileSync('server/src/mcp/tools/spaces.ts', 'utf8');
+    assert.ok(tools.includes(`pattern: ${SPACE_ID_PATTERN}`),
+      'no tool declares the space-id slug, so this exemption is either unused or misspelled');
+    assert.match(tools, /maxLength: 40, pattern: '\^\[a-z0-9-\]\+\$'/,
+      'the tool must also carry the same 40-character bound as the body, or the two surfaces accept different ids');
   });
 
   it('a DESCRIPTION mentioning UUID does not count as a constraint', () => {

--- a/testing/standalone/mcp-tool-schemas.test.js
+++ b/testing/standalone/mcp-tool-schemas.test.js
@@ -19,14 +19,17 @@ const schemas = {
 const schemaOf = (name) => ALL_TOOLS.find(t => t.name === name).inputSchema(schemas);
 
 describe('MCP tool schemas — universal invariants', () => {
-  it('exposes exactly 37 tools', () => {
+  it('exposes exactly 38 tools', () => {
     // A deliberate tripwire, not a fact worth asserting for its own sake: the number changing means a tool
     // was added or removed, and every tool needs an audit mapping, a read-only classification and a docs
     // row. Bump it when you have done those three, never to make the suite quiet.
     // 36 -> 37: `update_space_schema`. Its three prerequisites are done — `audit-map.ts` maps it to
     // `space.update`, it is `mutating: true` + `admin: true` and listed among the tools a readOnly token cannot
     // see, and `16-mcp.md` carries its row.
-    assert.equal(ALL_TOOLS.length, 37);
+    // 37 -> 38: `create_space`. Prerequisites done — `audit-map.ts` maps it to `space.create`, it is
+    // `mutating: true` + `admin: true` and listed among the tools a readOnly token cannot see, and `16-mcp.md`
+    // carries its row.
+    assert.equal(ALL_TOOLS.length, 38);
   });
 
   it('every tool advertises a closed object schema (type:object, additionalProperties:false)', () => {


### PR DESCRIPTION
## What this closes

Fourth of the five REST-only capabilities, and the one where *"just call the existing function"* was most tempting and
most dangerous. **`createSpace()` has existed all along**, so a tool could have called it on day one — and produced
spaces a REST caller cannot:

- un-seeded, with no `validationMode` and no `strictLinkage`;
- proxying a space that does not exist;
- nesting a proxy inside a proxy.

That is why the chain was extracted first (#850). This calls it.

## The tool

`planSpaceCreate` + `applySpaceCreate`, so every refusal is the route's: both proxy checks, `422` for a missing
schema-library `$ref`, the `faceDescriptorDims` bounds, and the strict-posture seeding — including that a `proxyFor`
space is left **un-seeded**, because it stores nothing of its own to validate.

**`faceDescriptorDims` is on the tool deliberately.** It is the parameter breituai-platform was blocked on for a week,
and it is create-only by design: a populated gallery cannot be re-dimensioned. Leaving it off would have meant an agent
could create a space but never one that works with a 512-float recogniser — the exact shape of their complaint.

**A taken id is reported as `conflict`**, machine-readably, not as a generic failure. It is often a successful retry
whose response was lost, and an agent that can tell the two apart stops retrying.

`purpose` is translated to the body's `description` at the call site rather than widening the body schema — the REST
field is the deprecated spelling, and a new surface adopting an old name on the day it is written is a debt taken for
nothing.

## The UUID gate needed a refinement, not an exemption

`caller-supplied-ids-are-uuids.test.js` fired on this tool, and it was **right to look**: a space `id` is a
caller-supplied `id`. It is also deliberately not a UUID — it is chosen by a human, appears in every URL and collection
name, and is documented as a slug.

So the gate now recognises **two identity shapes**, the record UUID and the space slug. That is an allowlist of
*shapes*, not of tools, and the distinction is the whole point: a per-tool exemption is exactly what let the original
defect hide in a fourth tool nobody had named.

**The slug arm is not a hole.** A new assertion requires it to match what `CreateSpaceBody` enforces — the same regex
*and* the same 40-character bound — so the two surfaces cannot drift apart with the looser one deciding.

**Mutation-tested**: restoring the unconstrained shape that shipped on `create_chrono` still fails the gate and still
names the file.

## The map is down to one row

| capability | state |
|---|---|
| `retry_embedding` | built |
| `list_tokens` | built |
| `update_space_schema` | built (extraction first) |
| `create_space` | **built here** (extraction first) |
| `reindex` | **still mapped** — its re-embedding loop is inline in the route handler, so there is genuinely no function for a tool to call |

`mcp-rest-parity.test.js` asserts both halves of the surviving row, so it cannot rot in either direction.

## Verification

Serially, on a rebuilt image:

```
mcp-create-space                                     ℹ pass 12   ℹ fail 0
+ space-create-contract + mcp-tools                  ℹ tests 130  ℹ pass 130  ℹ fail 0
```

Plus `npm run preflight` green after the branch was replayed onto merged `main`.

## Docs

`docs/integration-guide/16-mcp.md` — the tool's row, its entry in the list a `readOnly` token cannot see, and the
admin-only note. The row states the create-only permanence of `faceDescriptorDims`, because that is the one parameter
here a caller cannot correct later.

🤖 Generated with Claude Code
