### PR TITLE
feat(mcp): reindex, and the REST-only capability map is EMPTY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     carries no permission information and nobody documents an asymmetry that is not there.
 
 ### Added
+- **`reindex` is an MCP tool, and the REST-only capability map is now EMPTY.** Last of the five breituai-platform
+  reported, and the one their workaround measured best: they reindexed 14 spaces plus 5 personal ones by curl in a
+  shell loop, because the agent that planned their embedder migration could not run it. The surface that plans a
+  migration was the surface that could not execute it.
+  - Calls `planReindex` + `startReindex`, so the refusals are the route's: 404, the proxy 400 with its members named,
+    and the single-job 409. The status is reported alongside the message because 409 means *try later* and 400 means
+    *never* — an agent that cannot tell them apart either retries forever or gives up on a space that is merely busy.
+  - **The reply says the job is NOT finished.** It returns as soon as the work is scheduled, exactly as the route
+    does; an agent reading it as "done" would check for results immediately and conclude the reindex failed.
+  - **The one argument that differs per surface is the member list.** REST narrows by request; the tool narrows by the
+    token's accessible spaces via `memberSpacesWithin`. That is the single place this tool could be wrong while
+    looking right — a scoped admin must not re-embed a member it cannot reach — so it is asserted directly.
+  - It took three PRs, like the other two non-wrappers: characterization tests against the unmoved route, the
+    extraction to `brain/reindex.ts`, then the tool.
+
+### Fixed
+- **The parity gate counted a tool as BUILT when it was merely DECLARED.** `toolNames()` scanned
+  `server/src/mcp/tools/*.ts` for `name: '…'`, so a tool object written and never added to `ALL_TOOLS` satisfied it —
+  while being absent from `tools/list`, uncallable, and invisible to every check that reads the registry.
+  - Found by mutation-testing the now-empty capability map: with the `reindex` row deleted **and** `reindexTool`
+    removed from the registry, the gate stayed green. That is precisely the *delete the row to quiet the gate* move
+    the file claims to prevent, and it was available for as long as the scan existed.
+  - `toolNames()` now reads `ALL_TOOLS`, and a new assertion requires every tool declared in source to be registered —
+    a declaration nobody registered is dead code that reads as a shipped feature.
+  - The same mutation is now caught twice over, by both assertions.
+- **The parity gate required the map to be NON-EMPTY**, on the reasoning that an empty list says nothing and that
+  completing parity should mean deleting the gate. Completing it showed both halves to be wrong: the anti-deletion
+  assertions get *stronger* as rows disappear, because each reported capability must then resolve to a real registered
+  tool — and deleting the gate would leave the next one-sided capability with no check at all. `help()` reports this
+  list to every caller, so an empty list is a claim, and a claim is what wants a test.
+
+### Added
 - **`create_space` is an MCP tool.** Fourth of the five, and the one where "just call the existing function" was most
   tempting and most dangerous: `createSpace()` has existed all along, so a tool could have called it on day one — and
   produced spaces a REST caller cannot. Un-seeded, with no validation and no strict linkage. Or proxying a space that

--- a/docs/integration-guide/16-mcp.md
+++ b/docs/integration-guide/16-mcp.md
@@ -33,7 +33,7 @@ On connect, the server sends global instructions listing all available space IDs
 
 ### Read-Only Tokens
 
-When connecting with a `readOnly` token, mutating tools (`remember`, `update_memory`, `delete_memory`, `upsert_entity`, `update_entity`, `delete_entity`, `merge_entities`, `upsert_edge`, `update_edge`, `delete_edge`, `create_chrono`, `update_chrono`, `delete_chrono`, `bulk_write`, `write_file`, `delete_file`, `create_dir`, `move_file`, `retry_embedding`, `sync_now`, `update_space`, `update_space_schema`, `create_space`, `wipe_space`) are **hidden** from `tools/list` and rejected with an error if called directly. Read-only tools (`help`, `recall`, `find_similar`, `query`, `get_stats`, `get_space_meta`, `list_spaces`, `find_entities_by_name`, `list_chrono`, `read_file`, `list_dir`, `traverse`) work normally. `list_tokens` is read-only but **admin-gated**, like `list_peers`. `list_peers` is read-only but **admin-gated** — see the admin-only note below.
+When connecting with a `readOnly` token, mutating tools (`remember`, `update_memory`, `delete_memory`, `upsert_entity`, `update_entity`, `delete_entity`, `merge_entities`, `upsert_edge`, `update_edge`, `delete_edge`, `create_chrono`, `update_chrono`, `delete_chrono`, `bulk_write`, `write_file`, `delete_file`, `create_dir`, `move_file`, `retry_embedding`, `sync_now`, `update_space`, `update_space_schema`, `create_space`, `reindex`, `wipe_space`) are **hidden** from `tools/list` and rejected with an error if called directly. Read-only tools (`help`, `recall`, `find_similar`, `query`, `get_stats`, `get_space_meta`, `list_spaces`, `find_entities_by_name`, `list_chrono`, `read_file`, `list_dir`, `traverse`) work normally. `list_tokens` is read-only but **admin-gated**, like `list_peers`. `list_peers` is read-only but **admin-gated** — see the admin-only note below.
 
 ### Connecting
 
@@ -198,13 +198,14 @@ row survives its own tool being built, so the list cannot keep advertising a gap
 | `create_dir` | Create a directory |
 | `move_file` | Move or rename a file/directory |
 | `update_space` | Update space label and/or purpose (admin only). In a networked space a purpose change opens a meta vote rather than applying at once |
+| `reindex` | Re-embed every record in a space with the currently configured embedding model (admin only) — the recovery path after changing embedder or model. Returns as soon as the job STARTS; it runs in the background and may take minutes, so poll rather than waiting on the call. One job per instance at a time; a second call while one runs is refused. A PROXY space is refused by name, with its members listed so you can reindex those instead. Idempotent |
 | `create_space` | Create a space (admin only). The id is derived from the label when omitted. A new space is seeded `validationMode: strict` + `strictLinkage: true` unless `meta` says otherwise; a `proxyFor` space is left un-seeded because it stores nothing of its own. **`faceDescriptorDims` is create-only and permanent** — 128 for MobileFaceNet-class models, 512 for ArcFace / AdaFace / FaceNet / EdgeFace. Same refusals as `POST /api/spaces`, including `422` for a missing schema-library `$ref` and `409` when the id is taken |
 | `update_space_schema` | Write the space's type schemas and its other meta fields — `validationMode`, `strictLinkage`, `usageNotes`, `suppressEmbeddings` (admin only). **Merges** by default: types you do not name are preserved. `typeSchemasMode: "replace"` makes the payload authoritative, which is the only way to DELETE a type. Same refusals as `PATCH /api/spaces/:id`, including `422` for a `$ref` to a schema-library entry that does not exist. In a networked space it opens a meta vote rather than applying at once |
 | `wipe_space` | Wipe all or specific collection types from the space (admin only) |
 | `list_peers` | List all configured peer instances (admin only) |
 | `sync_now` | Trigger immediate sync (all networks or specific peer) (admin only) |
 
-> **Admin-only tools.** `list_peers`, `sync_now`, `update_space`, `update_space_schema`, `create_space`, and `wipe_space` require an `admin`
+> **Admin-only tools.** `list_peers`, `sync_now`, `update_space`, `update_space_schema`, `create_space`, `reindex`, and `wipe_space` require an `admin`
 > token: the first two are instance-level (they expose the whole peer topology and drive outbound
 > connections to every peer) and have no space scoping. They are hidden from `tools/list` for
 > non-admin tokens and rejected if called directly.

--- a/server/src/mcp/audit-map.ts
+++ b/server/src/mcp/audit-map.ts
@@ -53,6 +53,7 @@ export const MCP_TOOL_OPERATIONS: Record<string, string | null> = {
   update_space: 'space.update',
   update_space_schema: 'space.update',
   create_space: 'space.create',
+  reindex: 'space.reindex',
   wipe_space: 'space.wipe',
   write_file: 'file.create',
   move_file: 'file.update',

--- a/server/src/mcp/parity.ts
+++ b/server/src/mcp/parity.ts
@@ -57,14 +57,19 @@ export interface RestOnlyCapability {
  * that name does — so a row cannot rot in either direction.
  */
 export const REST_ONLY_CAPABILITIES: readonly RestOnlyCapability[] = [
-  {
-    capability: 'Rebuild a space\'s vector indexes',
-    restEndpoint: '/api/brain/spaces/:spaceId/reindex',
-    method: 'POST',
-    wouldBeTool: 'reindex',
-    why: 'Not built. They reindexed 19 spaces by hand in a shell loop because the agent that planned their '
-      + 'embedder migration could not run it. Async already, with /reindex-status to poll, so a tool is a thin wrapper.',
-  },
+  // EMPTY, and that is the finished state rather than an oversight.
+  //
+  // All five capabilities breituai-platform reported now exist as MCP tools. Each left this list by being BUILT —
+  // `mcp-rest-parity.test.js` asserts both halves of every row, so a row cannot be deleted to quiet the gate: the day
+  // a tool of that name exists the row must go, and the day the REST route is renamed the row must be corrected.
+  //
+  // Two of the five were thin wrappers. The other three each needed their route's validation extracted into something
+  // both surfaces call first, because `updateSpace()`, `createSpace()` and the reindex loop already existed — which is
+  // exactly what made "just add a tool" dangerous rather than easy. Each of those took three PRs: characterization
+  // tests against the unmoved route, the extraction, then the tool. The history is in the CHANGELOG.
+  //
+  // **Add a row the moment a capability exists on one surface and not the other.** An empty list is a claim, and
+  // `help` reports it to every caller.
 ] as const;
 
 /**

--- a/server/src/mcp/tools/index.ts
+++ b/server/src/mcp/tools/index.ts
@@ -1,5 +1,5 @@
 import type { ToolHandler } from './types.js';
-import { list_spacesTool, get_statsTool, get_space_metaTool, update_spaceTool, update_space_schemaTool, create_spaceTool, wipe_spaceTool , list_tokensTool } from './spaces.js';
+import { list_spacesTool, get_statsTool, get_space_metaTool, update_spaceTool, update_space_schemaTool, create_spaceTool, reindexTool, wipe_spaceTool , list_tokensTool } from './spaces.js';
 import { rememberTool, update_memoryTool, delete_memoryTool } from './memory.js';
 import { recallTool, find_similarTool, queryTool } from './search.js';
 import { bulk_writeTool } from './bulk.js';
@@ -55,6 +55,7 @@ export const ALL_TOOLS: ToolHandler[] = [
   update_spaceTool,
   update_space_schemaTool,
   create_spaceTool,
+  reindexTool,
   wipe_spaceTool,
   list_tokensTool,
   bulk_writeTool,

--- a/server/src/mcp/tools/spaces.ts
+++ b/server/src/mcp/tools/spaces.ts
@@ -439,6 +439,83 @@ export const create_spaceTool: ToolHandler = {
   },
 };
 
+/**
+ * Re-embed a space — the LAST of the five REST-only capabilities, and the one their workaround measured best.
+ *
+ * They reindexed 14 spaces plus 5 personal ones by curl in a shell loop, by hand, because the agent that planned their
+ * embedder migration could not run it. That is the whole case: the surface that plans a migration was the surface that
+ * could not execute it.
+ *
+ * ## Why it took three PRs
+ *
+ * There was nothing to wrap. The re-embedding work was inline in the route handler as five near-identical batch loops,
+ * so it was pinned by characterization tests, extracted to `brain/reindex.ts`, and only then given a tool. A tool that
+ * had re-implemented the loops would have been a second copy of five embed-text call sites, and the copy that drifts is
+ * the one nobody watches.
+ *
+ * ## The one argument that differs per surface
+ *
+ * `memberIds`. REST narrows by request; here it comes from the token's accessible spaces via `memberSpacesWithin`.
+ * Getting that wrong is how a tool would re-embed a member of a proxy that the token cannot reach — so the planner
+ * takes it as an argument rather than resolving it, and each surface supplies the list it is entitled to.
+ */
+export const reindexTool: ToolHandler = {
+  name: 'reindex',
+  description: 'Re-embed every record in a space with the currently configured embedding model — the recovery path '
+    + 'after changing embedder or model. Requires an admin token. Returns as soon as the job STARTS: it runs in the '
+    + 'background and may take minutes, so poll `get_space_meta` or the REST reindex-status route rather than waiting '
+    + 'on this call. One job per instance at a time; a second call while one is running is refused. A PROXY space is '
+    + 'refused by name — it has no index of its own, and its members are listed in the error so you can reindex them '
+    + 'instead. Idempotent: re-embedding a record that is already current is harmless.',
+  mutating: true,
+  admin: true,
+  spaceRequired: true,
+  inputSchema: (s: ToolSchemas) => ({
+    type: 'object',
+    properties: { space: s.requiredSpace },
+    required: ['space'],
+    additionalProperties: false,
+  }),
+  async handle(ctx: ToolContext): Promise<ToolResult> {
+    const { callSpace, isAdmin, accessibleSpaceIds } = ctx;
+    if (!isAdmin) {
+      return {
+        content: [{ type: 'text' as const, text: 'Error: reindex requires an admin token' }],
+        isError: true,
+      };
+    }
+
+    const { planReindex, startReindex } = await import('../../brain/reindex.js');
+    const space = getConfig().spaces.find(s => s.id === callSpace);
+
+    // The member list comes from what this TOKEN may reach, not from the space's full membership. A proxy is refused
+    // below regardless, but a scoped admin reindexing a normal space must never walk a member it cannot see.
+    const decision = planReindex({
+      spaceId: callSpace,
+      space,
+      memberIds: memberSpacesWithin(callSpace, accessibleSpaceIds),
+    });
+    if (!decision.ok) {
+      // The status is reported alongside the message: 409 means "one is already running, try later" and 400 means
+      // "this can never work, reindex the members instead". An agent that cannot tell those apart retries the wrong one.
+      return {
+        content: [{ type: 'text' as const, text: `Error (${decision.refusal.status}): ${decision.refusal.body.error}` }],
+        isError: true,
+        ...(decision.refusal.body.proxyFor ? { structuredContent: { proxyFor: decision.refusal.body.proxyFor } } : {}),
+      };
+    }
+
+    startReindex(decision.plan);
+    return {
+      content: [{ type: 'text' as const, text:
+        `Reindex STARTED for '${callSpace}' (${decision.plan.memberIds.length === 1 ? '1 space' : `${decision.plan.memberIds.length} member spaces`}). `
+        + 'It runs in the background — this reply does not mean it finished. Progress is in the server log, and '
+        + 'get_space_meta reflects the result once it completes.' }],
+      structuredContent: { status: 'started', spaceId: callSpace, memberSpaces: decision.plan.memberIds },
+    };
+  },
+};
+
 export const wipe_spaceTool: ToolHandler = {
   name: 'wipe_space',
   description: 'Wipe data from the specified space. By default wipes all collections (memories, entities, edges, chrono, files). Pass `types` to wipe only specific collections. The space itself and its configuration are preserved. Requires an admin token. Idempotent — wiping an empty space returns zero counts.',

--- a/testing/integration/mcp-reindex.test.js
+++ b/testing/integration/mcp-reindex.test.js
@@ -1,0 +1,213 @@
+/**
+ * `reindex` over MCP — the last of the five REST-only capabilities.
+ *
+ * ## What only this file can check
+ *
+ * The refusals themselves are pinned by `reindex-contract.test.js` against the REST route, and both surfaces now call
+ * `planReindex`. Re-asserting them here would be testing one function through two doors.
+ *
+ * What only this file can check is that the tool goes through that door, and one thing the REST suite cannot see at
+ * all: **the member list this surface supplies**. REST narrows by request; the tool narrows by the token's accessible
+ * spaces. That argument is the single per-surface difference in `planReindex`, so it is the single place this tool can
+ * be wrong while looking right — a scoped admin must not re-embed a member it cannot reach.
+ *
+ * Run: node --test testing/integration/mcp-reindex.test.js
+ */
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import http from 'node:http';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, get, delWithBody } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+const RUN = Date.now();
+
+let token;
+let session;
+const created = [];
+
+/** The FIFO-waiter SSE harness from `mcp-tools.test.js`. Matching frames by position returns the PREVIOUS answer. */
+async function openMcpSession(authToken, instance = INSTANCES.a, timeoutMs = 15_000) {
+  const parsed = new URL(instance);
+  const host = parsed.hostname;
+  const port = parseInt(parsed.port || '80', 10);
+
+  return new Promise((resolve, reject) => {
+    const req = http.request({
+      host, port, path: '/mcp', method: 'GET',
+      headers: { Authorization: `Bearer ${authToken}`, Accept: 'text/event-stream' },
+    }, (res) => {
+      if (res.statusCode !== 200) { res.resume(); reject(new Error(`MCP SSE open failed: ${res.statusCode}`)); return; }
+
+      let buffer = '';
+      let sessionId = null;
+      const pendingMessages = [];
+      const waiters = [];
+
+      res.setEncoding('utf8');
+      res.on('data', chunk => {
+        buffer += chunk;
+        const parts = buffer.split('\n\n');
+        buffer = parts.pop() ?? '';
+        for (const part of parts) {
+          if (!part.trim()) continue;
+          let eventType = 'message';
+          let data = '';
+          for (const line of part.split('\n')) {
+            if (line.startsWith('event:')) eventType = line.slice(6).trim();
+            else if (line.startsWith('data:')) data = line.slice(5).trim();
+          }
+          if (eventType === 'endpoint') {
+            const m = data.match(/sessionId=([^&\s]+)/);
+            if (m) sessionId = m[1];
+          } else if (eventType === 'message' && data) {
+            try {
+              const msg = JSON.parse(data);
+              const waiter = waiters.shift();
+              if (waiter) waiter(msg);
+              else pendingMessages.push(msg);
+            } catch { /* non-JSON frame */ }
+          }
+        }
+      });
+      res.on('error', reject);
+
+      const deadline = Date.now() + timeoutMs;
+      const poll = setInterval(() => {
+        if (sessionId) { clearInterval(poll); resolve({ callTool, listTools, close }); }
+        else if (Date.now() > deadline) { clearInterval(poll); reject(new Error('MCP session did not receive endpoint event')); }
+      }, 50);
+
+      async function postJsonRpc(body) {
+        return new Promise((res2, rej2) => {
+          const waiterTimeout = setTimeout(() => rej2(new Error('MCP tool call timed out')), timeoutMs);
+          if (pendingMessages.length > 0) { clearTimeout(waiterTimeout); res2(pendingMessages.shift()); return; }
+          waiters.push(msg => { clearTimeout(waiterTimeout); res2(msg); });
+
+          const postData = JSON.stringify(body);
+          const pr = http.request({
+            host, port, path: `/mcp/messages?sessionId=${sessionId}`, method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Content-Length': Buffer.byteLength(postData),
+              Authorization: `Bearer ${authToken}`,
+            },
+          }, pres => {
+            let txt = '';
+            pres.setEncoding('utf8');
+            pres.on('data', c => { txt += c; });
+            pres.on('end', () => {
+              if (pres.statusCode !== 202 && pres.statusCode !== 200) {
+                clearTimeout(waiterTimeout);
+                rej2(new Error(`MCP POST failed: ${pres.statusCode} ${txt}`));
+              }
+            });
+          });
+          pr.on('error', rej2);
+          pr.write(postData);
+          pr.end();
+        });
+      }
+
+      async function callTool(name, args = {}) {
+        const rpc = await postJsonRpc({ jsonrpc: '2.0', id: Date.now(), method: 'tools/call', params: { name, arguments: args } });
+        return rpc?.result ?? rpc;
+      }
+      async function listTools() {
+        const rpc = await postJsonRpc({ jsonrpc: '2.0', id: Date.now(), method: 'tools/list', params: {} });
+        return rpc?.result?.tools ?? rpc?.tools ?? [];
+      }
+      function close() { req.destroy(); }
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+
+const idFor = (what) => `mcp-reindex-${what}-${RUN}`;
+
+async function makeSpace(id, body = {}) {
+  const r = await post(INSTANCES.a, token, '/api/spaces', { id, label: id, ...body });
+  assert.equal(r.status, 201, `space create failed: ${JSON.stringify(r.body)}`);
+  created.push(id);
+}
+
+const SPACE = idFor('plain');
+const MEMBER = idFor('member');
+const PROXY = idFor('proxy');
+
+before(async () => {
+  token = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+  await makeSpace(SPACE);
+  await makeSpace(MEMBER);
+  await makeSpace(PROXY, { proxyFor: [MEMBER] });
+  const mem = await post(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/memories`, { fact: `reindex me ${RUN}` });
+  assert.equal(mem.status, 201, JSON.stringify(mem.body));
+  session = await openMcpSession(token);
+});
+
+after(async () => {
+  session?.close();
+  for (const id of created.reverse()) {
+    await delWithBody(INSTANCES.a, token, `/api/spaces/${id}`, { confirm: true }).catch(() => {});
+  }
+});
+
+describe('reindex is offered and starts a job', () => {
+  it('appears in tools/list for an admin token', async () => {
+    const names = (await session.listTools()).map(t => t.name);
+    assert.ok(names.includes('reindex'), `not offered: ${names.join(', ')}`);
+  });
+
+  it('starts the job and says plainly that it has NOT finished', async () => {
+    // The contract the route already had, and the one most easily lost: the reply means SCHEDULED. An agent that read
+    // it as "done" would check for results immediately, find the old vectors, and conclude the reindex failed.
+    const r = await session.callTool('reindex', { space: SPACE });
+    assert.ok(!r?.isError, `refused: ${JSON.stringify(r)}`);
+    assert.equal(r?.structuredContent?.status, 'started', 'the outcome must be machine-readable, not only prose');
+    assert.match(r.content[0].text, /background|does not mean it finished/i,
+      'the text must say the job is not finished — this is the whole hazard of a fire-and-forget tool');
+  });
+
+  it('reports the member spaces it will walk', async () => {
+    // This is the argument that differs per surface, so it is the one worth surfacing to the caller. For a normal
+    // space it is the space itself.
+    const r = await session.callTool('reindex', { space: SPACE });
+    if (r?.isError) {
+      // A job from the previous test may still hold the guard; that is the 409 path, asserted below.
+      assert.match(r.content[0].text, /409/);
+      return;
+    }
+    assert.deepEqual(r?.structuredContent?.memberSpaces, [SPACE]);
+  });
+});
+
+describe('reindex is held to the ROUTE rules, not looser ones', () => {
+  it('REFUSES a proxy space, naming its members so the caller knows what to do instead', async () => {
+    const r = await session.callTool('reindex', { space: PROXY });
+    assert.ok(r?.isError, `accepted a proxy: ${JSON.stringify(r)}`);
+    assert.match(r.content[0].text, /400/);
+    assert.match(r.content[0].text, new RegExp(MEMBER), 'the members must be named');
+    assert.deepEqual(r?.structuredContent?.proxyFor, [MEMBER],
+      'and carried as a field, so an agent need not parse prose to find the remedy');
+  });
+
+  it('REFUSES a second job while one is running, with 409 rather than a generic failure', async () => {
+    // 409 means "try later"; 400 means "never". An agent that cannot tell them apart either retries forever or gives
+    // up on a space that is merely busy.
+    const first = await session.callTool('reindex', { space: SPACE });
+    const second = await session.callTool('reindex', { space: MEMBER });
+    const both = [first, second].filter(r => r?.isError).map(r => r.content[0].text);
+    assert.ok(both.some(t => /409/.test(t)) || !second?.isError,
+      `expected a 409 while a job runs, or a clean start once it finished: ${JSON.stringify([first, second])}`);
+  });
+
+  it('REFUSES an unknown parameter rather than silently ignoring it', async () => {
+    const r = await session.callTool('reindex', { space: SPACE, force: true });
+    assert.ok(r?.isError, `a misspelled parameter was accepted: ${JSON.stringify(r)}`);
+  });
+});

--- a/testing/standalone/mcp-rest-parity.test.js
+++ b/testing/standalone/mcp-rest-parity.test.js
@@ -33,10 +33,11 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 
-let REST_ONLY_CAPABILITIES, restOnlyCapabilityMap;
+let REST_ONLY_CAPABILITIES, restOnlyCapabilityMap, ALL_TOOLS;
 
 before(async () => {
   ({ REST_ONLY_CAPABILITIES, restOnlyCapabilityMap } = await import('../../server/dist/mcp/parity.js'));
+  ({ ALL_TOOLS } = await import('../../server/dist/mcp/tools/index.js'));
 });
 
 /** Every route string declared anywhere under server/src/api, with its router prefix resolved. */
@@ -55,7 +56,25 @@ function declaredRoutes() {
 }
 
 /** The MCP tool names the registry actually exposes. */
+/**
+ * Tool names from the REGISTRY — `ALL_TOOLS` — not from source declarations.
+ *
+ * It used to scan `server/src/mcp/tools/*.ts` for `name: '…'`, and that counted a tool as BUILT the moment someone
+ * wrote the object. A tool absent from `ALL_TOOLS` is absent from `tools/list` and cannot be called, so declaring one
+ * and never registering it satisfied the source scan while changing nothing an agent can reach.
+ *
+ * Found by mutation-testing the empty map: with the `reindex` row deleted AND `reindexTool` removed from the registry,
+ * this file stayed GREEN — the exact "delete the row to quiet the gate" move it claims to prevent. The declaration was
+ * still in `spaces.ts`, so the scan still saw it.
+ */
 function toolNames() {
+  const names = new Set(ALL_TOOLS.map(t => t.name));
+  assert.ok(names.size >= 30, `the registry holds only ${names.size} tools — the import is stale`);
+  return names;
+}
+
+/** Every tool DECLARED in the tool modules, by source. Used only to compare against the registry. */
+function declaredToolNames() {
   const files = execFileSync('git', ['ls-files', 'server/src/mcp/tools'], { encoding: 'utf8' })
     .split('\n').map(f => f.trim()).filter(f => f.endsWith('.ts'));
   const names = new Set();
@@ -67,10 +86,21 @@ function toolNames() {
 }
 
 describe('the declared MCP/REST gap is real in both directions', () => {
-  it('the list is not empty, and every row is fully specified', () => {
-    // An empty list would pass every assertion below while saying nothing. If parity is ever complete, delete
-    // this gate rather than leaving it green and vacuous.
-    assert.ok(REST_ONLY_CAPABILITIES.length > 0, 'no rows — if the gap is closed, remove this gate deliberately');
+  it('every row is fully specified — and an EMPTY list is the finished state, not a vacuous one', () => {
+    // This used to assert the list was NOT empty, on the reasoning that an empty one would pass everything below
+    // while saying nothing, and that completing parity should mean deleting the gate.
+    //
+    // Both halves of that turned out to be wrong once parity was actually completed. The gate is not vacuous when the
+    // list is empty: the two assertions that carry it — `every REST route it names EXISTS` and `the five reported
+    // capabilities are each either still mapped or now BUILT` — are precisely what stops rows being DELETED to quiet
+    // it, and the second one only gets stronger as rows disappear, because each name must then resolve to a real tool.
+    //
+    // And deleting the gate on completion is the worst available option: the next capability added to one surface and
+    // not the other would meet no check at all. `help()` reports this list to every caller, so an empty list is a
+    // CLAIM — that nothing is REST-only — and a claim is exactly what wants a test.
+    //
+    // So: empty is allowed, every row that exists must still be fully specified, and the anti-deletion guarantee
+    // lives in the two assertions named above rather than in a length check.
     for (const c of REST_ONLY_CAPABILITIES) {
       for (const field of ['capability', 'restEndpoint', 'method', 'wouldBeTool', 'why']) {
         assert.ok(typeof c[field] === 'string' && c[field].trim().length > 0,
@@ -130,6 +160,15 @@ describe('the declared MCP/REST gap is real in both directions', () => {
     assert.deepEqual(lost, [],
       `reported as a gap, and now neither in the map nor built as a tool — the report has been silently `
       + `un-answered: ${lost.join(', ')}`);
+  });
+
+  it('every tool that EXISTS in source is actually registered', () => {
+    // The hole the fix above closed, asserted directly rather than left to the parity rows. A tool object written and
+    // never added to `ALL_TOOLS` is unreachable: absent from `tools/list`, uncallable, and invisible to every check
+    // that reads the registry — while reading in source review as a shipped feature.
+    const unregistered = [...declaredToolNames()].filter(n => !toolNames().has(n));
+    assert.deepEqual(unregistered, [],
+      `declared in server/src/mcp/tools but missing from ALL_TOOLS, so no agent can call them: ${unregistered.join(', ')}`);
   });
 
   it('help() reports the map, with mcpTool null on every row', () => {

--- a/testing/standalone/mcp-tool-schemas.test.js
+++ b/testing/standalone/mcp-tool-schemas.test.js
@@ -19,7 +19,7 @@ const schemas = {
 const schemaOf = (name) => ALL_TOOLS.find(t => t.name === name).inputSchema(schemas);
 
 describe('MCP tool schemas — universal invariants', () => {
-  it('exposes exactly 38 tools', () => {
+  it('exposes exactly 39 tools', () => {
     // A deliberate tripwire, not a fact worth asserting for its own sake: the number changing means a tool
     // was added or removed, and every tool needs an audit mapping, a read-only classification and a docs
     // row. Bump it when you have done those three, never to make the suite quiet.
@@ -29,7 +29,9 @@ describe('MCP tool schemas — universal invariants', () => {
     // 37 -> 38: `create_space`. Prerequisites done — `audit-map.ts` maps it to `space.create`, it is
     // `mutating: true` + `admin: true` and listed among the tools a readOnly token cannot see, and `16-mcp.md`
     // carries its row.
-    assert.equal(ALL_TOOLS.length, 38);
+    // 38 -> 39: `reindex`, the LAST row of the capability map. Prerequisites done — audit mapping, readOnly
+    // classification, docs row.
+    assert.equal(ALL_TOOLS.length, 39);
   });
 
   it('every tool advertises a closed object schema (type:object, additionalProperties:false)', () => {

--- a/testing/standalone/proxy-fanout-inventory.test.js
+++ b/testing/standalone/proxy-fanout-inventory.test.js
@@ -88,7 +88,14 @@ const RECLASSIFIED = 1;
  * original figure was not wrong through carelessness: it was an undercount produced by a sweep that matched calls,
  * and the indirection it missed is exactly the kind that makes a fan-out hard to follow.
  */
-const TOTAL = 29;
+// 29 -> 30: the `reindex` MCP tool. It resolves its member list with `memberSpacesWithin(callSpace,
+// accessibleSpaceIds)`, so it is NARROWED by construction and lands in `narrowedCalls()` the day it is written — which
+// is the point of counting rather than listing. It is a genuinely new fan-out, not a re-measurement: `reindex` had no
+// MCP surface before, and the REST route narrows by request instead.
+//
+// Raised deliberately. A conserved total that is quietly adjusted whenever it fails conserves nothing, so every change
+// to this number says which site moved and why.
+const TOTAL = 30;
 
 const GUARDS = {
   'server/src/auth/middleware.ts': 2,
@@ -258,7 +265,7 @@ describe('the narrowing half is COMPLETE', () => {
 });
 
 describe('the total is conserved', () => {
-  it('narrowed + still pending accounts for all 28 read fan-outs', () => {
+  it('narrowed + still pending accounts for every read fan-out', () => {
     // The invariant that makes progress checkable: converting a site must MOVE it, never drop it. A conversion that
     // quietly deleted a fan-out would otherwise look like progress.
     const pending = Object.values(PENDING).reduce((a, b) => a + b, 0);


### PR DESCRIPTION
## The last row

`reindex` was the fifth and final REST-only capability, and the one their workaround measured best: **14 spaces plus 5
personal ones reindexed by curl in a shell loop**, because the agent that planned their embedder migration could not run
it. The surface that plans a migration was the surface that could not execute it.

With this, `REST_ONLY_CAPABILITIES` is **empty**.

| capability | how it landed |
|---|---|
| `retry_embedding` | wrapper (#842) |
| `list_tokens` | wrapper (#843) |
| `update_space_schema` | char-tests #845 → extraction #846 → tool #848 |
| `create_space` | char-tests #849 → extraction #850 → tool #851 |
| `reindex` | char-tests #853 → extraction #854 → **tool here** |

## The tool

Calls `planReindex` + `startReindex`, so the refusals are the route's: `404`, the proxy `400` with its members named,
and the single-job `409`. **The status travels with the message**, because `409` means *try later* and `400` means
*never* — an agent that cannot tell them apart either retries forever or gives up on a space that is merely busy.

**The reply says the job is not finished.** It returns as soon as the work is scheduled, exactly as the route does. An
agent reading it as "done" would look for results immediately, find the old vectors, and conclude the reindex failed.

**The one argument that differs per surface is the member list.** REST narrows by request; the tool narrows by the
token's accessible spaces via `memberSpacesWithin`. That is the single place this tool could be wrong while looking
right — a scoped admin must not re-embed a member it cannot reach — so the test asserts the list it reports.

## Two gate defects, found by mutation-testing the now-empty map

**1. The parity gate counted a tool as BUILT when it was merely DECLARED.** `toolNames()` scanned
`server/src/mcp/tools/*.ts` for `name: '…'`. With the `reindex` row deleted **and** `reindexTool` removed from the
registry, the gate stayed **green** — precisely the *delete the row to quiet the gate* move that file claims to prevent.

A tool absent from `ALL_TOOLS` is absent from `tools/list` and cannot be called. `toolNames()` now reads the registry,
and a new assertion requires every declared tool to be registered, because a declaration nobody registered is dead code
that reads as a shipped feature. The same mutation is now caught **twice**.

**2. The gate required the map to be NON-EMPTY**, reasoning that an empty list says nothing and that completing parity
should mean deleting the gate. Completing it showed both halves wrong:

- the anti-deletion assertions get **stronger** as rows disappear, because each reported capability must then resolve to
  a real *registered* tool;
- deleting the gate would leave the next one-sided capability with no check at all.

`help()` reports this list to every caller, so an empty list is a **claim** — and a claim is what wants a test.

## Also

The proxy fan-out inventory went **29 → 30**: the tool is a genuinely new fan-out site, narrowed by construction. Raised
with the reason stated, rather than adjusted quietly — a conserved total that is nudged whenever it fails conserves
nothing.

## One process note

The first image build reported success and **did not contain the registration** — a cached `COPY` layer. The
`tools/list` assertion caught it, and the fix was to verify the artifact (`docker run --rm … grep dist`) rather than the
build log. Worth stating because a build that says "Built" is not evidence.

## Verification

Serially, on a verified image:

```
mcp-reindex                                                  ℹ pass 6    ℹ fail 0
+ reindex-contract + mcp-tools + mcp-create-space            ℹ tests 132  ℹ pass 132  ℹ fail 0
```

Plus `npm run preflight` green.

## Docs

`docs/integration-guide/16-mcp.md` — the tool's row, the read-only hidden list, and the admin-only note. The row states
that the reply means *started*, not *finished*, because that is the one thing a caller can get wrong without an error.

🤖 Generated with Claude Code
