### PR TITLE
test(reindex): pin the contract before the inline loop moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -357,6 +357,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     against the unmoved handler passes unchanged against the extracted one.
 
 ### Testing
+- **The `reindex` contract is pinned before its inline loop moves — in two files, because there are two failure
+  modes.** `reindex` is the last REST-only capability and the only one that could never have been wrapped: the
+  re-embedding work is written inline in the route handler as five near-identical batch loops (memories, entities,
+  edges, chrono, files), each with its own projection and its own `*EmbedText` builder.
+  - **Runtime** (`integration/reindex-contract.test.js`): `404` unknown space · `400` on a proxy, with its members
+    named in both the message and a `proxyFor` field · `409` while a job runs · `200 started` with **zeroed
+    counters**, because the response is sent before the work and an extraction that awaited it would turn a
+    multi-minute job into a request timeout · the job guard being released afterwards.
+  - **The assertion that is genuinely attributable to a reindex: it does NOT bump `seq` or `updatedAt`.** The loop
+    writes the embedding fields with a direct `$set`, deliberately not through the record update path. Routing it
+    through `updateMemory` for tidiness would look correct and would bump `seq` on every record in the space — a
+    sync-visible change on every peer for a local re-embed that changed no content. Mutation-tested: touching
+    `updatedAt` in one branch fails it.
+  - **Source** (`standalone/reindex-embeds-the-same-text.test.js`): each branch must call the builder its
+    collection's WRITE path uses. This cannot be a runtime test — the loop stores `embedding` and `embeddingModel`
+    and deliberately not `matchedText`, so a vector built from the wrong argument order is indistinguishable from a
+    right one through the API. It would keep recall working and quietly disagreeing with itself.
+  - The `excerpt` argument on the file branch and the `parentFileId` chunk exclusion are asserted by name — the first
+    because without it a reindex re-embeds converted documents without their own text, the second because
+    re-embedding a chunk overwrites a passage vector with file metadata. Both were comments; now they are checks.
 - **`POST /api/spaces` refusals are pinned before that chain moves too.** `create_space` is the 9-refusal member of
   the REST-only set, and the checks a tool calling `createSpace()` directly would skip are the ones nothing tested.
   Its own PR against the unmoved route, same reason as the `PATCH` pair.

--- a/testing/integration/reindex-contract.test.js
+++ b/testing/integration/reindex-contract.test.js
@@ -1,0 +1,221 @@
+/**
+ * The contract of `POST /api/brain/spaces/:spaceId/reindex` — characterization, ahead of an extraction.
+ *
+ * ## Why this lands before the code moves
+ *
+ * `reindex` is the last row of `REST_ONLY_CAPABILITIES`. It is the one capability that could not be given a tool by
+ * wrapping something, because there is nothing to wrap: the re-embedding work is written INLINE in the route handler
+ * as five near-identical batch loops — memories, entities, edges, chrono, files — each with its own projection, its
+ * own `*EmbedText` builder and its own per-record error tolerance. Their own workaround measures the gap: they
+ * reindexed 14 spaces plus 5 personal ones by curl in a shell loop, because the agent that planned their embedder
+ * migration could not run it.
+ *
+ * So the loop has to come out, and that is a refactor of code with weak coverage. This is the net under it, landing
+ * against the unmoved route for the reason the two earlier pairs had: a characterization test written in the same
+ * commit as the change it guards cannot show which behaviour it was describing.
+ *
+ * ## What is pinned at RUNTIME, and the one thing that cannot be
+ *
+ * Pinned here: the four answers (`404`, `400` on a proxy, `409` while running, `200 started`), that the response
+ * arrives BEFORE the work, that the job guard is released afterwards, and — the part that matters most — that all
+ * five collections actually come out with an embedding.
+ *
+ * **What the API cannot observe is WHICH TEXT was embedded.** The reindex loop writes `embedding` and
+ * `embeddingModel` and deliberately does not write `matchedText`, so there is no way from outside to tell
+ * `edgeEmbedText(from, label, to, …)` from `edgeEmbedText(label, from, to, …)` — both produce a vector. That is
+ * exactly what an extraction of five similar loops is most likely to get wrong, and it is why
+ * `reindex-embeds-the-same-text.test.js` exists beside this file as a source-level gate. Two checks because there
+ * are two failure modes, and neither can see the other's.
+ *
+ * Run: node --test testing/integration/reindex-contract.test.js
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, get, delWithBody, waitFor } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+const RUN = Date.now();
+const SPACE = `reindex-${RUN}`;
+const MEMBER = `reindex-member-${RUN}`;
+const PROXY = `reindex-proxy-${RUN}`;
+
+let token;
+const created = [];
+
+async function makeSpace(id, body = {}) {
+  const r = await post(INSTANCES.a, token, '/api/spaces', { id, label: id, ...body });
+  assert.equal(r.status, 201, `space create failed: ${JSON.stringify(r.body)}`);
+  created.push(id);
+}
+
+const reindex = (id) => post(INSTANCES.a, token, `/api/brain/spaces/${id}/reindex`, {});
+const status = (id) => get(INSTANCES.a, token, `/api/brain/spaces/${id}/reindex-status`);
+
+/** One record of every kind that the loop has a branch for. */
+async function seedOneOfEach(id) {
+  const mem = await post(INSTANCES.a, token, `/api/brain/spaces/${id}/memories`,
+    { fact: `Reindex fact ${RUN}`, tags: ['reindex'] });
+  assert.equal(mem.status, 201, JSON.stringify(mem.body));
+
+  const from = await post(INSTANCES.a, token, `/api/brain/spaces/${id}/entities`, { name: `From-${RUN}`, type: 'concept' });
+  const to = await post(INSTANCES.a, token, `/api/brain/spaces/${id}/entities`, { name: `To-${RUN}`, type: 'concept' });
+  assert.equal(from.status, 201, JSON.stringify(from.body));
+
+  const edge = await post(INSTANCES.a, token, `/api/brain/spaces/${id}/edges`,
+    { from: from.body._id, to: to.body._id, label: `relates-${RUN}` });
+  assert.equal(edge.status, 201, JSON.stringify(edge.body));
+
+  const chrono = await post(INSTANCES.a, token, `/api/brain/spaces/${id}/chrono`,
+    { title: `Reindex event ${RUN}`, type: 'event', startsAt: new Date().toISOString() });
+  assert.equal(chrono.status, 201, JSON.stringify(chrono.body));
+
+  // The path is a QUERY parameter, not a body field — `POST /api/files/:spaceId?path=…`.
+  const fileUrl = `${INSTANCES.a}/api/files/${id}?path=${encodeURIComponent(`reindex-${RUN}.txt`)}`;
+  const file = await fetch(fileUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ content: `Reindex file body ${RUN}`, encoding: 'utf8' }),
+  }).then(async r => ({ status: r.status, body: await r.json().catch(() => null) }));
+  // 202: the write lands and the embedding is queued (`embeddingStatus: 'pending'`), which is precisely why a file
+  // is worth seeding here — its vector arrives on a different path from the record.
+  assert.ok([200, 201, 202].includes(file.status), `file write failed: ${file.status} ${JSON.stringify(file.body)}`);
+
+  return { memoryId: mem.body._id, entityId: from.body._id, edgeId: edge.body._id, chronoId: chrono.body._id };
+}
+
+/** Records of one kind that carry an embedding, read through the query API rather than the database. */
+async function embeddedCount(id, collection) {
+  // `embedding` is always excluded from a query projection, so presence is asked about with $exists in the FILTER —
+  // the one way to observe it from outside without reaching into Mongo.
+  const r = await post(INSTANCES.a, token, `/api/brain/spaces/${id}/query`,
+    { collection, filter: { embedding: { $exists: true } }, limit: 100 });
+  assert.equal(r.status, 200, `query failed: ${JSON.stringify(r.body)}`);
+  return r.body.count ?? (r.body.results ?? []).length;
+}
+
+before(async () => {
+  token = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+  await makeSpace(SPACE);
+  await makeSpace(MEMBER);
+  await makeSpace(PROXY, { proxyFor: [MEMBER] });
+});
+
+after(async () => {
+  for (const id of created.reverse()) {
+    await delWithBody(INSTANCES.a, token, `/api/spaces/${id}`, { confirm: true }).catch(() => {});
+  }
+});
+
+describe('reindex — the four answers', () => {
+  it('404 for a space that does not exist', async () => {
+    const r = await reindex(`no-such-space-${RUN}`);
+    assert.equal(r.status, 404, JSON.stringify(r.body));
+    assert.match(r.body.error, /not found/i);
+  });
+
+  it('400 for a PROXY space, naming its members in both the message and a field', async () => {
+    // It used to answer `200 started` and then re-embed the members — which the caller was ALSO reindexing
+    // individually, because they are in the same space list, so everything under the proxy was embedded twice. The
+    // remedy is in the response because `GET /api/spaces` gives a caller nothing to branch on.
+    const r = await reindex(PROXY);
+    assert.equal(r.status, 400, JSON.stringify(r.body));
+    assert.match(r.body.error, /proxy space/i);
+    assert.match(r.body.error, new RegExp(MEMBER), 'the message must NAME the members to reindex instead');
+    assert.deepEqual(r.body.proxyFor, [MEMBER], 'and carry them as a field, so a client need not parse prose');
+  });
+
+  it('404 and a needsReindex flag on the status route', async () => {
+    const missing = await status(`no-such-space-${RUN}`);
+    assert.equal(missing.status, 404);
+
+    const ok = await status(SPACE);
+    assert.equal(ok.status, 200, JSON.stringify(ok.body));
+    assert.equal(ok.body.spaceId, SPACE);
+    assert.equal(typeof ok.body.needsReindex, 'boolean', 'the flag is what a caller polls; it must be a boolean');
+  });
+});
+
+describe('reindex — it answers BEFORE it works, and releases its guard', () => {
+  it('200 started, with a zeroed count, because the work has not happened yet', async () => {
+    // The counts in this response are always 0/0 and deliberately so: the job starts on the next turn so headers
+    // flush immediately. An extraction that awaited the work here would still answer 200 and would turn a
+    // multi-minute job into a request timeout — which is why the SHAPE of this response is pinned, not just its code.
+    await seedOneOfEach(SPACE);
+    const r = await reindex(SPACE);
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal(r.body.status, 'started');
+    assert.equal(r.body.spaceId, SPACE);
+    assert.equal(r.body.reindexed, 0, 'the response is sent before the work, so its counters are zero');
+    assert.equal(r.body.errors, 0);
+  });
+
+  it('accepts a SECOND reindex once the first has finished — the guard is released', async () => {
+    // The `finally` that clears `reindexJobRunning`. If an extraction moved the work behind a function that throws
+    // before reaching its own try/finally, the process would refuse every reindex from then on with 409 and only a
+    // restart would clear it. Nothing else in the suite would notice.
+    //
+    // This kicks its OWN reindex rather than relying on the test above having run one. A guard test that passes
+    // because nothing was ever running is the shape this whole file exists to avoid — it would report the guard
+    // released without a guard ever having been taken.
+    const first = await reindex(SPACE);
+    assert.ok([200, 409].includes(first.status), `unexpected: ${first.status} ${JSON.stringify(first.body)}`);
+
+    const second = await waitFor(async () => (await reindex(SPACE)).status === 200, 180_000, 1_000,
+      'a second reindex kept answering 409, so the job guard was never released');
+    assert.ok(second, 'a second reindex must eventually be accepted');
+  });
+});
+
+describe('reindex — what the API can actually attribute to it', () => {
+  it('leaves every collection embedded, in all five branches', async () => {
+    // **What this does and does not prove.** A normally-written record already carries an embedding, so this cannot
+    // show that the reindex is what produced one — the operation is idempotent by design. What it does show is that
+    // a reindex over records of every kind leaves them all embedded: no branch throws, and none clears a vector it
+    // fails to replace. Dropping a loop in the extraction would not fail this; dropping a loop that half-writes
+    // would.
+    //
+    // The assertion that a branch used the RIGHT text is not observable here at all — the loop does not store
+    // `matchedText` — and lives in `standalone/reindex-embeds-the-same-text.test.js`. Stated here so the pair is
+    // read as one net rather than this file being mistaken for the whole of it.
+    const seeded = { memories: 1, entities: 2, edges: 1, chrono: 1, files: 1 };
+
+    await reindex(SPACE);
+    for (const [collection, atLeast] of Object.entries(seeded)) {
+      const got = await waitFor(async () => (await embeddedCount(SPACE, collection)) >= atLeast, 180_000, 2_000,
+        `${collection}: fewer than ${atLeast} embedded record(s) after a reindex — a branch cleared or lost a vector`);
+      assert.ok(got, `${collection} must have at least ${atLeast} embedded record(s) after a reindex`);
+    }
+  });
+
+  it('does NOT bump seq or updatedAt — a re-embed is not a write', async () => {
+    // This one IS attributable, and it is the property an extraction is most likely to break: the loop writes the
+    // embedding fields with a direct `$set`, deliberately not through the record update path. Routing it through
+    // `updateMemory`/`updateEntity` for tidiness would look correct and would bump `seq` on every record in the
+    // space — which is a sync-visible change on every peer, for a local re-embed that changed no content. On the
+    // reporting operator's instance that is 19 spaces of churn.
+    const before = await post(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/query`,
+      { collection: 'memories', filter: {}, projection: { _id: 1, seq: 1, updatedAt: 1 }, limit: 20 });
+    assert.equal(before.status, 200, JSON.stringify(before.body));
+    const snapshot = new Map((before.body.results ?? []).map(r => [r._id, `${r.seq}|${r.updatedAt}`]));
+    assert.ok(snapshot.size > 0, 'nothing to compare — the space has no memories');
+
+    await reindex(SPACE);
+    // Give the job time to have touched them; the assertion is about what did NOT change, so waiting longer is safe.
+    await waitFor(async () => (await status(SPACE)).status === 200, 10_000, 1_000);
+    await new Promise(r => setTimeout(r, 5_000));
+
+    const after = await post(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/query`,
+      { collection: 'memories', filter: {}, projection: { _id: 1, seq: 1, updatedAt: 1 }, limit: 20 });
+    for (const r of after.body.results ?? []) {
+      const was = snapshot.get(r._id);
+      if (!was) continue;
+      assert.equal(`${r.seq}|${r.updatedAt}`, was,
+        `memory ${r._id} had its seq/updatedAt changed by a reindex — that is a write, and it syncs`);
+    }
+  });
+});

--- a/testing/standalone/reindex-embeds-the-same-text.test.js
+++ b/testing/standalone/reindex-embeds-the-same-text.test.js
@@ -1,0 +1,105 @@
+/**
+ * A reindex embeds the SAME text the normal write path embeds — asserted from source, because nothing else can.
+ *
+ * ## The gap this fills, stated precisely
+ *
+ * `reindex-contract.test.js` proves every collection comes out with an embedding. It cannot prove the embedding came
+ * from the right text: the reindex loop writes `embedding` and `embeddingModel` and deliberately does not write
+ * `matchedText`, so from outside the API a vector built from `edgeEmbedText(from, label, to, …)` and one built from
+ * `edgeEmbedText(label, from, to, …)` are indistinguishable. Both are 768 floats and both make the record findable
+ * by *something*.
+ *
+ * That is the failure an extraction of five near-identical loops is most likely to introduce, and the failure nobody
+ * would notice: recall would keep returning results, just slightly wrong ones, for the records reindexed after the
+ * refactor and not for the ones written before it.
+ *
+ * So this reads the source. A source gate is the weaker instrument in general, and here it is the only one that can
+ * see the thing at all — which is the whole argument for having both files.
+ *
+ * ## What is actually asserted
+ *
+ * Each of the five branches must call the `*EmbedText` builder that its collection's WRITE path calls. Derived by
+ * pairing collection → builder rather than by counting call sites, so a sixth collection added later is covered on
+ * the day it is written, and a branch that quietly starts building its own string fails.
+ *
+ * The `excerpt` argument on the file branch is asserted by name, and it has a specific history: without it a reindex
+ * re-embeds every converted document WITHOUT the document's own text, dropping exactly the phrases a reader
+ * searches for. The file's own comment says so; this is that comment with a test attached.
+ *
+ * Run: node --test testing/standalone/reindex-embeds-the-same-text.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const stripComments = (t) => t.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+/** The reindex handler, sliced out of the read/analytics router. */
+function reindexHandler() {
+  const src = stripComments(readFileSync('server/src/api/brain/search.ts', 'utf8'));
+  const start = src.indexOf("searchRouter.post('/spaces/:spaceId/reindex'");
+  assert.ok(start > 0, 'the reindex route moved — re-point this gate at wherever the loop now lives');
+  // To the end of the file or the next route, whichever comes first.
+  const next = src.indexOf('searchRouter.', start + 20);
+  return src.slice(start, next > 0 ? next : src.length);
+}
+
+/**
+ * collection → the embed-text builder its WRITE path uses.
+ *
+ * Not a list of what the reindex currently calls — that would agree with the code by construction. Each pairing is
+ * the one the record's own write path uses, so the assertion is *the reindex reproduces the write*, which is the
+ * property that matters.
+ */
+const BUILDERS = [
+  ['memories', 'memoryEmbedText'],
+  ['entities', 'entityEmbedText'],
+  ['edges', 'edgeEmbedText'],
+  ['chrono', 'chronoEmbedText'],
+  ['files', 'fileEmbedText'],
+];
+
+describe('a reindex reproduces what the write path embedded', () => {
+  const handler = reindexHandler();
+
+  it('found the handler, and it is the whole loop rather than a stub', () => {
+    // Floors it: if the slice were empty or tiny, every check below would pass on nothing. The five loops are
+    // hundreds of lines today, which is exactly why they are being extracted.
+    assert.ok(handler.length > 3000, `the sliced handler is only ${handler.length} chars — the slice is wrong`);
+  });
+
+  it('every collection is re-embedded through its own write-path builder', () => {
+    const missing = BUILDERS.filter(([, builder]) => !new RegExp(`\\b${builder}\\(`).test(handler))
+      .map(([collection, builder]) => `${collection} → ${builder}()`);
+    assert.deepEqual(missing, [],
+      'these collections are reindexed without calling the builder their write path uses, so their vectors are '
+      + 'built from different text than the records written normally — recall keeps working and quietly disagrees '
+      + `with itself:\n  ${missing.join('\n  ')}`);
+  });
+
+  it('the builders come from the shared module, not re-implemented locally', () => {
+    // The other way to break the pairing above: keep the name, declare it here. A local `const edgeEmbedText = …`
+    // would satisfy the regex and embed whatever it liked.
+    const src = readFileSync('server/src/api/brain/search.ts', 'utf8');
+    for (const [, builder] of BUILDERS) {
+      assert.match(src, new RegExp(`import \\{[^}]*\\b${builder}\\b[^}]*\\} from '[^']*embed-text\\.js'`, 's'),
+        `${builder} must be imported from brain/embed-text.js, not declared in the route file`);
+    }
+  });
+
+  it('the file branch passes `excerpt`, or a reindex drops every document body', () => {
+    // Specific and paid for: without `excerpt` a reindex re-embeds a converted document WITHOUT the document's own
+    // text, so the phrases a reader actually searches for disappear from the vector while the record still looks
+    // indexed. The route carries a comment saying exactly this; a comment is not a check.
+    const call = /fileEmbedText\(([^)]*)\)/.exec(handler);
+    assert.ok(call, 'the file branch no longer calls fileEmbedText');
+    assert.match(call[1], /excerpt/, 'fileEmbedText must be given the excerpt — see the comment at the call site');
+  });
+
+  it('chunk records are excluded, so a chunk is not re-embedded as a file', () => {
+    // Chunks carry `parentFileId` and have their own embedding logic. Re-embedding one here would overwrite a
+    // passage vector with a file-metadata vector, which is how a document becomes unsearchable by its own contents.
+    assert.match(handler, /parentFileId/,
+      'the files branch must still exclude chunk records (parentFileId set) from the file re-embed');
+  });
+});


### PR DESCRIPTION
## Why this is a PR of its own

`reindex` is the **last row** of `REST_ONLY_CAPABILITIES`, and the only one of the five that could never have been
given a tool by wrapping something — because there is nothing to wrap. The re-embedding work is written inline in the
route handler as five near-identical batch loops (memories, entities, edges, chrono, files), each with its own
projection, its own `*EmbedText` builder and its own per-record error tolerance.

Their workaround is the measure of the gap: 14 spaces plus 5 personal ones reindexed by curl in a shell loop, because
the agent that planned their embedder migration could not run it.

**No production code in this diff.** Two test files, because there are two failure modes and neither can see the
other's.

## Runtime — `integration/reindex-contract.test.js`

| pinned | why it matters to the extraction |
|---|---|
| `404` unknown space | — |
| `400` on a proxy, members named in the message **and** a `proxyFor` field | it used to answer `200 started` and re-embed the members, which the caller was already reindexing individually — everything under the proxy embedded twice |
| `409` while a job is running | — |
| `200 started` with **zeroed** counters | the response precedes the work; an extraction that awaited it would answer the same 200 and turn a multi-minute job into a request timeout |
| the guard is released afterwards | that is the `finally`. Lose it and the process refuses every reindex until restart, with nothing else noticing |

**The assertion genuinely attributable to a reindex: it does not bump `seq` or `updatedAt`.** The loop writes the
embedding fields with a direct `$set`, deliberately *not* through the record update path. Routing it through
`updateMemory` for tidiness would look correct and would bump `seq` on every record in the space — a **sync-visible
change on every peer** for a local re-embed that changed no content.

**What the API cannot attribute is stated in the test rather than implied.** A normally-written record already carries
an embedding, so *"everything is embedded afterwards"* shows that no branch throws or clears a vector — not that the
reindex produced one. A characterization test making a claim it cannot support is the failure this file exists to
prevent, so the claim is written down at its real strength.

## Source — `standalone/reindex-embeds-the-same-text.test.js`

Each branch must call the builder its collection's **write path** uses. This one cannot be a runtime test: the loop
stores `embedding` and `embeddingModel` and deliberately not `matchedText`, so a vector built from
`edgeEmbedText(label, from, to, …)` is indistinguishable through the API from one built correctly. Both are 768 floats;
both keep recall working, quietly disagreeing with every record written before the refactor.

- Pairing is **collection → builder**, not a count of call sites, so a sixth collection is covered the day it is
  written.
- The builders must be **imported** from `brain/embed-text.js`, so keeping the name while declaring it locally does
  not pass.
- **`excerpt`** on the file branch and the **`parentFileId`** chunk exclusion are asserted by name: without the first,
  a reindex re-embeds converted documents without their own text, dropping exactly the phrases a reader searches for;
  without the second, a chunk's passage vector is overwritten with file metadata. Both were comments until now.

## Mutation-tested — three shapes, three catches

| mutation | result |
|---|---|
| edge builder swapped for a local template string | caught |
| `excerpt` dropped from the file branch | caught |
| `updatedAt` touched in the memories branch | caught (needed an image rebuild) |

Source restored byte-identical after each — verified with `git diff --stat`, not assumed.

**One of those attempts initially proved nothing and was redone:** the `updatedAt` mutation used a multi-line anchor
against a CRLF file, so the replacement silently did not apply and the suite passed against unmutated code. A
mutation check that did not mutate looks exactly like a gate that works.

## Verification

```
reindex-contract                       ℹ pass 7    ℹ fail 0
+ brain.test.js (serially, as CI runs) ℹ tests 193  ℹ pass 193  ℹ fail 0
```

Plus `npm run preflight` green after rebasing onto `main`.

## What follows

Extract the five loops, then the tool — the same three-PR shape `update_space_schema` and `create_space` took. When
the tool lands, `REST_ONLY_CAPABILITIES` is empty.

🤖 Generated with Claude Code
