### PR TITLE
fix(todo): the tracker gate passed on things that were not open work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     nothing would have said so.
 
 ### Fixed
+- **`npm run todo:check` passed on trackers full of things that were not open work.** A development gate, and the
+  second one this cycle whose green verdict was the problem: the owner had to restate a rule it should have been
+  holding — *"only open and actionable items here. everything else in parked, reference or changelog"*.
+  - It caught work that was FINISHED, but only when announced as a checkbox, a `SHIPPED` marker or a heading. Four
+    other shapes walked past it: `**DONE** (#842)` in a nested bullet, `PROMOTED TO WORK AND FIXED` in an item title,
+    a bold `PROGRESS:` block, and `— DONE (#851)`.
+  - It had **no rule at all** for material that was never actionable: five watch items each saying so in their own
+    text (*"A watch item, not work"*), and two items blocked on an owner decision sitting in the open list rather than
+    in `_PARKED-DECISIONS.md`. That second kind is worse than clutter — it makes the queue look longer than the work,
+    and "the queue is empty" is the release gate.
+  - Both new rules are mutation-tested against the exact text that was removed: seven shapes, seven catches.
+  - **The `PROGRESS:` block was added by me**, three hours earlier, with a note saying the history was *"kept because
+    its reasoning is what made the extraction necessary"*. That is always the argument, which is why this is a gate
+    now and not a reminder.
 - **`deleteFields` could never remove a whole field from an entity or an edge — it answered 500.** Reported by
   breituai-platform (2026-08-12T2140Z) against `deleteFields: ["tags"]`, which the integration guide documents.
   Confirmed by reading the write paths, because the cause is total rather than conditional.

--- a/scripts/todo-consistency.mjs
+++ b/scripts/todo-consistency.mjs
@@ -86,11 +86,25 @@ console.log(`\n${YELLOW}todo/ consistency${R}  ${DIM}(owner rules 2026-08-02 and
   // shipped in #678, and P1 sat in section 1b with "CLOSED" in its own heading. Both announced their closure in a
   // *heading* rather than with a checkbox, so a checkbox-only check reported the queue clean. The rule is about
   // closed work being tracked as work, not about one syntax for saying so.
+  // 2026-08-13: four MORE shapes got through, and the owner had to say the rule again — *"only open and actionable
+  // items here. everything else in parked, reference or changelog"*. All four announced closure somewhere this
+  // check was not looking: inside a bullet rather than a heading, or in bold body text rather than a marker.
+  //
+  //   - [ ] **W-8 — PROMOTED TO WORK AND FIXED: …**        a bullet, not a heading
+  //   - `retry_embedding` — **DONE** (#842).               a nested bullet under an open item
+  //   **PROGRESS. The map shipped in #841 …**              bold body text
+  //
+  // The last one is the instructive one: it was ADDED during a tracker update, by me, with a note saying the
+  // history was "kept because its reasoning is what made the extraction necessary". That is always the argument,
+  // and the answer is that reasoning goes in `_REFERENCE.md` where it is read on demand.
   const CLOSED = [
     [/^\s*[-*]\s*\[x\]/im, 'a checked `[x]` item'],
     [/^\s*[-*]?\s*\*\*?SHIPPED/im, 'a SHIPPED marker'],
     [/^\s*#{1,4}\s+.*\b(SHIPPED|CLOSED|RESOLVED|DONE)\b/im, 'a heading announcing the item is finished'],
     [/^\s*[-*]\s*\[ \]\s*~~/im, 'a struck-through open item — delete it rather than crossing it out'],
+    [/\*\*DONE\*\*|\bDONE \(#\d+\)/i, 'a DONE marker inside an item — the closed part belongs in the CHANGELOG'],
+    [/\bAND FIXED\b|\bPROMOTED TO WORK AND\b/i, 'an item announcing its own fix'],
+    [/^\s*\*\*PROGRESS[.:]/im, 'a PROGRESS block — a record of what shipped, which is the CHANGELOG\'s job'],
   ];
   let clean = true;
   for (const f of files) {
@@ -195,6 +209,48 @@ console.log(`\n${YELLOW}todo/ consistency${R}  ${DIM}(owner rules 2026-08-02 and
   }
 }
 
+
+// ── rule 3b: a tracker holds WORK — not watches, and not things blocked on the owner
+{
+  /**
+   * The other half of *"only open and actionable items"* (owner, 2026-08-13). Rule 1 catches work that is FINISHED;
+   * this catches material that was never actionable in the first place, which is how the trackers actually grew:
+   *
+   *  - **a watch item.** Five of them, each saying so in its own text — *"A watch item, not work"*, *"WATCH, not
+   *    work"*. Nothing to do until it produces evidence, so it is a note. Its trigger belongs in
+   *    `_TODO-ORDERED.md §2` as one line, and its reasoning in `_REFERENCE.md`.
+   *  - **something blocked on the owner.** That is `_PARKED-DECISIONS.md`, and putting it in the open list is worse
+   *    than useless: it makes the queue look longer than the work, and "the queue is empty" — the release gate —
+   *    unreachable. Two were sitting in section 1 when this rule was written, one of them filed there by me the same
+   *    night.
+   *
+   * Both are matched on the item's OWN words, so an item does not become exempt by being described differently
+   * somewhere else. The phrasings are the ones that actually occurred, plus the obvious near-misses.
+   */
+  const NOT_WORK = [
+    [/\bwatch item\b/i, 'a watch item', 'its trigger goes in `_TODO-ORDERED.md §2`, its reasoning in `_REFERENCE.md`'],
+    [/\bWATCH,?\s+not\s+(a\s+)?(work|task)\b/i, 'an item labelled WATCH rather than work', 'same — §2 plus `_REFERENCE.md`'],
+    [/\bnot\s+work\s*[.:]/i, 'an item saying it is not work', 'same — §2 plus `_REFERENCE.md`'],
+    [/\bneeds? (an? )?owner (decision|call|word|sign.?off)\b/i, 'an item waiting on the owner', 'it belongs in `_PARKED-DECISIONS.md` with a recommended default'],
+    [/\bthat is a question for the owner\b/i, 'a question for the owner', 'it belongs in `_PARKED-DECISIONS.md` with a recommended default'],
+    [/\bis the owner['’]s call\b/i, "an owner's call", 'it belongs in `_PARKED-DECISIONS.md` with a recommended default'],
+  ];
+  let clean = true;
+  for (const f of files) {
+    if (NOT_A_QUEUE.has(f) || f === ORDERED) continue;   // §2 of the ordered file is where watch ROWS are allowed
+    const src = readFileSync(join(TODO, f), 'utf8');
+    for (const [re, what, where] of NOT_WORK) {
+      const m = re.exec(src);
+      if (!m) continue;
+      const line = src.slice(0, m.index).split(/\r?\n/).length;
+      fail(`${f}:${line} holds ${what}, which is not actionable work — ${where}.`);
+      clean = false;
+    }
+  }
+  console.log(clean
+    ? `${GREEN}  ✓${R} every tracker item is WORK, not a watch or an owner decision`
+    : `${RED}  ✗${R} a tracker holds something that is not actionable work`);
+}
 
 // ── rule 4: the working plan must describe work that is still ahead
 {


### PR DESCRIPTION
## Why this exists

The owner had to restate a rule this gate should have been holding: *"only open and actionable items here. everything
else in parked, reference or changelog"*. A rule that needs restating is a rule nothing is enforcing — and this is the
second time in this cycle that a **green verdict was the problem** rather than a red one (the first was `loop:check`
reporting a drained queue with eleven rows open).

## What walked past it

It caught work that was **finished**, in three shapes: a checked box, a `SHIPPED` marker, a heading saying
DONE/CLOSED/RESOLVED. Four others did not match any of them:

```
- `retry_embedding` — **DONE** (#842).        a nested bullet under an open item
- [ ] **W-8 — PROMOTED TO WORK AND FIXED: …** an item announcing its own fix
**PROGRESS: four of five are built.**         bold body text
- `create_space` — **DONE (#851)**            the same, one item over
```

And it had **no rule at all** for material that was never actionable, which is how the trackers actually grew:

| what was there | where it belongs |
|---|---|
| five watch items, each saying *"a watch item, not work"* in its own text | one line in the ordered file's watch section, reasoning in `_REFERENCE.md` |
| two items blocked on an owner decision, sitting in the **open** list | `_PARKED-DECISIONS.md`, with a recommended default |

The second is worse than clutter: an owner-blocked row in the open list makes the queue look longer than the work, and
**"the queue is empty" is the release gate.**

Both new rules match the item's **own words**, so an item cannot become exempt by being described differently
elsewhere.

## Mutation-tested, because a tracker gate that fires on nothing looks exactly like a clean tracker

Each of the seven shapes was appended to a real tracker and the gate re-run:

```
CAUGHT   DONE marker              CAUGHT   watch item
CAUGHT   PROMOTED/FIXED           CAUGHT   WATCH, not work
CAUGHT   PROGRESS block           CAUGHT   needs owner word
CAUGHT   question for owner
restored, gate green again: True
```

## The part worth being blunt about

**The `PROGRESS:` block was added by me**, about three hours before the owner said this, with a note claiming the
history was *"kept because its reasoning is what made the extraction necessary"*. That is always the argument, and it
is always available. It is why this is a gate rather than a resolution to be more careful.

## Scope

`scripts/todo-consistency.mjs` only — `todo/` is gitignored, so the cleanup itself is not in this diff. What shipped
here is the check that stops it recurring.

🤖 Generated with Claude Code
