### PR TITLE
refactor(reindex): the loop is a module, not a route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,6 +318,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     worse than the bug being fixed.
 
 ### Internal
+- **The reindex loop is now a module both surfaces can call, and the router lost 196 lines.** Last of the three
+  extractions B-2 needed, and the only one where nothing existed to wrap: the re-embedding work was inline in the
+  route handler as five near-identical batch loops.
+  - `brain/reindex.ts`: `planReindex` decides (404 · the proxy 400 · the single-job 409) and `startReindex` runs.
+  - **The guard and the metric moved WITH the work, which is the part that matters.** `reindexJobRunning` was module
+    state in the router; a second surface calling the loop directly would have run a concurrent job the guard could not
+    see, and `reindexInProgress` would have been left at 1 by whichever job finished second.
+  - `startReindex` returns as soon as the job is scheduled — never awaits it — so both surfaces keep the existing
+    contract: `status: 'started'` with zeroed counters, work on the next turn, headers flushed immediately.
+  - **Two gates got stronger rather than re-pointed.** The proxy gate asserted that `res.status(400)` came before
+    `reindexJobRunning = true`; it now asserts that the decision function never sets the flag *at all*, so no refusal
+    can leave it set. And the builder gate gained a check that the ROUTE still delegates — everything else in it now
+    reads the module, so a handler that re-grew its own loop would have satisfied all of it.
+  - Behaviour-preserving by construction: the loops moved verbatim, and the two suites that landed against the unmoved
+    route pass unchanged — 237 tests with `brain` and `proxy-spaces` alongside them.
 - **The space CREATE chain is now a function both surfaces can call.** Last of the three extractions B-2 needs, and
   the reason it was needed: `createSpace()` already exists in `lifecycle.ts`, so a tool could call it today — and
   would skip the two proxy refusals, the schema-library `$ref` check, and the strict-posture seeding. A token holding

--- a/server/src/api/brain/search.ts
+++ b/server/src/api/brain/search.ts
@@ -14,11 +14,11 @@ import { queryBrain } from '../../brain/query.js';
 import { findSimilar, recall, type RecallKnowledgeType, type RecallResult } from '../../brain/recall.js';
 import { validateFilterExpression, type FilterExpression } from '../../brain/filter.js';
 import { traverseGraph, traverseRecallSeeds, MAX_RECALL_TRAVERSE, resolveEdgeEntityNames } from '../../brain/edges.js';
-import { memoryEmbedText, entityEmbedText, edgeEmbedText, chronoEmbedText, fileEmbedText } from '../../brain/embed-text.js';
 import { embed } from '../../brain/embedding.js';
 import { getConfig } from '../../config/loader.js';
 import { col, asFilter } from '../../db/mongo.js';
-import { needsReindex, clearReindexFlag } from '../../spaces/_shared.js';
+import { needsReindex } from '../../spaces/_shared.js';
+import { planReindex, startReindex } from '../../brain/reindex.js';
 import { log } from '../../util/log.js';
 import { collectAcrossMembers } from '../../spaces/proxy.js';
 import { memberSpacesForRequest } from '../../spaces/proxy-scoped.js';
@@ -562,222 +562,26 @@ searchRouter.get('/spaces/:spaceId/reindex-status', globalRateLimit, requireSpac
 // POST /api/brain/spaces/:spaceId/reindex
 // Re-embeds all memories in a space using the currently configured model.
 // Long-running: may take minutes for large spaces. Progress is logged server-side.
+// POST /api/brain/spaces/:spaceId/reindex
+//
+// Every refusal -- 404, the proxy 400, the single-job 409 -- and the work itself live in `brain/reindex.ts`, so an
+// MCP tool reaches the same rules and the same guard instead of a weaker copy of them (B-2). What stays here is
+// resolving the member spaces from the REQUEST (which is where the token's scope is known) and turning a refusal into
+// a status.
+//
+// The response is sent as soon as the job is SCHEDULED, with zeroed counters. That is deliberate and pinned:
+// `reindex-contract.test.js` asserts the shape, because awaiting the work here would answer the same 200 and turn a
+// multi-minute job into a request timeout.
 searchRouter.post('/spaces/:spaceId/reindex', globalRateLimit, requireSpaceAuth, denyReadOnly, async (req, res) => {
   const spaceId = req.params['spaceId'] as string;
-  const cfg = getConfig();
-  if (!cfg.spaces.some(s => s.id === spaceId)) {
-    res.status(404).json({ error: `Space '${spaceId}' not found` });
+  const space = getConfig().spaces.find(s => s.id === spaceId);
+
+  const decision = planReindex({ spaceId, space, memberIds: memberSpacesForRequest(req, spaceId) });
+  if (!decision.ok) {
+    res.status(decision.refusal.status).json(decision.refusal.body);
     return;
   }
 
-  /**
-   * A PROXY is refused, by name, with its members listed.
-   *
-   * It used to answer `200 {"status":"started"}` and then re-embed the member spaces — which the caller was
-   * also reindexing individually, because they are in the same space list. Everything under the proxy got
-   * embedded twice. It is idempotent, so nothing broke: on the reporting operator's largest instance it was
-   * simply the longest job of the run and all of it was waste.
-   *
-   * The caller could not avoid it either. `GET /api/spaces` returns ids with no indication of which are
-   * proxies, so there was nothing to branch on — which is why this is a refusal here rather than a note in
-   * the docs.
-   *
-   * It is also what the rest of the model already does: a WRITE to a proxy requires an explicit
-   * `targetSpace`, because a proxy is not a place records live. Accepting one here without comment was the
-   * inconsistency.
-   *
-   * The members are named in the message so the remedy is the response rather than a second lookup.
-   */
-  const space = cfg.spaces.find(s => s.id === spaceId)!;
-  if (space.proxyFor && space.proxyFor.length > 0) {
-    res.status(400).json({
-      error: `'${spaceId}' is a proxy space and has no index of its own. `
-        + `Reindex its members instead: ${space.proxyFor.join(', ')}.`,
-      proxyFor: space.proxyFor,
-    });
-    return;
-  }
-
-  if (reindexJobRunning) {
-    res.status(409).json({ error: 'Reindex already in progress' });
-    return;
-  }
-
-  const memberIds = memberSpacesForRequest(req, spaceId);
-  reindexJobRunning = true;
-  reindexInProgress.set(1);
+  startReindex(decision.plan);
   res.json({ spaceId, reindexed: 0, errors: 0, status: 'started' });
-
-  // Start heavy work on the next turn so HTTP headers flush immediately.
-  setImmediate(() => {
-    void (async () => {
-      let reindexed = 0;
-      let errors = 0;
-      try {
-        for (const mid of memberIds) {
-        const BATCH = 50;
-
-        // Re-embed memories
-        {
-          let cursor: string | null = null;
-          // eslint-disable-next-line no-constant-condition
-          while (true) {
-            const q: Record<string, unknown> = cursor ? { _id: { $gt: cursor } } : {};
-            const batch: MemoryDoc[] = await col<MemoryDoc>(`${mid}_memories`)
-              .find(asFilter<MemoryDoc>(q), { projection: { _id: 1, fact: 1, tags: 1, entityIds: 1, description: 1, properties: 1 } })
-              .sort({ _id: 1 })
-              .limit(BATCH)
-              .toArray() as MemoryDoc[];
-            if (batch.length === 0) break;
-            for (const doc of batch) {
-              try {
-                const entityIds: string[] = Array.isArray(doc.entityIds) ? doc.entityIds : [];
-                const entityDocs = entityIds.length > 0
-                  ? await col<EntityDoc>(`${mid}_entities`)
-                      .find(asFilter<EntityDoc>({ _id: { $in: entityIds } }), { projection: { name: 1 } })
-                      .toArray() as Array<{ name: string }>
-                  : [];
-                const entityNames = entityDocs.map(e => e.name);
-                const result = await embed(memoryEmbedText(doc.fact, doc.tags ?? [], entityNames, doc.description, doc.properties));
-                await col<MemoryDoc>(`${mid}_memories`).updateOne(
-                  { _id: doc._id },
-                  { $set: { embedding: result.vector, embeddingModel: result.model } },
-                );
-                reindexed++;
-              } catch { errors++; }
-            }
-            cursor = batch[batch.length - 1]?._id ?? null;
-          }
-        }
-
-        // Re-embed entities (name + type + tags + description + properties)
-        {
-          let cursor: string | null = null;
-          // eslint-disable-next-line no-constant-condition
-          while (true) {
-            const q: Record<string, unknown> = cursor ? { _id: { $gt: cursor } } : {};
-            const batch: EntityDoc[] = await col<EntityDoc>(`${mid}_entities`)
-              .find(asFilter<EntityDoc>(q), { projection: { _id: 1, name: 1, type: 1, tags: 1, description: 1, properties: 1 } })
-              .sort({ _id: 1 })
-              .limit(BATCH)
-              .toArray() as EntityDoc[];
-            if (batch.length === 0) break;
-            for (const doc of batch) {
-              try {
-                const result = await embed(entityEmbedText(doc.name, doc.type, doc.tags ?? [], doc.description, doc.properties ?? {}));
-                await col<EntityDoc>(`${mid}_entities`).updateOne(
-                  { _id: doc._id },
-                  { $set: { embedding: result.vector, embeddingModel: result.model } },
-                );
-                reindexed++;
-              } catch { errors++; }
-            }
-            cursor = batch[batch.length - 1]?._id ?? null;
-          }
-        }
-
-        // Re-embed edges (tags + from-name + label + to-name + type + description + properties)
-        {
-          let cursor: string | null = null;
-          // eslint-disable-next-line no-constant-condition
-          while (true) {
-            const q: Record<string, unknown> = cursor ? { _id: { $gt: cursor } } : {};
-            const batch: EdgeDoc[] = await col<EdgeDoc>(`${mid}_edges`)
-              .find(asFilter<EdgeDoc>(q), { projection: { _id: 1, from: 1, label: 1, to: 1, type: 1, tags: 1, description: 1, properties: 1 } })
-              .sort({ _id: 1 })
-              .limit(BATCH)
-              .toArray() as EdgeDoc[];
-            if (batch.length === 0) break;
-            for (const doc of batch) {
-              try {
-                // Resolve from/to to entity NAMES (not IDs) and include properties — matching
-                // edgeEmbedText so a reindex reproduces exactly what upsertEdge embedded.
-                const [fromName, toName] = await resolveEdgeEntityNames(mid, doc.from, doc.to);
-                const result = await embed(edgeEmbedText(fromName, doc.label, toName, doc.tags ?? [], doc.type, doc.description, doc.properties));
-                await col<EdgeDoc>(`${mid}_edges`).updateOne(
-                  { _id: doc._id },
-                  { $set: { embedding: result.vector, embeddingModel: result.model } },
-                );
-                reindexed++;
-              } catch { errors++; }
-            }
-            cursor = batch[batch.length - 1]?._id ?? null;
-          }
-        }
-
-        // Re-embed chrono (type + status + title + tags + description + properties)
-        {
-          let cursor: string | null = null;
-          // eslint-disable-next-line no-constant-condition
-          while (true) {
-            const q: Record<string, unknown> = cursor ? { _id: { $gt: cursor } } : {};
-            const batch: ChronoEntry[] = await col<ChronoEntry>(`${mid}_chrono`)
-              .find(asFilter<ChronoEntry>(q), { projection: { _id: 1, title: 1, type: 1, status: 1, description: 1, tags: 1, properties: 1 } })
-              .sort({ _id: 1 })
-              .limit(BATCH)
-              .toArray() as ChronoEntry[];
-            if (batch.length === 0) break;
-            for (const doc of batch) {
-              try {
-                const result = await embed(chronoEmbedText(doc.title, doc.type, doc.status, doc.description, doc.tags ?? [], doc.properties));
-                await col<ChronoEntry>(`${mid}_chrono`).updateOne(
-                  { _id: doc._id },
-                  { $set: { embedding: result.vector, embeddingModel: result.model } },
-                );
-                reindexed++;
-              } catch { errors++; }
-            }
-            cursor = batch[batch.length - 1]?._id ?? null;
-          }
-        }
-
-        // Re-embed files (path + entity names + tags + description + property values)
-        {
-          let cursor: string | null = null;
-          // eslint-disable-next-line no-constant-condition
-          while (true) {
-            // Exclude chunk records (parentFileId set) — they have their own embedding logic
-            const q: Record<string, unknown> = cursor
-              ? { _id: { $gt: cursor }, parentFileId: { $exists: false } }
-              : { parentFileId: { $exists: false } };
-            const batch: FileMetaDoc[] = await col<FileMetaDoc>(`${mid}_files`)
-              .find(asFilter<FileMetaDoc>(q), { projection: { _id: 1, path: 1, tags: 1, description: 1, properties: 1, entityIds: 1 } })
-              .sort({ _id: 1 })
-              .limit(BATCH)
-              .toArray() as FileMetaDoc[];
-            if (batch.length === 0) break;
-            for (const doc of batch) {
-              try {
-                const entityIds: string[] = Array.isArray(doc.entityIds) ? doc.entityIds : [];
-                const entityDocs = entityIds.length > 0
-                  ? await col<EntityDoc>(`${mid}_entities`)
-                      .find(asFilter<EntityDoc>({ _id: { $in: entityIds } }), { projection: { name: 1 } })
-                      .toArray() as Array<{ name: string }>
-                  : [];
-                const entityNames = entityDocs.map(e => e.name);
-                // `excerpt` included, or a reindex would silently re-embed every converted document
-                // without the document's own text — dropping exactly the phrases a reader searches for.
-                const result = await embed(fileEmbedText(doc.path, doc.tags ?? [], doc.description, doc.properties, entityNames, doc.excerpt));
-                await col<FileMetaDoc>(`${mid}_files`).updateOne(
-                  { _id: doc._id },
-                  { $set: { embedding: result.vector, embeddingModel: result.model } },
-                );
-                reindexed++;
-              } catch { errors++; }
-            }
-            cursor = batch[batch.length - 1]?._id ?? null;
-          }
-        }
-
-          clearReindexFlag(mid);
-        }
-        log.info(`Reindex completed for space '${spaceId}': reindexed=${reindexed}, errors=${errors}`);
-      } catch (err) {
-        log.error(`Reindex job failed for space '${spaceId}': ${String(err)}`);
-      } finally {
-        reindexJobRunning = false;
-        reindexInProgress.set(0);
-      }
-    })();
-  });
 });

--- a/server/src/brain/reindex.ts
+++ b/server/src/brain/reindex.ts
@@ -1,0 +1,316 @@
+/**
+ * Re-embedding a space: the refusals, the single-job guard, and the five collection loops.
+ *
+ * ## Why this is a module and not a route
+ *
+ * `reindex` was the last row of `REST_ONLY_CAPABILITIES` -- five capabilities a token could HOLD and not exercise
+ * over MCP -- and the only one that could not be closed by wrapping something, because there was nothing to wrap.
+ * The work lived inline in the route handler: five near-identical batch loops, each with its own projection, its own
+ * `*EmbedText` builder and its own per-record error tolerance. Their workaround measured the gap: 14 spaces plus 5
+ * personal ones reindexed by curl in a shell loop, because the agent that planned their embedder migration could not
+ * run it.
+ *
+ * ## The split, and the two things that had to move WITH the work
+ *
+ * `planReindex` decides -- 404, the proxy refusal, the single-job 409 -- and `startReindex` runs. What is easy to get
+ * wrong is that the **guard and the metric belong to the work, not to the route**: `reindexJobRunning` was module
+ * state in the router, so a second surface calling the loop directly would have run a concurrent job the guard could
+ * not see, and `reindexInProgress` would have been left at 1 by whichever job finished second.
+ *
+ * `startReindex` returns as soon as the job is SCHEDULED, which is the contract the route already had: the response
+ * carries `status: 'started'` with zeroed counters, and the work runs on the next turn so headers flush immediately.
+ * Awaiting the work would turn a multi-minute job into a request timeout while still answering 200.
+ *
+ * ## Two properties of the loops that are easy to lose
+ *
+ *  - **A re-embed is not a write.** The embedding fields go in with a direct `$set` rather than through the record
+ *    update path, so `seq` and `updatedAt` do not move. Routing them through `updateMemory` would look tidier and
+ *    would bump `seq` on every record in the space -- a sync-visible change on every peer, for a local re-embed that
+ *    changed no content.
+ *  - **Each collection embeds the text its WRITE path embeds.** These loops call the same `*EmbedText` builders the
+ *    upsert paths call. Nothing stores `matchedText` here, so a vector built from the wrong argument order is
+ *    indistinguishable through the API -- it keeps recall working while quietly disagreeing with every record written
+ *    normally.
+ *
+ * Both are pinned, and both suites landed against the unmoved route: `integration/reindex-contract.test.js` for the
+ * contract and the `seq` property, `standalone/reindex-embeds-the-same-text.test.js` for the builders -- the second
+ * reads SOURCE because no runtime test can see which text was embedded.
+ */
+import { col, asFilter } from '../db/mongo.js';
+import { embed } from './embedding.js';
+import { memoryEmbedText, entityEmbedText, edgeEmbedText, chronoEmbedText, fileEmbedText } from './embed-text.js';
+import { clearReindexFlag } from '../spaces/_shared.js';
+import { resolveEdgeEntityNames } from './edges.js';
+import { reindexInProgress } from '../metrics/registry.js';
+import { log } from '../util/log.js';
+import type { SpaceConfig, MemoryDoc, EntityDoc, EdgeDoc, ChronoEntry, FileMetaDoc } from '../config/types.js';
+
+/**
+ * One job per process, and the guard lives HERE.
+ *
+ * It was module state in the router, which was correct while the router was the only caller. The moment a second
+ * surface can start a reindex, a guard that surface cannot see is not a guard: two concurrent jobs would re-embed the
+ * same records, and `reindexInProgress` would be left at 1 by whichever finished second.
+ */
+let reindexJobRunning = false;
+
+/** Whether a job is running. Both surfaces read this rather than each keeping its own flag. */
+export function reindexRunning(): boolean {
+  return reindexJobRunning;
+}
+
+/** A refusal, carrying the status the contract suite pins. */
+export type ReindexRefusal = {
+  status: 400 | 404 | 409;
+  body: { error: string; proxyFor?: string[] };
+};
+
+export type ReindexPlan = {
+  spaceId: string;
+  /** The member spaces to walk -- for a normal space, itself. Resolved by the caller, which knows the token scope. */
+  memberIds: string[];
+};
+
+export type ReindexDecision =
+  | { ok: false; refusal: ReindexRefusal }
+  | { ok: true; plan: ReindexPlan };
+
+/**
+ * Decide a reindex: refuse it, or return the job to start.
+ *
+ * `memberIds` is passed in rather than resolved here because scope resolution differs per surface -- REST narrows by
+ * request, MCP by the token's accessible spaces -- and re-deriving it here would be a second place for the two to
+ * disagree about which spaces a token may touch.
+ */
+export function planReindex(input: {
+  spaceId: string;
+  space: SpaceConfig | undefined;
+  memberIds: string[];
+}): ReindexDecision {
+  const { spaceId, space, memberIds } = input;
+
+  if (!space) {
+    return { ok: false, refusal: { status: 404, body: { error: `Space '${spaceId}' not found` } } };
+  }
+
+  /**
+   * A PROXY is refused, by name, with its members listed.
+   *
+   * It used to answer `200 {"status":"started"}` and then re-embed the member spaces -- which the caller was also
+   * reindexing individually, because they are in the same space list. Everything under the proxy got embedded twice.
+   * It is idempotent, so nothing broke: on the reporting operator's largest instance it was simply the longest job of
+   * the run, and all of it was waste.
+   *
+   * The caller could not avoid it either. `GET /api/spaces` returns ids with no indication of which are proxies, so
+   * there was nothing to branch on -- which is why this is a refusal rather than a note in the docs. It is also what
+   * the rest of the model already does: a WRITE to a proxy requires an explicit `targetSpace`, because a proxy is not
+   * a place records live.
+   *
+   * The members are named in the message so the remedy is the response rather than a second lookup.
+   */
+  if (space.proxyFor && space.proxyFor.length > 0) {
+    return {
+      ok: false,
+      refusal: {
+        status: 400,
+        body: {
+          error: `'${spaceId}' is a proxy space and has no index of its own. `
+            + `Reindex its members instead: ${space.proxyFor.join(', ')}.`,
+          proxyFor: space.proxyFor,
+        },
+      },
+    };
+  }
+
+  if (reindexJobRunning) {
+    return { ok: false, refusal: { status: 409, body: { error: 'Reindex already in progress' } } };
+  }
+
+  return { ok: true, plan: { spaceId, memberIds } };
+}
+
+/**
+ * Take the guard and SCHEDULE the work, then return.
+ *
+ * Never awaits the job. Both surfaces answer immediately with zeroed counters, and progress is read from
+ * `reindex-status` or the log. The guard is released in a `finally` around the whole job, so a throw anywhere in the
+ * five loops cannot wedge the process into refusing every later reindex until a restart.
+ */
+export function startReindex(plan: ReindexPlan): void {
+  const { spaceId, memberIds } = plan;
+  reindexJobRunning = true;
+  reindexInProgress.set(1);
+
+  // Start heavy work on the next turn so HTTP headers flush immediately.
+  setImmediate(() => {
+    void (async () => {
+      let reindexed = 0;
+      let errors = 0;
+      try {
+            for (const mid of memberIds) {
+            const BATCH = 50;
+
+            // Re-embed memories
+            {
+              let cursor: string | null = null;
+              // eslint-disable-next-line no-constant-condition
+              while (true) {
+                const q: Record<string, unknown> = cursor ? { _id: { $gt: cursor } } : {};
+                const batch: MemoryDoc[] = await col<MemoryDoc>(`${mid}_memories`)
+                  .find(asFilter<MemoryDoc>(q), { projection: { _id: 1, fact: 1, tags: 1, entityIds: 1, description: 1, properties: 1 } })
+                  .sort({ _id: 1 })
+                  .limit(BATCH)
+                  .toArray() as MemoryDoc[];
+                if (batch.length === 0) break;
+                for (const doc of batch) {
+                  try {
+                    const entityIds: string[] = Array.isArray(doc.entityIds) ? doc.entityIds : [];
+                    const entityDocs = entityIds.length > 0
+                      ? await col<EntityDoc>(`${mid}_entities`)
+                          .find(asFilter<EntityDoc>({ _id: { $in: entityIds } }), { projection: { name: 1 } })
+                          .toArray() as Array<{ name: string }>
+                      : [];
+                    const entityNames = entityDocs.map(e => e.name);
+                    const result = await embed(memoryEmbedText(doc.fact, doc.tags ?? [], entityNames, doc.description, doc.properties));
+                    await col<MemoryDoc>(`${mid}_memories`).updateOne(
+                      { _id: doc._id },
+                      { $set: { embedding: result.vector, embeddingModel: result.model } },
+                    );
+                    reindexed++;
+                  } catch { errors++; }
+                }
+                cursor = batch[batch.length - 1]?._id ?? null;
+              }
+            }
+
+            // Re-embed entities (name + type + tags + description + properties)
+            {
+              let cursor: string | null = null;
+              // eslint-disable-next-line no-constant-condition
+              while (true) {
+                const q: Record<string, unknown> = cursor ? { _id: { $gt: cursor } } : {};
+                const batch: EntityDoc[] = await col<EntityDoc>(`${mid}_entities`)
+                  .find(asFilter<EntityDoc>(q), { projection: { _id: 1, name: 1, type: 1, tags: 1, description: 1, properties: 1 } })
+                  .sort({ _id: 1 })
+                  .limit(BATCH)
+                  .toArray() as EntityDoc[];
+                if (batch.length === 0) break;
+                for (const doc of batch) {
+                  try {
+                    const result = await embed(entityEmbedText(doc.name, doc.type, doc.tags ?? [], doc.description, doc.properties ?? {}));
+                    await col<EntityDoc>(`${mid}_entities`).updateOne(
+                      { _id: doc._id },
+                      { $set: { embedding: result.vector, embeddingModel: result.model } },
+                    );
+                    reindexed++;
+                  } catch { errors++; }
+                }
+                cursor = batch[batch.length - 1]?._id ?? null;
+              }
+            }
+
+            // Re-embed edges (tags + from-name + label + to-name + type + description + properties)
+            {
+              let cursor: string | null = null;
+              // eslint-disable-next-line no-constant-condition
+              while (true) {
+                const q: Record<string, unknown> = cursor ? { _id: { $gt: cursor } } : {};
+                const batch: EdgeDoc[] = await col<EdgeDoc>(`${mid}_edges`)
+                  .find(asFilter<EdgeDoc>(q), { projection: { _id: 1, from: 1, label: 1, to: 1, type: 1, tags: 1, description: 1, properties: 1 } })
+                  .sort({ _id: 1 })
+                  .limit(BATCH)
+                  .toArray() as EdgeDoc[];
+                if (batch.length === 0) break;
+                for (const doc of batch) {
+                  try {
+                    // Resolve from/to to entity NAMES (not IDs) and include properties — matching
+                    // edgeEmbedText so a reindex reproduces exactly what upsertEdge embedded.
+                    const [fromName, toName] = await resolveEdgeEntityNames(mid, doc.from, doc.to);
+                    const result = await embed(edgeEmbedText(fromName, doc.label, toName, doc.tags ?? [], doc.type, doc.description, doc.properties));
+                    await col<EdgeDoc>(`${mid}_edges`).updateOne(
+                      { _id: doc._id },
+                      { $set: { embedding: result.vector, embeddingModel: result.model } },
+                    );
+                    reindexed++;
+                  } catch { errors++; }
+                }
+                cursor = batch[batch.length - 1]?._id ?? null;
+              }
+            }
+
+            // Re-embed chrono (type + status + title + tags + description + properties)
+            {
+              let cursor: string | null = null;
+              // eslint-disable-next-line no-constant-condition
+              while (true) {
+                const q: Record<string, unknown> = cursor ? { _id: { $gt: cursor } } : {};
+                const batch: ChronoEntry[] = await col<ChronoEntry>(`${mid}_chrono`)
+                  .find(asFilter<ChronoEntry>(q), { projection: { _id: 1, title: 1, type: 1, status: 1, description: 1, tags: 1, properties: 1 } })
+                  .sort({ _id: 1 })
+                  .limit(BATCH)
+                  .toArray() as ChronoEntry[];
+                if (batch.length === 0) break;
+                for (const doc of batch) {
+                  try {
+                    const result = await embed(chronoEmbedText(doc.title, doc.type, doc.status, doc.description, doc.tags ?? [], doc.properties));
+                    await col<ChronoEntry>(`${mid}_chrono`).updateOne(
+                      { _id: doc._id },
+                      { $set: { embedding: result.vector, embeddingModel: result.model } },
+                    );
+                    reindexed++;
+                  } catch { errors++; }
+                }
+                cursor = batch[batch.length - 1]?._id ?? null;
+              }
+            }
+
+            // Re-embed files (path + entity names + tags + description + property values)
+            {
+              let cursor: string | null = null;
+              // eslint-disable-next-line no-constant-condition
+              while (true) {
+                // Exclude chunk records (parentFileId set) — they have their own embedding logic
+                const q: Record<string, unknown> = cursor
+                  ? { _id: { $gt: cursor }, parentFileId: { $exists: false } }
+                  : { parentFileId: { $exists: false } };
+                const batch: FileMetaDoc[] = await col<FileMetaDoc>(`${mid}_files`)
+                  .find(asFilter<FileMetaDoc>(q), { projection: { _id: 1, path: 1, tags: 1, description: 1, properties: 1, entityIds: 1 } })
+                  .sort({ _id: 1 })
+                  .limit(BATCH)
+                  .toArray() as FileMetaDoc[];
+                if (batch.length === 0) break;
+                for (const doc of batch) {
+                  try {
+                    const entityIds: string[] = Array.isArray(doc.entityIds) ? doc.entityIds : [];
+                    const entityDocs = entityIds.length > 0
+                      ? await col<EntityDoc>(`${mid}_entities`)
+                          .find(asFilter<EntityDoc>({ _id: { $in: entityIds } }), { projection: { name: 1 } })
+                          .toArray() as Array<{ name: string }>
+                      : [];
+                    const entityNames = entityDocs.map(e => e.name);
+                    // `excerpt` included, or a reindex would silently re-embed every converted document
+                    // without the document's own text — dropping exactly the phrases a reader searches for.
+                    const result = await embed(fileEmbedText(doc.path, doc.tags ?? [], doc.description, doc.properties, entityNames, doc.excerpt));
+                    await col<FileMetaDoc>(`${mid}_files`).updateOne(
+                      { _id: doc._id },
+                      { $set: { embedding: result.vector, embeddingModel: result.model } },
+                    );
+                    reindexed++;
+                  } catch { errors++; }
+                }
+                cursor = batch[batch.length - 1]?._id ?? null;
+              }
+            }
+
+              clearReindexFlag(mid);
+            }
+        log.info(`Reindex completed for space '${spaceId}': reindexed=${reindexed}, errors=${errors}`);
+      } catch (err) {
+        log.error(`Reindex job failed for space '${spaceId}': ${String(err)}`);
+      } finally {
+        reindexJobRunning = false;
+        reindexInProgress.set(0);
+      }
+    })();
+  });
+}

--- a/testing/standalone/document-description.test.js
+++ b/testing/standalone/document-description.test.js
@@ -159,6 +159,7 @@ describe('provenance is recorded, not assumed', () => {
   it('a reindex re-embeds the excerpt instead of dropping it', () => {
     // The whole-space reindex builds its own embed text. Missing the excerpt there would silently strip
     // the document's own words out of every converted record's embedding.
-    assert.match(src('server/src/api/brain/search.ts'), /fileEmbedText\([^)]*doc\.excerpt\)/);
+    // The reindex loops moved to `brain/reindex.ts`; the guarantee is unchanged.
+    assert.match(src('server/src/brain/reindex.ts'), /fileEmbedText\([^)]*doc\.excerpt\)/);
   });
 });

--- a/testing/standalone/reindex-embeds-the-same-text.test.js
+++ b/testing/standalone/reindex-embeds-the-same-text.test.js
@@ -34,14 +34,21 @@ import { readFileSync } from 'node:fs';
 
 const stripComments = (t) => t.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
 
-/** The reindex handler, sliced out of the read/analytics router. */
-function reindexHandler() {
-  const src = stripComments(readFileSync('server/src/api/brain/search.ts', 'utf8'));
-  const start = src.indexOf("searchRouter.post('/spaces/:spaceId/reindex'");
-  assert.ok(start > 0, 'the reindex route moved — re-point this gate at wherever the loop now lives');
-  // To the end of the file or the next route, whichever comes first.
-  const next = src.indexOf('searchRouter.', start + 20);
-  return src.slice(start, next > 0 ? next : src.length);
+/**
+ * The five loops, wherever they live.
+ *
+ * They were inline in the route handler and now sit in `brain/reindex.ts`, so this reads the module. The route's own
+ * obligation — that it still DELEGATES rather than growing its own loop back — is a separate assertion below, because
+ * re-pointing a gate at moved code and forgetting the place it moved from is how a check quietly covers half of what
+ * it used to.
+ */
+const WORK = 'server/src/brain/reindex.ts';
+
+function reindexLoops() {
+  const src = stripComments(readFileSync(WORK, 'utf8'));
+  const start = src.indexOf('export function startReindex');
+  assert.ok(start > 0, `the reindex work moved out of ${WORK} — re-point this gate at wherever the loops now live`);
+  return src.slice(start);
 }
 
 /**
@@ -60,12 +67,12 @@ const BUILDERS = [
 ];
 
 describe('a reindex reproduces what the write path embedded', () => {
-  const handler = reindexHandler();
+  const handler = reindexLoops();
 
-  it('found the handler, and it is the whole loop rather than a stub', () => {
+  it('found the loops, and they are the whole job rather than a stub', () => {
     // Floors it: if the slice were empty or tiny, every check below would pass on nothing. The five loops are
-    // hundreds of lines today, which is exactly why they are being extracted.
-    assert.ok(handler.length > 3000, `the sliced handler is only ${handler.length} chars — the slice is wrong`);
+    // hundreds of lines, which is why they were extracted rather than duplicated for a second surface.
+    assert.ok(handler.length > 3000, `the sliced work is only ${handler.length} chars — the slice is wrong`);
   });
 
   it('every collection is re-embedded through its own write-path builder', () => {
@@ -80,11 +87,25 @@ describe('a reindex reproduces what the write path embedded', () => {
   it('the builders come from the shared module, not re-implemented locally', () => {
     // The other way to break the pairing above: keep the name, declare it here. A local `const edgeEmbedText = …`
     // would satisfy the regex and embed whatever it liked.
-    const src = readFileSync('server/src/api/brain/search.ts', 'utf8');
+    const src = readFileSync(WORK, 'utf8');
     for (const [, builder] of BUILDERS) {
       assert.match(src, new RegExp(`import \\{[^}]*\\b${builder}\\b[^}]*\\} from '[^']*embed-text\\.js'`, 's'),
-        `${builder} must be imported from brain/embed-text.js, not declared in the route file`);
+        `${builder} must be imported from brain/embed-text.js, not declared alongside the loops`);
     }
+  });
+
+  it('the ROUTE still delegates, rather than growing its own loop back', () => {
+    // The other half of re-pointing this gate. Everything above now reads `brain/reindex.ts`, so a handler that
+    // re-implemented the re-embed inline would satisfy all of it while embedding whatever it liked. Asserted where the
+    // route is: it must call `startReindex`, and must build no embed text of its own.
+    const route = stripComments(readFileSync('server/src/api/brain/search.ts', 'utf8'));
+    const at = route.indexOf("searchRouter.post('/spaces/:spaceId/reindex'");
+    assert.ok(at > 0, 'the reindex route is gone — if it moved, re-point this assertion too');
+    const next = route.indexOf('searchRouter.', at + 20);
+    const handlerSrc = route.slice(at, next > 0 ? next : route.length);
+    assert.match(handlerSrc, /startReindex\(/, 'the route must delegate the work');
+    assert.doesNotMatch(handlerSrc, /\bembed\(/, 'the route must not embed anything itself');
+    assert.doesNotMatch(handlerSrc, /EmbedText\(/, 'nor build embed text — that is the shared module’s job');
   });
 
   it('the file branch passes `excerpt`, or a reindex drops every document body', () => {

--- a/testing/standalone/reindex-refuses-a-proxy.test.js
+++ b/testing/standalone/reindex-refuses-a-proxy.test.js
@@ -29,14 +29,16 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
 const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
-const search = () => strip(readFileSync('server/src/api/brain/search.ts', 'utf8'));
+// The refusal moved into `planReindex` so both surfaces make it; the route only turns it into a status.
+const search = () => strip(readFileSync('server/src/brain/reindex.ts', 'utf8'));
 const spaces = () => strip(readFileSync('server/src/api/spaces.ts', 'utf8'));
 
 const handler = () => {
   const s = search();
-  const i = s.indexOf("searchRouter.post('/spaces/:spaceId/reindex'");
-  assert.ok(i > 0, 'the reindex route moved — re-point this test');
-  return s.slice(i, s.indexOf('setImmediate', i));
+  const i = s.indexOf('export function planReindex');
+  assert.ok(i > 0, 'planReindex moved — re-point this test at wherever the refusal is decided');
+  // To the end of the decision function: `startReindex` is the work, and nothing after it is a refusal.
+  return s.slice(i, s.indexOf('export function startReindex', i));
 };
 
 describe('a proxy is refused', () => {
@@ -44,7 +46,11 @@ describe('a proxy is refused', () => {
     const h = handler();
     assert.match(h, /space\.proxyFor && space\.proxyFor\.length > 0/,
       'an empty proxyFor array is not a proxy — treating it as one would refuse a normal space');
-    assert.match(h, /res\.status\(400\)/, 'a proxy must be refused, not started');
+    assert.match(h, /status: 400/, 'a proxy must be refused, not started');
+    // And the route must still send that status rather than inventing one.
+    const route = strip(readFileSync('server/src/api/brain/search.ts', 'utf8'));
+    assert.match(route, /res\.status\(decision\.refusal\.status\)\.json\(decision\.refusal\.body\)/,
+      'the route must answer with the refusal it was given, status and body both');
   });
 
   it('the message names the member spaces', () => {
@@ -71,9 +77,13 @@ describe('a proxy is refused', () => {
   it('nothing is marked running before the refusal', () => {
     // The flag is a global singleton. Setting it and then returning early would block every real reindex on
     // the instance until a restart — a worse bug than the one being fixed.
-    const h = handler();
-    assert.ok(h.indexOf('res.status(400)') < h.indexOf('reindexJobRunning = true'),
-      'the proxy refusal must not leave the singleton flag set');
+    // Stronger than the ordering check it replaces: the decision function does not SET the flag anywhere, so no
+    // refusal can leave it set. Taking the guard is `startReindex`'s job, and it is only reachable with a plan.
+    assert.doesNotMatch(handler(), /reindexJobRunning = true/,
+      'planReindex must not take the singleton — a refusal that set it would block every reindex until restart');
+    const work = search();
+    assert.match(work.slice(work.indexOf('export function startReindex')), /reindexJobRunning = true/,
+      'startReindex is where the guard is taken');
   });
 });
 


### PR DESCRIPTION
## What this is

Last of the three extractions B-2 needed, and the only one where **nothing existed to wrap**: the re-embedding work
was written inline in the route handler as five near-identical batch loops, each with its own projection, its own
`*EmbedText` builder and its own per-record error tolerance.

| | before | after |
|---|---|---|
| `server/src/api/brain/search.ts` | 784 lines | **588** |

**No behaviour change.** The two suites from #853, written against the unmoved route, pass unchanged.

## The split

`server/src/brain/reindex.ts` — `planReindex` decides (404 · the proxy 400 · the single-job 409), `startReindex` runs.

**`memberIds` is passed in rather than resolved inside**, because scope resolution differs per surface: REST narrows by
request, MCP by the token's accessible spaces. Re-deriving it in the module would be a second place for the two to
disagree about which spaces a token may touch — and that is the argument the tool PR has to get right.

## The part worth reviewing: what had to move *with* the work

**The guard and the metric.** `reindexJobRunning` was module state in the router. A second surface calling the loop
directly would have run a concurrent job the guard could not see — and `reindexInProgress` would have been left at
**1 by whichever job finished second**, so the gauge would report a reindex running forever on an instance with none.

`startReindex` returns as soon as the job is scheduled and never awaits it, keeping the contract the route already had:
`status: 'started'` with zeroed counters, work on the next turn, headers flushed immediately. Awaiting it would answer
the same 200 and turn a multi-minute job into a request timeout.

## Two gates got stronger, not just re-pointed

That is the outcome to aim for when a check has to follow moved code:

- **The proxy gate** asserted that `res.status(400)` appeared *before* `reindexJobRunning = true`. It now asserts the
  decision function **never sets the flag at all** — an absence, which cannot be satisfied by reordering — plus that
  `startReindex` is where the guard is taken.
- **The builder gate** now reads the module, so on its own it would pass for a route that re-grew its own loop. It
  gained the other half: the route must call `startReindex`, and must build no embed text itself.

Also re-pointed: the `document-description` excerpt check, and the `reindex-refuses-a-proxy` slice. The dead
`*EmbedText` import left behind in the router was removed rather than left to rot — it is exactly the leftover that
makes the next reader think the route still embeds.

## Verification

Serially, on a rebuilt image:

```
reindex-contract + brain + proxy-spaces   ℹ tests 237   ℹ pass 237   ℹ fail 0
```

Plus `npm run preflight` green after replaying onto `main`.

**One process note, since it affected this branch:** the push ran while preflight was failing, because I chained
`preflight | grep … && git push` and `&&` saw grep's exit code rather than preflight's. The failure was
`todo:check` on the gitignored plan file — no repo content was wrong, and preflight is green on the pushed tree — but
the chaining is what let it through.

## What follows

The `reindex` tool, in its own PR. When it lands, `REST_ONLY_CAPABILITIES` is **empty**.

🤖 Generated with Claude Code
