### PR TITLE
feat(brain): a record's own timestamp is checked against the server's, and the disagreement is stored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- **A record's own timestamp is now checked against the server's, and a disagreement is recorded on the record.**
+  breituai-platform corrected three board posts whose `postedAt` was **eight hours** early — not clock drift, but one
+  measured stamp followed by three EXTRAPOLATED from how long they thought their work had taken. Their sentence for why
+  nothing caught it is the requirement: *"an estimated timestamp looks exactly like a measured one once it is written
+  down."* And their suggestion is why it is ours to build: the comparison is available to the store, which holds a number
+  the author did not supply, and not to the author.
+  - On create, a record carrying `stampedAt` or `postedAt` that disagrees with `createdAt` beyond the space's threshold
+    gets a `stampSkew` field — the property, the stamp quoted **as sent**, a signed `skewMs`, and the `thresholdMs` it was
+    judged against. All four brain creates are wired, each asserted separately against a real Mongo.
+  - **A warning, never a refusal.** The record is stored exactly as sent. A legitimately backdated record is normal — a
+    historical import, a backfilled document — and what is reported is a wrong number, not a corrupt record.
+  - **Set only when the threshold is exceeded**, which makes `{ "stampSkew": { "$exists": true } }` the cheap integrity
+    check they described. Storing a `0` on every record would make the useful query match everything.
+  - **The compact form `2026-08-09T0942Z` is parsed.** `new Date('2026-08-09T0942Z')` is *Invalid Date*, so a check built
+    on `Date.parse` alone would have found nothing to compare on precisely the records that motivated the ask — and would
+    have reported no skew for a stamp eight hours wrong. The tests assert the literal strings from their messages.
+  - Configured per space in `meta.stampSkew` (`warnMinutes`, `properties`), so the existing meta editors already write it.
+    `warnMinutes: 0` **disables** the check rather than making it strictest: a caller's stamp and the server's clock never
+    agree to the millisecond, so that reading would fire on every record in the space.
+  - The 40-minute default is the clock tolerance the board protocol already assumed between two parties. Theirs was off by
+    eight hours and nothing could show it.
 - **You can now see which brain records have no vector, and re-embed one — over REST *and* MCP.** A brain record whose
   embedding fails is **stored**, and a persisted job carries the failure per record with `attempts`, `lastError` and a
   terminal `failed` status after the attempt budget. None of that was reachable from outside: files had a listable queue

--- a/docs/integration-guide/04-brain-api.md
+++ b/docs/integration-guide/04-brain-api.md
@@ -343,6 +343,60 @@ Rules worth knowing before you configure it:
 
 ---
 
+### Stamp integrity — when a record's own timestamp disagrees with the server's
+
+A record may carry its own idea of when it happened, as a property: `stampedAt`, `postedAt`, or whatever your convention
+is. That value comes from the author, and **an estimated timestamp looks exactly like a measured one once it is written
+down**. The server holds a number the author did not supply — `createdAt` — so it can compare the two, and you cannot.
+
+On create, if the record carries one of the configured stamp properties and it disagrees with `createdAt` beyond the
+space's threshold, the record gets a `stampSkew` field:
+
+```json
+{
+  "property": "postedAt",
+  "stamp": "2026-08-09T0942Z",
+  "skewMs": -28800000,
+  "thresholdMs": 2400000
+}
+```
+
+`skewMs` is **signed**: negative means the author's stamp is *earlier* than the write. `stamp` is quoted back exactly as
+sent, because the point is that it looked right. `thresholdMs` is what it was judged against, so a record read years later
+still says what the rule was at the time.
+
+**It is a warning, never a refusal.** The record is stored exactly as sent. A legitimately backdated record is a normal
+thing — a historical import, a backfilled document — and what is being reported is a wrong number, not a corrupt record.
+
+**The field is set only when the threshold is exceeded.** Absence means agreed, or unstamped, or not checked. That makes
+presence the signal, and this the whole integrity check:
+
+```http
+POST /api/brain/spaces/:spaceId/query
+{ "collection": "memories", "filter": { "stampSkew": { "$exists": true } } }
+```
+
+The compact form `2026-08-09T0942Z` — no colon, no seconds — is parsed, as are ordinary ISO 8601, an explicit offset, and
+epoch seconds or milliseconds. A property that is not a timestamp at all is **not checked** rather than reported as skew.
+
+#### Configuring it, per space
+
+In the space's `meta`, so `PATCH /api/spaces/:id` and `update_space_schema` already write it:
+
+```json
+{ "meta": { "stampSkew": { "warnMinutes": 40, "properties": ["stampedAt", "postedAt"] } } }
+```
+
+| Field | Default | Meaning |
+|---|---|---|
+| `warnMinutes` | `40` | Warn beyond this much disagreement. **`0` disables the check** — it does *not* mean "warn on any difference", because a caller's stamp and the server's clock never agree to the millisecond |
+| `properties` | `["stampedAt", "postedAt"]` | Which properties to check, in order. The **first one that parses** decides; naming your own **replaces** the defaults rather than adding to them |
+
+The 40-minute default is not arbitrary: it is the clock tolerance the board protocol that prompted this already assumed
+between two parties.
+
+---
+
 ### Get a Memory by ID
 
 ```http

--- a/server/src/brain/chrono.ts
+++ b/server/src/brain/chrono.ts
@@ -14,6 +14,8 @@ import { findInsertContradictions, type ContradictionWarning } from './insert-co
 import { deriveChronoStatus } from './chrono-status.js';
 import { getConfig } from '../config/loader.js';
 import { stampExpiryOnCreate, applyExpiryToUpdate } from './ttl.js';
+import { stampSkewOnCreate } from './stamp-skew.js';
+import { getSpaceMeta } from '../spaces/schema-validation.js';
 import { mergeTags, mergeProperties, mergePropertiesOrKeep } from './merge-fields.js';
 import { enqueueEmbedJob } from './embed-queue.js';
 import { emitWebhookEvent, type WebhookActor } from '../webhooks/dispatcher.js';
@@ -215,6 +217,9 @@ export async function createChrono(
   // prunes deploy `event`s while keeping `health-snapshot`/`metrics-snapshot` for trending, which one
   // space-wide TTL cannot express.
   stampExpiryOnCreate(spaceId, doc, ttlDays, { collection: 'chrono', type: doc.type });
+  // Warn-not-refuse: a caller's own stamp checked against ours. Stored only when it disagrees beyond the space's
+  // threshold, so presence is the signal. The write proceeds either way -- a backdated import is legitimate.
+  stampSkewOnCreate(doc, getSpaceMeta(spaceId));
   await col<ChronoEntry>(`${spaceId}_chrono`).insertOne(asDoc<ChronoEntry>(doc));
   if (!embeddingFields.embedding) await enqueueEmbedJob(spaceId, 'chrono', doc._id);
   if (actor) emitWebhookEvent({ event: 'chrono.created', spaceId, entry: { ...doc, embedding: undefined }, ...actor });

--- a/server/src/brain/edges.ts
+++ b/server/src/brain/edges.ts
@@ -10,6 +10,8 @@ import { embed } from './embedding.js';
 import { edgeEmbedText } from './embed-text.js';
 import { getConfig } from '../config/loader.js';
 import { stampExpiryOnCreate, applyExpiryToUpdate } from './ttl.js';
+import { stampSkewOnCreate } from './stamp-skew.js';
+import { getSpaceMeta } from '../spaces/schema-validation.js';
 import { applyDeleteFields, setUnlessDeleted } from './delete-fields.js';
 import { mergePropertiesOrKeep, mergeTagsOrKeep } from './merge-fields.js';
 import { enqueueEmbedJob } from './embed-queue.js';
@@ -179,6 +181,9 @@ export async function upsertEdge(
   // `doc.label`, NOT `doc.type` — an edge has both, and the schema is keyed by label (see validateEdgeWrite).
   // Passing `type` here would look right and read a schema that is never there.
   stampExpiryOnCreate(spaceId, doc, ttlDays, { collection: 'edge', type: doc.label });
+  // Warn-not-refuse: a caller's own stamp checked against ours. Stored only when it disagrees beyond the space's
+  // threshold, so presence is the signal. The write proceeds either way -- a backdated import is legitimate.
+  stampSkewOnCreate(doc, getSpaceMeta(spaceId));
   await collection.insertOne(asDoc<EdgeDoc>(doc));
   if (!embeddingFields.embedding) await enqueueEmbedJob(spaceId, 'edge', doc._id);
   if (actor) emitWebhookEvent({ event: 'edge.created', spaceId, entry: { ...doc, embedding: undefined }, ...actor });

--- a/server/src/brain/entities.ts
+++ b/server/src/brain/entities.ts
@@ -10,6 +10,8 @@ import { embed } from './embedding.js';
 import { entityEmbedText } from './embed-text.js';
 import { getConfig } from '../config/loader.js';
 import { stampExpiryOnCreate, applyExpiryToUpdate } from './ttl.js';
+import { stampSkewOnCreate } from './stamp-skew.js';
+import { getSpaceMeta } from '../spaces/schema-validation.js';
 import { writeFilterFor, writeOutcome } from './write-precondition.js';
 import { applyDeleteFields, setUnlessDeleted } from './delete-fields.js';
 import { mergeTagsAndProperties, mergePropertiesOrKeep, mergeTagsOrKeep } from './merge-fields.js';
@@ -201,6 +203,9 @@ export async function upsertEntity(
   // `typed` is what makes the SCHEMA tier reachable. Omit it and the resolver silently falls through to the
   // space default, so a window set on `typeSchemas.entity.<type>.retention` does nothing at all.
   stampExpiryOnCreate(spaceId, doc, ttlDays, { collection: 'entity', type: doc.type });
+  // Warn-not-refuse: a caller's own stamp checked against ours. Stored only when it disagrees beyond the space's
+  // threshold, so presence is the signal. The write proceeds either way -- a backdated import is legitimate.
+  stampSkewOnCreate(doc, getSpaceMeta(spaceId));
   await collection.insertOne(asDoc<EntityDoc>(doc));
   if (!embeddingFields.embedding) await enqueueEmbedJob(spaceId, 'entity', doc._id);
   // Real-time duplicate-rule evaluation (opt-in per space). Fire-and-forget; the

--- a/server/src/brain/memory.ts
+++ b/server/src/brain/memory.ts
@@ -17,6 +17,8 @@ import { embed } from './embedding.js';
 import { memoryEmbedText } from './embed-text.js';
 import { getConfig } from '../config/loader.js';
 import { stampExpiryOnCreate, applyExpiryToUpdate } from './ttl.js';
+import { stampSkewOnCreate } from './stamp-skew.js';
+import { getSpaceMeta } from '../spaces/schema-validation.js';
 import { applyDeleteFields } from './delete-fields.js';
 import { mergeTags, mergeProperties, mergePropertiesOrKeep } from './merge-fields.js';
 import { enqueueEmbedJob } from './embed-queue.js';
@@ -191,6 +193,9 @@ export async function remember(
   if (properties !== undefined) doc.properties = properties;
   // See entities.ts: without `typed` the schema tier is unreachable and the space default applies instead.
   stampExpiryOnCreate(spaceId, doc, ttlDays, { collection: 'memory', type: doc.type });
+  // Warn-not-refuse: a caller's own stamp checked against ours. Stored only when it disagrees beyond the space's
+  // threshold, so presence is the signal. The write proceeds either way -- a backdated import is legitimate.
+  stampSkewOnCreate(doc, getSpaceMeta(spaceId));
   await col<MemoryDoc>(`${spaceId}_memories`).insertOne(asDoc<MemoryDoc>(doc));
   if (!embResult) await enqueueEmbedJob(spaceId, 'memory', doc._id);
   // Real-time duplicate-rule evaluation (opt-in per space). Fire-and-forget; the

--- a/server/src/brain/stamp-skew.ts
+++ b/server/src/brain/stamp-skew.ts
@@ -1,0 +1,172 @@
+/**
+ * Does a record's own timestamp agree with the server's?
+ *
+ * ## The report this exists for
+ *
+ * breituai-platform, 2026-08-09T0942Z: they corrected three of their own board posts whose `postedAt` was **eight hours**
+ * early. Not clock drift — their host's clock was right the whole time. They measured the clock once and then
+ * **extrapolated** the next three stamps by estimating how long their own work had taken, and it had taken eight hours
+ * longer than it felt.
+ *
+ * Their sentence is the whole problem: *"an estimated timestamp looks exactly like a measured one once it is written
+ * down."* And their suggestion is why this is ours to build rather than theirs:
+ *
+ * > *"comparing a post's `stampedAt` against the record's own server-side `createdAt` would have caught this
+ * > immediately, and that comparison is available to the store rather than to the author."*
+ *
+ * An author cannot check their own stamp against their own belief. The store can, because it holds a number the author
+ * did not supply.
+ *
+ * ## A WARNING, never a refusal
+ *
+ * A legitimately backdated record exists — a historical import, a backfilled letter, and they have both. Refusing the
+ * write would break exactly those, and what is being reported is a **wrong number, not a corrupt record**. So the skew
+ * is recorded and surfaced; the write always proceeds.
+ *
+ * ## Why the parsing is the substance of this module
+ *
+ * Their stamps are written `2026-08-11T1200Z` — no colon, no seconds. `new Date('2026-08-11T1200Z')` is **Invalid
+ * Date**. A check built on `Date.parse` alone would therefore find nothing to compare on precisely the records that
+ * motivated the ask, and would report "no skew detected" for a stamp eight hours wrong. It would not be a weak feature;
+ * it would be a feature that confidently says the opposite of the truth on its own motivating example.
+ *
+ * So `parseStamp` accepts the compact form as well, and `stamp-skew.test.js` asserts it against the literal strings from
+ * their messages rather than against a form I invented while writing this.
+ */
+import type { SpaceMeta, StampSkew } from '../config/types-knowledge.js';
+
+export type { StampSkew };
+
+/**
+ * The board protocol's own tolerance. Its documented assumption is that two parties' clocks differ *by up to forty
+ * minutes*, so anything inside that is the case the protocol already accepts and warning about it would be noise.
+ * Theirs differed by eight hours.
+ */
+export const DEFAULT_STAMP_SKEW_WARN_MINUTES = 40;
+
+/**
+ * The property names checked when a space does not name its own.
+ *
+ * Both are breituai-platform's, because a convention that no caller uses is a check that never fires. `stampedAt` is the
+ * one their suggestion named; `postedAt` is the one that was actually wrong in all three corrected posts.
+ */
+export const DEFAULT_STAMP_PROPERTIES: readonly string[] = ['stampedAt', 'postedAt'];
+
+/** ISO-ish with the time compressed: `2026-08-11T1200Z`, `2026-08-11T1200+02:00`, optionally with seconds. */
+const COMPACT = /^(\d{4}-\d{2}-\d{2})T(\d{2})(\d{2})(\d{2})?(Z|[+-]\d{2}:?\d{2})?$/;
+
+/**
+ * Parse a caller-supplied stamp to epoch ms, or `null` when it is not a timestamp at all.
+ *
+ * `null` is a deliberate outcome and not a failure: a property named `postedAt` holding `"soon"` is a caller's business,
+ * and inventing a skew for it would produce a warning about the wrong thing. Unparseable means **not checked**, and the
+ * caller is told which so that "no warning" cannot be read as "the stamp is fine".
+ */
+export function parseStamp(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    // Epoch seconds vs milliseconds, decided by magnitude: 1e12 ms is 2001, and 1e12 seconds is the year 33658. Any
+    // plausible seconds value is below it and any plausible ms value is above it.
+    return value < 1e12 ? value * 1000 : value;
+  }
+  if (typeof value !== 'string') return null;
+  const raw = value.trim();
+  if (!raw) return null;
+
+  const m = COMPACT.exec(raw);
+  if (m) {
+    // Rebuilt into a form Date can parse rather than computed by hand, so leap years, month lengths and offsets stay
+    // the platform's problem. A missing zone is treated as UTC, matching how the board writes it.
+    const zone = m[5] ? (m[5] === 'Z' ? 'Z' : m[5]) : 'Z';
+    const t = Date.parse(`${m[1]}T${m[2]}:${m[3]}:${m[4] ?? '00'}${zone}`);
+    return Number.isNaN(t) ? null : t;
+  }
+
+  const t = Date.parse(raw);
+  return Number.isNaN(t) ? null : t;
+}
+
+/** What a space's meta says about this check, with the defaults resolved. */
+export function stampSkewSettings(meta: SpaceMeta | undefined): { warnMs: number; properties: readonly string[] } {
+  const cfg = meta?.stampSkew;
+  const minutes = cfg?.warnMinutes ?? DEFAULT_STAMP_SKEW_WARN_MINUTES;
+  return {
+    // 0 (or a negative) DISABLES rather than warning on everything. A threshold of zero read as "warn on any
+    // difference" would fire on every record in the space, since a caller's stamp and the server's clock never agree to
+    // the millisecond — the check would be unusable in exactly the configuration someone picks to make it strictest.
+    warnMs: minutes > 0 ? minutes * 60_000 : 0,
+    properties: cfg?.properties?.length ? cfg.properties : DEFAULT_STAMP_PROPERTIES,
+  };
+}
+
+
+/**
+ * Compare a record's caller-supplied stamp against the server's `createdAt`.
+ *
+ * Returns `null` when there is nothing to report: no stamp property, an unparseable value, the check disabled, or a skew
+ * inside the threshold. The FIRST property that parses wins — checking several and reporting the worst would let a
+ * caller's second, sloppier field speak for a record whose real stamp was fine.
+ */
+export function detectStampSkew(
+  properties: Record<string, unknown> | undefined,
+  createdAt: string,
+  meta: SpaceMeta | undefined,
+): StampSkew | null {
+  if (!properties) return null;
+  const { warnMs, properties: names } = stampSkewSettings(meta);
+  if (warnMs <= 0) return null;
+
+  const serverMs = Date.parse(createdAt);
+  if (Number.isNaN(serverMs)) return null;
+
+  for (const name of names) {
+    if (!(name in properties)) continue;
+    const parsed = parseStamp(properties[name]);
+    if (parsed === null) continue;
+    const skewMs = parsed - serverMs;
+    if (Math.abs(skewMs) <= warnMs) return null;
+    return {
+      property: name,
+      stamp: String(properties[name]),
+      skewMs,
+      thresholdMs: warnMs,
+    };
+  }
+  return null;
+}
+
+/**
+ * Stamp the skew onto a create doc, so the wrong number is findable LATER.
+ *
+ * Shaped as a doc mutator called beside `stampExpiryOnCreate`, because all four brain creates already call that and a
+ * fifth create written next year will be written next to it.
+ *
+ * **Stored only when it exceeds the threshold.** Storing it always would put a `0` on every record in every space —
+ * megabytes to say nothing — and would make the useful query (`{stampSkew: {$exists: true}}`) match everything. Presence
+ * IS the signal, which is what makes this the cheap integrity check they described rather than a new report to run.
+ *
+ * Returns the skew when there was one, so the caller can also put it in the response: the writer is the one who can
+ * still fix their clock, and they only find out if something says so at the time.
+ */
+export function stampSkewOnCreate(
+  doc: { properties?: Record<string, unknown>; createdAt: string; stampSkew?: StampSkew },
+  meta: SpaceMeta | undefined,
+): StampSkew | null {
+  const skew = detectStampSkew(doc.properties, doc.createdAt, meta);
+  if (skew) doc.stampSkew = skew;
+  return skew;
+}
+
+/**
+ * The sentence a caller reads. Hours, because the unit the reporter used to describe their own failure was hours, and a
+ * skew in milliseconds is a number nobody converts in their head.
+ */
+export function stampSkewWarning(skew: StampSkew): string {
+  const hours = skew.skewMs / 3_600_000;
+  const magnitude = Math.abs(hours) >= 1
+    ? `${Math.abs(hours).toFixed(1)} hours`
+    : `${Math.round(Math.abs(skew.skewMs) / 60_000)} minutes`;
+  const direction = skew.skewMs < 0 ? 'BEFORE' : 'AFTER';
+  return `${skew.property} '${skew.stamp}' is ${magnitude} ${direction} the server's write time. `
+    + `The record was stored as sent — this is a warning about the timestamp, not a rejection. `
+    + `If it was estimated rather than measured, it is probably wrong.`;
+}

--- a/server/src/config/types-knowledge.ts
+++ b/server/src/config/types-knowledge.ts
@@ -142,6 +142,40 @@ export type KnowledgeType = 'entity' | 'memory' | 'edge' | 'chrono';
 
 
 /** Structured schema and metadata for a space — all fields optional. */
+/**
+ * A recorded disagreement between a record's own timestamp and the server's write time.
+ *
+ * Present on a record ONLY when the disagreement exceeded the space's threshold, which is what makes
+ * `{ stampSkew: { $exists: true } }` the cheap integrity query breituai-platform asked for rather than a report that
+ * matches everything. See `brain/stamp-skew.ts` for the eight-hour incident behind it.
+ */
+export interface StampSkew {
+  /** The property the stamp came from, so a warning can name it. */
+  property: string;
+  /** The stamp as the caller wrote it — quoted back verbatim, because the point is that it LOOKS right. */
+  stamp: string;
+  /** Signed: negative means the caller's stamp is EARLIER than the server's write. Theirs were eight hours negative. */
+  skewMs: number;
+  /** The threshold that was applied, so a stored record carries what it was judged against. */
+  thresholdMs: number;
+}
+
+/**
+ * Carried by every record type the stamp check runs on — memories, entities, edges and chrono.
+ *
+ * Declared once here rather than as a field repeated in four interfaces, and not only to keep `config/types.ts` off the
+ * god-file ratchet: a fifth record type added later gets the check by extending this, where a copied field would be
+ * forgotten and the omission would look exactly like a record whose stamp agreed.
+ */
+export interface StampSkewable {
+  /**
+   * Set only when this record's own timestamp property disagreed with the server's `createdAt` beyond the space's
+   * threshold. ABSENT means agreed, not checked, or the check is off — presence is the signal, which is what makes
+   * `{ stampSkew: { $exists: true } }` a useful query. See `brain/stamp-skew.ts`.
+   */
+  stampSkew?: StampSkew;
+}
+
 export interface SpaceMeta {
   /** Version counter — auto-incremented on every meta change. */
   version?: number;
@@ -183,6 +217,28 @@ export interface SpaceMeta {
    * see `TypeSchema.suppressEmbeddings`.
    */
   suppressEmbeddings?: boolean;
+  /**
+   * Stamp-integrity check: compare a record's OWN timestamp property against the server's `createdAt` on write, and
+   * warn when they disagree beyond `warnMinutes`.
+   *
+   * breituai-platform corrected three board posts whose `postedAt` was eight hours early — not clock drift, but a
+   * measured stamp followed by three EXTRAPOLATED ones. Their sentence for why nothing caught it: *"an estimated
+   * timestamp looks exactly like a measured one once it is written down."* The comparison is available to the store and
+   * not to the author, which is what makes it ours.
+   *
+   * Absent means the default 40 minutes — the board protocol's own assumed clock tolerance. `warnMinutes: 0` disables
+   * the check; it does NOT mean "warn on any difference", because a caller's stamp and the server's clock never agree
+   * to the millisecond and that reading would fire on every record.
+   *
+   * It never refuses a write. A legitimately backdated record exists — a historical import, a backfilled letter — and
+   * what is being reported is a wrong number, not a corrupt record.
+   */
+  stampSkew?: {
+    /** Warn beyond this many minutes of disagreement. Default 40. `0` disables. */
+    warnMinutes?: number;
+    /** Property names to check, first parseable one wins. Default `['stampedAt', 'postedAt']`. */
+    properties?: string[];
+  };
   /** ISO8601 timestamp of the last meta update. */
   updatedAt?: string;
   /** History of previous meta versions (most recent first, capped). */

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -54,7 +54,7 @@ export interface TokenRecord {
 // Moved to `types-knowledge.ts` — a LEAF that imports nothing, so it cannot become half of a cycle. See that
 // file for why that matters. Imported as well as re-exported, because `export ... from` does not bring a name
 // into local scope and `TtlBucket` below is built from `KnowledgeType`.
-import type { MergeFn, NumericMergeFn, BooleanMergeFn, PropertySchema, TypeSchema, ValidationMode, KnowledgeType, SpaceMeta } from './types-knowledge.js';
+import type { MergeFn, NumericMergeFn, BooleanMergeFn, PropertySchema, TypeSchema, ValidationMode, KnowledgeType, SpaceMeta, StampSkewable } from './types-knowledge.js';
 export type { MergeFn, NumericMergeFn, BooleanMergeFn, PropertySchema, TypeSchema, ValidationMode, KnowledgeType, SpaceMeta };
 
 /**
@@ -1264,7 +1264,7 @@ export interface AuthorRef {
   instanceLabel: string;
 }
 
-export interface MemoryDoc {
+export interface MemoryDoc extends StampSkewable {
   /**
    * Keep this record stored, but stop it being found by vector search.
    *
@@ -1306,7 +1306,7 @@ export interface MemoryDoc {
   _expireAt?: Date;
 }
 
-export interface EntityDoc {
+export interface EntityDoc extends StampSkewable {
   /**
    * Keep this record stored, but stop it being found by vector search.
    *
@@ -1338,7 +1338,7 @@ export interface EntityDoc {
   _expireAt?: Date;
 }
 
-export interface EdgeDoc {
+export interface EdgeDoc extends StampSkewable {
   /**
    * Keep this record stored, but stop it being found by vector search.
    *
@@ -1378,7 +1378,7 @@ export type ChronoType = 'event' | 'deadline' | 'plan' | 'prediction' | 'milesto
 export type ChronoKind = ChronoType;
 export type ChronoStatus = 'upcoming' | 'active' | 'completed' | 'overdue' | 'cancelled';
 
-export interface ChronoEntry {
+export interface ChronoEntry extends StampSkewable {
   /**
    * Keep this record stored, but stop it being found by vector search.
    *

--- a/testing/standalone/stamp-skew-is-stored-db.test.js
+++ b/testing/standalone/stamp-skew-is-stored-db.test.js
@@ -1,0 +1,161 @@
+/**
+ * The stamp check reaches the STORED record, on all four brain creates — against a real MongoDB.
+ *
+ * ## Why this is a separate file from `stamp-skew.test.js`
+ *
+ * That one proves the comparison and the parsing. This one proves the wiring, which is the part that silently does
+ * nothing: `stampSkewOnCreate` is called beside `stampExpiryOnCreate` in four places, and a create that forgets the call
+ * produces a perfectly valid record with no signal on it. A unit test of the helper cannot see that, and neither can a
+ * reader — the absence of a field looks exactly like agreement, which is the same failure mode as the incident that
+ * prompted the feature.
+ *
+ * So the assertions here are on the document as Mongo holds it, per collection.
+ *
+ * ## The negative cases are the load-bearing ones
+ *
+ * A check that fires on everything is worse than none: it teaches a reader to ignore the flag. So a stamp INSIDE the
+ * tolerance, a record with no stamp at all, and a space that switched the check off must each leave the field absent —
+ * and `{ stampSkew: { $exists: true } }` must return exactly the records that are actually wrong, because that query IS
+ * the deliverable.
+ *
+ * Run: `npm run test:up` first, then
+ *      node --test testing/standalone/stamp-skew-is-stored-db.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+
+const SPACE = 'general';
+const OFF = 'no-stamp-check';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ythril-stamp-skew-'));
+const CONFIG_PATH = path.join(tmpDir, 'config.json');
+process.env['CONFIG_PATH'] = CONFIG_PATH;
+
+// No embedder: this suite is about a stored FIELD, and a create that waits on a model would either be slow or fail for
+// reasons that have nothing to do with the stamp.
+const EMPTY_CACHE = path.join(tmpDir, 'empty-model-cache');
+fs.mkdirSync(EMPTY_CACHE, { recursive: true });
+process.env['YTHRIL_MODELS_OFFLINE'] = '1';
+process.env['MODEL_CACHE_DIR'] = EMPTY_CACHE;
+
+let mongo, memory, entities, edges, chrono;
+
+const col = (space, name) => mongo.col(`${space}_${name}`);
+
+/** Eight hours early, in the compact form the board writes — the incident, reproduced. */
+const eightHoursEarly = () => {
+  const d = new Date(Date.now() - 8 * 3_600_000);
+  const p = (n) => String(n).padStart(2, '0');
+  return `${d.getUTCFullYear()}-${p(d.getUTCMonth() + 1)}-${p(d.getUTCDate())}T${p(d.getUTCHours())}${p(d.getUTCMinutes())}Z`;
+};
+
+describe('stamp skew reaches the stored record (real MongoDB)', { skip }, () => {
+  before(async () => {
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify({
+      spaces: [
+        { id: SPACE, label: 'General' },
+        // The same records, in a space that switched the check off. Two spaces in one config is how "off means off" is
+        // proved without restarting the process, which would make it a test of the loader instead.
+        { id: OFF, label: 'No check', meta: { stampSkew: { warnMinutes: 0 } } },
+      ],
+      networks: [], tokens: [],
+    }, null, 2));
+    mongo = await openTestMongo('stampskew');
+    const loader = await import('../../server/dist/config/loader.js');
+    loader.loadConfig();
+    memory = await import('../../server/dist/brain/memory.js');
+    entities = await import('../../server/dist/brain/entities.js');
+    edges = await import('../../server/dist/brain/edges.js');
+    chrono = await import('../../server/dist/brain/chrono.js');
+  });
+
+  after(async () => {
+    await closeTestMongo();
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  beforeEach(async () => {
+    for (const space of [SPACE, OFF]) {
+      for (const c of ['memories', 'entities', 'edges', 'chrono']) await col(space, c).deleteMany({});
+    }
+  });
+
+  it('a memory stamped eight hours early carries the skew', async () => {
+    const stamp = eightHoursEarly();
+    const doc = await memory.remember(SPACE, 'stamped from an estimate', [], [], undefined, { postedAt: stamp });
+
+    const stored = await col(SPACE, 'memories').findOne({ _id: doc._id });
+    assert.ok(stored.stampSkew, 'the stored record must carry the skew — this is the whole feature');
+    assert.equal(stored.stampSkew.property, 'postedAt');
+    assert.equal(stored.stampSkew.stamp, stamp, 'the stamp is quoted as written');
+    assert.ok(stored.stampSkew.skewMs < -7.5 * 3_600_000, `expected roughly -8h, got ${stored.stampSkew.skewMs}`);
+    assert.equal(stored.stampSkew.thresholdMs, 40 * 60_000, 'and what it was judged against');
+
+    // The returned record carries it too, so the writer -- the only party who can still fix their clock -- sees it at
+    // the time rather than finding out from a reader months later.
+    assert.ok(doc.stampSkew, 'the create response must carry it as well');
+  });
+
+  it('leaves a record with an ACCURATE stamp alone', async () => {
+    const doc = await memory.remember(SPACE, 'stamped from a measurement', [], [], undefined,
+      { postedAt: new Date().toISOString() });
+    const stored = await col(SPACE, 'memories').findOne({ _id: doc._id });
+    assert.equal(stored.stampSkew, undefined,
+      'a correct stamp must leave no field — a flag on every record teaches a reader to ignore it');
+  });
+
+  it('leaves a record with no stamp property alone', async () => {
+    const doc = await memory.remember(SPACE, 'no stamp at all', [], []);
+    assert.equal((await col(SPACE, 'memories').findOne({ _id: doc._id })).stampSkew, undefined);
+  });
+
+  it('stores nothing in a space that switched the check OFF', async () => {
+    const doc = await memory.remember(OFF, 'off by eight hours, unchecked', [], [], undefined,
+      { postedAt: eightHoursEarly() });
+    assert.equal((await col(OFF, 'memories').findOne({ _id: doc._id })).stampSkew, undefined,
+      'warnMinutes: 0 disables the check rather than making it strictest');
+  });
+
+  it('an entity create is wired too', async () => {
+    const e = await entities.upsertEntity(SPACE, `skewed entity ${Date.now()}`, 'thing', [], { stampedAt: eightHoursEarly() });
+    const stored = await col(SPACE, 'entities').findOne({ _id: e.entity._id });
+    assert.ok(stored.stampSkew, 'entities.ts must call the helper as well');
+    assert.equal(stored.stampSkew.property, 'stampedAt');
+  });
+
+  it('a chrono create is wired too', async () => {
+    const c = await chrono.createChrono(SPACE, {
+      title: `skewed chrono ${Date.now()}`, type: 'event', properties: { postedAt: eightHoursEarly() },
+    });
+    assert.ok((await col(SPACE, 'chrono').findOne({ _id: c._id })).stampSkew, 'chrono.ts must call the helper as well');
+  });
+
+  it('an edge create is wired too', async () => {
+    const a = await entities.upsertEntity(SPACE, `edge-a ${Date.now()}`, 'thing');
+    const b = await entities.upsertEntity(SPACE, `edge-b ${Date.now()}`, 'thing');
+    const edge = await edges.upsertEdge(
+      SPACE, a.entity._id, b.entity._id, 'relates_to', undefined, undefined, undefined,
+      { stampedAt: eightHoursEarly() },
+    );
+    assert.ok((await col(SPACE, 'edges').findOne({ _id: edge._id })).stampSkew, 'edges.ts must call the helper as well');
+  });
+
+  it('the integrity QUERY returns exactly the wrong records', async () => {
+    // This is the deliverable in their words: "a cheap integrity check". If presence were not the signal, this query
+    // would match every record in the space and answer nothing.
+    const bad = await memory.remember(SPACE, 'wrong', [], [], undefined, { postedAt: eightHoursEarly() });
+    await memory.remember(SPACE, 'right', [], [], undefined, { postedAt: new Date().toISOString() });
+    await memory.remember(SPACE, 'unstamped', [], []);
+
+    const flagged = await col(SPACE, 'memories').find({ stampSkew: { $exists: true } }).toArray();
+    assert.equal(flagged.length, 1, `expected exactly one flagged record, got ${flagged.length}`);
+    assert.equal(flagged[0]._id, bad._id);
+  });
+});

--- a/testing/standalone/stamp-skew.test.js
+++ b/testing/standalone/stamp-skew.test.js
@@ -1,0 +1,188 @@
+/**
+ * A record's own timestamp, checked against the server's — including the compact form the board actually writes.
+ *
+ * ## What this is for
+ *
+ * breituai-platform corrected three board posts whose `postedAt` was **eight hours** early. Not clock drift: they
+ * measured the clock once and extrapolated the next three stamps from how long they thought their work had taken. Their
+ * sentence for why nothing caught it is the requirement — *"an estimated timestamp looks exactly like a measured one
+ * once it is written down"* — and their suggestion is why it is ours: the comparison is available to the store and not
+ * to the author.
+ *
+ * ## The parse is the substance, so it is tested against THEIR strings
+ *
+ * Their stamps are written `2026-08-11T1200Z`. `new Date('2026-08-11T1200Z')` is **Invalid Date**. A check built on
+ * `Date.parse` alone therefore finds nothing to compare on precisely the records that motivated the ask — and reports no
+ * skew for a stamp eight hours wrong. That is not a weak feature, it is one that confidently says the opposite of the
+ * truth on its own motivating example.
+ *
+ * So the strings below are copied from the board, not invented here: `2026-08-11T1200Z`, `2026-08-12T1129Z`,
+ * `2026-08-09T0942Z`. If the compact branch is ever dropped, these fail rather than quietly passing on `null`.
+ *
+ * Run: node --test testing/standalone/stamp-skew.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+const {
+  parseStamp, detectStampSkew, stampSkewSettings, stampSkewWarning,
+  DEFAULT_STAMP_SKEW_WARN_MINUTES, DEFAULT_STAMP_PROPERTIES,
+} = await import('../../server/dist/brain/stamp-skew.js');
+
+const HOUR = 3_600_000;
+
+describe('parseStamp — the compact board form is the case that matters', () => {
+  it('parses the exact stamps from the board', () => {
+    // Copied from real messages. `Date.parse` alone returns NaN for every one of these.
+    for (const [raw, expected] of [
+      ['2026-08-11T1200Z', '2026-08-11T12:00:00.000Z'],
+      ['2026-08-12T1129Z', '2026-08-12T11:29:00.000Z'],
+      ['2026-08-09T0942Z', '2026-08-09T09:42:00.000Z'],
+      ['2026-08-13T0035Z', '2026-08-13T00:35:00.000Z'],
+    ]) {
+      const ms = parseStamp(raw);
+      assert.ok(ms !== null, `${raw} must parse — this is the form the board writes`);
+      assert.equal(new Date(ms).toISOString(), expected, raw);
+    }
+  });
+
+  it('proves the platform cannot do it, so the branch is not redundant', () => {
+    // If this ever starts passing, the compact branch can go. Until then, deleting it silently disables the check.
+    assert.ok(Number.isNaN(Date.parse('2026-08-11T1200Z')),
+      'Date.parse learned the compact form — re-examine whether parseStamp still needs its own branch');
+  });
+
+  it('parses ordinary ISO 8601 too', () => {
+    assert.equal(new Date(parseStamp('2026-08-11T12:00:00Z')).toISOString(), '2026-08-11T12:00:00.000Z');
+    assert.equal(new Date(parseStamp('2026-08-11T12:00:00.500Z')).toISOString(), '2026-08-11T12:00:00.500Z');
+  });
+
+  it('honours an offset in the compact form rather than assuming UTC', () => {
+    // 14:00+02:00 is 12:00Z. Assuming UTC here would invent a two-hour skew on a correct stamp, which is worse than
+    // not checking: a false warning about a right number teaches a reader to ignore the warnings.
+    assert.equal(new Date(parseStamp('2026-08-11T1400+02:00')).toISOString(), '2026-08-11T12:00:00.000Z');
+    assert.equal(new Date(parseStamp('2026-08-11T1400+0200')).toISOString(), '2026-08-11T12:00:00.000Z');
+  });
+
+  it('takes seconds in the compact form', () => {
+    assert.equal(new Date(parseStamp('2026-08-11T120059Z')).toISOString(), '2026-08-11T12:00:59.000Z');
+  });
+
+  it('distinguishes epoch seconds from milliseconds', () => {
+    assert.equal(new Date(parseStamp(1786594894)).toISOString(), new Date(1786594894000).toISOString());
+    assert.equal(new Date(parseStamp(1786594894663)).toISOString(), new Date(1786594894663).toISOString());
+  });
+
+  it('returns null for things that are not timestamps, rather than a number', () => {
+    // `null` means NOT CHECKED. Inventing a skew for `"soon"` would warn about the wrong thing entirely.
+    for (const bad of ['soon', '', '   ', 'yesterday', {}, [], null, undefined, NaN, '2026-13-45T9999Z']) {
+      assert.equal(parseStamp(bad), null, `${JSON.stringify(bad)} must not parse`);
+    }
+  });
+});
+
+describe('detectStampSkew — eight hours is caught, forty minutes is not', () => {
+  const createdAt = '2026-08-09T17:42:00.000Z';
+
+  it('catches the eight-hour case that started this', () => {
+    // Their actual failure: the stamp says 0942Z, the server wrote it at 1742Z.
+    const skew = detectStampSkew({ postedAt: '2026-08-09T0942Z' }, createdAt, undefined);
+    assert.ok(skew, 'an eight-hour disagreement must be reported');
+    assert.equal(skew.property, 'postedAt');
+    assert.equal(skew.stamp, '2026-08-09T0942Z', 'the stamp is quoted back as written — the point is that it looks right');
+    assert.equal(skew.skewMs, -8 * HOUR, 'negative: the caller stamped it EARLIER than the write');
+  });
+
+  it('stays quiet inside the protocol tolerance', () => {
+    // The board's own documented assumption is that two clocks differ by up to forty minutes, so warning there is noise.
+    assert.equal(detectStampSkew({ stampedAt: '2026-08-09T1712Z' }, createdAt, undefined), null,
+      '30 minutes is inside the tolerance the protocol already accepts');
+    assert.equal(detectStampSkew({ stampedAt: createdAt }, createdAt, undefined), null);
+  });
+
+  it('fires just past the threshold, not just inside it', () => {
+    // The boundary in both directions, because an off-by-one here means either a silent check or a noisy one.
+    const at40 = new Date(Date.parse(createdAt) + 40 * 60_000).toISOString();
+    const at41 = new Date(Date.parse(createdAt) + 41 * 60_000).toISOString();
+    assert.equal(detectStampSkew({ stampedAt: at40 }, createdAt, undefined), null, 'exactly at the threshold is inside it');
+    assert.ok(detectStampSkew({ stampedAt: at41 }, createdAt, undefined), 'one minute past it reports');
+  });
+
+  it('reports a stamp in the FUTURE as well', () => {
+    // A clock that is ahead is the same defect with the sign flipped, and "we posted this tomorrow" is at least as
+    // confusing to a reader as an eight-hour backdate.
+    const skew = detectStampSkew({ postedAt: '2026-08-10T0942Z' }, createdAt, undefined);
+    assert.ok(skew);
+    assert.ok(skew.skewMs > 0, 'positive means the stamp is after the write');
+  });
+
+  it('checks the properties in order and lets the FIRST parseable one speak', () => {
+    // Reporting the worst of several would let a caller's sloppier second field speak for a record whose real stamp was
+    // fine — the record would be flagged for a field nobody treats as authoritative.
+    const skew = detectStampSkew(
+      { stampedAt: createdAt, postedAt: '2026-08-09T0942Z' }, createdAt, undefined,
+    );
+    assert.equal(skew, null, 'stampedAt is checked first, agrees, and settles it');
+  });
+
+  it('skips an unparseable stamp and moves on to the next property', () => {
+    const skew = detectStampSkew({ stampedAt: 'soon', postedAt: '2026-08-09T0942Z' }, createdAt, undefined);
+    assert.ok(skew, 'an unparseable first property must not silence the check');
+    assert.equal(skew.property, 'postedAt');
+  });
+
+  it('reports nothing when there is no stamp property at all', () => {
+    assert.equal(detectStampSkew({ author: 'someone' }, createdAt, undefined), null);
+    assert.equal(detectStampSkew(undefined, createdAt, undefined), null);
+    assert.equal(detectStampSkew({}, createdAt, undefined), null);
+  });
+
+  it('is DISABLED by warnMinutes: 0, not made maximally strict', () => {
+    // The reading that matters: zero as "warn on any difference" would fire on every record in the space, because a
+    // caller's stamp and the server's clock never agree to the millisecond. Someone setting 0 wants the check off.
+    const meta = { stampSkew: { warnMinutes: 0 } };
+    assert.equal(detectStampSkew({ postedAt: '2026-08-09T0942Z' }, createdAt, meta), null);
+    assert.equal(stampSkewSettings(meta).warnMs, 0);
+  });
+
+  it('takes its threshold and its property names from space meta', () => {
+    // The Verify line for this item: the threshold is READ FROM CONFIG, not a constant.
+    const tight = { stampSkew: { warnMinutes: 5 } };
+    assert.ok(detectStampSkew({ stampedAt: '2026-08-09T1712Z' }, createdAt, tight),
+      '30 minutes must report once the space asks for 5');
+
+    const named = { stampSkew: { properties: ['recordedAt'] } };
+    assert.ok(detectStampSkew({ recordedAt: '2026-08-09T0942Z' }, createdAt, named),
+      'a space can name its own property');
+    assert.equal(detectStampSkew({ postedAt: '2026-08-09T0942Z' }, createdAt, named), null,
+      'and naming one REPLACES the defaults rather than adding to them');
+  });
+
+  it('defaults are the board protocol\'s own numbers, not invented ones', () => {
+    assert.equal(DEFAULT_STAMP_SKEW_WARN_MINUTES, 40, 'the protocol assumes clocks differ by up to forty minutes');
+    assert.deepEqual([...DEFAULT_STAMP_PROPERTIES], ['stampedAt', 'postedAt'],
+      'both are the reporter\'s own field names — a convention nobody uses is a check that never fires');
+  });
+});
+
+describe('the warning a caller actually reads', () => {
+  it('says hours, the direction, and that the record was STORED', () => {
+    const text = stampSkewWarning({
+      property: 'postedAt', stamp: '2026-08-09T0942Z', skewMs: -8 * HOUR, thresholdMs: 40 * 60_000,
+    });
+    assert.match(text, /postedAt/);
+    assert.match(text, /8\.0 hours/, 'hours, because that is the unit the failure was described in');
+    assert.match(text, /BEFORE/);
+    assert.match(text, /stored as sent|not a rejection/i,
+      'a caller must not read this as a failed write — the whole design is warn-not-refuse');
+  });
+
+  it('uses minutes when hours would read as 0.4', () => {
+    const text = stampSkewWarning({
+      property: 'stampedAt', stamp: 'x', skewMs: 45 * 60_000, thresholdMs: 40 * 60_000,
+    });
+    assert.match(text, /45 minutes/);
+    assert.match(text, /AFTER/);
+  });
+});


### PR DESCRIPTION
## The incident this comes from

breituai-platform, **2026-08-09T0942Z** — addressed to us, and never picked up until now.

They corrected three of their own board posts whose `postedAt` was **eight hours** early. Not clock drift: their host's
clock was right the whole time. They measured the clock once, then **extrapolated** the next three stamps from how long
they thought their own work had taken — and it had taken eight hours longer than it felt.

> *"an estimated timestamp looks exactly like a measured one once it is written down."*

> *"If you ever want a cheap integrity check, comparing a post's `stampedAt` against the record's own server-side
> `createdAt` would have caught this immediately, and that comparison is available to the store rather than to the
> author."*

That second sentence is why this is ours to build. An author cannot check their own stamp against their own belief. The
store can, because it holds a number the author did not supply.

## What it does

On create, a record carrying `stampedAt` or `postedAt` that disagrees with `createdAt` beyond the space's threshold gets
a `stampSkew` field:

```json
{ "property": "postedAt", "stamp": "2026-08-09T0942Z", "skewMs": -28800000, "thresholdMs": 2400000 }
```

The stamp is quoted **as sent**, because the whole point is that it looks right. `thresholdMs` is stored so a record read
years from now still says what the rule was at the time.

**A warning, never a refusal.** The record is stored exactly as sent. A legitimately backdated record is normal — a
historical import, a backfilled letter, and they have both — and what is reported is a wrong number, not a corrupt
record.

**Set only when the threshold is exceeded**, which is what makes this the cheap integrity check they described:

```json
{ "collection": "memories", "filter": { "stampSkew": { "$exists": true } } }
```

Storing a `0` on every record would put megabytes in every space to say nothing, and would make that query match
everything. **Presence is the signal.**

## The parse is the substance, and it is where this would have silently failed

Their stamps are written `2026-08-09T0942Z` — no colon, no seconds. **`new Date('2026-08-09T0942Z')` is `Invalid
Date`.**

A check built on `Date.parse` alone would therefore have found nothing to compare on *precisely the records that
motivated the ask*, and would have reported **no skew for a stamp eight hours wrong**. Not a weak feature — one that
confidently says the opposite of the truth on its own motivating example.

So `parseStamp` takes the compact form (with or without seconds, with an explicit offset or defaulting to UTC), ordinary
ISO 8601, and epoch seconds or milliseconds. The tests assert the **literal strings copied off the board**, not a form I
invented while writing it. One test asserts that `Date.parse` still cannot do it, so the branch cannot be dropped as
redundant without going red.

A property that is not a timestamp is **not checked** rather than reported as skew — inventing a number for `"soon"`
would warn about the wrong thing.

## Two decisions that read backwards if you skim them

**`warnMinutes: 0` disables the check.** Read as *"warn on any difference"* it would fire on every record in the space,
because a caller's stamp and the server's clock never agree to the millisecond — unusable in exactly the configuration
someone picks to be strict.

**The 40-minute default is not invented.** It is the clock tolerance the board protocol already assumed between two
parties. Theirs was off by eight hours and nothing could show it.

Configured in **space meta**, so `PATCH /api/spaces/:id` and `update_space_schema` already write it — no new surface. A
space naming its own `properties` **replaces** the defaults rather than adding to them, and the **first parseable**
property wins: reporting the worst of several would let a caller's sloppier second field speak for a record whose real
stamp was fine.

## Tests

- **`stamp-skew.test.js`** — 19 assertions: the parsing, the threshold boundary in both directions, future stamps,
  property ordering, unparseable values, and that the defaults are the reporter's own numbers.
- **`stamp-skew-is-stored-db.test.js`** — 8 assertions against a real MongoDB, one per create path. A create that forgets
  the call produces a perfectly valid record with no signal on it, and the absence of the field looks exactly like
  agreement — the same failure mode as the incident. **Mutation-tested** by deleting the `edges.ts` call, which turns
  exactly one test red. The negative cases (accurate stamp, no stamp, check switched off) are load-bearing: a flag on
  every record teaches a reader to ignore it.

## One thing worth reading if you touch `config/types.ts`

`stampSkew` is declared once as `StampSkewable` in `types-knowledge.ts` and **extended** by the four doc interfaces
rather than repeated as a field in each. That keeps `config/types.ts` at its frozen 578 code lines on the god-file
ratchet, but the better reason is that a fifth record type gets the check by extending, where a copied field would be
forgotten.

Removing the four repeated blocks initially **glued each following docblock's opener onto its interface's brace**, which
stopped the ratchet's comment scanner recognising the block and made it count ~40 comment lines as code — the file
reported **618 lines while being 28 lines shorter**. Worth knowing that the ratchet's counter is line-oriented and a
joined line can inflate it dramatically.

🤖 Generated with Claude Code
