### PR TITLE
fix(security): space meta, completeness and type schemas ignored token scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Security
+- **Three space read routes served a space's schema, purpose and usage notes to any authenticated token, regardless of
+  its scope.** A token scoped to one space could read another's `meta`, its completeness report and any individual type
+  schema. Found while verifying a `404`/`403` asymmetry breituai-platform reported from a token-scoping proof run — the
+  asymmetry was something else entirely, and this was underneath it.
+  - `GET /api/spaces/:id/meta` · `GET /api/spaces/:id/completeness` ·
+    `GET /api/spaces/:id/meta/typeSchemas/:knowledgeType/:typeName` were mounted behind `requireAuth`, which
+    authenticates and nothing more. Every other space route uses a guard that calls `enforceSpaceScope`.
+  - **What made it a defect rather than a design choice:** the same instance filters that space out of
+    `GET /api/spaces` for the same token. It knew the scope, and three sibling routes served the space's contents
+    anyway. A schema is not nothing — type names, property names, enum values, the purpose and the usage notes are all
+    business information.
+  - **Swept: the other candidates are clean.** Thirteen routes take a space-ish `:id` under `requireAuth`; the ten in
+    `conflicts.ts`, `contradictions.ts` and `duplicates.ts` resolve through `accessibleSpaces(req, …)` and enforce
+    scope internally.
+  - **The first fix was a no-op that looked correct, and that is the reusable part.** Mounting `requireSpaceAuth`
+    changed nothing: it reads `req.params.spaceId`, these routes declare `:id`, and `enforceSpaceScope` returns TRUE
+    for an undefined id — correctly, since a route with no space in its path has no scope to check. So the guard
+    authenticated and waved the request through, reading as enforcement at the mount site. The source gate went green
+    on it; a red-team test caught it minutes later.
+  - Fixed with `requireSpaceAuthScoped(paramName)`, mirroring the existing `requireAdminMfaScoped`, bound explicitly to
+    `'id'`. `requireSpaceAuth` is now the `'spaceId'` binding of it, so no other call site changed.
+  - **Two checks, because a middleware can be right in source and wrong in its mounting.** A red-team test proves all
+    three refuse an out-of-scope token *and* that the allowed space still reads — a scoping fix that breaks the
+    permitted path is worse than the leak. A derived gate requires every `:id` space route to use a guard **bound to
+    the parameter that route declares**, which a bare `requireSpaceAuth` cannot satisfy.
+  - **The reported asymmetry is a missing route, not a mask.** `GET /api/spaces/:id` does not exist, so the app's
+    catch-all answers `{"error":"Not found"}` for every id — permitted or not. The tell is the body: the real routes
+    answer `Space 'x' not found`. Asserted in the red-team test against a space the token CAN reach, so the status
+    carries no permission information and nobody documents an asymmetry that is not there.
+
 ### Added
 - **`create_space` is an MCP tool.** Fourth of the five, and the one where "just call the existing function" was most
   tempting and most dangerous: `createSpace()` has existed all along, so a tool could have called it on day one — and

--- a/docs/integration-guide/06-spaces-api.md
+++ b/docs/integration-guide/06-spaces-api.md
@@ -395,6 +395,18 @@ Authorization: Bearer <token>
 
 Returns the full schema definition for a space along with derived stats.
 
+**Requires the token to be scoped to that space.** A token whose `spaces` allowlist excludes the space is refused with
+`403` — as are `GET /api/spaces/:id/completeness` and the single-type
+`GET /api/spaces/:id/meta/typeSchemas/:knowledgeType/:typeName`. Before 2.8.0 these three answered `200` for any
+authenticated token, which is a fixed defect rather than a behaviour to rely on: a space's `purpose`, `usageNotes` and
+type schemas are readable only by tokens that may reach the space.
+
+> **A bare space id — `/api/spaces/<id>` with no sub-path — is not an endpoint.** It answers
+> `404 {"error":"Not found"}`, the generic API catch-all, for **every** id, whether or not your token may reach it. So
+> that status carries no information about permission and must not be branched on. Use the `/meta` route above
+> instead: it answers `403` when scope refuses and `404 {"error":"Space 'x' not found"}` when the space genuinely does
+> not exist, and the two bodies are how you tell them apart.
+
 **Response** `200`:
 
 ```json

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { registerReembedRoute } from './spaces-reembed.js';
 import { registerActivityResetRoute } from './spaces-activity.js';
 import path from 'path';
-import { requireAuth, requireAdmin, requireAdminMfa, requireAdminMfaScoped } from '../auth/middleware.js';
+import { requireAuth, requireSpaceAuthScoped, requireAdmin, requireAdminMfa, requireAdminMfaScoped } from '../auth/middleware.js';
 import { globalRateLimit } from '../rate-limit/middleware.js';
 import { getConfig, saveConfig, getSecrets, getDataRoot, getSchemaLibrary, getDocumentProcessingConfig, getMediaEmbeddingConfig, getStorageConfig } from '../config/loader.js';
 import { capDocExtractionMode } from '../files/converters/extraction-level.js';
@@ -371,7 +371,7 @@ spacesRouter.put('/:id/schema', globalRateLimit, requireAdminMfaScoped('id'), as
 });
 
 // GET /api/spaces/:id/meta — read the meta block with derived stats
-spacesRouter.get('/:id/meta', globalRateLimit, requireAuth, async (req, res) => {
+spacesRouter.get('/:id/meta', globalRateLimit, requireSpaceAuthScoped('id'), async (req, res) => {
   const id = req.params['id'] as string;
   const cfg = getConfig();
   const space = cfg.spaces.find(s => s.id === id);
@@ -423,7 +423,7 @@ spacesRouter.get('/:id/meta', globalRateLimit, requireAuth, async (req, res) => 
 // Separate from `/meta` rather than folded into its `stats`: `/meta` is read on every schema edit and
 // must stay cheap, while this walks the collections. Read-only, so no audit entry — the
 // audit-route-coverage gate is about mutating verbs.
-spacesRouter.get('/:id/completeness', globalRateLimit, requireAuth, async (req, res) => {
+spacesRouter.get('/:id/completeness', globalRateLimit, requireSpaceAuthScoped('id'), async (req, res) => {
   const id = req.params['id'] as string;
   const space = getConfig().spaces.find(s => s.id === id);
   if (!space) {
@@ -440,7 +440,7 @@ const VALID_KNOWLEDGE_TYPES = new Set(['entity', 'memory', 'edge', 'chrono']);
 const MAX_TYPES_PER_KIND = 200;
 
 // GET /api/spaces/:id/meta/typeSchemas/:knowledgeType/:typeName
-spacesRouter.get('/:id/meta/typeSchemas/:knowledgeType/:typeName', globalRateLimit, requireAuth, (req, res) => {
+spacesRouter.get('/:id/meta/typeSchemas/:knowledgeType/:typeName', globalRateLimit, requireSpaceAuthScoped('id'), (req, res) => {
   const { id, knowledgeType, typeName } = req.params as { id: string; knowledgeType: string; typeName: string };
 
   if (!VALID_KNOWLEDGE_TYPES.has(knowledgeType)) {

--- a/server/src/auth/middleware.ts
+++ b/server/src/auth/middleware.ts
@@ -489,27 +489,46 @@ export async function acceptSchemaLibraryToken(
 }
 
 /**
- * Middleware that requires a valid Bearer PAT token AND that the token
- * has access to the space ID in req.params.spaceId.
+ * Middleware requiring a valid PAT **and** that the token reaches the space named by `req.params[paramName]`.
+ *
+ * ## Why the parameter name is an argument
+ *
+ * Because getting it wrong is SILENT. `enforceSpaceScope` returns `true` when the id is undefined — correctly, since
+ * a route with no space in its path has no scope to check — so a guard bound to a parameter the route does not have
+ * authenticates and waves the request through. It reads as enforcement at the mount site and enforces nothing.
+ *
+ * That is not hypothetical. Three space read routes leaked a space's schema, purpose and usage notes to any
+ * authenticated token; the first fix mounted `requireSpaceAuth` on them, which reads `spaceId`, while those routes use
+ * `:id`. The middleware was right, the mount looked right, and the leak was untouched — caught by a red-team test
+ * afterwards, not by the source gate that had just gone green.
+ *
+ * So the binding is explicit and asserted: `space-routes-honour-token-scope.test.js` requires a route declaring `:id`
+ * to use a guard bound to `'id'`, which a bare `requireSpaceAuth` cannot satisfy.
  */
-export async function requireSpaceAuth(
-  req: Request,
-  res: Response,
-  next: NextFunction,
-): Promise<void> {
-  const auth = await resolveAuthOrFail(req, res, { recordInvalidMetric: true });
-  if (!auth) return;
-  const { record, bearer } = auth;
+export function requireSpaceAuthScoped(paramName: string) {
+  return async function (req: Request, res: Response, next: NextFunction): Promise<void> {
+    const auth = await resolveAuthOrFail(req, res, { recordInvalidMetric: true });
+    if (!auth) return;
+    const { record, bearer } = auth;
 
-  const spaceId = req.params['spaceId'] as string | undefined;
-  if (!enforceSpaceScope(res, record, spaceId)) return;
-  if (!enforceAreaRung(res, record, req, spaceTargets(spaceId, record))) return;
+    const spaceId = req.params[paramName] as string | undefined;
+    if (!enforceSpaceScope(res, record, spaceId)) return;
+    if (!enforceAreaRung(res, record, req, spaceTargets(spaceId, record))) return;
 
-  authAttemptsTotal.inc({ result: 'success' });
-  attachToken(req, record, bearer);
-  req.resolvedSpaceId = spaceId;
-  next();
+    authAttemptsTotal.inc({ result: 'success' });
+    attachToken(req, record, bearer);
+    req.resolvedSpaceId = spaceId;
+    next();
+  };
 }
+
+/**
+ * Middleware that requires a valid Bearer PAT token AND that the token has access to `req.params.spaceId`.
+ *
+ * The `spaceId` binding of {@link requireSpaceAuthScoped}, kept as its own export because the brain and file routers
+ * mount it dozens of times and every one of them names the parameter `spaceId`.
+ */
+export const requireSpaceAuth = requireSpaceAuthScoped('spaceId');
 
 /**
  * Like requireAdminMfa, but also enforces the token's `spaces` allowlist

--- a/testing/red-team-tests/space-meta-respects-scope.test.js
+++ b/testing/red-team-tests/space-meta-respects-scope.test.js
@@ -1,0 +1,137 @@
+/**
+ * A scoped token cannot read a space it is not scoped to — including its SCHEMA, purpose and usage notes.
+ *
+ * ## The leak this is written for
+ *
+ * Three space read routes were mounted behind `requireAuth`, which authenticates and nothing more. Every other
+ * space-scoped route uses a guard that calls `enforceSpaceScope`. So a token scoped to one space could read another
+ * space's meta, its completeness report and any individual type schema — while the same instance correctly filtered
+ * that space out of `GET /api/spaces` for the same token.
+ *
+ * Found while verifying a 404/403 asymmetry breituai-platform reported from a scoping proof run. The asymmetry they
+ * described turned out to be a nonexistent endpoint (`GET /api/spaces/:id` does not exist, so the app's catch-all
+ * answers `{"error":"Not found"}` for every id). This was underneath it, and their run passed within one request of it.
+ *
+ * ## Why a red-team test and not an integration test
+ *
+ * The question is not "does the route work" but "can a token get something it must not". That is this suite's subject,
+ * and the assertions are written the way its neighbours are: mint a real token with a real scope, then try.
+ *
+ * A source gate lives beside it (`standalone/space-routes-honour-token-scope.test.js`) and derives the rule for every
+ * space route rather than these three. Two checks because a middleware can be right in source and wrong in mounting
+ * order, and because a fourth route added later needs catching on the day it is written.
+ *
+ * Run: node --test testing/red-team-tests/space-meta-respects-scope.test.js
+ */
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, get, del, delWithBody } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+const RUN = Date.now();
+
+const ALLOWED = `scope-ok-${RUN}`;
+const FORBIDDEN = `scope-no-${RUN}`;
+
+let adminToken;
+let scopedToken;
+let scopedTokenId;
+
+/** A GET as the SCOPED token. */
+const asScoped = (p) => get(INSTANCES.a, scopedToken, p);
+
+before(async () => {
+  adminToken = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+
+  for (const id of [ALLOWED, FORBIDDEN]) {
+    const r = await post(INSTANCES.a, adminToken, '/api/spaces', {
+      id, label: id,
+      meta: {
+        purpose: `CONFIDENTIAL directive for ${id}`,
+        usageNotes: `internal notes for ${id}`,
+        typeSchemas: { entity: { SecretType: { namingPattern: '^S-' } } },
+      },
+    });
+    assert.equal(r.status, 201, `space create failed: ${JSON.stringify(r.body)}`);
+  }
+
+  const t = await post(INSTANCES.a, adminToken, '/api/tokens', { name: `scope-probe-${RUN}`, spaces: [ALLOWED] });
+  assert.equal(t.status, 201, `token mint failed: ${JSON.stringify(t.body)}`);
+  scopedToken = t.body.plaintext;
+  scopedTokenId = t.body.token.id;
+});
+
+after(async () => {
+  if (scopedTokenId) await del(INSTANCES.a, adminToken, `/api/tokens/${scopedTokenId}`).catch(() => {});
+  for (const id of [ALLOWED, FORBIDDEN]) {
+    await delWithBody(INSTANCES.a, adminToken, `/api/spaces/${id}`, { confirm: true }).catch(() => {});
+  }
+});
+
+describe('a scoped token reaches its own space', () => {
+  // The other half of every refusal below. Without these, the file would pass just as well against a build that
+  // refused everything — and a scoping fix that breaks the allowed path is worse than the leak.
+  it('reads the meta of the space it IS scoped to', async () => {
+    const r = await asScoped(`/api/spaces/${ALLOWED}/meta`);
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal(r.body.purpose, `CONFIDENTIAL directive for ${ALLOWED}`);
+  });
+
+  it('reads its own completeness report and its own type schema', async () => {
+    assert.equal((await asScoped(`/api/spaces/${ALLOWED}/completeness`)).status, 200);
+    assert.equal((await asScoped(`/api/spaces/${ALLOWED}/meta/typeSchemas/entity/SecretType`)).status, 200);
+  });
+
+  it('sees ONLY that space in the list', async () => {
+    const r = await asScoped('/api/spaces');
+    const ids = (r.body.spaces ?? []).map(s => s.id);
+    assert.deepEqual(ids, [ALLOWED],
+      'the list route has always filtered by scope — which is what made the read routes below a defect rather than '
+      + `a design choice: got ${JSON.stringify(ids)}`);
+  });
+});
+
+describe('a scoped token is REFUSED on a space it is not scoped to', () => {
+  it('cannot read its meta — purpose, usage notes and typeSchemas are not public', async () => {
+    const r = await asScoped(`/api/spaces/${FORBIDDEN}/meta`);
+    assert.equal(r.status, 403, `leaked the meta: ${r.status} ${JSON.stringify(r.body)}`);
+    // And nothing of the space's content may appear in the refusal itself.
+    const body = JSON.stringify(r.body);
+    assert.ok(!body.includes('CONFIDENTIAL'), `the refusal echoed the purpose back: ${body}`);
+    assert.ok(!body.includes('internal notes'), `the refusal echoed the usage notes back: ${body}`);
+  });
+
+  it('cannot read its completeness report', async () => {
+    const r = await asScoped(`/api/spaces/${FORBIDDEN}/completeness`);
+    assert.equal(r.status, 403, `leaked the completeness report: ${r.status} ${JSON.stringify(r.body)}`);
+  });
+
+  it('cannot read an individual type schema', async () => {
+    // The narrowest of the three, and the one most likely to be forgotten: it is a nested path under `/meta`, so a
+    // fix applied to the two obvious routes would leave this one open.
+    const r = await asScoped(`/api/spaces/${FORBIDDEN}/meta/typeSchemas/entity/SecretType`);
+    assert.equal(r.status, 403, `leaked an individual schema: ${r.status} ${JSON.stringify(r.body)}`);
+  });
+
+  it('still cannot write to it either — the write path was never the problem', async () => {
+    const r = await post(INSTANCES.a, scopedToken, `/api/brain/spaces/${FORBIDDEN}/memories`, { fact: 'nope' });
+    assert.equal(r.status, 403, JSON.stringify(r.body));
+  });
+});
+
+describe('the reported 404 is a missing ROUTE, not a mask', () => {
+  it('GET /api/spaces/:id does not exist, so it 404s for a space the token CAN reach', async () => {
+    // breituai-platform read `GET /api/spaces/adrs -> 404 {"error":"Not found"}` as the read path masking a
+    // permission failure, and concluded reads mask while writes refuse. Asserted here against the space the token IS
+    // scoped to: still 404, so the status carries no information about permission at all. The tell is the body — the
+    // real routes answer `Space 'x' not found`, this one answers the app's catch-all `Not found`.
+    const r = await asScoped(`/api/spaces/${ALLOWED}`);
+    assert.equal(r.status, 404);
+    assert.equal(r.body?.error, 'Not found',
+      'if this route now exists, the asymmetry the partner described becomes real and needs documenting');
+  });
+});

--- a/testing/standalone/space-routes-honour-token-scope.test.js
+++ b/testing/standalone/space-routes-honour-token-scope.test.js
@@ -1,0 +1,144 @@
+/**
+ * Every route that takes a space id enforces the token's scope — derived from source, not from a list of routes.
+ *
+ * ## What happened
+ *
+ * Three READ routes were mounted behind `requireAuth`, which authenticates and nothing else. Every other
+ * space-scoped route uses `requireSpaceAuth` or `requireAdminMfaScoped`, both of which call `enforceSpaceScope`. So a
+ * token scoped to `["general"]` could read another space's schema, purpose and usage notes:
+ *
+ *     GET /api/spaces/other/meta                                  -> 200  purpose, usageNotes, typeSchemas
+ *     GET /api/spaces/other/completeness                           -> 200  per-type counts
+ *     GET /api/spaces/other/meta/typeSchemas/entity/SecretType     -> 200  the individual schema
+ *     POST /api/brain/spaces/other/memories                        -> 403  (correct)
+ *
+ * The contrast is what made it a defect rather than a design choice: the same instance filtered that space out of
+ * `GET /api/spaces` for the same token. It knew the scope perfectly well, and three sibling routes served the space's
+ * contents anyway.
+ *
+ * ## Why this gate is derived rather than a list
+ *
+ * A list of three would have been written against the routes that existed and agreed with itself. This enumerates
+ * every `spacesRouter` handler that takes `:id` and requires each to sit behind a scope-enforcing middleware — so a
+ * fourth route added later is covered on the day it is written, which is the only day it is cheap.
+ *
+ * **The middlewares are themselves derived**, by reading which exported guards in `auth/middleware.ts` call
+ * `enforceSpaceScope`. Naming them here would let a future guard that authenticates only pass this check by being
+ * added to a list, which is the same failure one level up.
+ *
+ * Run: node --test testing/standalone/space-routes-honour-token-scope.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const strip = (s) => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+const ROUTER = 'server/src/api/spaces.ts';
+const MIDDLEWARE = 'server/src/auth/middleware.ts';
+
+/**
+ * Exported guards that enforce the token's space scope, read from the middleware module.
+ *
+ * A guard qualifies when its body reaches `enforceSpaceScope`. `requireAuth` does not — it delegates to
+ * `performAuth`, which authenticates and sets `req.authToken`, and that is the whole of it.
+ */
+function scopeEnforcingGuards() {
+  const src = strip(readFileSync(MIDDLEWARE, 'utf8'));
+  const guards = [];
+  // `export function NAME(` / `export async function NAME(` / `export const NAME = ` — take the body to the next export.
+  const re = /export (?:async )?(?:function|const) (require[A-Za-z]+)\b/g;
+  const starts = [...src.matchAll(re)].map(m => ({ name: m[1], at: m.index }));
+  for (let i = 0; i < starts.length; i++) {
+    const body = src.slice(starts[i].at, starts[i + 1]?.at ?? src.length);
+    if (/enforceSpaceScope\(/.test(body)) guards.push(starts[i].name);
+  }
+  // Plus ALIASES: `export const requireSpaceAuth = requireSpaceAuthScoped('spaceId')` enforces scope by being a
+  // binding of one that does. Resolved rather than listed, because the alias is how most routes mount it — and
+  // because a detector that missed it would call every brain route unguarded and be ignored for crying wolf.
+  for (const m of src.matchAll(/export const (require[A-Za-z]+)\s*=\s*(require[A-Za-z]+)\(/g)) {
+    if (guards.includes(m[2]) && !guards.includes(m[1])) guards.push(m[1]);
+  }
+  return guards;
+}
+
+/**
+ * Every `spacesRouter.<verb>('<path>', <middlewares…>` whose path takes a space id.
+ *
+ * The middleware list is captured with `[\s\S]*?` up to `(req`, NOT with `[^)]*?`. The first version used the latter
+ * and stopped at the first closing paren — so every route guarded by `requireAdminMfaScoped('id')` was skipped, and
+ * the sweep silently ran over the three routes that happened to have paren-free guards: exactly the three that were
+ * broken. It reported them fixed and said nothing about the other ten.
+ *
+ * The floor assertion below is what caught that, which is the entire reason it is there.
+ */
+function spaceIdRoutes() {
+  const src = strip(readFileSync(ROUTER, 'utf8'));
+  const out = [];
+  const re = /spacesRouter\.(get|post|put|patch|delete)\(\s*'([^']*)'\s*,([\s\S]*?)(?:async )?\(req/g;
+  let m;
+  while ((m = re.exec(src)) !== null) {
+    const [, verb, path, middlewares] = m;
+    if (!path.includes(':id')) continue;    // `/` and `/reorder` take no space id
+    out.push({ verb: verb.toUpperCase(), path, middlewares });
+  }
+  return out;
+}
+
+describe('a space route cannot be reached by a token that is not scoped to that space', () => {
+  const guards = scopeEnforcingGuards();
+  const routes = spaceIdRoutes();
+
+  it('found the guards and the routes — or every check below is vacuous', () => {
+    assert.ok(guards.includes('requireSpaceAuth'), `requireSpaceAuth must enforce scope; found ${JSON.stringify(guards)}`);
+    assert.ok(guards.includes('requireAdminMfaScoped'), `requireAdminMfaScoped must enforce scope; found ${JSON.stringify(guards)}`);
+    assert.ok(!guards.includes('requireAuth'),
+      'requireAuth appears to enforce space scope now — if that is true this whole gate is obsolete, and if it is '
+      + 'not, the detector is wrong');
+    assert.ok(routes.length >= 8, `only ${routes.length} space-id routes found in ${ROUTER} — the parser is wrong`);
+  });
+
+  it('every space-id route sits behind a scope-enforcing guard', () => {
+    const open = routes
+      .filter(r => !guards.some(g => new RegExp(`\\b${g}\\b`).test(r.middlewares)))
+      .map(r => `${r.verb} ${r.path}`);
+    assert.deepEqual(open, [],
+      'these take a space id and never check whether the token may reach that space, so any authenticated token can '
+      + 'read or act on any space — while `GET /api/spaces` correctly hides it from the same token:\n  '
+      + open.join('\n  '));
+  });
+
+  it('and the guard is BOUND to the parameter that route actually declares', () => {
+    // The assertion this file was missing, and the reason the first fix shipped as a no-op that looked correct.
+    //
+    // `enforceSpaceScope` returns TRUE when the id is undefined — right for a route with no space in its path, fatal
+    // for a guard bound to the wrong parameter name. Mounting `requireSpaceAuth` (which reads `spaceId`) on a route
+    // declaring `:id` authenticates and waves the request through. The previous version of this gate checked the
+    // guard's NAME, went green, and the leak was completely untouched; a red-team test caught it minutes later.
+    //
+    // So: a route declaring `:id` must use a guard bound to `'id'`. Derived from the path, not from a list.
+    const wrong = [];
+    for (const r of routes) {
+      const param = r.path.includes(':spaceId') ? 'spaceId' : 'id';
+      const boundHere = new RegExp(`\\((?:'${param}'|"${param}")\\)`).test(r.middlewares);
+      // A bare `requireSpaceAuth` is the `spaceId` binding, so it is correct only on a `:spaceId` route.
+      const bareSpaceIdGuard = /\brequireSpaceAuth\b(?!Scoped)/.test(r.middlewares);
+      const ok = boundHere || (param === 'spaceId' && bareSpaceIdGuard);
+      if (!ok) wrong.push(`${r.verb} ${r.path} — declares :${param}, guard not bound to it`);
+    }
+    assert.deepEqual(wrong, [],
+      'these mount a scope guard that reads a parameter the route does not declare. `enforceSpaceScope` passes on an '
+      + 'undefined id, so the guard authenticates and enforces NOTHING — it reads as protection at the mount site:\n  '
+      + wrong.join('\n  '));
+  });
+
+  it('the three that leaked are specifically covered', () => {
+    // Not the mechanism — the mechanism is the derived check above. These three are named because they are the ones
+    // that shipped wrong, and a regression on exactly them is the thing most worth failing loudly.
+    for (const path of ['/:id/meta', '/:id/completeness', '/:id/meta/typeSchemas/:knowledgeType/:typeName']) {
+      const r = routes.find(x => x.path === path && x.verb === 'GET');
+      assert.ok(r, `GET ${path} is gone — if it moved, re-point this assertion`);
+      assert.ok(guards.some(g => new RegExp(`\\b${g}\\b`).test(r.middlewares)),
+        `GET ${path} must enforce the token's space scope — it leaked a space's schema and purpose without it`);
+    }
+  });
+});


### PR DESCRIPTION
## The leak

A token scoped to one space could read **another space's schema, purpose and usage notes**. Reproduced on a scratch
instance with a token scoped to `["probe-ok"]`:

```
GET /api/spaces/probe-no/meta                                 200  purpose: "SECRET", usageNotes, typeSchemas
GET /api/spaces/probe-no/completeness                         200  per-type counts
GET /api/spaces/probe-no/meta/typeSchemas/entity/SecretType    200  the individual schema
POST /api/brain/spaces/probe-no/memories                      403  (correct)
GET /api/spaces                                               ['probe-ok']  — correctly hidden
```

All three were mounted behind `requireAuth`, which authenticates and nothing more. Every other space route uses a guard
that calls `enforceSpaceScope`.

**What makes it a defect rather than a design choice:** the last line. The same instance filters that space out of the
list for the same token — it knows the scope perfectly well, and three sibling routes served the space's contents
anyway. A schema is not nothing: type names, property names, enum values, the purpose and the usage notes are all
business information.

Found while verifying a `404`/`403` asymmetry breituai-platform reported from a token-scoping proof run. The asymmetry
turned out to be something else (below); this was underneath it, one request away from what they ran.

## Swept, not spot-fixed

Thirteen routes take a space-ish `:id` under `requireAuth`. The ten in `conflicts.ts`, `contradictions.ts` and
`duplicates.ts` all resolve through `accessibleSpaces(req, …)` and so enforce scope internally. Only these three did not.

## The part worth reading: my first fix was a no-op that looked correct

Mounting `requireSpaceAuth` on the three routes changed **nothing**:

- it reads `req.params.spaceId`;
- these routes declare `:id`;
- `enforceSpaceScope` returns `true` when the id is undefined — correctly, since a route with no space in its path has
  no scope to check.

So the guard authenticated and waved the request through, while reading as enforcement at the mount site. **The source
gate I had just written went green on it.** The red-team test caught it against a rebuilt image, minutes later.

The fix is therefore an explicit binding: `requireSpaceAuthScoped(paramName)`, mirroring the existing
`requireAdminMfaScoped`, bound to `'id'`. `requireSpaceAuth` is now the `'spaceId'` binding of it, so no other call
site changed.

## Two checks, because a middleware can be right in source and wrong in its mounting

- **Red-team** (`space-meta-respects-scope.test.js`): all three refuse an out-of-scope token, the refusal does not echo
  the purpose or notes back, **and the allowed space still reads**. Every refusal is paired with an acceptance — a
  scoping fix that breaks the permitted path is worse than the leak.
- **Derived gate** (`space-routes-honour-token-scope.test.js`): every `:id` space route must use a guard **bound to the
  parameter that route declares**. A bare `requireSpaceAuth` cannot satisfy it. The scope-enforcing guards are
  themselves derived by reading which exports reach `enforceSpaceScope`, including alias bindings, so a future
  authenticate-only guard cannot pass by being added to a list.

**Its floor assertion earned its place immediately.** The first parser captured middlewares with `[^)]*?`, stopped at
the first `)`, skipped every `requireAdminMfaScoped('id')` route, and swept only the three paren-free ones — the three
that were already broken. It would have reported the tree clean while covering nothing else.

## The reported asymmetry is a missing route, not a mask

`/api/spaces/<id>` with no sub-path is **not an endpoint**, so the app's catch-all answers `{"error":"Not found"}` for
every id, permitted or not. The tell is the body — the real routes answer `Space 'x' not found`. Asserted in the
red-team test against a space the token *can* reach, so the status is shown to carry no permission information and
nobody documents an asymmetry that is not there.

## Behaviour change

**A token that could read another space's schema now gets 403.** That is the point, but a client relying on it —
accidentally, since nothing documented it — would notice. `06-spaces-api.md` now states the scope requirement, and
which status means which.

## Verification

On a rebuilt image:

```
red-team suite (8 new)                                      ℹ tests 283  ℹ pass 283  ℹ fail 0
spaces + type-schema-crud + proxy-spaces + meta-contract     ℹ tests 110  ℹ pass 110  ℹ fail 0
```

Plus `npm run preflight` green.

🤖 Generated with Claude Code
