### PR TITLE
fix(schema): the enum chips were unstyled, so the remove button was a raw browser button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- **The schema editor's enum chips were completely unstyled — the remove button rendered as a browser-default
+  `<button>`.** Reported by breituai-platform (2026-08-12T2230Z) as *"oversized and clip their own labels"*, and that is
+  exactly what an unstyled `<button>` inside an unstyled `<span>` looks like.
+  - **Nothing was wrong with the CSS.** `schema-type-editor.component.ts` renders `.chip-wrap`, `.chip`, `.chip-rm` and
+    `.chip-field`; its only stylesheet was `SCHEMA_MD_STYLES`, which defines none of them; and `styles.scss` has no
+    global chip rules. Angular scopes component styles, so when the editor body was extracted out of the schema TAB —
+    which does carry those rules — the styles did not follow the markup.
+  - `space-dialog.styles.ts` had even written the rule down: *"a child that renders the chip inputs needs these rules in
+    its OWN metadata"*. A comment is not a check.
+  - The chip-input rules now live once, in `shared/chip.styles.ts`. The three copies that existed
+    (`space-dialog.styles.ts`, `prop-schema-table`, `schema-library`) were **confirmed identical before consolidating**,
+    so it changed no pixels. The brain's separate chip family is deliberately left alone — folding it in would restyle
+    the brain tabs as a side effect of fixing a button.
+  - **A gate now fails when a component renders a chip class it cannot reach**, because this failure mode produces no
+    error anywhere: the template compiles, the class is present, the build is clean, and the component renders with
+    browser defaults. Same shape as an unregistered `<ph-icon name>` rendering blank.
+  - **The gate's first version did not catch the defect it was written for**, and that is worth recording: it checked
+    whether the component *imported* a stylesheet defining the class, not whether that stylesheet was in the `styles: []`
+    array. The editor still imports `CHIP_STYLES`. Verifying proximity and calling it effect — the same error as a scope
+    guard bound to the wrong parameter, found the same way, by mutation.
+  - Their report was two items. This is the trigger; the refusal it led to is documented separately.
+
 ### Documentation
 - **The guide promised that a pre-existing schema violation never blocks an unrelated patch. It does block.** Corrected
   in `16-mcp.md`, because the code is deliberate and the sentence was simply false — on both surfaces, which share

--- a/client/src/app/pages/schema-library/schema-library.component.ts
+++ b/client/src/app/pages/schema-library/schema-library.component.ts
@@ -26,6 +26,7 @@ import { PropSchemaTableComponent } from '../../shared/prop-schema-table.compone
 import { ErrorStateComponent } from '../../shared/error-state.component';
 import { httpErrorReason } from '../../core/http-error';
 import { ModalDirective } from '../../shared/modal.directive';
+import { CHIP_STYLES } from '../../shared/chip.styles';
 
 // ── Local form state ────────────────────────────────────────────────────────
 
@@ -147,21 +148,8 @@ export function entriesFromTypeSchemas(
   selector: 'app-schema-library',
   standalone: true,
   imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, PropSchemaTableComponent, ErrorStateComponent, ModalDirective],
-  styles: [`
+  styles: [CHIP_STYLES, `
     /* chip inputs — same as spaces.component.ts */
-    .chip-wrap {
-      display:flex; flex-wrap:wrap; gap:4px; align-items:center;
-      border:1px solid var(--border); border-radius:var(--radius-sm);
-      padding:4px 8px; min-height:34px; background:var(--bg-surface); cursor:text;
-    }
-    .chip {
-      display:inline-flex; align-items:center; gap:3px;
-      background:color-mix(in srgb,var(--accent) 15%,transparent);
-      color:var(--accent); border-radius:3px; padding:1px 6px; font-size:12px;
-    }
-    .chip-rm { background:none; border:none; color:var(--text-muted); cursor:pointer; padding:0 2px; font-size:14px; line-height:1; }
-    .chip-rm:hover { color:var(--danger); }
-    .chip-field { border:none; background:none; outline:none; font-size:12px; min-width:100px; flex:1; color:var(--text-primary); font-family:var(--font); padding:1px 0; }
     /* create / edit dialog */
     .dialog-backdrop { position:fixed; inset:0; background:var(--bg-scrim); display:flex; align-items:center; justify-content:center; z-index:100; }
     .dialog { background:var(--bg-primary); border:1px solid var(--border); border-radius:var(--radius-lg); padding:24px; width:92vw; max-width:980px; max-height:90vh; overflow-y:auto; }

--- a/client/src/app/pages/settings/schema-type-editor.component.ts
+++ b/client/src/app/pages/settings/schema-type-editor.component.ts
@@ -46,13 +46,17 @@ import type { KnowledgeType, PropertySchema } from '../../core/api.types';
 import type { TypeSchemaState } from './space-settings-state.service';
 import { addProp, removeProp, addEnumVal, removeEnumVal } from './type-schema-edits';
 import { SCHEMA_MD_STYLES } from './schema-styles';
+import { CHIP_STYLES } from '../../shared/chip.styles';
 
 @Component({
   selector: 'app-schema-type-editor',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [FormsModule, TranslocoPipe, PhIconComponent, HscrollTopDirective],
-  styles: [SCHEMA_MD_STYLES],
+  // CHIP_STYLES is not decoration here: this component renders `.chip-wrap`/`.chip`/`.chip-rm`/`.chip-field`, and
+  // Angular scopes styles — without it those chips render as browser defaults, which is the oversized remove
+  // button breituai-platform reported. It came loose when this editor was extracted out of the schema TAB.
+  styles: [SCHEMA_MD_STYLES, CHIP_STYLES],
   template: `
 @if (libRef(); as libRef) {
   <!-- Linked library schema — editable only after unlinking; shown read-only meanwhile. -->

--- a/client/src/app/pages/settings/space-dialog.styles.ts
+++ b/client/src/app/pages/settings/space-dialog.styles.ts
@@ -8,21 +8,10 @@
  * convention. Angular AOT statically resolves an imported const, so `styles: [SPACE_DIALOG_STYLES]`
  * compiles; if it ever could not, the build would fail loudly rather than drop the styles.
  */
+import { CHIP_STYLES } from '../../shared/chip.styles';
+
 export const SPACE_DIALOG_STYLES = `
-/* chip inputs */
-.chip-wrap {
-  display:flex; flex-wrap:wrap; gap:4px; align-items:center;
-  border:1px solid var(--border); border-radius:var(--radius-sm);
-  padding:4px 8px; min-height:34px; background:var(--bg-surface); cursor:text;
-}
-.chip {
-  display:inline-flex; align-items:center; gap:3px;
-  background:color-mix(in srgb,var(--accent) 15%,transparent);
-  color:var(--accent); border-radius:3px; padding:1px 6px; font-size:12px;
-}
-.chip-rm { background:none; border:none; color:var(--text-muted); cursor:pointer; padding:0 2px; font-size:14px; line-height:1; }
-.chip-rm:hover { color:var(--danger); }
-.chip-field { border:none; background:none; outline:none; font-size:12px; min-width:100px; flex:1; color:var(--text-primary); font-family:var(--font); padding:1px 0; }
+${CHIP_STYLES}
 /* storage bar */
 .st-bar { height:6px; border-radius:3px; background:var(--border); overflow:hidden; }
 .st-bar-fill { height:100%; border-radius:3px; transition:width .3s; }

--- a/client/src/app/shared/chip.styles.ts
+++ b/client/src/app/shared/chip.styles.ts
@@ -1,0 +1,42 @@
+/**
+ * The chip-input rules, in ONE place, because a component that renders a chip and does not carry them shows the
+ * browser's defaults instead.
+ *
+ * ## The defect that produced this file
+ *
+ * breituai-platform, 2026-08-12T2230Z: *"the schema editor's enum-value remove buttons are oversized and clip their
+ * own labels"*. They were unstyled. `schema-type-editor.component.ts` renders `.chip-wrap`, `.chip`, `.chip-rm` and
+ * `.chip-field`, and its only stylesheet was `SCHEMA_MD_STYLES`, which defines none of them — so `.chip-rm`, a
+ * `<button>`, rendered with the browser's border, background, padding and ~13px font inside a `<span>` with no
+ * inline-flex and no padding. Oversized, and colliding with the label beside it. Exactly as reported.
+ *
+ * **Nothing was wrong with the CSS; the component simply never saw it.** Angular scopes component styles, so when the
+ * editor body was extracted out of `space-schema-tab.component.ts` — which does carry these rules — the styles did not
+ * follow the markup. There are no global `.chip` rules in `styles.scss` to fall back on, and `chip-styles-reach-their-
+ * markup.test.js` now fails when a component uses a chip class it cannot reach.
+ *
+ * ## Why a shared const rather than a fourth copy
+ *
+ * `space-dialog.styles.ts` already warned about this: *"Rather than paste ~90 lines into each of the six components —
+ * five copies free to drift apart — they share this one const."* The chip block had nevertheless been copied into
+ * `prop-schema-table` and `schema-library` verbatim. Three identical copies were confirmed identical before being
+ * replaced by this one, so consolidating changed no pixels.
+ *
+ * It lives in `shared/` rather than beside the spaces dialog because the consumers span three feature areas: settings,
+ * the schema library, and the shared property table.
+ */
+export const CHIP_STYLES = `
+.chip-wrap {
+  display:flex; flex-wrap:wrap; gap:4px; align-items:center;
+  border:1px solid var(--border); border-radius:var(--radius-sm);
+  padding:4px 8px; min-height:34px; background:var(--bg-surface); cursor:text;
+}
+.chip {
+  display:inline-flex; align-items:center; gap:3px;
+  background:color-mix(in srgb,var(--accent) 15%,transparent);
+  color:var(--accent); border-radius:3px; padding:1px 6px; font-size:12px;
+}
+.chip-rm { background:none; border:none; color:var(--text-muted); cursor:pointer; padding:0 2px; font-size:14px; line-height:1; }
+.chip-rm:hover { color:var(--danger); }
+.chip-field { border:none; background:none; outline:none; font-size:12px; min-width:100px; flex:1; color:var(--text-primary); font-family:var(--font); padding:1px 0; }
+`;

--- a/client/src/app/shared/prop-schema-table.component.ts
+++ b/client/src/app/shared/prop-schema-table.component.ts
@@ -3,6 +3,7 @@ import { FormsModule } from '@angular/forms';
 import { TranslocoPipe } from '@jsverse/transloco';
 import { PropertySchema } from '../core/api.types';
 import { PhIconComponent } from './ph-icon.component';
+import { CHIP_STYLES } from './chip.styles';
 
 export interface PropSchemaRow {
   key: string;
@@ -14,7 +15,7 @@ export interface PropSchemaRow {
   selector: 'app-prop-schema-table',
   standalone: true,
   imports: [FormsModule, TranslocoPipe, PhIconComponent],
-  styles: [`
+  styles: [CHIP_STYLES, `
     .prop-table { width:100%; border-collapse:collapse; font-size:13px; }
     .prop-table th { text-align:left; font-size:11px; font-weight:600; color:var(--text-muted); padding:5px 8px; border-bottom:1px solid var(--border); }
     .prop-table td { padding:6px 8px; border-bottom:1px solid var(--border); vertical-align:middle; }
@@ -28,11 +29,6 @@ export interface PropSchemaRow {
     .req-toggle { display:inline-flex; align-items:center; gap:6px; font-size:12px; cursor:pointer; color:var(--text-muted); background:none; border:1px solid var(--border); font-family:var(--font); padding:3px 10px; border-radius:var(--radius-sm); transition:all .15s; }
     .req-toggle:hover { background:var(--bg-elevated); color:var(--text-primary); border-color:color-mix(in srgb,var(--accent) 40%,transparent); }
     .req-toggle.is-req { color:var(--warning); border-color:color-mix(in srgb,var(--warning) 50%,transparent); background:color-mix(in srgb,var(--warning) 8%,transparent); font-weight:600; }
-    .chip-wrap { display:flex; flex-wrap:wrap; gap:4px; align-items:center; border:1px solid var(--border); border-radius:var(--radius-sm); padding:4px 8px; min-height:34px; background:var(--bg-surface); cursor:text; }
-    .chip { display:inline-flex; align-items:center; gap:3px; background:color-mix(in srgb,var(--accent) 15%,transparent); color:var(--accent); border-radius:3px; padding:1px 6px; font-size:12px; }
-    .chip-rm { background:none; border:none; color:var(--text-muted); cursor:pointer; padding:0 2px; font-size:14px; line-height:1; }
-    .chip-rm:hover { color:var(--danger); }
-    .chip-field { border:none; background:none; outline:none; font-size:12px; min-width:100px; flex:1; color:var(--text-primary); font-family:var(--font); padding:1px 0; }
     .add-prop-row { display:flex; gap:8px; align-items:center; margin-top:10px; padding-top:10px; border-top:1px solid var(--border); }
   `],
   template: `

--- a/testing/standalone/chip-styles-reach-their-markup.test.js
+++ b/testing/standalone/chip-styles-reach-their-markup.test.js
@@ -1,0 +1,172 @@
+/**
+ * A component that renders a chip class can REACH a rule for it.
+ *
+ * ## The defect
+ *
+ * breituai-platform, 2026-08-12T2230Z: *"the schema editor's enum-value remove buttons are oversized and clip their own
+ * labels"*. They were unstyled. `schema-type-editor.component.ts` renders `.chip-wrap`, `.chip`, `.chip-rm` and
+ * `.chip-field`; its only stylesheet was `SCHEMA_MD_STYLES`, which defines none of them; and `styles.scss` has no global
+ * chip rules to fall back on. So `.chip-rm` — a `<button>` — rendered with the browser's own border, background, padding
+ * and font size, inside a `<span>` with no `inline-flex` and no padding.
+ *
+ * **Nothing was wrong with the CSS.** Angular scopes component styles, so when the editor body was extracted out of the
+ * schema TAB — which does carry those rules — the styles did not follow the markup. `space-dialog.styles.ts` had even
+ * written the rule down: *"a child that renders the chip inputs needs these rules in its OWN metadata"*. A comment is
+ * not a check.
+ *
+ * ## Why this failure mode needs a gate specifically
+ *
+ * It produces **no error anywhere**. The template compiles, the class attribute is present, the build is clean, and the
+ * component renders — just with browser defaults. The same shape as an unregistered `<ph-icon name>` rendering blank:
+ * invisible to every automated check, obvious only to someone looking at the pixels. Nobody looked for four days, and
+ * the partner found it.
+ *
+ * ## Derived, not listed
+ *
+ * The chip families are read from the source: every `class="chip…"` in any component template, and every `.chip…` rule
+ * in any file. A component satisfies the check when the rule is defined in its own `styles`, in a style constant it
+ * imports, or globally in `styles.scss`. So a NEW chip variant, or a new component using one, is covered on the day it
+ * is written — which is the only day it is cheap.
+ *
+ * Run: node --test testing/standalone/chip-styles-reach-their-markup.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { dirname, join, resolve } from 'node:path';
+
+const files = execFileSync('git', ['ls-files', 'client/src'], { encoding: 'utf8' })
+  .split('\n').map(f => f.trim()).filter(f => f.endsWith('.ts') && !f.endsWith('.spec.ts'));
+
+const GLOBAL_CSS = 'client/src/styles.scss';
+
+/** Every chip class used in a template, per file. */
+function chipClassesUsed(src) {
+  const used = new Set();
+  for (const m of src.matchAll(/class="([^"]*)"/g)) {
+    for (const cls of m[1].split(/\s+/)) if (/^chip(-[a-z]+)*$/.test(cls)) used.add(cls);
+  }
+  return used;
+}
+
+/** Every chip class a stylesheet body defines. */
+function chipClassesDefined(src) {
+  const defined = new Set();
+  for (const m of src.matchAll(/\.(chip(?:-[a-z]+)*)\s*(?::[a-z-]+)?\s*\{/g)) defined.add(m[1]);
+  return defined;
+}
+
+/**
+ * The stylesheets a component ACTUALLY APPLIES — the contents of its `styles: [...]` array, nothing else.
+ *
+ * The first version of this read every relative import instead, and it did not catch the defect it was written for.
+ * `schema-type-editor.component.ts` still *imports* `CHIP_STYLES`; removing it from the `styles` array is what breaks
+ * the rendering. An import is not an application, so a gate keyed on imports reports reachable when nothing is reached.
+ *
+ * That is the same mistake as a scope guard bound to the wrong parameter: it verifies PROXIMITY and calls it EFFECT.
+ * Mutation-testing found it — the gate went green on the exact shipped defect.
+ *
+ * So: take the `styles: [...]` array, and for each entry either read the inline backtick block or resolve the named
+ * constant through the file's imports and read that.
+ */
+function appliedStyleSources(file, src) {
+  const at = src.indexOf('styles: [');
+  if (at < 0) return [];
+  // To the matching `]`, counting brackets so a `[` inside a template literal cannot end it early.
+  let i = at + 'styles: ['.length, depth = 1;
+  while (i < src.length && depth > 0) {
+    if (src[i] === '[') depth++;
+    else if (src[i] === ']') depth--;
+    i++;
+  }
+  const arr = src.slice(at, i);
+
+  const out = [];
+  // Inline blocks: `styles: [\`.chip { … }\`]`.
+  for (const m of arr.matchAll(/`([^`]*)`/g)) out.push(m[1]);
+  // Named constants: resolve each through this file's own imports.
+  for (const m of arr.matchAll(/\b([A-Z][A-Z0-9_]*)\b/g)) {
+    const imp = new RegExp(`import \\{[^}]*\\b${m[1]}\\b[^}]*\\} from '(\\.[^']*)'`).exec(src);
+    if (!imp) continue;
+    const base = resolve(dirname(file), imp[1]).replace(/\\/g, '/');
+    const rel = base.slice(base.indexOf('client/src'));
+    for (const cand of [`${rel}.ts`, `${rel}/index.ts`]) {
+      try { out.push(readFileSync(cand, 'utf8')); break; } catch { /* not this one */ }
+    }
+  }
+  return out;
+}
+
+describe('a chip class in a template can reach a rule for it', () => {
+  const globalCss = readFileSync(GLOBAL_CSS, 'utf8');
+  const globalChips = chipClassesDefined(globalCss);
+
+  it('found the components to check — and the chip families they use', () => {
+    // Floors it. A parser that matched nothing would report the whole client clean.
+    const users = files.filter(f => chipClassesUsed(readFileSync(f, 'utf8')).size > 0);
+    assert.ok(users.length >= 5, `only ${users.length} components use a chip class — the parser is wrong`);
+    const all = new Set(users.flatMap(f => [...chipClassesUsed(readFileSync(f, 'utf8'))]));
+    assert.ok(all.has('chip-rm') || all.has('chip-remove'),
+      `no remove-button variant found among ${[...all].join(', ')} — that is the class that shipped unstyled`);
+  });
+
+  it('every component reaches a rule for every chip class it renders', () => {
+    const orphans = [];
+    for (const f of files) {
+      const src = readFileSync(f, 'utf8');
+      const used = chipClassesUsed(src);
+      if (used.size === 0) continue;
+
+      const reachable = new Set([
+        ...chipClassesDefined(src),                                        // its own inline styles
+        ...appliedStyleSources(f, src).flatMap(s => [...chipClassesDefined(s)]),  // a style APPLIED via styles: []
+        ...globalChips,                                                    // or a global rule
+      ]);
+      for (const cls of used) {
+        if (!reachable.has(cls)) orphans.push(`${f.replace('client/src/app/', '')} → .${cls}`);
+      }
+    }
+    assert.deepEqual(orphans, [],
+      'these render a chip class with no rule in reach, so the element falls back to browser defaults — an unstyled '
+      + '<button> is oversized and collides with the label beside it, and nothing errors:\n  ' + orphans.join('\n  '));
+  });
+
+  it('the chip-INPUT rules live in one place, so the three copies cannot drift again', () => {
+    // Scoped to the input family — `chip-wrap`, `chip-rm`, `chip-field` — because that is the family that had three
+    // identical copies (`space-dialog.styles.ts`, `prop-schema-table`, `schema-library`) and the one whose absence
+    // caused the reported defect. They were confirmed identical before consolidating, so it changed no pixels.
+    //
+    // **A SECOND family exists and is deliberately left alone.** `brain-form.styles.ts` defines `.chip`, `.chip-name`,
+    // `.chip-remove` and `.chip-list` — a visually different chip used across the brain tabs — and `graph.styles.ts`
+    // has its own. Folding those into one constant would change how the brain UI looks, which is not something to do
+    // as a side effect of fixing an unstyled button. Asserting one home for ALL chip rules would have demanded exactly
+    // that, so this asserts one home for the family that was broken and names the family that was not.
+    //
+    // What the two families DO share is `.chip` itself, which is why the next assertion exists.
+    const INPUT_FAMILY = ['chip-wrap', 'chip-rm', 'chip-field'];
+    const definers = files.filter(f => {
+      if (f.endsWith('shared/chip.styles.ts')) return false;
+      const defined = chipClassesDefined(readFileSync(f, 'utf8'));
+      return INPUT_FAMILY.some(c => defined.has(c));
+    });
+    assert.deepEqual(definers, [],
+      'the chip-input rules are defined outside shared/chip.styles.ts, which is how copies drift apart: '
+      + definers.join(', '));
+  });
+
+  it('no component pulls in BOTH chip families, because they both define `.chip`', () => {
+    // `.chip` is defined by the input family and by the brain family with different padding, colour and display. A
+    // component importing both would get whichever came last in its styles array — a difference that shows up as a
+    // slightly wrong chip and reads as a CSS mystery. Cheap to forbid, and nothing needs both today.
+    const both = [];
+    for (const f of files) {
+      const src = readFileSync(f, 'utf8');
+      // `\b` matters: /CHIP_STYLES/ is a SUBSTRING of BRAIN_CHIP_STYLES, so the naive test named every brain
+      // component as importing both families. A gate that cries wolf on nine files is a gate people switch off.
+      if (/\bCHIP_STYLES\b/.test(src) && /\bBRAIN_CHIP_STYLES\b/.test(src)) both.push(f);
+    }
+    assert.deepEqual(both, [],
+      `these import both chip families, so \`.chip\` resolves by array order: ${both.join(', ')}`);
+  });
+});


### PR DESCRIPTION
## The defect, and it is not a CSS mistake

breituai-platform, 2026-08-12T2230Z: *"the schema editor's enum-value remove buttons are oversized and clip their own
labels"*. They were **completely unstyled**.

`schema-type-editor.component.ts` renders `.chip-wrap`, `.chip`, `.chip-rm` and `.chip-field`. Its only stylesheet was
`SCHEMA_MD_STYLES`, which defines none of them, and `styles.scss` has no global chip rules to fall back on. Angular
scopes component styles — so when the editor body was extracted out of the schema **tab**, which does carry those rules,
the styles did not follow the markup.

`space-dialog.styles.ts` had even written the rule down: *"a child that renders the chip inputs needs these rules in its
OWN metadata."* A comment is not a check.

## Verified with a before/after, not a claim

Driven on an isolated instance (scratch config + scratch Mongo DB, port 3260), with the fix removed and restored around
the same capture:

| | `.chip` | remove `<button>` |
|---|---|---|
| **before** | `display: inline`, no padding, no background, 13px, **16px tall** | `border: solid`, `background: rgb(240,240,240)`, `padding: 7px 14px`, **28px tall** |
| **after** | `display: flex`, `padding: 1px 6px`, accent @15%, 12px, **21px tall** | `border: none`, transparent, `padding: 0 2px`, **12px tall** |

A 28px light-grey button beside a 16px label is exactly *"oversized"*, and in the screenshot the buttons **overlap the
labels** — "active" is partly covered, "retired" and "draft" collide with the button next to them. Their words, confirmed
literally. After the fix: three compact accent pills, each with a small inline `×`, labels intact.

## The fix

The chip-input rules now live once, in `client/src/app/shared/chip.styles.ts`. Three copies existed
(`space-dialog.styles.ts`, `prop-schema-table`, `schema-library`) and were **confirmed identical before consolidating**,
so it changed no pixels anywhere else.

The brain's separate chip family (`chip-name`, `chip-remove`, `chip-list`) is deliberately left alone — folding it in
would restyle the brain tabs as a side effect of fixing a button.

## The gate, and why this failure mode needs one

It produces **no error anywhere**: the template compiles, the class attribute is present, the build is clean, and the
component renders — with browser defaults. Same shape as an unregistered `<ph-icon name>` rendering blank.

`chip-styles-reach-their-markup.test.js` derives the rule: every chip class used in a template must be reachable from
that component's own `styles`, a style constant it applies, or a global rule. Plus two narrower checks — the input family
lives in one file, and no component pulls in both families (they both define `.chip`, so it would resolve by array
order).

**Its first version did not catch the defect it was written for**, which is the part worth recording: it checked whether
the component *imported* a stylesheet defining the class, not whether that stylesheet was in the `styles: []` array. The
editor still imports `CHIP_STYLES`. Verifying proximity and calling it effect — the same error as a scope guard bound to
the wrong parameter, and found the same way, by mutation. It now reads the `styles` array and **catches the exact shipped
defect**.

Two other self-inflicted issues, both caught by existing gates rather than by me: my check matched `CHIP_STYLES` as a
substring of `BRAIN_CHIP_STYLES` and accused nine innocent files, and my editing script wrote five raw `0x08` bytes into
the test file — which `source-text-hygiene` refused, because a control byte makes git treat the file as binary.

## Their report was two items

- **the mis-click** — this, the layout defect that made it easy;
- **the freeze** — a pre-existing schema violation blocking an unrelated edit, documented separately and parked as a
  behavioural decision.

Fixing the CSS and closing the report would have left the freeze in place.

🤖 Generated with Claude Code
