### PR TITLE
docs(mcp): a pre-existing violation DOES block an unrelated patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Documentation
+- **The guide promised that a pre-existing schema violation never blocks an unrelated patch. It does block.** Corrected
+  in `16-mcp.md`, because the code is deliberate and the sentence was simply false — on both surfaces, which share
+  `classifyUpdateViolations`.
+  - Reproduced while investigating breituai-platform's *"a mis-click freezes records"* report: write a record with
+    `properties.status = "retired"`, remove `"retired"` from the enum, then `PATCH` only that record's `description` →
+    **422** with `introduced: []` and `preExisting: [properties.status]`. The record is uneditable until the unrelated
+    field is repaired in the same request.
+  - The doc now states that both kinds block in a `strict` space, names the consequence — **tightening a schema freezes
+    the records that no longer fit it** — and says that `warn` reports the same violations and proceeds.
+  - **Whether the behaviour should change is a decision, not a defect**, so it is parked with a recommendation rather
+    than flipped: the refusal is intentional and its message names the remedy, but a violation that is already stored
+    is not improved by refusing an unrelated edit. Documented as it is today either way, so nothing claims otherwise
+    while it is open.
+  - Their report was two items, not one: the mis-click is a layout defect in the enum editor, and the freeze is this.
+
 ### Security
 - **Three space read routes served a space's schema, purpose and usage notes to any authenticated token, regardless of
   its scope.** A token scoped to one space could read another's `meta`, its completeness report and any individual type

--- a/docs/integration-guide/16-mcp.md
+++ b/docs/integration-guide/16-mcp.md
@@ -25,9 +25,17 @@ On connect, the server sends global instructions listing all available space IDs
 >
 > **`introduced` vs `preExisting` is the field worth branching on.** `introduced` means your patch caused it —
 > fix the patch. `preExisting` means the stored record already violated the schema there and your write
-> neither caused nor fixed it, which makes this write the moment to repair it. A write is only refused for
-> what it introduces, so a pre-existing violation never blocks an unrelated patch. `content` still carries
-> the same information as a sentence, so a client that reads only text loses nothing.
+> neither caused nor fixed it.
+>
+> **In a `strict` space, BOTH block the write.** The merged record is what would be stored, so a write is refused
+> while any violation remains — including one your patch neither caused nor touched. The remedy is in the message:
+> include the offending field in the same request and the write repairs the record. `content` still carries the same
+> information as a sentence, so a client that reads only text loses nothing.
+>
+> **The consequence to plan for: tightening a schema freezes the records that no longer fit it.** Remove a value from
+> an `enum` and every stored record still carrying it is uneditable until that field is repaired — even an edit to an
+> unrelated field like `description`. Under `warn` the same violations are reported and the write proceeds. Branch on
+> `introduced` being empty to tell "my patch is fine, this record needs repair" from "my patch is wrong".
 >
 > **Tool inputs are self-describing — and enforced.** Every tool's complete input contract — each parameter, its allowed values (`enum`), numeric bounds (`minimum`/`maximum`/`default`), string limits, the filter-operator allowlist, and `additionalProperties: false` — is published in its `inputSchema` via `tools/list`. The dispatcher **validates every call against that schema before running the tool**, rejecting a non-conforming call with an `isError` result — so unknown properties, out-of-range numbers, out-of-enum values, and malformed ids are hard errors, not silently ignored or clamped. Treat `tools/list` as the authoritative, machine-readable reference and read a tool's schema before constructing arguments; the `help` tool points here too.
 


### PR DESCRIPTION
## The false sentence

`16-mcp.md` promised:

> A write is only refused for what it introduces, so a pre-existing violation never blocks an unrelated patch.

It does block. Reproduced against the API while investigating breituai-platform's *"a mis-click freezes records"*
report:

```
1. write an entity with properties.status = "retired"   (the enum allows it)   -> 201
2. remove "retired" from the enum                                              -> 200
3. PATCH that record's DESCRIPTION only                                        -> 422
   { "introduced": [], "preExisting": [ properties.status ] }
```

The record is uneditable until the unrelated field is repaired in the same request. Both surfaces behave this way —
REST and MCP share `classifyUpdateViolations`, and `blocked` is computed from **all** post-merge violations.

## What changed here

Only the documentation. It now says that in a `strict` space both kinds block, names the consequence — **tightening a
schema retroactively freezes the records that no longer fit it** — and notes that `warn` reports the same violations and
proceeds.

## Why the behaviour is not changed in this PR

Because it is deliberate and both sides have a real argument. The refusal message explains itself and names the remedy
(*"include them in this same request to repair the record"*), which is not the shape of an accident.

Against it: the violation is **already stored**, so refusing an unrelated edit does not improve the data — it only
blocks maintenance, and one schema tightening can freeze a large number of records.

So it is parked as **P-6** with a recommendation (block only on `introduced`, keep reporting `preExisting`), and the docs
are made true today either way. A doc that promises the opposite of what ships is worse than either behaviour.

## Their report was two items

- the **mis-click** — the enum editor's remove button is oversized and clips its label. Still open as a layout defect,
  and it needs a screenshot rather than a measurement.
- the **freeze** — this. Not a UI bug at all.

Splitting them is the point: fixing the CSS and closing the report would have left the freeze in place.

## Docs-only

`git diff --name-only origin/main` is `CHANGELOG.md` and `docs/integration-guide/16-mcp.md` — no `.ts`, no test, no
workflow — so per the standing rule this merges after preflight rather than waiting on CI. `markdownlint` and the full
preflight are green.

🤖 Generated with Claude Code
