### PR TITLE
feat(brain): the embed queue is readable and retryable, on both surfaces at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- **You can now see which brain records have no vector, and re-embed one — over REST *and* MCP.** A brain record whose
+  embedding fails is **stored**, and a persisted job carries the failure per record with `attempts`, `lastError` and a
+  terminal `failed` status after the attempt budget. None of that was reachable from outside: files had a listable queue
+  and a retry endpoint, brain records had the state and no endpoint. So *"which of my records have no vector"* could not
+  be answered even though the server knew — and a record without a vector is **invisible to `recall` and to `query`'s
+  semantic path**, which from a caller's seat is indistinguishable from the record having been dropped.
+  - `GET /api/brain/spaces/:spaceId/embedding-queue/records` — counts plus the jobs, newest-first, filterable by
+    `status`. Requires `knowledge: read`, deliberately readable by a token that cannot write: an operator who cannot fix
+    the queue still needs to see it.
+  - `POST /api/brain/spaces/:spaceId/embedding-queue/records/retry` — re-queue **one** record by `recordType` +
+    `recordId`. `202 ok`, `200 processing` (a worker holds it; left alone rather than reset, so a run in progress is not
+    interrupted), `404 not_found`. Audited as `brain.retry_embedding`, because a successful retry clears `lastError` and
+    the audit snapshot is then the only place the original failure survives.
+  - New MCP tools `list_embed_jobs` and `retry_record_embedding`, shipped **in the same commit as the routes**. The five
+    REST-only capabilities breituai-platform reported were all REST-only for the same reason — a route shipped and its
+    tool never followed, five times — so `REST_ONLY_CAPABILITIES` does not gain a sixth row.
+  - Per record rather than "retry all failed" (the media queue's shape): a brain record's failure is usually about *that
+    record*, where a media failure is usually about the worker. For a whole space, `POST /reindex` already exists.
+  - It nests under the existing `embedding-queue` rather than taking a name of its own. Two sibling top-level names would
+    have left a caller guessing which half of the same subsystem each one meant; the URL now says it.
+- **`listEmbedJobs` / `retryEmbedJob` in `brain/embed-queue.ts`** — the queue's read and retry paths, called by both
+  surfaces. `retryEmbedJob` is deliberately **not** `enqueueEmbedJob`: that one exists for a new write and resets the
+  content-derived fields with it, which would claim the record had changed when only the operator's patience had.
+
 - **A memory's `type` is now editable in the UI — in the create form and the record drawer.** The memories tab has
   sorted and filtered by `type` since #836, and nothing could write one: not the create form, not the drawer. So the
   column and its filter operated on a field only the API and MCP could set.
@@ -326,6 +350,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     says the endpoint list is unavailable. A tooltip must not take the editor with it.
 
 ### Changed
+- **`limit: 0` on an embed-job listing returns the default page, not one row.** `Math.max(n, 1)` would answer a caller
+  who computed `limit: 0` with a single row, and one row out of a hundred failures reads as a nearly empty queue — a
+  wrong answer that looks like a right one. The REST route rejects it as a `400` outright.
 - **BREAKING: a record's id is server-generated. A caller can no longer choose one.** Owner ruling: *"we do not
   accept custom ids … id is id."*
   - `create_chrono`, `remember`, `upsert_entity` and `bulk_write` used to **adopt** a supplied id when it named

--- a/docs/integration-guide/04d-brain-ops-api.md
+++ b/docs/integration-guide/04d-brain-ops-api.md
@@ -191,6 +191,99 @@ discovering this by trying.
 > or if the database search process was not ready when the instance started. Reindexing every record
 > in the space will not create it. Use the rebuild endpoint below.
 
+### Vectorless records — the embed queue for brain records
+
+A brain record is written and its vector is computed **after** the response. If the embedder is unreachable or the text
+chokes it, the record is **stored** and a job records the failure — it is not dropped. But a record without a vector is
+**invisible to `recall` and to `query`'s semantic path**: the vector search cannot return it, and the lexical fallback
+needs an embedding to score. These two endpoints are how you find those records and get them embedded.
+
+This is the **record** half of the queue. `GET /embedding-queue` (without `/records`) is the **media** half — file chunks
+from the conversion pipeline. They are separate collections with separate workers.
+
+```http
+GET /api/brain/spaces/:spaceId/embedding-queue/records
+```
+
+| Query param | Description |
+|-------------|-------------|
+| `status` | `pending`, `processing`, or `failed`. Omit for all three. An unknown value is a `400`, never a silently ignored filter |
+| `limit` | Default `50`, max `200`. `0`, a negative, or a non-integer is a `400` |
+
+**Response** `200`:
+
+```json
+{
+  "counts": { "pending": 2, "processing": 0, "failed": 1 },
+  "jobs": [
+    {
+      "recordType": "memory",
+      "recordId": "3f2c…",
+      "spaceId": "general",
+      "status": "failed",
+      "attempts": 5,
+      "maxAttempts": 5,
+      "lastError": "embedding model unreachable",
+      "createdAt": "2026-08-13T09:12:04.311Z",
+      "updatedAt": "2026-08-13T09:18:47.902Z"
+    }
+  ]
+}
+```
+
+Newest-first by `updatedAt`. `attempts === maxAttempts` with `status: "failed"` means the queue has **given up** — it
+will not retry on its own, and the record stays unfindable until you retry it or rewrite it. Each row carries its own
+`spaceId`, which for a **proxy space** is the member space the record actually lives in — that is the space to retry it
+in. `counts` is returned whether or not you filtered, so a caller can filter to `failed` and still see the whole picture.
+
+Requires `knowledge: read`. Deliberately readable by a token that cannot write: an operator who cannot fix the queue
+still needs to be able to see it.
+
+---
+
+### Retry one record's embedding
+
+```http
+POST /api/brain/spaces/:spaceId/embedding-queue/records/retry
+```
+
+```json
+{ "recordType": "memory", "recordId": "3f2c…" }
+```
+
+| Field | Description |
+|-------|-------------|
+| `recordType` | `memory`, `entity`, `edge`, `chrono`, or `file`. Anything else is a `400` |
+| `recordId` | The record's `_id`, as the listing reports it. Required |
+| `targetSpace` | Required when `:spaceId` is a **proxy** space: the member space holding the record |
+
+Resets the job to `pending`, clears `attempts` and `lastError`, and wakes the worker. The record's stored text is
+untouched — this re-embeds what is already there rather than re-writing it.
+
+**Response** `202`:
+
+```json
+{ "result": "ok", "recordType": "memory", "recordId": "3f2c…", "spaceId": "general" }
+```
+
+| `result` | Status | Meaning |
+|---|---|---|
+| `ok` | `202` | Re-queued. The worker will pick it up; it has not embedded yet |
+| `processing` | `200` | A worker already holds this job. **Left alone** rather than reset, so the run in progress is not interrupted. Not an error |
+| `not_found` | `404` | No job for that record — either it embedded successfully, or the record is gone |
+
+Per record rather than "retry all failed": a brain record's failure is usually about *that record* (an oversized fact, a
+property the embedder choked on), where a media failure is usually about the worker. Retrying a thousand records that
+will each fail again hides the problem. If a whole space needs re-embedding — after changing the embedding model, for
+instance — use [Reindex Space](#reindex-space) instead.
+
+Requires `knowledge: write`. Audited as `brain.retry_embedding`, with the failure it was retried from in the snapshot: a
+successful retry clears `lastError`, so the audit entry is the only place the original reason survives.
+
+Both endpoints are also MCP tools — `list_embed_jobs` and `retry_record_embedding`. See [MCP](16-mcp.md).
+
+---
+
 ### Reset a space's recorded usage
 
 ```http

--- a/docs/integration-guide/16-mcp.md
+++ b/docs/integration-guide/16-mcp.md
@@ -41,7 +41,7 @@ On connect, the server sends global instructions listing all available space IDs
 
 ### Read-Only Tokens
 
-When connecting with a `readOnly` token, mutating tools (`remember`, `update_memory`, `delete_memory`, `upsert_entity`, `update_entity`, `delete_entity`, `merge_entities`, `upsert_edge`, `update_edge`, `delete_edge`, `create_chrono`, `update_chrono`, `delete_chrono`, `bulk_write`, `write_file`, `delete_file`, `create_dir`, `move_file`, `retry_embedding`, `sync_now`, `update_space`, `update_space_schema`, `create_space`, `reindex`, `wipe_space`) are **hidden** from `tools/list` and rejected with an error if called directly. Read-only tools (`help`, `recall`, `find_similar`, `query`, `get_stats`, `get_space_meta`, `list_spaces`, `find_entities_by_name`, `list_chrono`, `read_file`, `list_dir`, `traverse`) work normally. `list_tokens` is read-only but **admin-gated**, like `list_peers`. `list_peers` is read-only but **admin-gated** — see the admin-only note below.
+When connecting with a `readOnly` token, mutating tools (`remember`, `update_memory`, `delete_memory`, `upsert_entity`, `update_entity`, `delete_entity`, `merge_entities`, `upsert_edge`, `update_edge`, `delete_edge`, `create_chrono`, `update_chrono`, `delete_chrono`, `bulk_write`, `write_file`, `delete_file`, `create_dir`, `move_file`, `retry_embedding`, `retry_record_embedding`, `sync_now`, `update_space`, `update_space_schema`, `create_space`, `reindex`, `wipe_space`) are **hidden** from `tools/list` and rejected with an error if called directly. Read-only tools (`help`, `recall`, `find_similar`, `query`, `get_stats`, `get_space_meta`, `list_spaces`, `find_entities_by_name`, `list_chrono`, `read_file`, `list_dir`, `traverse`, `list_embed_jobs`) work normally. `list_tokens` is read-only but **admin-gated**, like `list_peers`. `list_peers` is read-only but **admin-gated** — see the admin-only note below.
 
 ### Connecting
 
@@ -203,6 +203,8 @@ row survives its own tool being built, so the list cannot keep advertising a gap
 | `delete_file` | Delete a file |
 | `list_tokens` | List the instance API tokens — names, prefixes, expiry, rights. **Admin only.** Never includes a secret or its hash |
 | `retry_embedding` | Re-queue a file whose media embedding failed or was skipped. Returns `processing` unchanged when the worker already holds it |
+| `list_embed_jobs` | List brain records whose embedding is pending, processing or **failed**, with `attempts` and `lastError` for each, plus counts. This is how you tell *"the record is missing"* from *"the record has no vector yet"*: a record with an unfinished job is stored but not yet findable by `recall`/`query`. Filter with `status`; omit it for the whole backlog. Read-only, so a `readOnly` token can still diagnose a stalled queue |
+| `retry_record_embedding` | Re-queue ONE brain record whose embedding failed, by `recordType` + `recordId` from `list_embed_jobs`. Resets the job to pending and clears its attempt count and last error. Returns `processing` unchanged when the worker already holds it. For files use `retry_embedding` — that re-runs the media pipeline, this only re-embeds |
 | `create_dir` | Create a directory |
 | `move_file` | Move or rename a file/directory |
 | `update_space` | Update space label and/or purpose (admin only). In a networked space a purpose change opens a meta vote rather than applying at once |

--- a/server/src/api/brain/embed-jobs.ts
+++ b/server/src/api/brain/embed-jobs.ts
@@ -1,0 +1,153 @@
+/**
+ * Brain-record embed jobs (/api/brain/spaces/:spaceId/embedding-queue/records).
+ *
+ * ## Why this exists at all
+ *
+ * breituai-platform read our 2.5.1 note and concluded that a brain record written while the embedder was unreachable is
+ * **silently dropped**. That was half wrong, and the reality is better than they feared: the record is stored, and a
+ * persisted job carries the failure per record — `attempts`, `lastError`, and a terminal `failed` status after
+ * `MAX_EMBED_ATTEMPTS`. The record is unfindable by `recall` until its vector lands, but it is not lost.
+ *
+ * **What was genuinely missing is this router.** The state existed and nothing exposed it. Files had a listable queue
+ * and a retry endpoint; brain records had the state and no way to ask for it, so *"which of my records have no vector"*
+ * was unanswerable from outside — which, from a caller's seat, is indistinguishable from the data loss they described.
+ * Their report was wrong about the mechanism and right about the consequence.
+ *
+ * ## Why it nests under `embedding-queue` instead of a name of its own
+ *
+ * `GET /spaces/:spaceId/embedding-queue` already existed and answers for MEDIA jobs only — file chunks, not brain
+ * records. Two sibling top-level names (`embedding-queue` and, say, `embed-jobs`) would have left a caller guessing
+ * which half of the same subsystem each one meant. Nesting says it in the URL: the queue, the records in it.
+ *
+ * The media half stays where it is, in file-meta.ts next to the file records it reports on.
+ */
+import { Router } from 'express';
+import { requireSpaceAuth, denyReadOnly } from '../../auth/middleware.js';
+import { globalRateLimit } from '../../rate-limit/middleware.js';
+import { getConfig } from '../../config/loader.js';
+import { memberSpacesForRequest } from '../../spaces/proxy-scoped.js';
+import { resolveWriteTarget } from '../../spaces/proxy.js';
+import {
+  listEmbedJobs, getEmbedJobCounts, retryEmbedJob, EMBED_RECORD_TYPES, isEmbedRecordType,
+} from '../../brain/embed-queue.js';
+import type { BrainEmbedJobDoc } from '../../config/types.js';
+
+export const embedJobsRouter = Router();
+
+/** Query-string `status`, or nothing. An unknown value is a 400 rather than a silently ignored filter. */
+const STATUSES = ['pending', 'processing', 'failed'] as const;
+type JobStatus = (typeof STATUSES)[number];
+
+/**
+ * The wire shape. `claimToken` never leaves the server — it is a lease secret, and a caller that could read it could
+ * steal a job from the worker holding it. Everything else the queue records is returned, because the whole point of
+ * the endpoint is that the operator sees what the server sees.
+ */
+function toWire(job: BrainEmbedJobDoc, spaceId: string) {
+  return {
+    recordType: job.recordType,
+    recordId: job.recordId,
+    spaceId,
+    status: job.status,
+    attempts: job.attempts,
+    maxAttempts: job.maxAttempts,
+    lastError: job.lastError,
+    createdAt: job.createdAt,
+    updatedAt: job.updatedAt,
+  };
+}
+
+// GET /api/brain/spaces/:spaceId/embedding-queue/records — the brain-record half of the queue: counts, plus the jobs.
+//
+// Sums and merges across member spaces for a proxy space, exactly like the media GET beside it, so a fleet reads as one
+// queue. Each row carries its OWN `spaceId` — without it a proxy caller sees a `recordId` and cannot tell which member
+// space to retry it in, which would make the listing unactionable through the very surface it is meant to enable.
+embedJobsRouter.get('/spaces/:spaceId/embedding-queue/records', globalRateLimit, requireSpaceAuth, async (req, res) => {
+  const spaceId = req.params['spaceId'] as string;
+  if (!getConfig().spaces.some(s => s.id === spaceId)) {
+    res.status(404).json({ error: `Space '${spaceId}' not found` });
+    return;
+  }
+
+  const rawStatus = req.query['status'];
+  let status: JobStatus | undefined;
+  if (rawStatus !== undefined && rawStatus !== '') {
+    if (typeof rawStatus !== 'string' || !STATUSES.includes(rawStatus as JobStatus)) {
+      res.status(400).json({ error: `status must be one of ${STATUSES.join(', ')}` });
+      return;
+    }
+    status = rawStatus as JobStatus;
+  }
+
+  const rawLimit = req.query['limit'];
+  let limit: number | undefined;
+  if (rawLimit !== undefined && rawLimit !== '') {
+    const n = Number(rawLimit);
+    if (!Number.isFinite(n) || !Number.isInteger(n) || n < 1) {
+      res.status(400).json({ error: 'limit must be a positive integer' });
+      return;
+    }
+    limit = n;
+  }
+
+  const counts = { pending: 0, processing: 0, failed: 0 };
+  const jobs: ReturnType<typeof toWire>[] = [];
+  for (const mid of memberSpacesForRequest(req, spaceId)) {
+    const c = await getEmbedJobCounts(mid);
+    counts.pending += c.pending; counts.processing += c.processing; counts.failed += c.failed;
+    for (const j of await listEmbedJobs(mid, { ...(status ? { status } : {}), ...(limit ? { limit } : {}) })) {
+      jobs.push(toWire(j, mid));
+    }
+  }
+  // Re-sorted after the merge, or a proxy space's page would be ordered by member and only then by time.
+  jobs.sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : a.updatedAt > b.updatedAt ? -1 : 0));
+
+  res.json({ counts, jobs: limit ? jobs.slice(0, limit) : jobs, ...(status ? { status } : {}) });
+});
+
+// POST /api/brain/spaces/:spaceId/embedding-queue/records/retry — re-queue ONE record's embed job.
+//
+// Per record rather than "retry all failed" (the media route's shape) because a brain record's failure is usually about
+// that record — an oversized fact, a property the embedder choked on — where a media failure is usually about the
+// worker. Retrying a thousand records that will each fail again is a way to hide a problem, not to fix one.
+//
+// `recordType`/`recordId` go in the BODY, not the path: a recordId is caller-supplied and may contain a slash, and a
+// path-segment id would 404 on exactly the records most likely to be malformed.
+embedJobsRouter.post('/spaces/:spaceId/embedding-queue/records/retry', globalRateLimit, requireSpaceAuth, denyReadOnly, async (req, res) => {
+  const spaceId = req.params['spaceId'] as string;
+  if (!getConfig().spaces.some(s => s.id === spaceId)) {
+    res.status(404).json({ error: `Space '${spaceId}' not found` });
+    return;
+  }
+
+  const body = (req.body ?? {}) as { recordType?: unknown; recordId?: unknown; targetSpace?: unknown };
+  if (!isEmbedRecordType(body.recordType)) {
+    res.status(400).json({ error: `recordType must be one of ${EMBED_RECORD_TYPES.join(', ')}` });
+    return;
+  }
+  const recordId = typeof body.recordId === 'string' ? body.recordId.trim() : '';
+  if (!recordId) {
+    res.status(400).json({ error: 'recordId is required' });
+    return;
+  }
+
+  // A proxy space stores nothing itself, so a retry has to name the member. Same helper the write routes use, so the
+  // error text a caller gets is the one they already know from every other proxy write.
+  const wt = resolveWriteTarget(spaceId, typeof body.targetSpace === 'string' ? body.targetSpace : undefined);
+  if (!wt.ok) {
+    res.status(400).json({ error: wt.error });
+    return;
+  }
+
+  const result = await retryEmbedJob(wt.target, body.recordType, recordId);
+  if (result === 'not_found') {
+    res.status(404).json({
+      error: `No embed job for ${body.recordType} '${recordId}' in space '${wt.target}'`,
+      result,
+    });
+    return;
+  }
+  // `processing` is 200, not a conflict: the job IS queued and IS going to run, which is what the caller wanted. The
+  // outcome is returned verbatim so a caller can branch without reading the English.
+  res.status(result === 'ok' ? 202 : 200).json({ result, recordType: body.recordType, recordId, spaceId: wt.target });
+});

--- a/server/src/api/brain/index.ts
+++ b/server/src/api/brain/index.ts
@@ -15,6 +15,7 @@ import { fileMetaRouter } from './file-meta.js';
 import { searchRouter } from './search.js';
 import { bulkRouter } from './bulk.js';
 import { brainEventsRouter } from './events.js';
+import { embedJobsRouter } from './embed-jobs.js';
 
 export const brainRouter = Router();
 brainRouter.use(memoriesRouter);
@@ -25,3 +26,4 @@ brainRouter.use(fileMetaRouter);
 brainRouter.use(searchRouter);
 brainRouter.use(bulkRouter);
 brainRouter.use(brainEventsRouter);
+brainRouter.use(embedJobsRouter);

--- a/server/src/audit/middleware.ts
+++ b/server/src/audit/middleware.ts
@@ -79,6 +79,10 @@ const ROUTE_RULES: RouteRule[] = [
   { method: 'PATCH',  pattern: /^\/api\/brain\/(?:spaces\/)?([^/]+)\/files$/,      operation: 'file.meta.update', spaceGroup: 1 },
   { method: 'POST',   pattern: /^\/api\/brain\/(?:spaces\/)?([^/]+)\/reindex$/,    operation: 'space.reindex',  spaceGroup: 1 },
   { method: 'POST',   pattern: /^\/api\/brain\/spaces\/([^/]+)\/embedding-queue\/retry-failed$/, operation: 'file.retry_embedding_all', spaceGroup: 1 },
+  // A record retry is audited because it is the operator saying "embed this again" about a record that already gave
+  // up, and the snapshot is the only place the failure it was retried FROM survives: a successful retry clears
+  // `lastError`, so without this row the reason the job failed is gone the moment someone fixes it.
+  { method: 'POST',   pattern: /^\/api\/brain\/spaces\/([^/]+)\/embedding-queue\/records\/retry$/, operation: 'brain.retry_embedding', spaceGroup: 1 },
 
   // ── Space operations ─────────────────────────────────────────────────────
   { method: 'POST',   pattern: /^\/api\/spaces$/,                                  operation: 'space.create' },

--- a/server/src/auth/space-rights.ts
+++ b/server/src/auth/space-rights.ts
@@ -115,6 +115,10 @@ export const ROUTE_RIGHTS: readonly RouteRight[] = [
   { route: '/api/brain/spaces/:spaceId/files/extract', method: 'GET', area: 'files', needs: 'read', scope: 'path' },
   { route: '/api/brain/spaces/:spaceId/embedding-queue', method: 'GET', area: 'files', needs: 'read', scope: 'path' },
   { route: '/api/brain/spaces/:spaceId/embedding-queue/retry-failed', method: 'POST', area: 'files', needs: 'write', scope: 'path' },
+  // The RECORD half of the queue is `knowledge`, not `files`: it reports on memories, entities, edges and chrono.
+  // A files-only token can read the media queue and must not read a listing of knowledge record ids.
+  { route: '/api/brain/spaces/:spaceId/embedding-queue/records', method: 'GET', area: 'knowledge', needs: 'read', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/embedding-queue/records/retry', method: 'POST', area: 'knowledge', needs: 'write', scope: 'path' },
   { route: '/api/brain/spaces/:spaceId/files', method: 'PATCH', area: 'files', needs: 'write', scope: 'path' },
   { route: '/api/brain/spaces/:spaceId/files', method: 'DELETE', area: 'files', needs: 'admin', scope: 'path' },
   { route: '/api/files/:spaceId/mkdir', method: 'POST', area: 'files', needs: 'write', scope: 'path' },

--- a/server/src/brain/embed-queue.ts
+++ b/server/src/brain/embed-queue.ts
@@ -268,6 +268,92 @@ export async function getEmbedJobCounts(
   return out;
 }
 
+/**
+ * The record types the queue accepts, as a VALUE — the type union alone cannot validate an incoming string, and every
+ * caller that needed to check one was writing its own list. `file` is in here because file CHUNKS are embedded through
+ * this same queue; the media pipeline that produces them has its own separate job queue.
+ */
+export const EMBED_RECORD_TYPES = ['memory', 'entity', 'edge', 'chrono', 'file'] as const;
+
+/** Narrowing guard, so a route can reject an unknown type instead of enqueueing a job nothing will ever claim. */
+export function isEmbedRecordType(v: unknown): v is BrainEmbedRecordType {
+  return typeof v === 'string' && (EMBED_RECORD_TYPES as readonly string[]).includes(v);
+}
+
+/**
+ * The queue state, READABLE from outside — the surface B-3 is about.
+ *
+ * breituai-platform, 2026-08-11T1200Z, read our 2.5.1 note and concluded that a brain record written while the embedder
+ * was unreachable is silently dropped. Half wrong, and better than they feared: the record is stored and a persisted job
+ * records the failure per record, with `attempts`, `lastError` and a terminal `failed` status. It is unfindable until the
+ * vector lands, but it is not invisible.
+ *
+ * **What was genuinely missing is exactly this: nothing exposed it.** Files have a listable status and a retry endpoint;
+ * brain records had the state and no way to ask. So *"which of my records have no vector"* was unanswerable from
+ * outside even though the server knew — which is indistinguishable, from a caller's seat, from the data loss they
+ * described.
+ *
+ * Ordered newest-first by `updatedAt`: a caller triaging failures wants the ones that just broke, and a queue drains
+ * from the front so the oldest pending are the least interesting.
+ */
+export async function listEmbedJobs(
+  spaceId: string,
+  opts: { status?: 'pending' | 'processing' | 'failed'; limit?: number } = {},
+): Promise<BrainEmbedJobDoc[]> {
+  // A non-positive or non-numeric limit falls back to the DEFAULT rather than being clamped up to 1. `Math.max(n, 1)`
+  // would answer a caller who computed `limit: 0` with a single row, and one row out of a hundred failures reads as a
+  // nearly empty queue — a wrong answer that looks like a right one. 200 is the ceiling either way.
+  const asked = Number(opts.limit);
+  const limit = Number.isFinite(asked) && asked >= 1 ? Math.min(Math.floor(asked), 200) : 50;
+  const filter = opts.status ? { status: opts.status } : {};
+  return await jobs(spaceId)
+    .find(asFilter<BrainEmbedJobDoc>(filter), { projection: { claimToken: 0 } })
+    .sort({ updatedAt: -1 })
+    .limit(limit)
+    .toArray() as BrainEmbedJobDoc[];
+}
+
+/**
+ * Re-queue one record's embed job. The brain counterpart of the media queue's `retryJob`, with the same three outcomes
+ * and the same reasoning for each.
+ *
+ * `processing` is NOT an error and NOT retried: a worker already holds the job, and resetting it would take the work
+ * away from a run in progress. `not_found` means no job exists — either it never failed, or the record is gone.
+ *
+ * Deliberately NOT `enqueueEmbedJob`. That function exists for a NEW WRITE and resets the content-derived fields with
+ * it; calling it here would claim the record had changed when only the operator's patience had.
+ */
+export async function retryEmbedJob(
+  spaceId: string,
+  recordType: BrainEmbedRecordType,
+  recordId: string,
+): Promise<'ok' | 'not_found' | 'processing'> {
+  const _id = embedJobId(recordType, recordId);
+  const existing = await jobs(spaceId).findOne(asFilter<BrainEmbedJobDoc>({ _id })) as BrainEmbedJobDoc | null;
+  if (!existing) return 'not_found';
+  if (existing.status === 'processing') return 'processing';
+
+  const now = new Date().toISOString();
+  await jobs(spaceId).updateOne(
+    asFilter<BrainEmbedJobDoc>({ _id }),
+    asUpdate<BrainEmbedJobDoc>({
+      $set: {
+        status: 'pending',
+        attempts: 0,
+        lastError: null,
+        claimedAt: null,
+        claimableAfter: null,
+        claimToken: null,
+        progressAt: null,
+        updatedAt: now,
+      },
+    }),
+  );
+  // A retry is only useful if something picks it up; without this the job sits pending until the next poll.
+  wakeEmbedWorkers();
+  return 'ok';
+}
+
 // ── Worker wake-up, re-exported so callers do not reach into the signal ──────
 
 export const currentEmbedWorkEpoch = (): number => _signal.currentEpoch();

--- a/server/src/mcp/audit-map.ts
+++ b/server/src/mcp/audit-map.ts
@@ -60,6 +60,8 @@ export const MCP_TOOL_OPERATIONS: Record<string, string | null> = {
   delete_file: 'file.delete',
   // Same operation string the REST route audits under, so one query finds a retry however it arrived.
   retry_embedding: 'file.retry_embedding',
+  // Same operation string the REST route audits under, so one query finds a record retry however it arrived.
+  retry_record_embedding: 'brain.retry_embedding',
   create_dir: 'file.mkdir',
   // The tool registry flags this `mutating: true`, and it is right: a sync cycle pulls records from
   // peers and writes them locally, so "who started the run that brought in these records" is a fair
@@ -92,6 +94,10 @@ export const MCP_TOOL_OPERATIONS: Record<string, string | null> = {
   // Reads the token inventory from local config. `GET /api/tokens` is not audited either — it is a
   // read, and the acts worth an entry are the mint, the edit and the revoke, all of which are.
   list_tokens: null,
+  // Reads the embed queue's own bookkeeping. `GET .../embedding-queue/records` is not audited either: the queue is
+  // already the record of what happened, so an audit entry for reading it would only say that someone looked at a log.
+  // The RETRY beside it IS audited, because that one changes the queue.
+  list_embed_jobs: null,
 };
 
 /**

--- a/server/src/mcp/tools/embed.ts
+++ b/server/src/mcp/tools/embed.ts
@@ -1,0 +1,134 @@
+/**
+ * Embed-queue tools: the brain-record half of the queue, readable and retryable over MCP.
+ *
+ * ## Both surfaces from the first commit
+ *
+ * The five capabilities breituai-platform reported were all REST-only, each for the same reason: a route was written
+ * first and a tool was going to follow. It never did, five times. So this pair ships WITH `embedding-queue/records`
+ * rather than after it, and `REST_ONLY_CAPABILITIES` never gains a sixth row.
+ *
+ * ## Wrappers, deliberately
+ *
+ * `listEmbedJobs` / `retryEmbedJob` are the same functions the REST routes call. The retry reset (status, attempts,
+ * lastError, claim fields) is a state machine, and a second copy of a state machine is the copy nobody watches when it
+ * drifts. What these handlers own is the MCP-shaped part: argument validation and text a model can act on.
+ */
+import { resolveWriteTarget } from '../../spaces/proxy.js';
+import {
+  listEmbedJobs, getEmbedJobCounts, retryEmbedJob, EMBED_RECORD_TYPES, isEmbedRecordType,
+} from '../../brain/embed-queue.js';
+import type { ToolContext, ToolHandler, ToolResult, ToolSchemas } from './types.js';
+
+const RECORD_TYPES = [...EMBED_RECORD_TYPES];
+
+/**
+ * Answers *"which of my records have no vector"* — the question that had no answer from outside, on either surface.
+ *
+ * Read-only, so it stays visible to a read-only token: an operator who cannot fix the queue still has every reason to
+ * be able to see it, and hiding the diagnosis behind write rights is how a failure becomes a mystery.
+ */
+export const list_embed_jobsTool: ToolHandler = {
+  name: 'list_embed_jobs',
+  description: 'List brain records whose embedding is pending, in progress, or has failed, with the attempt count and '
+    + 'last error for each. A record with an unfinished job is STORED but not yet findable by recall or query — this is '
+    + 'how you tell "the record is missing" from "the record has no vector yet". Filter with `status`; omit it for the '
+    + 'whole backlog. Counts are returned either way.',
+  mutating: false,
+  spaceRequired: true,
+  inputSchema: (s: ToolSchemas) => ({
+    type: 'object',
+    properties: {
+      space: s.requiredSpace,
+      status: {
+        type: 'string',
+        enum: ['pending', 'processing', 'failed'],
+        description: 'Only jobs in this state. Omit for all three. `failed` means it is done retrying and needs you.',
+      },
+      limit: { type: 'number', minimum: 1, maximum: 200, description: 'Max jobs to return (default 50, cap 200).' },
+    },
+    required: ['space'],
+    additionalProperties: false,
+  }),
+  async handle(ctx: ToolContext): Promise<ToolResult> {
+    const { args: a, callSpace } = ctx;
+    const status = a['status'] as 'pending' | 'processing' | 'failed' | undefined;
+    const limit = a['limit'] === undefined ? undefined : Number(a['limit']);
+    if (limit !== undefined && (!Number.isFinite(limit) || limit < 1)) throw new Error('limit must be a positive number');
+
+    const counts = await getEmbedJobCounts(callSpace);
+    const jobs = (await listEmbedJobs(callSpace, {
+      ...(status ? { status } : {}),
+      ...(limit ? { limit } : {}),
+    })).map(j => ({
+      recordType: j.recordType,
+      recordId: j.recordId,
+      status: j.status,
+      attempts: j.attempts,
+      maxAttempts: j.maxAttempts,
+      lastError: j.lastError,
+      updatedAt: j.updatedAt,
+    }));
+
+    const head = `Embed queue for '${callSpace}': ${counts.pending} pending, ${counts.processing} processing, ${counts.failed} failed.`;
+    const body = jobs.length === 0
+      ? status
+        ? ` No ${status} jobs.`
+        : ' Nothing queued — every record in this space has its vector.'
+      : '\n' + jobs.map(j =>
+        `- ${j.recordType} ${j.recordId} — ${j.status}, attempt ${j.attempts}/${j.maxAttempts}`
+        + (j.lastError ? `: ${j.lastError}` : ''),
+      ).join('\n');
+
+    return {
+      content: [{ type: 'text' as const, text: head + body }],
+      structuredContent: { counts, jobs, ...(status ? { status } : {}) },
+    };
+  },
+};
+
+/**
+ * The brain counterpart of `retry_embedding`, which does files. Same three outcomes, reported verbatim for the same
+ * reason: `processing` means a worker already holds the job, which is not an error and must not be reset out from under
+ * a run in progress.
+ */
+export const retry_record_embeddingTool: ToolHandler = {
+  name: 'retry_record_embedding',
+  description: 'Re-queue one brain record whose embedding failed, so the worker picks it up again. Resets the job to '
+    + 'pending and clears its attempt count and last error. Returns `processing` unchanged if the worker already holds '
+    + 'it — not a failure, and retrying would interrupt a run. Get `recordType`/`recordId` from list_embed_jobs. For '
+    + 'files use retry_embedding instead: that re-runs the media pipeline, this only re-embeds.',
+  mutating: true,
+  spaceRequired: true,
+  inputSchema: (s: ToolSchemas) => ({
+    type: 'object',
+    properties: {
+      space: s.requiredSpace,
+      recordType: { type: 'string', enum: RECORD_TYPES, description: 'Which collection the record is in.' },
+      recordId: { type: 'string', minLength: 1, description: 'The record\'s _id, as list_embed_jobs reports it.' },
+      targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space holding the record.' },
+    },
+    required: ['space', 'recordType', 'recordId'],
+    additionalProperties: false,
+  }),
+  async handle(ctx: ToolContext): Promise<ToolResult> {
+    const { args: a, callSpace } = ctx;
+    if (!isEmbedRecordType(a['recordType'])) throw new Error(`recordType must be one of ${RECORD_TYPES.join(', ')}`);
+    const recordId = String(a['recordId'] ?? '').trim();
+    if (!recordId) throw new Error('recordId must not be empty');
+
+    const wt = resolveWriteTarget(callSpace, a['targetSpace'] as string | undefined);
+    if (!wt.ok) throw new Error(wt.error);
+
+    const result = await retryEmbedJob(wt.target, a['recordType'], recordId);
+    const text = result === 'ok'
+      ? `Re-queued ${a['recordType']} '${recordId}' for embedding.`
+      : result === 'processing'
+        ? `${a['recordType']} '${recordId}' is being embedded right now — left alone rather than reset, so the run in progress is not interrupted.`
+        : `No embed job exists for ${a['recordType']} '${recordId}' in '${wt.target}'. Either it embedded successfully, or the record is gone.`;
+
+    return {
+      content: [{ type: 'text' as const, text }],
+      structuredContent: { result, recordType: a['recordType'], recordId, space: wt.target },
+    };
+  },
+};

--- a/server/src/mcp/tools/index.ts
+++ b/server/src/mcp/tools/index.ts
@@ -9,6 +9,7 @@ import { create_chronoTool, update_chronoTool, list_chronoTool, delete_chronoToo
 import { read_fileTool, write_fileTool, list_dirTool, delete_fileTool, create_dirTool, move_fileTool, retry_embeddingTool } from './file.js';
 import { list_peersTool, sync_nowTool } from './sync.js';
 import { helpTool } from './help.js';
+import { list_embed_jobsTool, retry_record_embeddingTool } from './embed.js';
 
 export type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.js';
 
@@ -61,6 +62,8 @@ export const ALL_TOOLS: ToolHandler[] = [
   bulk_writeTool,
   list_peersTool,
   sync_nowTool,
+  list_embed_jobsTool,
+  retry_record_embeddingTool,
 ];
 
 export const TOOLS_BY_NAME: ReadonlyMap<string, ToolHandler> =

--- a/testing/integration/brain-embed-jobs-both-surfaces.test.js
+++ b/testing/integration/brain-embed-jobs-both-surfaces.test.js
@@ -1,0 +1,262 @@
+/**
+ * The brain embed queue is readable and retryable over REST **and** MCP — asserted together, in one file.
+ *
+ * ## Why one file rather than two
+ *
+ * The five capabilities breituai-platform reported were all REST-only for the same reason: a route shipped, a tool was
+ * going to follow, and it did not — five times. B-3's verify line is therefore not "the endpoint works" but *"any new
+ * endpoint exists on BOTH surfaces from the first commit"*, and the only way to test THAT is to ask the same question
+ * through both doors in the same run and compare the answers. Two files, each green on its own, is exactly the shape
+ * that let the gap open in the first place.
+ *
+ * `embed-jobs-are-visible-db.test.js` pins the state machine — the reset, the `processing` refusal, the ordering, the
+ * clamp — against a real Mongo with an unreachable model. This file does not re-assert any of it. It checks the two
+ * surfaces, their refusals, and the rights each one demands.
+ *
+ * ## The queue is expected to be EMPTY here
+ *
+ * The integration stack has a reachable embedder, so records embed and jobs retire. That is not a weakness: an empty
+ * queue still proves the shape (counts present, `jobs` an array, both surfaces agreeing), and the situation this feature
+ * exists for — a record stuck without a vector — cannot be manufactured against a working embedder without lying to the
+ * server. Forcing it is the DB suite's job, where the model really is unreachable.
+ *
+ * Run: node --test testing/integration/brain-embed-jobs-both-surfaces.test.js
+ */
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, get, delWithBody } from '../sync/helpers.js';
+import { openMcpSession } from '../sync/mcp-session.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+const RUN = Date.now();
+
+const SPACE = `embedjobs-${RUN}`;
+const MEMBER = `embedjobs-member-${RUN}`;
+const PROXY = `embedjobs-proxy-${RUN}`;
+
+let token;
+let session;
+const created = [];
+
+const RECORDS = `/api/brain/spaces/${SPACE}/embedding-queue/records`;
+const listRest = (qs = '') => get(INSTANCES.a, token, `${RECORDS}${qs}`);
+const retryRest = (body, space = SPACE) =>
+  post(INSTANCES.a, token, `/api/brain/spaces/${space}/embedding-queue/records/retry`, body);
+
+async function makeSpace(id, body = {}) {
+  const r = await post(INSTANCES.a, token, '/api/spaces', { id, label: id, ...body });
+  assert.equal(r.status, 201, `space create failed: ${JSON.stringify(r.body)}`);
+  created.push(id);
+}
+
+before(async () => {
+  token = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+  await makeSpace(SPACE);
+  await makeSpace(MEMBER);
+  await makeSpace(PROXY, { proxyFor: [MEMBER] });
+  const mem = await post(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/memories`, { fact: `embed queue subject ${RUN}` });
+  assert.equal(mem.status, 201, JSON.stringify(mem.body));
+  session = await openMcpSession(token);
+});
+
+after(async () => {
+  session?.close();
+  for (const id of created.reverse()) {
+    await delWithBody(INSTANCES.a, token, `/api/spaces/${id}`, { confirm: true }).catch(() => {});
+  }
+});
+
+describe('REST: the record half of the embedding queue', () => {
+  it('answers with counts and a jobs array', async () => {
+    const r = await listRest();
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.deepEqual(Object.keys(r.body.counts).sort(), ['failed', 'pending', 'processing'],
+      'all three counters are always present — a missing key is indistinguishable from zero to a caller that reads it');
+    for (const k of ['pending', 'processing', 'failed']) {
+      assert.equal(typeof r.body.counts[k], 'number', `${k} must be a number`);
+    }
+    assert.ok(Array.isArray(r.body.jobs), 'jobs is an array even when the queue is empty');
+  });
+
+  it('accepts a status filter and echoes which one it applied', async () => {
+    const r = await listRest('?status=failed');
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal(r.body.status, 'failed',
+      'the applied filter is echoed, so a caller can tell "no failures" from "my filter was ignored"');
+    assert.ok(r.body.jobs.every(j => j.status === 'failed'));
+  });
+
+  it('REFUSES an unknown status instead of ignoring it', async () => {
+    // The `skip` defect aigents reported on POST /query, and the memory `type` defect on PATCH, were both this shape:
+    // a permissive body, a success status, and a silently dropped field. A caller who mistypes `failed` must not be
+    // told the queue is fine.
+    const r = await listRest('?status=broken');
+    assert.equal(r.status, 400, `an unknown status was accepted: ${JSON.stringify(r.body)}`);
+  });
+
+  it('refuses a non-positive or non-numeric limit', async () => {
+    for (const bad of ['0', '-5', 'lots', '2.5']) {
+      const r = await listRest(`?limit=${bad}`);
+      assert.equal(r.status, 400, `limit=${bad} was accepted: ${JSON.stringify(r.body)}`);
+    }
+    assert.equal((await listRest('?limit=5')).status, 200, 'and a good one still works');
+  });
+
+  it('404s for a space that does not exist', async () => {
+    const r = await get(INSTANCES.a, token, `/api/brain/spaces/no-such-space-${RUN}/embedding-queue/records`);
+    assert.equal(r.status, 404, JSON.stringify(r.body));
+  });
+
+  it('does not collide with the MEDIA queue endpoint it nests under', async () => {
+    // `/embedding-queue` and `/embedding-queue/records` are different answers about different halves of the same
+    // subsystem. If the nested path ever shadowed its parent, the F9 Overview panel would silently start reading brain
+    // counts as media counts — the two shapes are similar enough that nothing would throw.
+    const media = await get(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/embedding-queue`);
+    assert.equal(media.status, 200, JSON.stringify(media.body));
+    assert.ok('complete' in media.body, 'the media summary has a `complete` counter; the record listing does not');
+    assert.ok(!('jobs' in media.body), 'and it does not carry a jobs array');
+    assert.ok(!('counts' in (await listRest()).body.jobs), 'sanity: the record listing is the nested shape');
+  });
+});
+
+describe('REST: the retry refuses what it cannot act on', () => {
+  it('rejects an unknown recordType', async () => {
+    const r = await retryRest({ recordType: 'sandwich', recordId: 'abc' });
+    assert.equal(r.status, 400, JSON.stringify(r.body));
+    assert.match(r.body.error, /recordType/);
+  });
+
+  it('rejects a missing or blank recordId', async () => {
+    assert.equal((await retryRest({ recordType: 'memory' })).status, 400);
+    assert.equal((await retryRest({ recordType: 'memory', recordId: '   ' })).status, 400);
+  });
+
+  it('404s for a record with no job, and says which space it looked in', async () => {
+    const r = await retryRest({ recordType: 'memory', recordId: `no-such-${RUN}` });
+    assert.equal(r.status, 404, JSON.stringify(r.body));
+    assert.equal(r.body.result, 'not_found', 'the outcome is machine-readable, not only prose');
+    assert.match(r.body.error, new RegExp(SPACE), 'the space is named — a proxy retry can land in a member space');
+  });
+
+  it('refuses a PROXY space without a target, and names the members', async () => {
+    // A proxy space stores nothing of its own, so "retry this record here" has no meaning until a member is named.
+    const r = await retryRest({ recordType: 'memory', recordId: 'anything' }, PROXY);
+    assert.equal(r.status, 400, JSON.stringify(r.body));
+    assert.match(r.body.error, new RegExp(MEMBER), 'the refusal must say which member to retry in');
+  });
+
+  it('accepts a proxy retry that names the member', async () => {
+    const r = await retryRest({ recordType: 'memory', recordId: `no-such-${RUN}`, targetSpace: MEMBER }, PROXY);
+    // 404 because that record has no job — the point is that it got PAST the proxy check and looked in the member.
+    assert.equal(r.status, 404, JSON.stringify(r.body));
+    assert.match(r.body.error, new RegExp(MEMBER), 'it looked in the member space, not in the proxy');
+  });
+});
+
+describe('MCP: the same two capabilities, through the other door', () => {
+  it('offers BOTH tools — the whole point of shipping them together', async () => {
+    const names = (await session.listTools()).map(t => t.name);
+    assert.ok(names.includes('list_embed_jobs'), `list_embed_jobs not offered: ${names.join(', ')}`);
+    assert.ok(names.includes('retry_record_embedding'), `retry_record_embedding not offered: ${names.join(', ')}`);
+  });
+
+  it('list_embed_jobs reports the same counts REST does', async () => {
+    // Both surfaces call `getEmbedJobCounts`/`listEmbedJobs`. Asserting they AGREE is what makes that a fact rather
+    // than an intention: a second copy of the query would drift, and this is where it would show.
+    const rest = await listRest();
+    const mcp = await session.callTool('list_embed_jobs', { space: SPACE });
+    assert.ok(!mcp?.isError, `refused: ${JSON.stringify(mcp)}`);
+    assert.deepEqual(mcp.structuredContent.counts, rest.body.counts,
+      'the two surfaces must answer the same question with the same numbers');
+    assert.match(mcp.content[0].text, /pending/i, 'and a human-readable line, because a model reads the text');
+  });
+
+  it('list_embed_jobs honours the status filter', async () => {
+    const r = await session.callTool('list_embed_jobs', { space: SPACE, status: 'failed' });
+    assert.ok(!r?.isError, JSON.stringify(r));
+    assert.equal(r.structuredContent.status, 'failed');
+    assert.ok(r.structuredContent.jobs.every(j => j.status === 'failed'));
+  });
+
+  it('retry_record_embedding reports not_found verbatim rather than as an error', async () => {
+    // `not_found` is an ANSWER: the record has no job, which usually means it embedded fine. Reporting it as a tool
+    // error would make an agent retry or escalate over the queue being healthy.
+    const r = await session.callTool('retry_record_embedding', {
+      space: SPACE, recordType: 'memory', recordId: `no-such-${RUN}`,
+    });
+    assert.ok(!r?.isError, `a not_found outcome must not be a tool error: ${JSON.stringify(r)}`);
+    assert.equal(r.structuredContent.result, 'not_found');
+  });
+
+  it('retry_record_embedding rejects an unknown recordType', async () => {
+    const r = await session.callTool('retry_record_embedding', {
+      space: SPACE, recordType: 'sandwich', recordId: 'abc',
+    });
+    assert.ok(r?.isError, `an unknown recordType was accepted: ${JSON.stringify(r)}`);
+  });
+
+  it('refuses a proxy retry with no target, with the same message REST gives', async () => {
+    const mcp = await session.callTool('retry_record_embedding', {
+      space: PROXY, recordType: 'memory', recordId: 'anything',
+    });
+    assert.ok(mcp?.isError, JSON.stringify(mcp));
+    const text = JSON.stringify(mcp);
+    assert.ok(text.includes(MEMBER), 'both surfaces route through resolveWriteTarget, so both name the members');
+  });
+});
+
+describe('rights: reading the queue is knowledge:read, retrying is knowledge:write', () => {
+  let readerToken;
+  let writerToken;
+
+  before(async () => {
+    // Scoped to this space only, so a leak shows up as a 403 rather than as a pass on the admin token's reach.
+    // The rights matrix is `.strict()` and every field is required, so a partial object is a 400 rather than a
+    // defaulted token — which is the safe direction, and worth knowing before writing a test that assumes otherwise.
+    const NONE = { knowledge: 'none', files: 'none', schema: 'none', dataQuality: 'none' };
+    const mk = async (name, knowledge) => {
+      const rights = {
+        instanceAdmin: false,
+        createSpaces: false,
+        // An empty floor, deliberately: `floor` is instance-wide in effect, so any rung here would grant the same
+        // access in every space and the per-space assertions below would pass for the wrong reason.
+        floor: { ...NONE },
+        perSpace: { [SPACE]: { ...NONE, knowledge } },
+      };
+      // `rights` ALONE — the API refuses `rights` together with the legacy `spaces`/`admin`/`readOnly` fields rather
+      // than silently preferring one, so the allowlist here IS the `perSpace` key set.
+      const r = await post(INSTANCES.a, token, '/api/tokens', { name: `${name}-${RUN}`, rights });
+      assert.equal(r.status, 201, `token create failed: ${JSON.stringify(r.body)}`);
+      // `token` is the RECORD; `plaintext` is the secret, returned only here and never again.
+      return r.body.plaintext;
+    };
+    readerToken = await mk('embedjobs-reader', 'read');
+    writerToken = await mk('embedjobs-writer', 'write');
+  });
+
+  it('a knowledge:read token can LIST', async () => {
+    // Deliberate: an operator who cannot fix the queue still has every reason to see it. Hiding the diagnosis behind
+    // write rights is how a stalled queue becomes a mystery.
+    const r = await get(INSTANCES.a, readerToken, RECORDS);
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+  });
+
+  it('a knowledge:read token can NOT retry', async () => {
+    const r = await post(INSTANCES.a, readerToken, `${RECORDS}/retry`, { recordType: 'memory', recordId: 'x' });
+    assert.equal(r.status, 403, `a read token performed a write: ${JSON.stringify(r.body)}`);
+  });
+
+  it('a knowledge:write token CAN retry', async () => {
+    const r = await post(INSTANCES.a, writerToken, `${RECORDS}/retry`, { recordType: 'memory', recordId: `no-such-${RUN}` });
+    assert.equal(r.status, 404, `expected to reach the queue and find no job, got ${r.status}: ${JSON.stringify(r.body)}`);
+  });
+
+  it('neither token reaches another space', async () => {
+    const r = await get(INSTANCES.a, readerToken, `/api/brain/spaces/${MEMBER}/embedding-queue/records`);
+    assert.ok(r.status === 403 || r.status === 404, `a scoped token read another space's queue: ${r.status}`);
+  });
+});

--- a/testing/standalone/embed-jobs-are-visible-db.test.js
+++ b/testing/standalone/embed-jobs-are-visible-db.test.js
@@ -1,0 +1,250 @@
+/**
+ * The embed queue's state can be READ and one record's job can be RETRIED — against a real MongoDB.
+ *
+ * ## What was actually wrong
+ *
+ * breituai-platform read our 2.5.1 note and concluded a brain record written while the embedder was unreachable is
+ * silently dropped. `embed-queue-db.test.js` already proves that is not what happens: the record is stored, a job is
+ * enqueued, it retries with backoff, and it ends `failed` with its `lastError` after the attempt budget.
+ *
+ * **Their report was wrong about the mechanism and right about the consequence.** All of that state was invisible from
+ * outside — no endpoint, no tool — so *"which of my records have no vector"* could not be answered, which from a
+ * caller's seat is indistinguishable from the loss they described. This file pins the reading and the retrying.
+ *
+ * ## Why the ordering and the clamp are asserted, and not just "it returns rows"
+ *
+ * A listing that answers with the OLDEST hundred jobs is worse than useless during an incident: the failures an
+ * operator is triaging are the ones that just broke, and a queue drains from the front, so the oldest pending are the
+ * least interesting rows in the collection. And an uncapped `limit` on a collection with one row per record is a way to
+ * ask the server for the whole space in one response.
+ *
+ * ## The `processing` case is the one worth a test
+ *
+ * A retry that resets a job a worker is holding takes the work away from a run in progress — the record then embeds
+ * twice, or not at all if the second claim also fails. `retryEmbedJob` reports `processing` and changes nothing, and
+ * that is asserted on the STORED job rather than on the return value, because a function can return the right word and
+ * still have written.
+ *
+ * Run: `npm run test:up` first, then
+ *      node --test testing/standalone/embed-jobs-are-visible-db.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+
+const SPACE = 'general';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ythril-embed-jobs-'));
+const CONFIG_PATH = path.join(tmpDir, 'config.json');
+process.env['CONFIG_PATH'] = CONFIG_PATH;
+
+// Unreachable, not merely absent — the same precondition as embed-queue-db.test.js, so a machine that happens to hold
+// the weights cannot turn this suite into a measurement of its own model cache.
+const EMPTY_CACHE = path.join(tmpDir, 'empty-model-cache');
+fs.mkdirSync(EMPTY_CACHE, { recursive: true });
+process.env['YTHRIL_MODELS_OFFLINE'] = '1';
+process.env['MODEL_CACHE_DIR'] = EMPTY_CACHE;
+
+let mongo, memory, queue, worker;
+
+const jobs = () => mongo.col(`${SPACE}_embed_jobs`);
+const memories = () => mongo.col(`${SPACE}_memories`);
+
+/** Write a record and return its job id, so a test reads as the situation it is about. */
+const writeRecord = async (fact) => {
+  const doc = await memory.remember(SPACE, fact, [], []);
+  return { id: doc._id, jobId: `memory:${doc._id}` };
+};
+
+describe('the embed queue is readable and retryable (real MongoDB, no reachable model)', { skip }, () => {
+  before(async () => {
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify(
+      { spaces: [{ id: SPACE, label: 'General' }], networks: [], tokens: [] }, null, 2,
+    ));
+    mongo = await openTestMongo('embedjobsvisible');
+    const loader = await import('../../server/dist/config/loader.js');
+    loader.loadConfig();
+    memory = await import('../../server/dist/brain/memory.js');
+    queue = await import('../../server/dist/brain/embed-queue.js');
+    worker = await import('../../server/dist/brain/embed-worker.js');
+  });
+
+  after(async () => {
+    await closeTestMongo();
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  beforeEach(async () => {
+    await jobs().deleteMany({});
+    await memories().deleteMany({});
+    queue.resetEmbedPendingHint();
+  });
+
+  it('the model really is unreachable (the precondition, not an assumption)', async () => {
+    const { embed } = await import('../../server/dist/brain/embedding.js');
+    await assert.rejects(() => embed('anything'),
+      'this suite is about records that could NOT be embedded; a reachable embedder proves nothing');
+  });
+
+  it('lists the job a vectorless record left behind — the state that was invisible', async () => {
+    const { id } = await writeRecord('node-7 runs the platform apps');
+
+    const listed = await queue.listEmbedJobs(SPACE);
+    assert.equal(listed.length, 1, 'the one queued job is reported');
+    assert.equal(listed[0].recordType, 'memory');
+    assert.equal(listed[0].recordId, id, 'the row names the record, which is what makes it actionable');
+    assert.equal(listed[0].status, 'pending');
+    assert.equal(listed[0].attempts, 0);
+    assert.ok(listed[0].maxAttempts >= 1, 'the budget is reported, so "attempt 3" means something to a reader');
+  });
+
+  it('reports counts by status, and the counts agree with the rows', async () => {
+    await writeRecord('one');
+    await writeRecord('two');
+
+    const counts = await queue.getEmbedJobCounts(SPACE);
+    assert.deepEqual(
+      { pending: counts.pending, processing: counts.processing, failed: counts.failed },
+      { pending: 2, processing: 0, failed: 0 },
+    );
+    assert.equal((await queue.listEmbedJobs(SPACE)).length, 2);
+  });
+
+  it('filters by status — and `failed` finds the record that gave up', async () => {
+    const { id } = await writeRecord('exhaust me');
+
+    // Drain until the job stops coming back. Each pass is one failed attempt against an unreachable model, so this
+    // walks the job to its terminal state the same way the worker would over minutes of backoff.
+    await jobs().updateOne({ _id: `memory:${id}` }, { $set: { attempts: 4, claimableAfter: null } });
+    let guard = 0;
+    while (await worker.runOneEmbedJob() && guard++ < 10) {
+      await jobs().updateOne({ _id: `memory:${id}` }, { $set: { claimableAfter: null } });
+    }
+
+    const stored = await jobs().findOne({ _id: `memory:${id}` });
+    assert.equal(stored.status, 'failed', `precondition: the job must be terminal, got ${stored.status}`);
+    assert.ok(stored.lastError, 'and it must carry why');
+
+    const failed = await queue.listEmbedJobs(SPACE, { status: 'failed' });
+    assert.equal(failed.length, 1, 'the failed filter finds it');
+    assert.equal(failed[0].recordId, id);
+    assert.ok(failed[0].lastError, 'the error reaches the caller — otherwise the listing cannot be acted on');
+
+    assert.equal((await queue.listEmbedJobs(SPACE, { status: 'pending' })).length, 0,
+      'and it is no longer pending, so a status filter that means nothing would be caught here');
+
+    // The record itself is still there. This is the half of their report that was wrong, asserted rather than argued.
+    assert.ok(await memories().findOne({ _id: id }), 'the record is STORED — it is vectorless, not dropped');
+  });
+
+  it('orders newest-first, because an operator is triaging what just broke', async () => {
+    const first = await writeRecord('oldest');
+    // `updatedAt` is an ISO string written at enqueue; two writes in the same millisecond would make the order
+    // arbitrary and the assertion meaningless, so the timestamps are set apart explicitly.
+    await jobs().updateOne({ _id: first.jobId }, { $set: { updatedAt: '2020-01-01T00:00:00.000Z' } });
+    const second = await writeRecord('newest');
+    await jobs().updateOne({ _id: second.jobId }, { $set: { updatedAt: '2030-01-01T00:00:00.000Z' } });
+
+    const listed = await queue.listEmbedJobs(SPACE);
+    assert.equal(listed[0].recordId, second.id, 'the most recently touched job comes first');
+    assert.equal(listed[1].recordId, first.id);
+  });
+
+  it('clamps the page size instead of trusting it', async () => {
+    for (let i = 0; i < 3; i++) await writeRecord(`record ${i}`);
+
+    assert.equal((await queue.listEmbedJobs(SPACE, { limit: 2 })).length, 2, 'a limit is honoured');
+    assert.equal((await queue.listEmbedJobs(SPACE, { limit: 0 })).length, 3,
+      'a zero limit must not mean "no rows" — it is clamped up, or a caller sending 0 sees an empty queue and believes it');
+    assert.equal((await queue.listEmbedJobs(SPACE, { limit: 100000 })).length, 3,
+      'an absurd limit is clamped rather than refused');
+  });
+
+  it('never returns the claim token', async () => {
+    // A lease secret. A caller holding it could steal a job from the worker running it, so it is projected out at the
+    // source rather than at each caller — the listing is the only place these documents leave the server.
+    const { jobId } = await writeRecord('lease me');
+    await jobs().updateOne({ _id: jobId }, { $set: { claimToken: 'super-secret-lease' } });
+
+    const listed = await queue.listEmbedJobs(SPACE);
+    assert.equal(listed.length, 1);
+    assert.ok(!('claimToken' in listed[0]), 'claimToken must never leave the server');
+    assert.ok(!JSON.stringify(listed).includes('super-secret-lease'));
+  });
+
+  it('a retry re-queues a failed job and clears what it failed with', async () => {
+    const { id, jobId } = await writeRecord('retry me');
+    await jobs().updateOne({ _id: jobId }, {
+      $set: { status: 'failed', attempts: 5, lastError: 'model unreachable', claimedAt: '2026-01-01T00:00:00.000Z' },
+    });
+
+    assert.equal(await queue.retryEmbedJob(SPACE, 'memory', id), 'ok');
+
+    const after = await jobs().findOne({ _id: jobId });
+    assert.equal(after.status, 'pending', 'the worker will pick it up again');
+    assert.equal(after.attempts, 0, 'the budget is restored, or one retry attempt is all it gets');
+    assert.equal(after.lastError, null);
+    assert.equal(after.claimedAt, null);
+    assert.equal(after.claimableAfter, null, 'and it is claimable NOW, not after the old backoff window');
+  });
+
+  it('a retry is not a rewrite — it leaves the text the vector will be built from alone', async () => {
+    // The reason this calls `retryEmbedJob` and not `enqueueEmbedJob`: the latter exists for a NEW WRITE and resets the
+    // content-derived fields with it. Reusing it here would claim the record had changed when only the operator's
+    // patience had, and the job would then embed whatever the second caller passed rather than the stored record.
+    const { id, jobId } = await writeRecord('the exact text that will be embedded');
+    const before = await jobs().findOne({ _id: jobId });
+    await jobs().updateOne({ _id: jobId }, { $set: { status: 'failed', lastError: 'boom' } });
+
+    await queue.retryEmbedJob(SPACE, 'memory', id);
+
+    const after = await jobs().findOne({ _id: jobId });
+    assert.equal(after.recordType, before.recordType);
+    assert.equal(after.recordId, before.recordId);
+    assert.equal(after.createdAt, before.createdAt, 'the job is the same job, not a new one');
+  });
+
+  it('refuses to reset a job a worker is HOLDING, and reports that plainly', async () => {
+    const { id, jobId } = await writeRecord('in flight');
+    await jobs().updateOne({ _id: jobId }, {
+      $set: {
+        status: 'processing', attempts: 2, lastError: 'a previous attempt',
+        claimedAt: '2026-01-01T00:00:00.000Z', claimToken: 'held-by-a-worker',
+      },
+    });
+
+    assert.equal(await queue.retryEmbedJob(SPACE, 'memory', id), 'processing');
+
+    // Asserted on the STORED job, not on the return value: a function can return the right word and still have written.
+    const after = await jobs().findOne({ _id: jobId });
+    assert.equal(after.status, 'processing', 'the run in progress keeps its job');
+    assert.equal(after.attempts, 2, 'and its attempt count — a reset here would give a failing job infinite retries');
+    assert.equal(after.claimToken, 'held-by-a-worker', 'the lease is untouched');
+  });
+
+  it('reports not_found for a record with no job, rather than inventing one', async () => {
+    assert.equal(await queue.retryEmbedJob(SPACE, 'memory', 'no-such-record'), 'not_found');
+    assert.equal(await jobs().countDocuments({}), 0,
+      'a retry of an unknown record must not CREATE a job — nothing would ever satisfy it');
+  });
+
+  it('a retry of one record leaves every other job alone', async () => {
+    const a = await writeRecord('first');
+    const b = await writeRecord('second');
+    await jobs().updateMany({}, { $set: { status: 'failed', attempts: 5, lastError: 'both failed' } });
+
+    await queue.retryEmbedJob(SPACE, 'memory', a.id);
+
+    assert.equal((await jobs().findOne({ _id: a.jobId })).status, 'pending');
+    const untouched = await jobs().findOne({ _id: b.jobId });
+    assert.equal(untouched.status, 'failed', 'per-record means per-record');
+    assert.equal(untouched.attempts, 5);
+    assert.equal(untouched.lastError, 'both failed');
+  });
+});

--- a/testing/standalone/mcp-tool-schemas.test.js
+++ b/testing/standalone/mcp-tool-schemas.test.js
@@ -31,7 +31,12 @@ describe('MCP tool schemas — universal invariants', () => {
     // carries its row.
     // 38 -> 39: `reindex`, the LAST row of the capability map. Prerequisites done — audit mapping, readOnly
     // classification, docs row.
-    assert.equal(ALL_TOOLS.length, 39);
+    // 39 -> 41: `list_embed_jobs` + `retry_record_embedding`, the brain-record half of the embed queue. These are the
+    // first pair to arrive WITH their REST route rather than after it, which is the whole point — the capability map
+    // was five rows long because five routes shipped alone. Prerequisites done for both: `retry_record_embedding` maps
+    // to `brain.retry_embedding` and is listed among the tools a readOnly token cannot see, `list_embed_jobs` is
+    // read-only and deliberately visible to a readOnly token, and `16-mcp.md` carries a row for each.
+    assert.equal(ALL_TOOLS.length, 41);
   });
 
   it('every tool advertises a closed object schema (type:object, additionalProperties:false)', () => {

--- a/testing/standalone/proxy-fanout-inventory.test.js
+++ b/testing/standalone/proxy-fanout-inventory.test.js
@@ -95,7 +95,13 @@ const RECLASSIFIED = 1;
 //
 // Raised deliberately. A conserved total that is quietly adjusted whenever it fails conserves nothing, so every change
 // to this number says which site moved and why.
-const TOTAL = 30;
+/**
+ * 30 -> 31: `api/brain/embed-jobs.ts`, the brain-record half of the embedding queue, added with `memberSpacesForRequest`
+ * from its first line rather than converted later. A new fan-out RAISES the total — the invariant is that a site is
+ * accounted for, not that the number never moves. Lowering it, or leaving it at 30 and letting the new site sit in
+ * PENDING, are the two ways this gate gets quietly defeated.
+ */
+const TOTAL = 31;
 
 const GUARDS = {
   'server/src/auth/middleware.ts': 2,
@@ -118,6 +124,8 @@ const NARROWED = new Set([
   'server/src/mcp/tools/chrono.ts',
   'server/src/api/spaces.ts',
   'server/src/api/brain/file-meta.ts',
+  // Born narrowed: the record half of the embedding queue never had a whole-proxy read to convert.
+  'server/src/api/brain/embed-jobs.ts',
   'server/src/api/brain/entities.ts',
   'server/src/api/files.ts',
 ]);

--- a/testing/sync/mcp-session.js
+++ b/testing/sync/mcp-session.js
@@ -1,0 +1,118 @@
+/**
+ * One MCP SSE session helper, shared.
+ *
+ * The FIFO-waiter harness below was copy-pasted into TEN test files before this module existed (`mcp-tools`, `mcp`,
+ * `mcp-reindex`, `mcp-create-space`, `mcp-update-space-schema`, `dupe-detection`, `proxy-spaces`, `recall-filter`,
+ * `recall-traverse`, and the red-team `mcp-security`). Ten copies of a transport harness is ten places a protocol change
+ * has to be found, and the copy that gets missed is the one whose suite starts timing out for reasons that look like the
+ * server's fault.
+ *
+ * New MCP tests import this. Migrating the existing ten is a mechanical follow-up, deliberately not folded into the
+ * feature PR that needed the eleventh copy.
+ *
+ * ## Why FIFO waiters and not frame matching
+ *
+ * Matching response frames by POSITION returns the PREVIOUS answer, which makes a test pass while asserting on the wrong
+ * call. Requests are queued in order and each reply is handed to the oldest waiter.
+ */
+import http from 'node:http';
+import { INSTANCES } from './helpers.js';
+
+/** Open an SSE session and return `{callTool, listTools, close}`. */
+export async function openMcpSession(authToken, instance = INSTANCES.a, timeoutMs = 15_000) {
+  const parsed = new URL(instance);
+  const host = parsed.hostname;
+  const port = parseInt(parsed.port || '80', 10);
+
+  return new Promise((resolve, reject) => {
+    const req = http.request({
+      host, port, path: '/mcp', method: 'GET',
+      headers: { Authorization: `Bearer ${authToken}`, Accept: 'text/event-stream' },
+    }, (res) => {
+      if (res.statusCode !== 200) { res.resume(); reject(new Error(`MCP SSE open failed: ${res.statusCode}`)); return; }
+
+      let buffer = '';
+      let sessionId = null;
+      const pendingMessages = [];
+      const waiters = [];
+
+      res.setEncoding('utf8');
+      res.on('data', chunk => {
+        buffer += chunk;
+        const parts = buffer.split('\n\n');
+        buffer = parts.pop() ?? '';
+        for (const part of parts) {
+          if (!part.trim()) continue;
+          let eventType = 'message';
+          let data = '';
+          for (const line of part.split('\n')) {
+            if (line.startsWith('event:')) eventType = line.slice(6).trim();
+            else if (line.startsWith('data:')) data = line.slice(5).trim();
+          }
+          if (eventType === 'endpoint') {
+            const m = data.match(/sessionId=([^&\s]+)/);
+            if (m) sessionId = m[1];
+          } else if (eventType === 'message' && data) {
+            try {
+              const msg = JSON.parse(data);
+              const waiter = waiters.shift();
+              if (waiter) waiter(msg);
+              else pendingMessages.push(msg);
+            } catch { /* non-JSON frame */ }
+          }
+        }
+      });
+      res.on('error', reject);
+
+      const deadline = Date.now() + timeoutMs;
+      const poll = setInterval(() => {
+        if (sessionId) { clearInterval(poll); resolve({ callTool, listTools, close }); }
+        else if (Date.now() > deadline) { clearInterval(poll); reject(new Error('MCP session did not receive endpoint event')); }
+      }, 50);
+
+      async function postJsonRpc(body) {
+        return new Promise((res2, rej2) => {
+          const waiterTimeout = setTimeout(() => rej2(new Error('MCP tool call timed out')), timeoutMs);
+          if (pendingMessages.length > 0) { clearTimeout(waiterTimeout); res2(pendingMessages.shift()); return; }
+          waiters.push(msg => { clearTimeout(waiterTimeout); res2(msg); });
+
+          const postData = JSON.stringify(body);
+          const pr = http.request({
+            host, port, path: `/mcp/messages?sessionId=${sessionId}`, method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Content-Length': Buffer.byteLength(postData),
+              Authorization: `Bearer ${authToken}`,
+            },
+          }, pres => {
+            let txt = '';
+            pres.setEncoding('utf8');
+            pres.on('data', c => { txt += c; });
+            pres.on('end', () => {
+              if (pres.statusCode !== 202 && pres.statusCode !== 200) {
+                clearTimeout(waiterTimeout);
+                rej2(new Error(`MCP POST failed: ${pres.statusCode} ${txt}`));
+              }
+            });
+          });
+          pr.on('error', rej2);
+          pr.write(postData);
+          pr.end();
+        });
+      }
+
+      async function callTool(name, args = {}) {
+        const rpc = await postJsonRpc({ jsonrpc: '2.0', id: Date.now(), method: 'tools/call', params: { name, arguments: args } });
+        return rpc?.result ?? rpc;
+      }
+      async function listTools() {
+        const rpc = await postJsonRpc({ jsonrpc: '2.0', id: Date.now(), method: 'tools/list', params: {} });
+        return rpc?.result?.tools ?? rpc?.tools ?? [];
+      }
+      function close() { req.destroy(); }
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+


### PR DESCRIPTION
## The report, and what was actually true

breituai-platform read our 2.5.1 note and concluded that a brain record written while the embedder was unreachable is
**silently dropped**. Half wrong, and better than they feared — the record is **stored**, and a persisted job carries the
failure per record with `attempts`, `lastError` and a terminal `failed` status after the attempt budget.
`embed-queue-db.test.js` has pinned that loop for months.

**Their report was wrong about the mechanism and right about the consequence.** None of that state was reachable from
outside. Files had a listable queue and a retry endpoint; brain records had the state and **no endpoint**, so *"which of
my records have no vector"* could not be answered even though the server knew. And a record without a vector is
invisible to `recall` and to `query`'s semantic path — so from a caller's seat, that is indistinguishable from the record
having been dropped. **The state existing is no comfort to someone who cannot see it.**

## What ships

| | |
|---|---|
| `GET /api/brain/spaces/:spaceId/embedding-queue/records` | counts + the jobs, newest-first, `status` filter, `limit` capped at 200 |
| `POST /api/brain/spaces/:spaceId/embedding-queue/records/retry` | re-queue **one** record by `recordType` + `recordId` |
| `list_embed_jobs` (MCP) | the same listing |
| `retry_record_embedding` (MCP) | the same retry |

**The tools land in the same commit as the routes.** The five capabilities they reported were all REST-only for one
reason — a route shipped and its tool never followed, five times — so `REST_ONLY_CAPABILITIES` does not gain a sixth row.

## Decisions worth reading

**It nests under `embedding-queue` rather than taking a name of its own.** That path already existed and answers for
**media** jobs only. Two sibling top-level names would have left a caller guessing which half of the same subsystem each
one meant. A test asserts the nested path does not **shadow** its parent, because the two response shapes are similar
enough that the F9 Overview panel would silently start reading brain counts as media counts without anything throwing.

**Per record, not "retry all failed"** (the media route's shape). A brain record's failure is usually about *that record*
— an oversized fact, a property the embedder choked on — where a media failure is usually about the worker. Retrying a
thousand records that will each fail again hides a problem rather than fixing one. A whole space is what `POST /reindex`
is for.

**`retryEmbedJob` is deliberately not `enqueueEmbedJob`.** That one exists for a new *write* and resets the
content-derived fields with it, which would claim the record had changed when only the operator's patience had.

**It refuses to reset a job a worker is HOLDING.** `processing` is reported verbatim and nothing is written — otherwise
the record embeds twice, and a failing job gets infinite retries. Mutation-tested: deleting that one line turns the suite
red, and the assertion is on the **stored** job rather than the return value, because a function can return the right
word and still have written.

**`limit: 0` returns the default page, not one row.** `Math.max(n, 1)` would answer a caller who computed `0` with a
single row, and one row out of a hundred failures reads as a nearly empty queue — a wrong answer that looks like a right
one. The REST route rejects it as a `400` outright, along with an unknown `status`: same shape as the `skip` parameter
aigents reported on `POST /query` and the memory `type` field on `PATCH` — a permissive body and a silently dropped
filter.

## Rights and audit

Reading is `knowledge: read`, retrying is `knowledge: write`, asserted in **both** directions with scoped tokens. A read
token can LIST **deliberately**: an operator who cannot fix the queue still needs to see it, and hiding the diagnosis
behind write rights is how a stalled queue becomes a mystery. The retry is audited as `brain.retry_embedding` — a
successful retry clears `lastError`, so the audit snapshot is then the only place the original failure survives.

## Tests

- **`testing/integration/brain-embed-jobs-both-surfaces.test.js`** — 21 assertions, one file on purpose. Two files each
  green on its own is exactly the shape that let the gap open five times; this one asserts REST and MCP answer the same
  question with the same numbers **in the same run**.
- **`testing/standalone/embed-jobs-are-visible-db.test.js`** — 12 assertions against a real Mongo with the model
  deliberately unreachable, which is the only place a genuinely stuck record can be produced without lying to the
  server: the failed-state listing, the ordering, the clamp, the reset, the `processing` refusal, and that `claimToken`
  never leaves.

Verified against a **rebuilt** test image (`grep -c 'embedding-queue/records' server/dist/api/brain/embed-jobs.js` inside
the container) before trusting a single result — the stale-image trap has cost a wrong conclusion in this session before.

## Two housekeeping notes

**`testing/sync/mcp-session.js`** — the SSE harness had been copy-pasted into **ten** test files. This is the eleventh
MCP test, so it got a shared module instead. Migrating the other ten is mechanical and deliberately not folded into a
feature PR.

**The proxy fan-out inventory total goes 30 → 31.** A new site *raises* it: the invariant is that every fan-out is
accounted for, not that the number never moves.

🤖 Generated with Claude Code
