### PR TITLE
feat(brain): a memory's type is editable, and the PATCH route stops dropping it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- **A memory's `type` is now editable in the UI — in the create form and the record drawer.** The memories tab has
+  sorted and filtered by `type` since #836, and nothing could write one: not the create form, not the drawer. So the
+  column and its filter operated on a field only the API and MCP could set.
+  - **It is a free-text input with suggestions, deliberately not a `<select>`.** The server does not restrict a memory
+    type: `validateMemory` uses it only to look up `typeSchemas.memory[type]` for property validation, and unlike chrono
+    there is no `getAllowedMemoryTypes` allowlist — any string is accepted. A closed select would have been **stricter
+    than the API**, making types the server accepts unreachable from the UI, which is the mirror image of the gap being
+    closed. `memoryTypeOptions()` already merges the schema's keys with the values present in the data, so it is a
+    suggestion list by construction.
+  - Checking that first is what the item asked for, and it changed the design: the tracker's own proposal had been a
+    `<select>`.
+  - **The typed client did not model the field either**, so the form alone would have been a control that changes
+    nothing: `createMemory` and `updateMemory` had no `type` in their body types. Same shape as #840, where the typed
+    client was discarding `rights`.
+  - Blank means ABSENT on create and EXPLICITLY EMPTY on update — an omitted field on a PATCH means "leave it alone", so
+    clearing the box has to reach the API as an empty value or a type could be set and never unset. Both directions are
+    asserted.
+
+### Fixed
+- **`PATCH /api/brain/spaces/:spaceId/memories/:id` silently ignored `type`.** `POST` read it; the update handler never
+  destructured it, so changing a memory's type answered **200 and changed nothing**.
+  - `updateMemory` had accepted `type` and written `$set.type` all along, so the field was plumbed the whole way down
+    and lost at the door. One line of destructuring.
+  - **Found by driving the UI, not by reading it.** The browser sent `{"type":"note", …}`, the request succeeded, and the
+    stored record still said `decision`. Adding the control is what made a server gap visible — the reason a UI change
+    was worth verifying end to end rather than at the component boundary.
+  - Same shape as the `skip` parameter aigents reported on `POST /query`: a permissive body, a success status, and a
+    silently dropped field. Now covered at the API level, because the client is not where it broke — including that an
+    absent `type` leaves the stored one alone, so the clear path cannot wipe it by accident.
+
 ### Security
 - **A space-restricted administrator could edit ANY token on the instance — including writing
   `rights.instanceAdmin` onto it.** `PATCH /api/tokens/:id` is gated by `requireAdminMfa`, and a space-restricted admin

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -469,6 +469,7 @@
   "brain.query.noDocuments": "Keine Dokumente stimmten mit dem Filter überein.",
   "brain.memories.searchPlaceholder": "Semantische Erinnerungssuche…",
   "brain.memories.addButton": "+ Speicher hinzufügen",
+  "brain.memories.form.typePlaceholder": "optional",
   "brain.memories.table.fact": "Tatsache",
   "brain.memories.table.description": "Beschreibung",
   "brain.memories.table.type": "Typ",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -469,6 +469,7 @@
   "brain.query.noDocuments": "No documents matched the filter.",
   "brain.memories.searchPlaceholder": "Semantic memory search…",
   "brain.memories.addButton": "+ Add memory",
+  "brain.memories.form.typePlaceholder": "optional",
   "brain.memories.table.fact": "Fact",
   "brain.memories.table.description": "Description",
   "brain.memories.table.type": "Type",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -469,6 +469,7 @@
   "brain.query.noDocuments": "Żadne dokumenty nie pasują do filtra.",
   "brain.memories.searchPlaceholder": "Wyszukiwanie semantyczne wspomnień…",
   "brain.memories.addButton": "+ Dodaj pamięć",
+  "brain.memories.form.typePlaceholder": "fakultatywny",
   "brain.memories.table.fact": "Fakt",
   "brain.memories.table.description": "Opis",
   "brain.memories.table.type": "Typ",

--- a/client/src/app/core/brain-api.service.ts
+++ b/client/src/app/core/brain-api.service.ts
@@ -126,11 +126,11 @@ export class BrainApi {
     return this.http.delete<void>(`/api/brain/spaces/${spaceId}/memories/${id}`);
   }
 
-  createMemory(spaceId: string, body: { fact: string; tags?: string[]; entityIds?: string[]; description?: string; properties?: Record<string, string | number | boolean> }): Observable<Memory> {
+  createMemory(spaceId: string, body: { fact: string; type?: string; tags?: string[]; entityIds?: string[]; description?: string; properties?: Record<string, string | number | boolean> }): Observable<Memory> {
     return this.http.post<Memory>(`/api/brain/spaces/${spaceId}/memories`, body);
   }
 
-  updateMemory(spaceId: string, id: string, body: Partial<{ fact: string; tags: string[]; entityIds: string[]; description: string; properties: Record<string, string | number | boolean>; deleteFields: string[] }>): Observable<Memory> {
+  updateMemory(spaceId: string, id: string, body: Partial<{ fact: string; type: string; tags: string[]; entityIds: string[]; description: string; properties: Record<string, string | number | boolean>; deleteFields: string[] }>): Observable<Memory> {
     return this.http.patch<Memory>(`/api/brain/spaces/${spaceId}/memories/${id}`, body);
   }
 

--- a/client/src/app/pages/brain/memories-tab.component.spec.ts
+++ b/client/src/app/pages/brain/memories-tab.component.spec.ts
@@ -129,7 +129,7 @@ describe('MemoriesTabComponent', () => {
     const c = fixture.componentInstance;
     const mutated = vi.fn();
     c.mutated.subscribe(mutated);
-    c.memoryForm = { fact: '  a fact  ', tags: ['t'], entityIds: 'e1, , e2', description: ' d ', properties: { k: 'v' } };
+    c.memoryForm = { fact: '  a fact  ', type: '', tags: ['t'], entityIds: 'e1, , e2', description: ' d ', properties: { k: 'v' } };
     c.createMemory();
     expect(api.createMemory).toHaveBeenCalledWith('work', {
       fact: 'a fact', tags: ['t'], entityIds: ['e1', 'e2'], description: 'd', properties: { k: 'v' },
@@ -139,9 +139,24 @@ describe('MemoriesTabComponent', () => {
 
   it('createMemory is a no-op when fact is blank', () => {
     const c = make().componentInstance;
-    c.memoryForm = { fact: '   ', tags: [], entityIds: '', description: '', properties: {} };
+    c.memoryForm = { fact: '   ', type: '', tags: [], entityIds: '', description: '', properties: {} };
     c.createMemory();
     expect(api.createMemory).not.toHaveBeenCalled();
+  });
+
+  it('createMemory sends `type` when set, and OMITS it when blank', () => {
+    // Both directions matter. Blank must stay ABSENT rather than become "": the server uses `type` to look up
+    // `typeSchemas.memory[type]`, so an empty string selects nothing and stores a value no filter offers.
+    const f = make();
+    const c = f.componentInstance;
+    c.memoryForm = { fact: 'f', type: '  decision  ', tags: [], entityIds: '', description: '', properties: {} };
+    c.createMemory();
+    expect(api.createMemory).toHaveBeenCalledWith('work', { fact: 'f', type: 'decision' });
+
+    api.createMemory.mockClear();
+    c.memoryForm = { fact: 'f', type: '   ', tags: [], entityIds: '', description: '', properties: {} };
+    c.createMemory();
+    expect(api.createMemory).toHaveBeenCalledWith('work', { fact: 'f' });
   });
 
   it('saveEditMemory sends the full shape, clears editingId, and patches the store list', () => {

--- a/client/src/app/pages/brain/memories-tab.component.ts
+++ b/client/src/app/pages/brain/memories-tab.component.ts
@@ -70,6 +70,21 @@ import { TimestampComponent } from '../../shared/timestamp.component';
               </div>
               <div class="form-row rich">
                 <div class="field">
+                  <!-- TYPE is free text with SUGGESTIONS, not a closed select.
+                       The server does not restrict it: validateMemory uses type only to LOOK UP
+                       typeSchemas.memory[type] for property validation, and unlike chrono there is no
+                       getAllowedMemoryTypes allowlist — any string is accepted. A <select> would therefore be
+                       stricter than the API and would make a type the server accepts unreachable from the UI, which is
+                       the mirror image of the bug this fixes. memoryTypeOptions() already merges the schema's keys
+                       with the values present in the data, so it is a suggestion list by construction. -->
+                  <label>{{ 'common.form.type' | transloco }}</label>
+                  <input type="text" [(ngModel)]="memoryForm.type" name="memFormType" list="memTypeOptions"
+                         [placeholder]="'brain.memories.form.typePlaceholder' | transloco" />
+                  <datalist id="memTypeOptions">
+                    @for (t of store.memoryTypeOptions(); track t) { <option [value]="t"></option> }
+                  </datalist>
+                </div>
+                <div class="field">
                   <label>{{ 'common.form.tags' | transloco }}</label>
                   <app-tag-input [(value)]="memoryForm.tags" [suggestions]="store.memoryTagSuggestions()" inputName="memFormTags" />
                 </div>
@@ -252,7 +267,7 @@ export class MemoriesTabComponent extends RecordTabBase {
   showMemoryForm = signal(false);
   creatingMemory = signal(false);
   createMemoryError = signal('');
-  memoryForm = { fact: '', tags: [] as string[], entityIds: '', description: '', properties: {} as Record<string, string | number | boolean> };
+  memoryForm = { fact: '', type: '', tags: [] as string[], entityIds: '', description: '', properties: {} as Record<string, string | number | boolean> };
   editMemory = { fact: '', tags: [] as string[], entityIds: '', description: '', properties: {} as Record<string, string | number | boolean> };
 
   private _memSemTimer: ReturnType<typeof setTimeout> | null = null;
@@ -333,7 +348,7 @@ export class MemoriesTabComponent extends RecordTabBase {
   }
 
   openMemoryForm(): void {
-    this.memoryForm = { fact: '', tags: [], entityIds: '', description: '', properties: this.store.buildPropertiesObject('memory') };
+    this.memoryForm = { fact: '', type: '', tags: [], entityIds: '', description: '', properties: this.store.buildPropertiesObject('memory') };
     this.showMemoryForm.set(true);
   }
 
@@ -343,6 +358,9 @@ export class MemoriesTabComponent extends RecordTabBase {
     this.createMemoryError.set('');
     const entityIds = this.memoryForm.entityIds.split(',').map(s => s.trim()).filter(Boolean);
     const body: Parameters<BrainApi['createMemory']>[1] = { fact: this.memoryForm.fact.trim() };
+    // Sent only when non-empty: an empty `type` must stay ABSENT rather than become the string "", which would
+    // select typeSchemas.memory[""], find nothing, and store a type nobody can filter for.
+    if (this.memoryForm.type.trim()) body.type = this.memoryForm.type.trim();
     if (this.memoryForm.tags.length) body.tags = this.memoryForm.tags;
     if (entityIds.length) body.entityIds = entityIds;
     if (this.memoryForm.description.trim()) body.description = this.memoryForm.description.trim();
@@ -351,7 +369,7 @@ export class MemoriesTabComponent extends RecordTabBase {
       next: () => {
         this.creatingMemory.set(false);
         this.showMemoryForm.set(false);
-        this.memoryForm = { fact: '', tags: [], entityIds: '', description: '', properties: {} as Record<string, string | number | boolean> };
+        this.memoryForm = { fact: '', type: '', tags: [], entityIds: '', description: '', properties: {} as Record<string, string | number | boolean> };
         this.mutated.emit();
         this.load();
       },

--- a/client/src/app/pages/brain/record-drawer-state.service.ts
+++ b/client/src/app/pages/brain/record-drawer-state.service.ts
@@ -64,7 +64,7 @@ export class RecordDrawerState {
    */
   readonly lastSaved = signal<DrawerRecord | null>(null);
 
-  drawerEditMemory = { fact: '', tags: [] as string[], entityIds: '', description: '', properties: {} as Record<string, string | number | boolean> };
+  drawerEditMemory = { fact: '', type: '', tags: [] as string[], entityIds: '', description: '', properties: {} as Record<string, string | number | boolean> };
   drawerEditEntity = { name: '', type: '', tags: [] as string[], description: '', properties: {} as Record<string, string | number | boolean> };
   drawerEditEdge = { label: '', type: '', weight: null as number | null, tags: [] as string[], description: '', properties: {} as Record<string, string | number | boolean> };
   drawerEditChrono = { title: '', kind: 'event' as string, status: 'upcoming' as string, startsAt: '', endsAt: '', description: '', tags: [] as string[], entityIds: '', confidence: null as number | null, memoryIds: [] as string[], properties: {} as Record<string, string | number | boolean> };
@@ -110,6 +110,7 @@ export class RecordDrawerState {
       const r = target.record;
       this.drawerEditMemory = {
         fact: r.fact,
+        type: r.type ?? '',
         tags: [...(r.tags ?? [])],
         entityIds: (r.entityIds ?? []).join(', '),
         description: r.description ?? '',
@@ -171,6 +172,9 @@ export class RecordDrawerState {
       const props = this.drawerEditMemory.properties;
       this.brainApi.updateMemory(spaceId, id, {
         fact: this.drawerEditMemory.fact.trim(),
+        // Trimmed, and sent even when empty: on an UPDATE an absent field means "leave it alone", so clearing the
+        // box has to reach the API as an explicit empty value or the type could be set and never unset.
+        type: this.drawerEditMemory.type.trim(),
         tags: this.drawerEditMemory.tags,
         entityIds: this.drawerEditMemory.entityIds.split(',').map(s => s.trim()).filter(Boolean),
         description: this.drawerEditMemory.description.trim(),

--- a/client/src/app/pages/brain/record-drawer.component.ts
+++ b/client/src/app/pages/brain/record-drawer.component.ts
@@ -69,6 +69,16 @@ import { BRAIN_CHIP_STYLES, BRAIN_DRAWER_STYLES } from './brain-form.styles';
                   <textarea [(ngModel)]="state.drawerEditMemory.description" name="drwMemDesc" rows="3" style="resize:vertical;"></textarea>
                 </div>
                 <div class="drawer-field">
+                  <!-- Free text with suggestions, matching the create form and the edge drawer's own type input.
+                       See the note there: memory type has no server-side allowlist, so a closed select would be
+                       stricter than the API. -->
+                  <div class="drawer-label">{{ 'common.form.type' | transloco }}</div>
+                  <input type="text" [(ngModel)]="state.drawerEditMemory.type" name="drwMemType" list="drwMemTypeOptions" />
+                  <datalist id="drwMemTypeOptions">
+                    @for (t of store.memoryTypeOptions(); track t) { <option [value]="t"></option> }
+                  </datalist>
+                </div>
+                <div class="drawer-field">
                   <div class="drawer-label">{{ 'common.form.tags' | transloco }}</div>
                   <app-tag-input [(value)]="state.drawerEditMemory.tags" [suggestions]="store.memoryTagSuggestions()" inputName="drwMemTags" />
                 </div>

--- a/server/src/api/brain/memories.ts
+++ b/server/src/api/brain/memories.ts
@@ -202,7 +202,7 @@ memoriesRouter.patch('/spaces/:spaceId/memories/:id', globalRateLimit, requireSp
   if (!wt.ok) { res.status(400).json({ error: wt.error }); return; }
   const ifMatch = ifMatchFromRequest(req);
   if (!ifMatch.ok) { res.status(400).json({ error: ifMatch.error }); return; }
-  const { fact, tags, entityIds, description, properties, deleteFields } = req.body ?? {};
+  const { fact, tags, entityIds, description, properties, deleteFields, type: memoryType } = req.body ?? {};
   // Validate deleteFields
   const dfResult = validateDeleteFields(deleteFields);
   if (!dfResult.ok) { res.status(400).json({ error: dfResult.error }); return; }
@@ -210,7 +210,15 @@ memoriesRouter.patch('/spaces/:spaceId/memories/:id', globalRateLimit, requireSp
   if (ttlErr) { res.status(400).json({ error: ttlErr }); return; }
   const ttlDaysProvided = !!req.body && typeof req.body === 'object' && 'ttlDays' in req.body;
   const dfPaths: string[] | undefined = Array.isArray(deleteFields) && deleteFields.length > 0 ? deleteFields : undefined;
-  const updates: { fact?: string; tags?: string[]; entityIds?: string[]; description?: string; properties?: Record<string, string | number | boolean>; excludeFromVectorSearch?: boolean } = {};
+  const updates: { fact?: string; type?: string; tags?: string[]; entityIds?: string[]; description?: string; properties?: Record<string, string | number | boolean>; excludeFromVectorSearch?: boolean } = {};
+  // `type` was accepted on CREATE and silently DROPPED here: this handler never destructured it, so a caller PATCHing
+  // a memory's type got 200 and no change. `updateMemory` has always accepted it and writes `$set.type`, so the field
+  // was plumbed the whole way down and lost at the door. An empty string CLEARS it, which is how the UI unsets a type —
+  // the store distinguishes `undefined` (leave alone) from `''` (write empty), and this route must preserve that.
+  if (memoryType !== undefined) {
+    if (typeof memoryType !== 'string') { res.status(400).json({ error: '`type` must be a string' }); return; }
+    updates.type = memoryType.trim();
+  }
   if (fact !== undefined) {
     if (typeof fact !== 'string' || !fact.trim()) { res.status(400).json({ error: '`fact` must be a non-empty string' }); return; }
     updates.fact = fact;

--- a/testing/integration/memory-type-is-editable.test.js
+++ b/testing/integration/memory-type-is-editable.test.js
@@ -1,0 +1,108 @@
+/**
+ * A memory's `type` can be SET on create, CHANGED on update, and CLEARED — over REST.
+ *
+ * ## What was measured
+ *
+ * The memories tab has sorted and filtered by `type` since #836, and nothing in the UI could write one. Adding the
+ * control surfaced a server gap underneath it: `POST` read `type`, and `PATCH` never destructured it, so a caller
+ * changing a memory's type got **200 and no change**.
+ *
+ * Found by driving the UI rather than by reading: the browser sent `{"type":"note", …}`, the request succeeded, and the
+ * stored record still said `decision`. `updateMemory` had accepted `type` and written `$set.type` all along — the field
+ * was plumbed the whole way down and lost at the door.
+ *
+ * That is the same shape as the `skip` parameter aigents reported on `POST /query`: a permissive body, a success status,
+ * and a silently ignored field. Worth a test at the API level rather than only in the client, because the client is not
+ * where it broke.
+ *
+ * ## The `''` case is not decoration
+ *
+ * An omitted field on a PATCH means *leave it alone*, so clearing a type has to reach the API as an explicit empty
+ * string. Without that distinction a type could be set and never unset — the box would refuse to empty, and nothing
+ * would report an error.
+ *
+ * Run: node --test testing/integration/memory-type-is-editable.test.js
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, get, patch, del, delWithBody } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+const RUN = Date.now();
+const SPACE = `memtype-${RUN}`;
+
+let token;
+
+const create = (body) => post(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/memories`, body);
+const edit = (id, body) => patch(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/memories/${id}`, body);
+const read = async (id) => (await get(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/memories/${id}`)).body;
+
+before(async () => {
+  token = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+  const r = await post(INSTANCES.a, token, '/api/spaces', {
+    id: SPACE, label: SPACE,
+    // `warn` rather than `strict`: this file is about the type FIELD, not about property validation refusing a write.
+    meta: { validationMode: 'warn', typeSchemas: { memory: { decision: {}, note: {} } } },
+  });
+  assert.equal(r.status, 201, `space create failed: ${JSON.stringify(r.body)}`);
+});
+
+after(async () => {
+  await delWithBody(INSTANCES.a, token, `/api/spaces/${SPACE}`, { confirm: true }).catch(() => {});
+});
+
+describe('a memory type survives create, update and clear', () => {
+  it('is stored on create', async () => {
+    const r = await create({ fact: `created with a type ${RUN}`, type: 'decision' });
+    assert.equal(r.status, 201, JSON.stringify(r.body));
+    assert.equal(r.body.type, 'decision');
+    assert.equal((await read(r.body._id)).type, 'decision', 'and it must be there when read back');
+  });
+
+  it('CHANGES on update — this is what silently did nothing', async () => {
+    const id = (await create({ fact: `to be retyped ${RUN}`, type: 'decision' })).body._id;
+    const r = await edit(id, { type: 'note' });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal((await read(id)).type, 'note',
+      'the PATCH answered 200 and the stored type did not change — the handler dropped the field');
+  });
+
+  it('CLEARS on an explicit empty string', async () => {
+    // The unset path. Nothing else can express it: an absent field means "leave it alone".
+    const id = (await create({ fact: `to be cleared ${RUN}`, type: 'decision' })).body._id;
+    assert.equal((await edit(id, { type: '' })).status, 200);
+    const after = await read(id);
+    assert.ok(!after.type, `type should be empty, got ${JSON.stringify(after.type)}`);
+  });
+
+  it('is LEFT ALONE when the field is absent', async () => {
+    // The other half of the clear case, and the one that makes it safe: a PATCH of some other field must not wipe the
+    // type. Without this, "absent means leave alone" is an assumption rather than a tested rule.
+    const id = (await create({ fact: `keep my type ${RUN}`, type: 'decision' })).body._id;
+    assert.equal((await edit(id, { description: 'an unrelated edit' })).status, 200);
+    const after = await read(id);
+    assert.equal(after.type, 'decision', 'an unrelated PATCH must not clear the type');
+    assert.equal(after.description, 'an unrelated edit');
+  });
+
+  it('accepts a type the SCHEMA does not declare — there is no allowlist', async () => {
+    // Deliberate, and the reason the UI control is free text with suggestions rather than a closed select. `validateMemory`
+    // uses `type` only to look up `typeSchemas.memory[type]`; unlike chrono there is no `getAllowedMemoryTypes`. A UI
+    // that offered only declared types would be stricter than the API — so if this ever starts refusing, the control
+    // must change with it.
+    const r = await create({ fact: `undeclared type ${RUN}`, type: 'observation' });
+    assert.equal(r.status, 201, `an undeclared memory type was refused: ${JSON.stringify(r.body)}`);
+    assert.equal((await read(r.body._id)).type, 'observation');
+  });
+
+  it('refuses a non-string type rather than coercing it', async () => {
+    const id = (await create({ fact: `bad type ${RUN}` })).body._id;
+    const r = await edit(id, { type: 42 });
+    assert.equal(r.status, 400, `a numeric type was accepted: ${JSON.stringify(r.body)}`);
+  });
+});


### PR DESCRIPTION
## The gap

The memories tab has sorted and filtered by `type` since #836, and **nothing could write one** — not the create form,
not the drawer. A column and its filter operated on a field only the API and MCP could set.

## Free text with suggestions, not a `<select>` — and checking first changed the design

The item proposed a `<select>` bound to `memoryTypeOptions()`. The server does not restrict a memory type:
`validateMemory` uses it only to look up `typeSchemas.memory[type]` for property validation, and **unlike chrono there
is no `getAllowedMemoryTypes` allowlist** — any string is accepted.

A closed select would have been **stricter than the API**, making types the server accepts unreachable from the UI —
the mirror image of the gap being closed. `memoryTypeOptions()` already merges the schema's keys with the values
present in the data, so it is a suggestion list by construction. The verification shows it offering
`["decision","note","observation"]`: two declared in the schema, one existing only in the data.

## Two layers underneath, both of which would have made the control a no-op

**1. The typed client did not model the field.** `createMemory` and `updateMemory` had no `type` in their body types —
the same shape as #840, where the typed client was discarding `rights`.

**2. The server dropped it on update.** `POST` read `type`; the `PATCH` handler never destructured it, so changing a
memory's type answered **200 and changed nothing**. `updateMemory` had accepted it and written `$set.type` all along —
the field was plumbed the whole way down and lost at the door.

That second one was **found by driving the UI, not by reading it**: the browser sent `{"type":"note", …}`, the request
succeeded, and the stored record still said `decision`. Adding a control is what made a server gap visible, which is
the argument for verifying a UI change end-to-end rather than at the component boundary.

Same shape as the `skip` parameter aigents reported on `POST /query`: permissive body, success status, silently dropped
field.

## The clear path

Blank means **absent** on create and **explicitly empty** on update — an omitted field on a PATCH means *leave it
alone*, so clearing the box has to reach the API as an empty value or a type could be set and never unset. Asserted
both directions, plus that an **unrelated** PATCH does not wipe the type, which is what makes the clear path safe
rather than lucky.

## Verification, end to end on an isolated instance

| checked | result |
|---|---|
| create form renders, styled like its siblings | screenshot read, "TYPE" field with the `optional` placeholder |
| suggestion list | `["decision","note","observation"]` — schema ∪ data |
| create writes | stored `type: "decision"` |
| drawer opens populated | input present, value `decision` |
| drawer save persists | stored `type: "note"` |
| memories table | Type column shows both values |

Plus 6 new API tests, `1119` client tests, and `npm run preflight` green.

## One process note

**The drawer save appeared to do nothing on the first two attempts.** It was a stale scratch server holding port 3260 —
`/health` answered `200` from the *old* process, so the new code never ran. I nearly filed that as a second defect. The
`EADDRINUSE` check in the log is the only thing that distinguishes "my fix doesn't work" from "my fix isn't running",
and it is the second time in this session that trap cost a wrong conclusion.

🤖 Generated with Claude Code
