### PR TITLE
fix(security): a space-restricted admin could edit ANY token, any field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Security
+- **A space-restricted administrator could edit ANY token on the instance — including writing
+  `rights.instanceAdmin` onto it.** `PATCH /api/tokens/:id` is gated by `requireAdminMfa`, and a space-restricted admin
+  carries `admin: true`, so it was admitted like any other administrator. Measured, not supposed:
+
+  | attempt, by an admin scoped to one space, against a token scoped to another | before |
+  |---|---|
+  | rename that token | **200** |
+  | grant it `rights.instanceAdmin: true` | **200, and stored** |
+  | grant it `rights.createSpaces: true` | **200, and stored** |
+  | `GET /api/tokens` | **200**, every token on the instance |
+
+  - **Both escalated rights were INERT**, because the admin-only routes read the legacy `admin` flag rather than
+    `rights.instanceAdmin` — so this was a stored escalation, not a live one. That is exactly why it was worth closing
+    now: the 2.6 rights matrix exists so guards can move onto `rights`, and the day one does, every token a space admin
+    has touched carries whatever it was handed.
+  - `capRights` did not stop it. The editor's own record had `rights: null` and `admin: true`, so its derived rights read
+    as a full instance admin, and a `spaces` allowlist is not part of that comparison. Rung-capping and scope-capping are
+    different questions, which is why this is a separate guard rather than a change to that one.
+  - **The rule, in the owner's terms:** a space admin for X may edit `rights.perSpace[X]` and nothing else. `floor` is
+    refused outright rather than capped — it applies to every space **including ones that do not exist yet**, so however
+    modest its rungs look it is instance-wide in effect.
+  - Also refused: editing a token that reaches any space outside the caller's scope (which is how the bare rename
+    succeeded), and editing an unrestricted token, which reaches every space by definition.
+  - `refusalsOutsideEditorScope` is one function called by the edit route, mirroring the rule `POST /api/tokens` already
+    applied to a space-restricted creator. An edit route without it was the same escalation by a shorter path.
+  - **`GET /api/tokens` is now scoped for a space-restricted caller.** It listed every token's name, prefix, scope and
+    rights instance-wide; nothing secret (the hash is omitted by `listTokens()`'s own type), but it is an inventory of
+    access — and the same token is now refused when it tries to edit any of those rows.
+  - **Ten red-team tests, each refusal paired with the allowed case**, because a boundary that refuses everything is an
+    outage with good intentions and would pass a file full of refusals. The tier is proven to WORK: a space admin grants
+    per-space rights for its own space, and renames tokens inside its scope.
+
 ### Fixed
 - **The schema editor's enum chips were completely unstyled — the remove button rendered as a browser-default
   `<button>`.** Reported by breituai-platform (2026-08-12T2230Z) as *"oversized and clip their own labels"*, and that is

--- a/docs/integration-guide/07-tokens-api.md
+++ b/docs/integration-guide/07-tokens-api.md
@@ -200,6 +200,25 @@ Three fields are editable: **`name`** (1–200 chars, same bound as create), **`
 regenerate to rotate the secret. Audited as `token.update`, with the second factor recorded on both sides of
 the diff.
 
+> **A SPACE-RESTRICTED administrator may edit only its own spaces' rows.** An admin token that carries a `spaces`
+> allowlist is admitted here, and then held to a narrower rule than an unrestricted admin:
+>
+> - it may set `rights.perSpace[X]` only for spaces X in its own allowlist;
+> - it may **never** set `instanceAdmin` or `createSpaces`;
+> - it may **never** set `floor` — a floor applies to every space *including ones that do not exist yet*, so however
+>   modest its rungs look, it is instance-wide in effect. It is refused rather than capped, because there is no
+>   per-space version of it to cap to;
+> - it may only edit a token whose own `spaces` are all inside its allowlist. Editing an **unrestricted** token is
+>   refused, because such a token reaches every space by definition.
+>
+> Each refusal answers `403` with a `refusals` array naming what was rejected, so a client can report the specific
+> reason rather than "forbidden". This mirrors the rule `POST /api/tokens` already applies to a space-restricted
+> creator. An unrestricted admin is unaffected.
+>
+> **`GET /api/tokens` is scoped the same way**: a space-restricted caller sees only the tokens it could edit.
+
+<!-- markdownlint-disable-next-line MD028 -->
+
 > **Granting `mfa: "exempt"` costs a live TOTP code on the request** whenever MFA is enabled instance-wide —
 > the same rule create has, and for the same reason. Admin authentication here is satisfied by an admin token
 > that is itself exempt, so without it one exemption could grant the next until the instance-wide switch

--- a/server/src/api/tokens.ts
+++ b/server/src/api/tokens.ts
@@ -7,6 +7,7 @@ import { isMfaEnabled, verifyMfaCode } from '../auth/totp.js';
 import { z } from 'zod';
 import { SPACE_AREAS, RUNGS } from '../config/rights-shape.js';
 import { ROUTE_RIGHTS } from '../auth/space-rights.js';
+import { refusalsOutsideEditorScope } from '../auth/editor-scope.js';
 import { capRights, describeExcess } from '../auth/mint-cap.js';
 import { refuseSelfFloorRaise } from '../auth/floor-guard.js';
 import { migrateToken } from '../auth/rights-migration.js';
@@ -134,8 +135,21 @@ function exemptionNeedsLiveCode(req: Request, res: Response, mfa: string | undef
 }
 
 // GET /api/tokens — list tokens (hashes excluded) — admin only
-tokensRouter.get('/', requireAdmin, (_req, res) => {
-  res.json({ tokens: listTokens() });
+tokensRouter.get('/', requireAdmin, (req, res) => {
+  // A space-restricted administrator sees only the tokens it could act on.
+  //
+  // It used to receive every token on the instance — names, prefixes, scopes and rights for spaces it cannot reach.
+  // Nothing secret leaks (`listTokens()` omits the hash by its own type), but it is an inventory of the instance's
+  // access, and the same token is now refused when it tries to EDIT any of those rows. A list that shows what you
+  // cannot touch is an invitation to try.
+  //
+  // Unrestricted admins are unaffected. A `schemaLibrary` token has no space access, so it is inside every scope.
+  const callerSpaces = req.authToken?.spaces;
+  const all = listTokens();
+  const visible = callerSpaces
+    ? all.filter(t => t.schemaLibrary || (t.spaces?.every(s => callerSpaces.includes(s)) ?? false))
+    : all;
+  res.json({ tokens: visible });
 });
 
 // POST /api/tokens — create a new PAT — admin + MFA
@@ -319,6 +333,28 @@ tokensRouter.patch('/:id', requireAdminMfa, (req, res) => {
   const previous = listTokens().find(t => t.id === id);
   if (!previous) {
     res.status(404).json({ error: 'Token not found' });
+    return;
+  }
+
+  // A SPACE-RESTRICTED administrator may only touch its own spaces' rows.
+  //
+  // `requireAdminMfa` admits a space-restricted admin, because it carries `admin: true` — so before this guard existed,
+  // such a token could rename any token on the instance and write `rights.instanceAdmin` onto it. Measured, not
+  // supposed: both answered 200 and the rights were stored. They were inert only because the admin routes still gate on
+  // the legacy `admin` flag rather than on `rights`.
+  //
+  // Same rule the MINT route applies to a space-restricted creator, expressed once in `refusalsOutsideEditorScope` so
+  // the two cannot drift into disagreeing about what "outside your scope" means.
+  const scopeRefusals = refusalsOutsideEditorScope({
+    editorSpaces: req.authToken?.spaces,
+    target: previous,
+    rights: rights as never,
+  });
+  if (scopeRefusals.length > 0) {
+    res.status(403).json({
+      error: `A space-restricted administrator cannot make this edit — ${scopeRefusals.join('; ')}.`,
+      refusals: scopeRefusals,
+    });
     return;
   }
 

--- a/server/src/auth/editor-scope.ts
+++ b/server/src/auth/editor-scope.ts
@@ -1,0 +1,101 @@
+/**
+ * What a SPACE-RESTRICTED administrator may do to another token.
+ *
+ * ## The hole this closes, measured rather than assumed
+ *
+ * Probed on 2026-08-13 with an admin token scoped to one space, editing a token scoped to a different one:
+ *
+ * ```
+ * rename that token                            -> 200
+ * grant it rights.instanceAdmin: true          -> 200, and STORED
+ * grant it rights.createSpaces: true           -> 200, and STORED
+ * ```
+ *
+ * There was no boundary at all. `PATCH /api/tokens/:id` is gated by `requireAdminMfa`, and a space-restricted admin
+ * carries `admin: true`, so it was admitted like any other administrator.
+ *
+ * **Both escalated rights were inert at the time**, because the admin-only routes read the legacy `admin` flag rather
+ * than `rights.instanceAdmin` — so this was a stored escalation, not a live one. That is precisely why it needed
+ * fixing before anything else: the 2.6 rights matrix exists so guards can move onto `rights`, and the day one does,
+ * every token a space admin has touched carries whatever it was handed.
+ *
+ * `capRights` did not stop it either. The editor's record had `rights: null` and `admin: true`, so its derived rights
+ * read as a full instance admin — and a `spaces` allowlist is not part of that comparison. Rung-capping and
+ * scope-capping are different questions, which is why this is a separate guard rather than a change to that one.
+ *
+ * ## The rule, in the owner's words
+ *
+ * *"as space admin i want to be able to edit token rights"* — for THEIR space. So: a space admin for X may edit
+ * `rights.perSpace[X]` and nothing else.
+ *
+ * `floor` is refused outright rather than capped, and that is the non-obvious one: a floor applies to every space
+ * **including spaces that do not exist yet**, so however narrow it looks, it is instance-wide in effect. A space admin
+ * granting a floor of `read` would be granting read on every space the instance ever gains.
+ *
+ * ## Why it mirrors the MINT guard instead of inventing a second rule
+ *
+ * `POST /api/tokens` already refuses a space-restricted creator minting outside its own scope. An edit route without
+ * the same rule is the same escalation by a shorter path — mint is guarded, edit was not — and two surfaces with one
+ * rule expressed twice is how they come to disagree. This function is the single expression; both routes call it.
+ */
+import type { TokenRecord } from '../config/types.js';
+
+/** The rights object as the API accepts it. */
+export type EditableRights = {
+  instanceAdmin: boolean;
+  createSpaces: boolean;
+  floor: Record<string, string> | null;
+  perSpace: Record<string, Record<string, string>>;
+};
+
+/**
+ * Reasons a space-restricted editor may not make this edit. Empty means allowed.
+ *
+ * `editorSpaces === undefined` is an UNRESTRICTED administrator — every check here is skipped, because an instance
+ * admin editing anything is the tier that already worked and is not what this guard is about.
+ */
+export function refusalsOutsideEditorScope(input: {
+  editorSpaces: readonly string[] | undefined;
+  target: Pick<TokenRecord, 'spaces' | 'schemaLibrary'> | undefined;
+  rights: EditableRights | undefined;
+}): string[] {
+  const { editorSpaces, target, rights } = input;
+  if (!editorSpaces) return [];                       // unrestricted admin — tier 1, unchanged
+
+  const out: string[] = [];
+
+  // 1. The TARGET must live inside the editor's scope.
+  //
+  // Without this, a space admin could rename or re-right a token that reaches spaces it cannot see — which is how the
+  // rename above succeeded. A `schemaLibrary` token has no space access at all, so it is inside any scope; a token
+  // with NO allowlist reaches every space and is therefore outside every restricted scope.
+  if (target && !target.schemaLibrary) {
+    if (!target.spaces) {
+      out.push('that token is unrestricted (it reaches every space), so a space-restricted administrator cannot edit it');
+    } else {
+      const outside = target.spaces.filter(s => !editorSpaces.includes(s));
+      if (outside.length > 0) {
+        out.push(`that token reaches space(s) outside your scope: ${outside.join(', ')}`);
+      }
+    }
+  }
+
+  if (!rights) return out;
+
+  // 2. Instance-wide flags are never a space administrator's to grant.
+  if (rights.instanceAdmin) out.push('`instanceAdmin` is instance-wide and cannot be granted by a space-restricted administrator');
+  if (rights.createSpaces) out.push('`createSpaces` is instance-wide and cannot be granted by a space-restricted administrator');
+
+  // 3. A floor is instance-wide in EFFECT, even when its rungs look modest: it applies to every space, including ones
+  //    created later. Refused rather than capped, because there is no per-space version of it to cap to.
+  if (rights.floor && Object.keys(rights.floor).length > 0) {
+    out.push('`floor` applies to every space including ones not yet created, so it cannot be set by a space-restricted administrator');
+  }
+
+  // 4. Per-space rows only for spaces the editor holds.
+  const rows = Object.keys(rights.perSpace ?? {});
+  const foreign = rows.filter(s => !editorSpaces.includes(s));
+  if (foreign.length > 0) out.push(`per-space rights for space(s) outside your scope: ${foreign.join(', ')}`);
+
+  return out;
+}

--- a/testing/red-team-tests/space-admin-edit-boundary.test.js
+++ b/testing/red-team-tests/space-admin-edit-boundary.test.js
@@ -1,0 +1,184 @@
+/**
+ * A space-restricted administrator may edit its OWN spaces' rights and nothing else.
+ *
+ * ## What was measured before this existed
+ *
+ * `PATCH /api/tokens/:id` is gated by `requireAdminMfa`, and a space-restricted admin carries `admin: true`, so it was
+ * admitted like any other administrator. Probed 2026-08-13 with an admin scoped to one space, against a token scoped to
+ * a different one:
+ *
+ * ```
+ * rename that token                       -> 200
+ * grant it rights.instanceAdmin: true     -> 200, and STORED
+ * grant it rights.createSpaces: true      -> 200, and STORED
+ * GET /api/tokens                         -> 200, every token on the instance
+ * ```
+ *
+ * **Both escalated rights were inert**, because the admin routes read the legacy `admin` flag rather than `rights` — so
+ * it was a stored escalation, not a live one. That is exactly why it was worth fixing first: the rights matrix exists so
+ * guards can move onto `rights`, and the day one does, every token a space admin touched carries what it was handed.
+ *
+ * ## Why these are red-team tests and not unit tests
+ *
+ * The owner's Verify line asked for it in those words, and the reason holds: the question is not "does the helper return
+ * the right array" but "can a real token, over HTTP, get something it must not". A unit test on
+ * `refusalsOutsideEditorScope` would have passed all along on a route that never called it.
+ *
+ * **Every refusal is paired with the ALLOWED case.** A boundary that refuses everything is not a tier — it is an outage
+ * with good intentions, and it would pass a file full of refusals.
+ *
+ * Run: node --test testing/red-team-tests/space-admin-edit-boundary.test.js
+ */
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, get, patch, del, delWithBody } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+const RUN = Date.now();
+
+const MINE = `sa-mine-${RUN}`;      // the space the space-admin holds
+const THEIRS = `sa-theirs-${RUN}`;  // a space it does not
+
+let adminToken;                 // unrestricted instance admin
+let spaceAdmin;                 // admin: true, spaces: [MINE]
+let spaceAdminId;
+let insideId;                   // a token scoped to MINE
+let outsideId;                  // a token scoped to THEIRS
+const madeTokens = [];
+
+/**
+ * The rights object the API requires: `.strict()` with all four keys, and every AREA MAP must name all four areas.
+ *
+ * The second half is not obvious and cost a first run: `z.record(z.enum(SPACE_AREAS), z.enum(RUNGS))` requires every
+ * area, so `{ knowledge: 'read' }` is a 400 rather than a partial grant — which also means an earlier manual probe of
+ * `floor` and `perSpace` had been measuring my own malformed body, not the guard.
+ */
+const areas = (rung, over = {}) => ({ knowledge: rung, files: rung, schema: rung, dataQuality: rung, ...over });
+const rights = (over = {}) => ({ instanceAdmin: false, createSpaces: false, floor: null, perSpace: {}, ...over });
+
+const mint = async (body) => {
+  const r = await post(INSTANCES.a, adminToken, '/api/tokens', body);
+  assert.equal(r.status, 201, `token mint failed: ${JSON.stringify(r.body)}`);
+  madeTokens.push(r.body.token.id);
+  return r.body;
+};
+
+before(async () => {
+  adminToken = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+  for (const id of [MINE, THEIRS]) {
+    const r = await post(INSTANCES.a, adminToken, '/api/spaces', { id, label: id });
+    assert.equal(r.status, 201, `space create failed: ${JSON.stringify(r.body)}`);
+  }
+  const sa = await mint({ name: `sa-admin-${RUN}`, admin: true, spaces: [MINE] });
+  spaceAdmin = sa.plaintext;
+  spaceAdminId = sa.token.id;
+  insideId = (await mint({ name: `sa-inside-${RUN}`, spaces: [MINE] })).token.id;
+  outsideId = (await mint({ name: `sa-outside-${RUN}`, spaces: [THEIRS] })).token.id;
+});
+
+after(async () => {
+  for (const id of madeTokens) await del(INSTANCES.a, adminToken, `/api/tokens/${id}`).catch(() => {});
+  for (const id of [MINE, THEIRS]) {
+    await delWithBody(INSTANCES.a, adminToken, `/api/spaces/${id}`, { confirm: true }).catch(() => {});
+  }
+});
+
+/** The stored record, read back as the instance admin — the status code is not the assertion. */
+async function stored(id) {
+  const r = await get(INSTANCES.a, adminToken, '/api/tokens');
+  assert.equal(r.status, 200, JSON.stringify(r.body));
+  return (r.body.tokens ?? []).find(t => t.id === id);
+}
+
+describe('the tier WORKS — a space admin edits its own space', () => {
+  it('grants per-space rights for the space it holds', async () => {
+    const r = await patch(INSTANCES.a, spaceAdmin, `/api/tokens/${insideId}`,
+      { rights: rights({ perSpace: { [MINE]: areas('read') } }) });
+    assert.equal(r.status, 200, `the allowed edit was refused: ${JSON.stringify(r.body)}`);
+    const rec = await stored(insideId);
+    assert.equal(rec?.rights?.perSpace?.[MINE]?.knowledge, 'read', 'the grant must actually be stored');
+  });
+
+  it('renames a token inside its own scope', async () => {
+    const r = await patch(INSTANCES.a, spaceAdmin, `/api/tokens/${insideId}`, { name: `renamed-${RUN}` });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal((await stored(insideId))?.name, `renamed-${RUN}`);
+  });
+});
+
+describe('the tier is BOUNDED — each refusal, and nothing written', () => {
+  it('cannot grant instanceAdmin', async () => {
+    const before = await stored(insideId);
+    const r = await patch(INSTANCES.a, spaceAdmin, `/api/tokens/${insideId}`,
+      { rights: rights({ instanceAdmin: true }) });
+    assert.equal(r.status, 403, `instanceAdmin was granted: ${JSON.stringify(r.body)}`);
+    assert.match(r.body.error, /instanceAdmin/);
+    assert.notEqual((await stored(insideId))?.rights?.instanceAdmin, true, 'nothing may be written by a refused edit');
+    assert.equal((await stored(insideId))?.name, before?.name, 'and the rest of the record is untouched');
+  });
+
+  it('cannot grant createSpaces', async () => {
+    const r = await patch(INSTANCES.a, spaceAdmin, `/api/tokens/${insideId}`,
+      { rights: rights({ createSpaces: true }) });
+    assert.equal(r.status, 403, `createSpaces was granted: ${JSON.stringify(r.body)}`);
+    assert.notEqual((await stored(insideId))?.rights?.createSpaces, true);
+  });
+
+  it('cannot set a FLOOR — it applies to spaces that do not exist yet', async () => {
+    // The non-obvious one. A floor of `read` looks narrower than an admin rung and is broader than any per-space row:
+    // it covers every space the instance ever gains.
+    const r = await patch(INSTANCES.a, spaceAdmin, `/api/tokens/${insideId}`,
+      { rights: rights({ floor: areas('read') }) });
+    assert.equal(r.status, 403, `a floor was set: ${JSON.stringify(r.body)}`);
+    assert.match(r.body.error, /floor/);
+    assert.equal((await stored(insideId))?.rights?.floor ?? null, null);
+  });
+
+  it('cannot grant rights for ANOTHER space', async () => {
+    const r = await patch(INSTANCES.a, spaceAdmin, `/api/tokens/${insideId}`,
+      { rights: rights({ perSpace: { [THEIRS]: areas('admin') } }) });
+    assert.equal(r.status, 403, `a foreign space's row was granted: ${JSON.stringify(r.body)}`);
+    assert.match(r.body.error, new RegExp(THEIRS));
+    assert.equal((await stored(insideId))?.rights?.perSpace?.[THEIRS], undefined);
+  });
+
+  it('cannot RENAME a token that reaches a space outside its scope', async () => {
+    // This is the one that shipped: a bare rename of another space's token answered 200.
+    const before = await stored(outsideId);
+    const r = await patch(INSTANCES.a, spaceAdmin, `/api/tokens/${outsideId}`, { name: 'pwned' });
+    assert.equal(r.status, 403, `renamed a token outside its scope: ${JSON.stringify(r.body)}`);
+    assert.match(r.body.error, new RegExp(THEIRS));
+    assert.equal((await stored(outsideId))?.name, before?.name, 'the name must be unchanged');
+  });
+
+  it('cannot edit an UNRESTRICTED token, which reaches every space', async () => {
+    // A token with no allowlist is outside every restricted scope by definition — including the instance admin's own.
+    const unrestricted = (await mint({ name: `sa-unrestricted-${RUN}` })).token.id;
+    const r = await patch(INSTANCES.a, spaceAdmin, `/api/tokens/${unrestricted}`, { name: 'nope' });
+    assert.equal(r.status, 403, `edited an unrestricted token: ${JSON.stringify(r.body)}`);
+    assert.match(r.body.error, /unrestricted/i);
+  });
+});
+
+describe('listing shows only what the caller could act on', () => {
+  it('a space admin does not see tokens from other spaces', async () => {
+    const r = await get(INSTANCES.a, spaceAdmin, '/api/tokens');
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    const ids = (r.body.tokens ?? []).map(t => t.id);
+    assert.ok(ids.includes(insideId), 'it must still see the tokens it can edit');
+    assert.ok(!ids.includes(outsideId),
+      'it was shown a token scoped to another space — an inventory of access it cannot touch');
+  });
+
+  it('an unrestricted admin still sees everything', async () => {
+    // The other half: narrowing the list must not narrow it for the tier that always had it.
+    const ids = ((await get(INSTANCES.a, adminToken, '/api/tokens')).body.tokens ?? []).map(t => t.id);
+    for (const id of [insideId, outsideId, spaceAdminId]) {
+      assert.ok(ids.includes(id), `the instance admin must still see ${id}`);
+    }
+  });
+});


### PR DESCRIPTION
## What a space-restricted admin could do

`PATCH /api/tokens/:id` is gated by `requireAdminMfa`, and a space-restricted admin carries `admin: true` — so it was
admitted like any other administrator, with no further boundary. Probed against a running instance with an admin scoped
to one space, acting on a token scoped to a **different** one:

| attempt | before |
|---|---|
| rename that token | **200** |
| grant it `rights.instanceAdmin: true` | **200, and stored** |
| grant it `rights.createSpaces: true` | **200, and stored** |
| `GET /api/tokens` | **200**, every token on the instance |

**Both escalated rights were inert**, and that distinction is the honest severity: `GET /api/tokens` and
`POST /api/spaces` still answered `403 Admin token required` to the escalated token, because those guards read the legacy
`admin` flag rather than `rights.instanceAdmin`. So this was a **stored** escalation, not a live one.

Which is exactly why it was worth closing now. The 2.6 rights matrix exists so guards can move onto `rights`; the day one
does, every token a space admin has touched carries whatever it was handed — and nothing about those records looks
unusual afterwards.

**`capRights` did not stop it.** The editor's own record had `rights: null` and `admin: true`, so its derived rights read
as a full instance admin, and a `spaces` allowlist is not part of that comparison. Rung-capping and scope-capping are
different questions, which is why this is a separate guard rather than a change to that one.

## The rule, in the owner's words

*"as space admin i want to be able to edit token rights"* — for **their** space. So a space admin for X may set
`rights.perSpace[X]` and nothing else:

- never `instanceAdmin`, never `createSpaces`;
- **never `floor`** — it applies to every space *including ones that do not exist yet*, so however modest its rungs look
  it is instance-wide in effect. Refused rather than capped, because there is no per-space version of it to cap to;
- only on a token whose own `spaces` are all inside the caller's allowlist — which is how the bare rename succeeded;
- and never on an **unrestricted** token, which reaches every space by definition.

`refusalsOutsideEditorScope` is one function, called by the edit route, mirroring the rule `POST /api/tokens` already
applied to a space-restricted *creator*. An edit route without it was the same escalation by a shorter path — and one
rule written twice is how two surfaces come to disagree.

Each refusal answers `403` with a `refusals` array, so a client reports the specific reason rather than "forbidden".

## `GET /api/tokens` is scoped too

It listed every token's name, prefix, scope and rights instance-wide. Nothing secret leaks — `listTokens()` omits the
hash by its own type — but it is an inventory of the instance's access, and the same token is now refused when it tries
to edit any of those rows. A list that shows what you cannot touch is an invitation to try.

## Ten red-team tests, each refusal paired with the allowed case

Per the item's own Verify line: *"each refusal as a RED-TEAM test, not a unit test"*. The reason holds — a unit test on
the helper would have passed all along against a route that never called it.

**The tier is proven to WORK**, not just to refuse: a space admin grants per-space rights for its own space and renames
tokens inside its scope. A boundary that refuses everything is an outage with good intentions, and it would pass a file
full of refusals.

Each refusal also asserts **nothing was written** — read back as the instance admin, because a status code is not the
state.

## One correction to my own measurement

My first manual probe of `floor` and `perSpace` returned `400`, which I could have mistaken for a refusal. It was my
malformed body: `z.record(z.enum(SPACE_AREAS), z.enum(RUNGS))` requires **all four areas**, so `{ knowledge: 'read' }` is
invalid rather than partial. The tests carry an `areas()` helper and a note, because that trap is the difference between
measuring the guard and measuring your own payload.

## Verification

```
red-team suite (10 new)          ℹ tests 293  ℹ pass 293  ℹ fail 0
auth + spaces integration        ℹ tests 39   ℹ pass 39   ℹ fail 0
```

Plus `npm run preflight` green, on an image verified to contain the guard (`docker run --rm … grep dist`) rather than
trusting the build log.

## Docs

`07-tokens-api.md` — the boundary, each refusal, why `floor` is refused rather than capped, and that `GET /api/tokens` is
scoped the same way.

🤖 Generated with Claude Code
