### PR TITLE
fix(brain): skip is honoured on /query, and four read routes stop accepting keys they cannot honour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- **`skip` on `POST /api/brain/spaces/:id/query` — and the four brain read routes now REFUSE a body key they cannot
+  honour.** aigents, 2026-08-12T1410Z: `skip` was accepted at `200` and silently ignored, so a paged sweep re-read page
+  one every time and was counted as if it had advanced — *"it cost us a fabricated number"*.
+  - **Two defects, two fixes.** Honouring `skip` is a feature; refusing an unhonourable key is the bug fix, and it is the
+    one that would have saved them the number. `/query`, `/recall`, `/traverse` and `/find-similar` now answer `400` with
+    `unrecognized_keys` naming the offenders. There is no `sort` on `/query`, so it is refused rather than ignored.
+  - **This is a deliberate break**: those bodies used to accept any key and honour the ones they recognised.
+  - `skip` is on the **MCP `query` tool** in the same commit. MCP already refused unknown arguments
+    (`additionalProperties: false`) — REST was the weaker of the two surfaces for the same rule, which is this codebase's
+    most repeated defect class.
+  - A negative or fractional `skip` is a `400`, not a silent `0`: reading it as *"start from the beginning"* returns a
+    page that is not the page asked for, with a success status. `limit` and `skip` are echoed in the response so a paging
+    loop can tell what was applied, and a `skip` past the end returns an empty page rather than the last one.
+  - **Fixed with it: `/query` on a PROXY space was returning up to `limit × members` rows, ordered by member.**
+    `collectAcrossMembers` concatenates without sorting or capping, so the caller's `limit` was never honoured there and
+    the documented order did not hold. The page is now computed over the merged set — first `skip + limit` from each
+    member, merged into the documented order, then the window. Same defect class as the report, found while fixing it.
+  - New gate `brain-read-bodies-are-strict.test.js` enumerates the read routes **from source** and asserts each refuses
+    unknown keys, returns the refusal it computed (the proxy-lens near-miss: compute and discard), and — after this fix
+    got it wrong — that every key a handler actually READS is in its allowed set.
 - **A record's own timestamp is now checked against the server's, and a disagreement is recorded on the record.**
   breituai-platform corrected three board posts whose `postedAt` was **eight hours** early — not clock drift, but one
   measured stamp followed by three EXTRAPOLATED from how long they thought their work had taken. Their sentence for why

--- a/docs/integration-guide/04d-brain-ops-api.md
+++ b/docs/integration-guide/04d-brain-ops-api.md
@@ -414,8 +414,11 @@ Run a constrained Mongo-style read query against one logical collection. Intende
 | `collection` | ✅ | One of: `memories`, `entities`, `edges`, `chrono`, `files` |
 | `filter` | — | Query filter object (defaults to `{}`) |
 | `projection` | — | Projection object (`1` include / `0` exclude) |
-| `limit` | — | Max rows (default `20`) |
+| `limit` | — | Max rows (default `20`, capped at `100`) |
+| `skip` | — | Rows to discard before the page (default `0`) — see below |
 | `maxTimeMS` | — | Query timeout in milliseconds (default `5000`) |
+
+Any other field is a `400`. See **Unknown body fields are refused** below.
 
 **Response** `200`:
 
@@ -423,9 +426,59 @@ Run a constrained Mongo-style read query against one logical collection. Intende
 {
   "results": [ ... ],
   "collection": "entities",
-  "count": 12
+  "count": 12,
+  "limit": 20,
+  "skip": 0
 }
 ```
+
+#### Paging with `skip`
+
+| Field | Default | Meaning |
+|---|---|---|
+| `limit` | `20` | Max documents, clamped to 100 |
+| `skip` | `0` | Rows to discard before the page. Must be a **non-negative integer** — a negative or fractional value is a `400`, not a silent `0` |
+
+The result order is **total** — `seq`, then `updatedAt`, `createdAt`, `_id` — so no row can drift between pages and be
+seen twice or missed. Concatenating `skip=0,5,10,…` gives you the collection exactly once, in order.
+
+```json
+{ "results": [ … ], "collection": "memories", "count": 3, "limit": 3, "skip": 4 }
+```
+
+`limit` and `skip` are echoed back, so a paging loop can distinguish *the page you asked for* from *what the server
+capped it to*. A `skip` past the end returns an empty `results` — it does **not** return the last page, so a loop that
+stops on an empty page terminates.
+
+On a **proxy space** the page is computed over the **merged** set of all member spaces, not per member: the server takes
+the first `skip + limit` rows from each member, merges them into the documented order, and returns the window. A deep
+page therefore costs more on a proxy space than on a plain one, but it is the same page.
+
+#### Unknown body fields are refused
+
+These four read routes accept a fixed set of body fields and **reject anything else with a `400`** naming the offending
+keys:
+
+| Route | Accepted fields |
+|---|---|
+| `POST /query` | `collection`, `filter`, `projection`, `limit`, `skip`, `maxTimeMS` |
+| `POST /recall` | `query`, `topK`, `types`, `minScore`, `filter`, `traverse`, `tags`, `minPerType`, `maxPerType`, `maxTimeMS`, `includeFreshWrites`, `includeContent` |
+| `POST /traverse` | `startId`, `direction`, `edgeLabels`, `maxDepth`, `limit`, `includeChrono`, `includeMemories`, `includeFiles`, `includeEdges` |
+| `POST /find-similar` | `entryId`, `entryType`, `topK`, `minScore`, `targetTypes`, `crossSpace` *(deprecated, still accepted)* |
+
+```json
+{
+  "error": "Unknown field(s): sort. Allowed: collection, filter, projection, limit, skip, maxTimeMS",
+  "unrecognized_keys": ["sort"]
+}
+```
+
+**This is a deliberate break with the previous behaviour, and it is the point.** These bodies used to accept any key and
+honour the ones they recognised. aigents paged a sweep with `skip` before it was implemented, got `200` every time, and
+counted page one repeatedly as if it had advanced — *"it cost us a fabricated number"*. A parameter the server cannot
+honour is now an error rather than a wrong answer that looks right.
+
+There is **no `sort`** on `/query`. It is refused rather than ignored for exactly that reason.
 
 ---
 

--- a/server/src/api/brain/search.ts
+++ b/server/src/api/brain/search.ts
@@ -10,7 +10,10 @@ import { globalRateLimit } from '../../rate-limit/middleware.js';
 import { NotFoundError } from '../../util/errors.js';
 import { countMemories } from '../../brain/memory.js';
 import { getEmbedJobCounts } from '../../brain/embed-queue.js';
-import { queryBrain } from '../../brain/query.js';
+import {
+  queryBrain, QUERY_BODY_FIELDS, TRAVERSE_BODY_FIELDS, RECALL_BODY_FIELDS, FIND_SIMILAR_BODY_FIELDS,
+  unknownBodyFields, compareQueryOrder,
+} from '../../brain/query.js';
 import { findSimilar, recall, type RecallKnowledgeType, type RecallResult } from '../../brain/recall.js';
 import { validateFilterExpression, type FilterExpression } from '../../brain/filter.js';
 import { traverseGraph, traverseRecallSeeds, MAX_RECALL_TRAVERSE, resolveEdgeEntityNames } from '../../brain/edges.js';
@@ -158,6 +161,9 @@ searchRouter.post('/spaces/:spaceId/traverse', globalRateLimit, requireSpaceAuth
     res.status(404).json({ error: `Space '${spaceId}' not found` });
     return;
   }
+  // Same refusal as /query, for the same reason: a mistyped `maxDepth` here returns a shallower graph with a 200.
+  const badTraverse = unknownBodyFields((req.body ?? {}) as Record<string, unknown>, TRAVERSE_BODY_FIELDS);
+  if (badTraverse) { res.status(400).json(badTraverse); return; }
   const { startId, direction, edgeLabels, maxDepth, limit } = req.body ?? {};
   if (!startId || typeof startId !== 'string') {
     res.status(400).json({ error: '`startId` string required' });
@@ -208,6 +214,16 @@ searchRouter.post('/spaces/:spaceId/traverse', globalRateLimit, requireSpaceAuth
 
 
 // POST /api/brain/spaces/:spaceId/query — structured query with filter/projection
+//
+// ## Two defects, one shape
+//
+// aigents, 2026-08-12T1410Z: `skip` was accepted at 200 and silently ignored, and *"it cost us a fabricated number"* —
+// a paged sweep re-read page one every time and was counted as if it had advanced. Their report names `skip`; the defect
+// is the PERMISSIVE BODY. Honouring one key would have left every other unknown key doing the same thing.
+//
+// So both halves are here: the body is strict, and `skip` is real. MCP's `query` tool already declared
+// `additionalProperties: false` and so already refused unknown keys — REST was the weaker of the two surfaces for the
+// same rule, which is this repo's most repeated defect class.
 searchRouter.post('/spaces/:spaceId/query', globalRateLimit, requireSpaceAuth, async (req, res) => {
   const spaceId = req.params['spaceId'] as string;
   const cfg = getConfig();
@@ -215,9 +231,14 @@ searchRouter.post('/spaces/:spaceId/query', globalRateLimit, requireSpaceAuth, a
     res.status(404).json({ error: `Space '${spaceId}' not found` });
     return;
   }
-  const { collection, filter, projection, limit, maxTimeMS } = req.body ?? {};
+
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const bad = unknownBodyFields(body, QUERY_BODY_FIELDS);
+  if (bad) { res.status(400).json(bad); return; }
+
+  const { collection, filter, projection, limit, maxTimeMS, skip } = body;
   const validCollections = ['memories', 'entities', 'edges', 'chrono', 'files'] as const;
-  if (!validCollections.includes(collection)) {
+  if (!validCollections.includes(collection as typeof validCollections[number])) {
     res.status(400).json({ error: `collection must be one of: ${validCollections.join(', ')}` });
     return;
   }
@@ -232,18 +253,41 @@ searchRouter.post('/spaces/:spaceId/query', globalRateLimit, requireSpaceAuth, a
   const safeLimit = typeof limit === 'number' ? limit : 20;
   const safeMaxTimeMS = typeof maxTimeMS === 'number' ? maxTimeMS : 5000;
 
+  // A non-integer or negative `skip` is refused rather than floored to 0. Silently reading it as "start from the
+  // beginning" is the same failure they reported: a page that is not the page asked for, returned with a 200.
+  if (skip !== undefined && (typeof skip !== 'number' || !Number.isInteger(skip) || skip < 0)) {
+    res.status(400).json({ error: 'skip must be a non-negative integer' });
+    return;
+  }
+  const safeSkip = typeof skip === 'number' ? skip : 0;
+
   try {
-    const docs = await collectAcrossMembers(spaceId, mid =>
+    // A PROXY space needs the page computed over the MERGED set, not per member.
+    //
+    // `collectAcrossMembers` concatenates, so asking each member for rows `[skip, skip+limit)` and flattening would
+    // return up to `limit × members` rows, ordered by member rather than by the documented sort, having skipped `skip`
+    // rows in each — three wrong answers at once, and none of them an error. That is the same class as the defect this
+    // route is being fixed for, so it is fixed here rather than left for the next report.
+    //
+    // Correct paging over a union: take the first `skip + limit` from each member, merge, sort by the documented key,
+    // then slice the window. The per-member fetch is bounded by the page the caller asked for, so a deep page costs
+    // more but never the whole collection.
+    const window = Math.min(safeSkip + Math.min(safeLimit, 100), 100);
+    const perMember = await collectAcrossMembers(spaceId, mid =>
       queryBrain(
         mid,
         collection as typeof validCollections[number],
         safeFilter,
         safeProjection,
-        safeLimit,
+        window,
         safeMaxTimeMS,
+        0,
       ),
     );
-    res.json({ results: docs, collection, count: docs.length });
+    const merged = perMember.sort(compareQueryOrder).slice(safeSkip, safeSkip + safeLimit);
+    // `limit` and `skip` are echoed so a caller paging in a loop can tell "the page you asked for" from "what I
+    // capped it to", which is exactly the distinction the fabricated number came from.
+    res.json({ results: merged, collection, count: merged.length, limit: safeLimit, skip: safeSkip });
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     res.status(400).json({ error: msg });
@@ -273,6 +317,9 @@ searchRouter.post('/spaces/:spaceId/recall', globalRateLimit, requireSpaceAuth, 
     res.status(404).json({ error: `Space '${spaceId}' not found` });
     return;
   }
+  // A mistyped `minScore` on recall silently returns the unfiltered ranking, which reads as a working search.
+  const badRecall = unknownBodyFields((req.body ?? {}) as Record<string, unknown>, RECALL_BODY_FIELDS);
+  if (badRecall) { res.status(400).json(badRecall); return; }
   const { query, topK, types, minScore, filter, traverse, tags, minPerType, maxPerType, maxTimeMS } = req.body ?? {};
   if (!query || typeof query !== 'string' || !query.trim()) {
     res.status(400).json({ error: 'query must be a non-empty string' });
@@ -497,6 +544,11 @@ searchRouter.post('/spaces/:spaceId/find-similar', globalRateLimit, requireSpace
   }
 
   const body = (req.body ?? {}) as Record<string, unknown>;
+  // `crossSpace` is deprecated here but still ALLOWED, so this refusal does not break the callers we told to stop
+  // using it before we have removed it. Refusing a key we still accept elsewhere would be a worse contract than the
+  // permissive body it replaces.
+  const badSimilar = unknownBodyFields(body, FIND_SIMILAR_BODY_FIELDS);
+  if (badSimilar) { res.status(400).json(badSimilar); return; }
   const entryId = typeof body['entryId'] === 'string' ? body['entryId'].trim() : '';
   const entryType = typeof body['entryType'] === 'string' ? body['entryType'].trim() : '';
   const topK = typeof body['topK'] === 'number' ? Math.min(Math.max(body['topK'], 1), 100) : 10;

--- a/server/src/brain/query.ts
+++ b/server/src/brain/query.ts
@@ -60,6 +60,93 @@ function sanitizeFilter(filter: unknown, depth = 0): unknown {
 
 const ALLOWED_COLLECTIONS = new Set(['memories', 'entities', 'edges', 'chrono', 'files']);
 
+/**
+ * The body keys `POST /api/brain/spaces/:id/query` accepts, as a VALUE so the route can refuse everything else.
+ *
+ * aigents sent `skip`, got a 200, and got page one back — *"it cost us a fabricated number"*. A permissive body is the
+ * defect; `skip` was only how they found it. This set lives beside `queryBrain` rather than in the router so that adding
+ * a parameter to the query and forgetting to allow it in the body is one edit rather than two.
+ */
+export const QUERY_BODY_FIELDS: ReadonlySet<string> = new Set([
+  'collection', 'filter', 'projection', 'limit', 'skip', 'maxTimeMS',
+]);
+
+/**
+ * The other three brain READ routes that take a body, and had the same permissive-body defect `/query` was reported
+ * for. aigents found it on `/query` because that is the one they were paging; `traverse`, `recall` and `find-similar`
+ * dropped unknown keys just as silently, and a mistyped `topK` or `minScore` there produces a wrong answer with a 200
+ * exactly the same way.
+ *
+ * Listed as data so `brain-read-bodies-are-strict.test.js` can assert BY SHAPE that every read route on the search
+ * router refuses unknown keys, rather than checking the one key that was reported.
+ */
+export const TRAVERSE_BODY_FIELDS: ReadonlySet<string> = new Set([
+  'startId', 'direction', 'edgeLabels', 'maxDepth', 'limit',
+  'includeChrono', 'includeMemories', 'includeFiles', 'includeEdges',
+]);
+
+export const RECALL_BODY_FIELDS: ReadonlySet<string> = new Set([
+  'query', 'topK', 'types', 'minScore', 'filter', 'traverse', 'tags',
+  'minPerType', 'maxPerType', 'maxTimeMS',
+  // NOT on the destructuring line — these two are read 120 lines further down the handler as
+  // `(req.body as {...}).includeFreshWrites` / `.includeContent`. The first version of this set was built from the
+  // destructuring alone and refused both, which `recall-fresh-writes.test.js` caught immediately.
+  //
+  // That is the standing hazard of making a body strict: the allowed set has to be the keys the handler READS, and a
+  // handler that reads its body in two places will be described by whichever place you looked at. Grep for `req.body`
+  // across the whole handler, not for the destructure.
+  'includeFreshWrites', 'includeContent',
+
+]);
+
+export const FIND_SIMILAR_BODY_FIELDS: ReadonlySet<string> = new Set([
+  'entryId', 'entryType', 'topK', 'minScore', 'targetTypes', 'crossSpace',
+]);
+
+/**
+ * The refusal itself, in one place so all four routes phrase it identically.
+ *
+ * Returns the offending keys, or `null` when the body is clean. The keys are NAMED: `{"error":"unknown field"}` sends a
+ * caller reading their own request looking for which one, and the entire value of refusing is to shorten that search to
+ * zero. `unrecognized_keys` matches the shape the spaces routes already return, so a client that already handles that
+ * one needs no new branch.
+ */
+export function unknownBodyFields(
+  body: Record<string, unknown>,
+  allowed: ReadonlySet<string>,
+): { error: string; unrecognized_keys: string[] } | null {
+  const unknown = Object.keys(body).filter(k => !allowed.has(k));
+  if (unknown.length === 0) return null;
+  return {
+    error: `Unknown field(s): ${unknown.join(', ')}. Allowed: ${[...allowed].join(', ')}`,
+    unrecognized_keys: unknown,
+  };
+}
+
+/**
+ * The documented result order — `seq` desc, then `updatedAt`, `createdAt`, `_id` — as a comparator, for merging pages
+ * across the members of a proxy space.
+ *
+ * A second expression of the sort is exactly the drift risk this repo keeps paying for, so it is defined next to the
+ * `.sort()` it mirrors and `query-order-matches-the-sort.test.js` asserts the two agree on the same documents rather
+ * than on my reading of them.
+ */
+export function compareQueryOrder(a: unknown, b: unknown): number {
+  const A = a as Record<string, unknown>;
+  const B = b as Record<string, unknown>;
+  for (const key of ['seq', 'updatedAt', 'createdAt', '_id'] as const) {
+    const av = A[key];
+    const bv = B[key];
+    // A record missing the key sorts LAST rather than first: `undefined` in a descending sort must not win, or a
+    // partially projected document would lead a page it has no claim to.
+    if (av === bv) continue;
+    if (av === undefined || av === null) return 1;
+    if (bv === undefined || bv === null) return -1;
+    return av > bv ? -1 : 1;
+  }
+  return 0;
+}
+
 /** Structured read-only query (operator whitelist enforced) */
 export async function queryBrain(
   spaceId: string,
@@ -68,6 +155,16 @@ export async function queryBrain(
   projection?: Record<string, unknown>,
   limit = 20,
   maxTimeMS = 5000,
+  /**
+   * Rows to discard before the page. aigents reported `skip` being accepted at 200 and silently ignored on
+   * `POST /query`, which cost them a fabricated number: a paged sweep re-read page one every time and was counted as
+   * if it had advanced. A wrong number that looks right is worse than an error, so this parameter is honoured here
+   * rather than validated at the door and dropped.
+   *
+   * Paging is only meaningful because the sort below is TOTAL — `_id` breaks every tie — so no row can drift between
+   * pages and be seen twice or missed.
+   */
+  skip = 0,
 ) {
   if (!ALLOWED_COLLECTIONS.has(collectionName)) {
     throw new Error(`Unknown collection '${collectionName}'`);
@@ -81,6 +178,9 @@ export async function queryBrain(
     // Deterministic newest-first ordering keeps recent writes visible under
     // the default limit even when historical datasets grow large.
     .sort({ seq: -1, updatedAt: -1, createdAt: -1, _id: -1 })
+    // Skip BEFORE limit, which is the order the driver applies regardless of call order — spelled out here because
+    // the reverse reading (limit the page, then drop rows from it) would silently return short pages.
+    .skip(Math.max(Math.floor(skip) || 0, 0))
     .limit(Math.min(limit, 100))
     // The embedding vector is never returned. This is MERGED with the caller's
     // projection rather than applied as a second `.project()` — a second call

--- a/server/src/mcp/tools/search.ts
+++ b/server/src/mcp/tools/search.ts
@@ -11,7 +11,7 @@ import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.
 import { UUID_V4_RE, entityDocToRecord, formatRecallSummary, toRecallRecord, uuidSchema, unitScoreSchema, QUERY_FILTER_OPERATORS, RECALL_FILTER_KEY_PATTERN, type McpRecallTraverseItem } from './shared.js';
 import { MAX_RECALL_TRAVERSE, traverseRecallSeeds } from '../../brain/edges.js';
 import { type FilterExpression, validateFilterExpression } from '../../brain/filter.js';
-import { queryBrain } from '../../brain/query.js';
+import { queryBrain, compareQueryOrder } from '../../brain/query.js';
 import { type RecallKnowledgeType, type RecallResult, findSimilar, recall, recallGlobal } from '../../brain/recall.js';
 import { collectAcrossMembers } from '../../spaces/proxy.js';
 import { memberSpacesWithin } from '../../spaces/proxy-scoped.js';
@@ -368,13 +368,14 @@ export const queryTool: ToolHandler = {
             },
             filter: {
               type: 'object',
-              description: `MongoDB filter document. Only these operators are allowed (any other $-operator is rejected): ${QUERY_FILTER_OPERATORS.join(', ')}. Nesting is capped at depth 8. $regex must be a string, length-limited, and rejected if it risks catastrophic backtracking; $options is allowed only alongside $regex and only with flags i, m, s, x. Results are ordered seq/updatedAt/createdAt descending — there is no sort parameter.`,
+              description: `MongoDB filter document. Only these operators are allowed (any other $-operator is rejected): ${QUERY_FILTER_OPERATORS.join(', ')}. Nesting is capped at depth 8. $regex must be a string, length-limited, and rejected if it risks catastrophic backtracking; $options is allowed only alongside $regex and only with flags i, m, s, x. Results are ordered seq/updatedAt/createdAt descending — there is no sort parameter, but 'skip' pages through that order.`,
             },
             projection: {
               type: 'object',
               description: 'Fields to include (1) or exclude (0). The `embedding` field is always excluded and cannot be re-included.',
             },
             limit: { type: 'number', minimum: 1, maximum: 100, default: 20, description: 'Max documents to return (clamped to 1–100). Default 20.' },
+            skip: { type: 'number', minimum: 0, description: 'Rows to discard before the page, for paging. The result order is total (`_id` breaks every tie), so no row can be seen twice or missed between pages. On a proxy space the page is computed over the MERGED set, not per member.' },
             maxTimeMS: { type: 'number', minimum: 1, maximum: 10000, default: 5000, description: 'Server-side query timeout in ms. Default 5000, hard-capped at 10000.' },
           },
           required: ['space', 'collection', 'filter'],
@@ -391,21 +392,33 @@ export const queryTool: ToolHandler = {
         ? (a['filter'] as Record<string, unknown>)
         : {};
     const limit = typeof a['limit'] === 'number' ? a['limit'] : 20;
+    // Same refusal as the REST route: a non-integer or negative skip is an error, not a silent 0. Reading it as "start
+    // from the beginning" returns a page that is not the page asked for, with no sign that anything went wrong.
+    if (a['skip'] !== undefined && (typeof a['skip'] !== 'number' || !Number.isInteger(a['skip']) || a['skip'] < 0)) {
+      throw new Error('skip must be a non-negative integer');
+    }
+    const skip = typeof a['skip'] === 'number' ? a['skip'] : 0;
     const maxTimeMS = typeof a['maxTimeMS'] === 'number' ? a['maxTimeMS'] : 5000;
     const projection =
       a['projection'] != null && typeof a['projection'] === 'object'
         ? (a['projection'] as Record<string, unknown>)
         : undefined;
 
-    const docs = await collectAcrossMembers(callSpace, mid =>
+    // The proxy-merge is the same as the REST route's, and for the same reason: asking each member for rows
+    // [skip, skip+limit) and concatenating skips that many rows PER MEMBER and orders the result by member. Take the
+    // first skip+limit from each, merge by the documented order, then slice the window.
+    const window = Math.min(skip + Math.min(limit, 100), 100);
+    const perMember = await collectAcrossMembers(callSpace, mid =>
       queryBrain(
         mid,
         collName as 'memories' | 'entities' | 'edges' | 'chrono' | 'files',
         filter,
         projection,
-        limit,
+        window,
         maxTimeMS,
+        0,
       ));
+    const docs = perMember.sort(compareQueryOrder).slice(skip, skip + limit);
     return {
       content: [
         {

--- a/testing/integration/query-skip-and-strict-bodies.test.js
+++ b/testing/integration/query-skip-and-strict-bodies.test.js
@@ -1,0 +1,220 @@
+/**
+ * `skip` is honoured on `POST /query`, and the four brain read routes refuse a key they cannot honour — REST and MCP.
+ *
+ * ## The report
+ *
+ * aigents, 2026-08-12T1410Z: `skip` was accepted at 200 and silently ignored, and *"it cost us a fabricated number"* —
+ * a paged sweep re-read page one every time and was counted as if it had advanced.
+ *
+ * Two defects, and they need different fixes. Honouring `skip` is a feature; **refusing a key the route cannot honour is
+ * the bug fix**, and it is the one that would have saved them the number. So this file asserts the refusal on all four
+ * read routes, not the one key on the one route.
+ *
+ * MCP's `query` already declared `additionalProperties: false` and so already refused unknown arguments — REST was the
+ * weaker of the two surfaces for the same rule. That is the pattern this codebase keeps producing, so the MCP half here
+ * checks the thing MCP could still get wrong: that `skip` is offered and honoured there too, rather than becoming a
+ * REST-only parameter the day after we emptied the REST-only capability map.
+ *
+ * ## Paging is asserted by TILING, not by "page two differs from page one"
+ *
+ * Two different pages can both be wrong. The assertion is that the concatenated pages equal one unpaged read exactly —
+ * same ids, same order, no repeats — because a sweep that re-reads or drops a row still returns plausible pages, which is
+ * precisely how the fabricated number was produced.
+ *
+ * Run: node --test testing/integration/query-skip-and-strict-bodies.test.js
+ */
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, delWithBody } from '../sync/helpers.js';
+import { openMcpSession } from '../sync/mcp-session.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+const RUN = Date.now();
+
+const SPACE = `qskip-${RUN}`;
+const M1 = `qskip-m1-${RUN}`;
+const M2 = `qskip-m2-${RUN}`;
+const PROXY = `qskip-proxy-${RUN}`;
+const TOTAL = 12;
+
+let token;
+let session;
+const created = [];
+
+const query = (body, space = SPACE) => post(INSTANCES.a, token, `/api/brain/spaces/${space}/query`, body);
+
+async function makeSpace(id, body = {}) {
+  const r = await post(INSTANCES.a, token, '/api/spaces', { id, label: id, ...body });
+  assert.equal(r.status, 201, `space create failed: ${JSON.stringify(r.body)}`);
+  created.push(id);
+}
+
+before(async () => {
+  token = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+  await makeSpace(SPACE);
+  await makeSpace(M1);
+  await makeSpace(M2);
+  await makeSpace(PROXY, { proxyFor: [M1, M2] });
+
+  // Sequential, so `seq` is strictly increasing and the documented order is total.
+  for (let i = 0; i < TOTAL; i++) {
+    const r = await post(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/memories`, {
+      fact: `paged ${String(i).padStart(2, '0')} ${RUN}`,
+    });
+    assert.equal(r.status, 201, JSON.stringify(r.body));
+  }
+  // Half in each member, so a proxy page has to interleave rather than concatenate.
+  for (let i = 0; i < 6; i++) {
+    for (const m of [M1, M2]) {
+      await post(INSTANCES.a, token, `/api/brain/spaces/${m}/memories`, { fact: `${m} row ${i} ${RUN}` });
+    }
+  }
+  session = await openMcpSession(token);
+});
+
+after(async () => {
+  session?.close();
+  for (const id of created.reverse()) {
+    await delWithBody(INSTANCES.a, token, `/api/spaces/${id}`, { confirm: true }).catch(() => {});
+  }
+});
+
+describe('REST: skip paginates instead of being ignored', () => {
+  it('page two does not start where page one did', async () => {
+    const p1 = await query({ collection: 'memories', filter: {}, limit: 5, skip: 0 });
+    const p2 = await query({ collection: 'memories', filter: {}, limit: 5, skip: 5 });
+    assert.equal(p1.status, 200, JSON.stringify(p1.body));
+    assert.equal(p2.status, 200, JSON.stringify(p2.body));
+    assert.equal(p1.body.results.length, 5);
+    assert.notEqual(p1.body.results[0]._id, p2.body.results[0]._id,
+      'this is the reported defect: page two returned page one');
+  });
+
+  it('the pages TILE the collection — no repeats, no gaps, same order', async () => {
+    const all = await query({ collection: 'memories', filter: {}, limit: 100 });
+    assert.equal(all.body.results.length, TOTAL);
+
+    const stitched = [];
+    for (let s = 0; s < TOTAL; s += 5) {
+      const page = await query({ collection: 'memories', filter: {}, limit: 5, skip: s });
+      stitched.push(...page.body.results);
+    }
+    assert.deepEqual(stitched.map(d => d._id), all.body.results.map(d => d._id));
+    assert.equal(new Set(stitched.map(d => d._id)).size, TOTAL);
+  });
+
+  it('echoes limit and skip, so a caller can tell what was applied', async () => {
+    // The distinction the fabricated number came from: "the page I asked for" vs "what the server capped it to".
+    const r = await query({ collection: 'memories', filter: {}, limit: 3, skip: 4 });
+    assert.equal(r.body.limit, 3);
+    assert.equal(r.body.skip, 4);
+    assert.equal(r.body.count, 3);
+  });
+
+  it('a skip past the end is an empty page, not the last one', async () => {
+    // Returning the tail here makes a paging loop run for ever.
+    const r = await query({ collection: 'memories', filter: {}, limit: 5, skip: TOTAL + 50 });
+    assert.equal(r.status, 200);
+    assert.deepEqual(r.body.results, []);
+  });
+
+  it('refuses a negative or fractional skip rather than reading it as 0', async () => {
+    for (const bad of [-1, 1.5, '3', null]) {
+      const r = await query({ collection: 'memories', filter: {}, skip: bad });
+      assert.equal(r.status, 400, `skip=${JSON.stringify(bad)} was accepted: ${JSON.stringify(r.body)}`);
+    }
+  });
+
+  it('pages a PROXY space over the merged set, not per member', async () => {
+    // The compounding defect: asking each member for [skip, skip+limit) and concatenating skips that many rows PER
+    // MEMBER and orders the result by member. Twelve rows across two members must page exactly like twelve in one.
+    const all = await query({ collection: 'memories', filter: {}, limit: 100 }, PROXY);
+    assert.equal(all.status, 200, JSON.stringify(all.body));
+    assert.equal(all.body.results.length, 12, 'both members are read');
+
+    const stitched = [];
+    for (let s = 0; s < 12; s += 4) {
+      const page = await query({ collection: 'memories', filter: {}, limit: 4, skip: s }, PROXY);
+      assert.ok(page.body.results.length <= 4,
+        `a proxy page returned ${page.body.results.length} rows for limit 4 — the limit is per member, not per page`);
+      stitched.push(...page.body.results);
+    }
+    assert.equal(new Set(stitched.map(d => d._id)).size, 12, 'every row exactly once across the proxy pages');
+    assert.deepEqual(stitched.map(d => d._id), all.body.results.map(d => d._id),
+      'and in the same order as the unpaged read');
+  });
+});
+
+describe('REST: the four read routes refuse a key they cannot honour', () => {
+  const cases = [
+    ['/query', { collection: 'memories', filter: {}, sort: { seq: 1 } }, 'sort'],
+    ['/recall', { query: 'anything', topk: 5 }, 'topk'],
+    ['/traverse', { startId: '00000000-0000-4000-8000-000000000000', depth: 2 }, 'depth'],
+    ['/find-similar', { entryId: '00000000-0000-4000-8000-000000000000', entryType: 'memory', limit: 5 }, 'limit'],
+  ];
+
+  for (const [route, body, offender] of cases) {
+    it(`${route} names the unknown key '${offender}' in a 400`, async () => {
+      // Naming it matters: `{"error":"unknown field"}` sends a caller reading their own request to find which one, and
+      // the entire value of refusing is to shorten that search to zero.
+      const r = await post(INSTANCES.a, token, `/api/brain/spaces/${SPACE}${route}`, body);
+      assert.equal(r.status, 400, `${route} accepted '${offender}': ${JSON.stringify(r.body)}`);
+      assert.ok(JSON.stringify(r.body).includes(offender), `the 400 must name '${offender}': ${JSON.stringify(r.body)}`);
+      assert.deepEqual(r.body.unrecognized_keys, [offender]);
+    });
+  }
+
+  it('still accepts every documented key on /query', async () => {
+    // The other half of strictness, and the one that breaks callers if it is wrong.
+    const r = await query({
+      collection: 'memories', filter: {}, projection: { fact: 1 }, limit: 2, skip: 1, maxTimeMS: 3000,
+    });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+  });
+
+  it('still accepts the DEPRECATED crossSpace on find-similar', async () => {
+    // Refusing a key we deprecated but still accept elsewhere would be a worse contract than the permissive body this
+    // replaces: we told callers to stop using it, not that it would start erroring.
+    const r = await post(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/find-similar`, {
+      entryId: '00000000-0000-4000-8000-000000000000', entryType: 'memory', crossSpace: false,
+    });
+    assert.notEqual(r.status, 400, `crossSpace was refused: ${JSON.stringify(r.body)}`);
+  });
+});
+
+describe('MCP: query offers skip too, rather than it becoming REST-only', () => {
+  it('advertises skip in the tool schema', async () => {
+    const tool = (await session.listTools()).find(t => t.name === 'query');
+    assert.ok(tool, 'query tool missing');
+    assert.ok(tool.inputSchema.properties.skip,
+      'skip must be on the MCP schema as well — a parameter added to REST alone is how the capability map filled up');
+  });
+
+  it('honours it, and the pages tile', async () => {
+    const call = (args) => session.callTool('query', { space: SPACE, collection: 'memories', filter: {}, ...args });
+    const all = JSON.parse((await call({ limit: 100 })).content[0].text);
+    assert.equal(all.length, TOTAL);
+
+    const stitched = [];
+    for (let s = 0; s < TOTAL; s += 5) {
+      stitched.push(...JSON.parse((await call({ limit: 5, skip: s })).content[0].text));
+    }
+    assert.deepEqual(stitched.map(d => d._id), all.map(d => d._id), 'MCP pages must tile exactly as REST does');
+  });
+
+  it('refuses a fractional skip', async () => {
+    const r = await session.callTool('query', { space: SPACE, collection: 'memories', filter: {}, skip: 1.5 });
+    assert.ok(r?.isError, `a fractional skip was accepted: ${JSON.stringify(r)}`);
+  });
+
+  it('already refused unknown arguments, and still does', async () => {
+    // `additionalProperties: false` was always there. Asserted so that a future relaxation of the schema shows up here
+    // rather than as a silently ignored argument, which is the REST defect arriving on the other surface.
+    const r = await session.callTool('query', { space: SPACE, collection: 'memories', filter: {}, sort: { seq: 1 } });
+    assert.ok(r?.isError, `MCP accepted an unknown argument: ${JSON.stringify(r)}`);
+  });
+});

--- a/testing/standalone/brain-read-bodies-are-strict.test.js
+++ b/testing/standalone/brain-read-bodies-are-strict.test.js
@@ -1,0 +1,186 @@
+/**
+ * No brain READ route silently drops a body key.
+ *
+ * ## Why a gate and not four tests
+ *
+ * aigents reported `skip` being accepted at 200 and silently ignored on `POST /query` — *"it cost us a fabricated
+ * number"*. The reported key is not the defect. The defect is a body that accepts anything and honours some of it, and
+ * `/query` was simply the route they happened to be paging. `traverse`, `recall` and `find-similar` had it too.
+ *
+ * A test per route would have been satisfied by fixing the three that exist today and would say nothing about the fifth
+ * read route somebody adds next year. So this enumerates the POST routes on the search router **from source** and
+ * requires each one to either refuse unknown keys or be exempt with a reason — the same shape as the audit-route
+ * coverage gate, and for the same reason: the list of routes must come from the code, not from me.
+ *
+ * ## It also checks that the allowed set covers what the handler READS, and that is not decoration
+ *
+ * The first version of this fix built `RECALL_BODY_FIELDS` from recall's destructuring line and so refused
+ * `includeFreshWrites` and `includeContent` — both real parameters, read 120 lines further down as
+ * `(req.body as {...}).includeFreshWrites`. Making a body strict converts every key the author failed to notice into a
+ * 400, so the allowed set has to be the keys the handler READS, and a handler that reads its body in two places is
+ * described by whichever place you happened to look at.
+ *
+ * `recall-fresh-writes.test.js` caught it, which is luck: it exists because fresh-write recall was worth a test, not
+ * because anybody was guarding this. So the check below derives each handler's read keys from source and demands the set
+ * covers them.
+ *
+ * ## What it still cannot check
+ *
+ * The other direction — a key ALLOWED but never read. That is the original defect (accepted, ignored) surviving inside
+ * the fix, and nothing here sees it: `query-paging-db.test.js` covers `skip` by asserting the pages tile the collection,
+ * and the rest rely on the integration suite exercising each parameter.
+ *
+ * Run: node --test testing/standalone/brain-read-bodies-are-strict.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SEARCH = join(ROOT, 'server', 'src', 'api', 'brain', 'search.ts');
+
+/**
+ * Routes that take a body and deliberately do NOT enumerate its keys, each with the reason.
+ *
+ * A route may only be here because refusing would be wrong, never because nobody has got to it — an empty reason or a
+ * vague one is what makes an exemption list rot into a to-do list.
+ */
+const EXEMPT = {
+  '/spaces/:spaceId/reindex': 'Takes no body at all. There is nothing to be strict about, and inventing a key set for '
+    + 'an empty body would be a check that can only ever pass.',
+};
+
+/** Source with comments stripped, so a gate cannot pass on the comment that explains the fix. */
+function stripComments(src) {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .map(l => l.replace(/(^|[^:])\/\/.*$/, '$1'))
+    .join('\n');
+}
+
+const src = stripComments(readFileSync(SEARCH, 'utf8'));
+
+/** Every `searchRouter.post('<path>', …)` and the body of its handler, up to the next route registration. */
+function postRoutes() {
+  const out = [];
+  const re = /searchRouter\.post\(\s*'([^']+)'/g;
+  const starts = [];
+  let m;
+  while ((m = re.exec(src)) !== null) starts.push({ path: m[1], at: m.index });
+  for (let i = 0; i < starts.length; i++) {
+    const next = src.indexOf('searchRouter.', starts[i].at + 10);
+    out.push({ path: starts[i].path, body: src.slice(starts[i].at, next === -1 ? src.length : next) });
+  }
+  return out;
+}
+
+describe('brain read routes refuse unknown body keys', () => {
+  it('finds the routes (the gate itself works)', () => {
+    const paths = postRoutes().map(r => r.path);
+    assert.ok(paths.length >= 4, `expected at least four POST routes on the search router, found ${paths.length}`);
+    // The four this was reported for, named explicitly: if one is renamed the gate must not quietly stop covering it.
+    for (const p of ['/spaces/:spaceId/query', '/spaces/:spaceId/recall', '/spaces/:spaceId/traverse',
+      '/spaces/:spaceId/find-similar']) {
+      assert.ok(paths.includes(p), `${p} is no longer registered under that path — re-point this gate`);
+    }
+  });
+
+  it('every POST route validates its body keys or is exempt with a reason', () => {
+    const offenders = [];
+    for (const { path, body } of postRoutes()) {
+      if (path in EXEMPT) continue;
+      // By shape: the shared helper called against a named field set. The argument text is NOT constrained -- the first
+      // version of this gate required a comma-free first argument and so flagged two routes that pass
+      // `(req.body ?? {}) as Record<string, unknown>`, whose type parameter contains a comma. A gate that reports
+      // correct code is worse than no gate: it gets relaxed under pressure, and the relaxation is what ships.
+      const refuses = /unknownBodyFields\([\s\S]{0,200}?[A-Z_]+_BODY_FIELDS\s*\)/.test(body);
+      if (!refuses) offenders.push(path);
+    }
+    assert.deepEqual(offenders, [],
+      'these POST routes read a body without refusing unknown keys, so a mistyped parameter is dropped and the '
+      + 'request still answers 200 — the defect aigents reported on /query, which cost them a fabricated number');
+  });
+
+  it('a refusing route actually returns 400 with the offending keys, not just a computed value', () => {
+    // The near-miss version of this fix: compute the unknown keys and forget to return. That is the proxy-lens defect
+    // (a narrowed list computed and discarded) and it would satisfy the check above on its own.
+    for (const { path, body } of postRoutes()) {
+      if (path in EXEMPT) continue;
+      // The name is READ from the assignment rather than listed here, so a fifth route may call its variable anything
+      // and still be covered. Hard-coding the four current names would make this gate stop working silently.
+      const assigned = body.match(/const\s+(\w+)\s*=\s*unknownBodyFields\(/);
+      assert.ok(assigned, `${path}: expected the refusal's result to be assigned to a const`);
+      // An exact substring rather than a constructed RegExp: building one from an identifier means escaping the dots
+      // and parens of `res.status(400).json(x)`, and the first version of this line got that wrong in a way that made
+      // the pattern match more loosely than intended. A gate whose own pattern is subtle is a gate nobody trusts.
+      assert.ok(body.includes(`res.status(400).json(${assigned[1]})`),
+        `${path} computes its unknown keys into \`${assigned[1]}\` and never returns it — the value is discarded, `
+        + 'which is exactly what the proxy lens did with its narrowed space list on three shipped routes');
+    }
+  });
+
+  it('every key a handler READS is in its allowed set', () => {
+    // The check that would have caught `includeFreshWrites`. Three access shapes appear in these handlers:
+    //   const { a, b } = req.body ?? {}          — the destructure
+    //   body['a'] / (req.body as X)['a']         — bracket access
+    //   (req.body as { a?: unknown }).a          — cast-then-dot, which is how the two missed keys were read
+    const QUERY_SRC = readFileSync(join(ROOT, 'server', 'src', 'brain', 'query.ts'), 'utf8');
+    const missing = [];
+
+    for (const { path, body } of postRoutes()) {
+      if (path in EXEMPT) continue;
+      const setName = body.match(/unknownBodyFields\([\s\S]{0,200}?([A-Z_]+_BODY_FIELDS)\s*\)/)?.[1];
+      assert.ok(setName, `${path}: no named field set`);
+
+      // The set's members, read from query.ts rather than imported: this gate reads source everywhere else, and
+      // importing would make it depend on a build.
+      const block = QUERY_SRC.slice(QUERY_SRC.indexOf(`export const ${setName}`));
+      const declared = new Set([...block.slice(0, block.indexOf(']')).matchAll(/'([^']+)'/g)].map(m => m[1]));
+
+      const read = new Set();
+      for (const m of body.matchAll(/const\s*\{([^}]+)\}\s*=\s*req\.body/g)) {
+        for (const nm of m[1].split(',')) {
+          const clean = nm.trim().split(':')[0].trim();
+          if (clean) read.add(clean);
+        }
+      }
+      for (const m of body.matchAll(/(?:req\.body[^)]*\)|\bbody)\s*\[\s*'([^']+)'\s*\]/g)) read.add(m[1]);
+      for (const m of body.matchAll(/\(\s*req\.body\s+as\s*\{[^}]*\}\s*\)\s*\.\s*(\w+)/g)) read.add(m[1]);
+
+      for (const key of read) {
+        if (!declared.has(key)) missing.push(`${path} reads '${key}' but ${setName} does not allow it`);
+      }
+    }
+
+    assert.deepEqual(missing, [],
+      'a strict body turns every unlisted key into a 400, so a key the handler reads and the set omits breaks a '
+      + 'documented parameter — which is what happened to recall\'s includeFreshWrites in the first version of this fix');
+  });
+
+  it('the read-key extraction actually finds keys (the check is not vacuous)', () => {
+    // Without this, a regex that matches nothing makes the assertion above pass for every route for ever — the shape of
+    // a green gate that measures nothing.
+    const recall = postRoutes().find(r => r.path === '/spaces/:spaceId/recall');
+    const found = [...recall.body.matchAll(/\(\s*req\.body\s+as\s*\{[^}]*\}\s*\)\s*\.\s*(\w+)/g)].map(m => m[1]);
+    assert.ok(found.includes('includeFreshWrites'),
+      'the cast-then-dot pattern must be detected — it is the one that was missed, and if this stops matching the '
+      + 'coverage check silently stops covering it');
+  });
+
+  it('every exemption carries a real reason', () => {
+    for (const [path, reason] of Object.entries(EXEMPT)) {
+      assert.ok(reason && reason.length > 40, `${path}: an exemption needs a reason, not a placeholder`);
+      assert.ok(!/todo|later|for now|not yet/i.test(reason),
+        `${path}: "${reason}" is a deferral, not a reason — an exemption list that accepts those becomes a to-do list`);
+    }
+  });
+
+  it('no exemption names a route that no longer exists', () => {
+    const paths = new Set(postRoutes().map(r => r.path));
+    const stale = Object.keys(EXEMPT).filter(p => !paths.has(p));
+    assert.deepEqual(stale, [], 'a stale exemption silently covers nothing, and hides the next route that needs it');
+  });
+});

--- a/testing/standalone/query-paging-db.test.js
+++ b/testing/standalone/query-paging-db.test.js
@@ -1,0 +1,150 @@
+/**
+ * `skip` on `POST /query` pages without overlap or gaps, and the comparator agrees with the `.sort()` it mirrors.
+ *
+ * ## The report
+ *
+ * aigents, 2026-08-12T1410Z: `skip` was accepted at 200 and silently ignored, and *"it cost us a fabricated number"* —
+ * a paged sweep re-read page one every time and was counted as if it had advanced. A wrong number that looks right.
+ *
+ * ## What only a DB test can check here
+ *
+ * That the pages actually tile the collection. An over-eager `skip` (applied after `limit`) returns short pages; an
+ * off-by-one returns a row twice or drops one; and either one produces a plausible sweep whose total is wrong — which is
+ * exactly the failure being fixed, reproduced by the fix. So the assertion is that concatenated pages equal the whole
+ * collection **exactly**, ids and order.
+ *
+ * ## And why the comparator is tested against the driver rather than against my reading of it
+ *
+ * A proxy space's page is merged in application code with `compareQueryOrder`, which is a SECOND expression of the sort
+ * `queryBrain` hands to MongoDB. Two expressions of one rule is this repo's most repeated defect, so the test sorts the
+ * same documents both ways and demands the same sequence. Nothing here asserts that my comparator is right in the
+ * abstract; it asserts the two agree, which is the property that matters.
+ *
+ * Run: `npm run test:up` first, then
+ *      node --test testing/standalone/query-paging-db.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+
+const SPACE = 'general';
+const TOTAL = 25;
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ythril-query-paging-'));
+const CONFIG_PATH = path.join(tmpDir, 'config.json');
+process.env['CONFIG_PATH'] = CONFIG_PATH;
+const EMPTY_CACHE = path.join(tmpDir, 'empty-model-cache');
+fs.mkdirSync(EMPTY_CACHE, { recursive: true });
+process.env['YTHRIL_MODELS_OFFLINE'] = '1';
+process.env['MODEL_CACHE_DIR'] = EMPTY_CACHE;
+
+let mongo, query, memory;
+
+describe('query paging (real MongoDB)', { skip }, () => {
+  before(async () => {
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify(
+      { spaces: [{ id: SPACE, label: 'General' }], networks: [], tokens: [] }, null, 2,
+    ));
+    mongo = await openTestMongo('querypaging');
+    const loader = await import('../../server/dist/config/loader.js');
+    loader.loadConfig();
+    query = await import('../../server/dist/brain/query.js');
+    memory = await import('../../server/dist/brain/memory.js');
+
+    await mongo.col(`${SPACE}_memories`).deleteMany({});
+    // Written one at a time so `seq` is strictly increasing — the primary sort key, and what makes the order total.
+    for (let i = 0; i < TOTAL; i++) await memory.remember(SPACE, `paged record ${String(i).padStart(2, '0')}`, [], []);
+  });
+
+  after(async () => {
+    await closeTestMongo();
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  const page = (limit, skipN) => query.queryBrain(SPACE, 'memories', {}, undefined, limit, 5000, skipN);
+
+  it('the fixture is there (the precondition, not an assumption)', async () => {
+    assert.equal(await mongo.col(`${SPACE}_memories`).countDocuments({}), TOTAL);
+  });
+
+  it('skip ADVANCES the page — the defect was that it did not', async () => {
+    const first = await page(10, 0);
+    const second = await page(10, 10);
+    assert.equal(first.length, 10);
+    assert.equal(second.length, 10);
+    assert.notEqual(first[0]._id, second[0]._id,
+      'page two started at the same row as page one — this is the reported defect, exactly');
+  });
+
+  it('pages tile the collection exactly: no gaps, no repeats, right order', async () => {
+    // The assertion the fabricated number needed. A sweep that re-reads or skips a row still returns plausible pages.
+    const all = await page(100, 0);
+    assert.equal(all.length, TOTAL);
+
+    const stitched = [];
+    for (let s = 0; s < TOTAL; s += 7) stitched.push(...await page(7, s));
+
+    assert.deepEqual(stitched.map(d => d._id), all.map(d => d._id),
+      'concatenated pages must equal one unpaged read, in the same order');
+    assert.equal(new Set(stitched.map(d => d._id)).size, TOTAL, 'and every id exactly once');
+  });
+
+  it('a skip past the end is an empty page, not the last one', async () => {
+    // Returning the tail here would make a paging loop never terminate.
+    assert.deepEqual(await page(10, TOTAL), []);
+    assert.deepEqual(await page(10, TOTAL + 500), []);
+  });
+
+  it('the last page is SHORT rather than padded', async () => {
+    const last = await page(10, 20);
+    assert.equal(last.length, 5, `expected the 5 remaining rows, got ${last.length}`);
+  });
+
+  it('skip is applied BEFORE limit', async () => {
+    // The reverse order — limit the page, then drop rows from it — yields 3 rows here instead of 7, and a caller sees
+    // short pages that still look like data.
+    assert.equal((await page(7, 3)).length, 7);
+  });
+
+  it('a garbage skip does not silently become 0 at this layer either', async () => {
+    // The route refuses these with a 400; the function is the last line of defence for an internal caller.
+    for (const bad of [-5, Number.NaN, undefined]) {
+      const rows = await page(5, bad);
+      assert.equal(rows.length, 5, `skip=${String(bad)} must still return a full first page rather than throwing`);
+      assert.equal(rows[0]._id, (await page(5, 0))[0]._id, 'and it must be the FIRST page, not an arbitrary one');
+    }
+  });
+
+  it('compareQueryOrder agrees with the sort queryBrain gives MongoDB', async () => {
+    // Two expressions of one rule. The proxy merge uses the comparator; a single space uses the driver. If they ever
+    // disagree, a proxy space's page order silently stops matching a plain space's for the same query.
+    const fromDriver = await page(100, 0);
+    const shuffled = [...fromDriver].reverse();
+    const fromComparator = shuffled.sort(query.compareQueryOrder);
+    assert.deepEqual(fromComparator.map(d => d._id), fromDriver.map(d => d._id),
+      'the application-side comparator must reproduce the database ordering exactly');
+  });
+
+  it('the comparator puts a record MISSING the sort key last, not first', async () => {
+    // A descending sort on `undefined` must not win, or a partially projected document would lead a page it has no
+    // claim to. Constructed rather than queried, because a real record always has `seq`.
+    const sorted = [{ _id: 'a' }, { _id: 'b', seq: 5 }].sort(query.compareQueryOrder);
+    assert.equal(sorted[0]._id, 'b', 'the record with a seq comes first');
+  });
+
+  it('QUERY_BODY_FIELDS names skip, or the route would refuse the parameter it just gained', async () => {
+    // The two halves of this fix have to agree: honouring `skip` while the strict body rejects it as unknown would turn
+    // a silently ignored parameter into a 400 for the caller who reported it.
+    assert.ok(query.QUERY_BODY_FIELDS.has('skip'));
+    for (const k of ['collection', 'filter', 'projection', 'limit', 'maxTimeMS']) {
+      assert.ok(query.QUERY_BODY_FIELDS.has(k), `${k} must stay allowed`);
+    }
+    assert.ok(!query.QUERY_BODY_FIELDS.has('sort'), 'sort is not implemented, so it must not be quietly accepted');
+  });
+});


### PR DESCRIPTION
## The report

aigents, **2026-08-12T1410Z**: `skip` was accepted at `200` and silently ignored on `POST /query`, so a paged sweep
re-read page one every time and was counted as if it had advanced.

> *"it cost us a fabricated number"*

## Two defects, two different fixes

Honouring `skip` is a **feature**. Refusing a key the route cannot honour is the **bug fix** — and it is the one that
would have saved them the number. So both are here, and the refusal goes on **all four** brain read routes rather than on
the one key that was reported:

| Route | now refuses unknown keys |
|---|---|
| `POST /query` | ✅ `collection`, `filter`, `projection`, `limit`, `skip`, `maxTimeMS` |
| `POST /recall` | ✅ + `includeFreshWrites`, `includeContent` |
| `POST /traverse` | ✅ + the four `include*` flags |
| `POST /find-similar` | ✅ `crossSpace` still accepted (deprecated ≠ erroring) |

```json
{ "error": "Unknown field(s): sort. Allowed: collection, filter, projection, limit, skip, maxTimeMS",
  "unrecognized_keys": ["sort"] }
```

**This is a deliberate break.** Those bodies used to accept any key and honour the ones they recognised. There is no
`sort` on `/query`, so it is now refused rather than ignored.

`skip` lands on the **MCP `query` tool in the same commit**. MCP already declared `additionalProperties: false` and so
already refused unknown arguments — REST was the weaker of two surfaces for one rule, and adding a parameter to REST
alone is exactly how the REST-only capability map filled up.

## Found while fixing it: `/query` on a proxy space was never paging at all

`collectAcrossMembers` concatenates without sorting or capping, so `/query` on a proxy space returned up to
**`limit × members`** rows **ordered by member** — the caller's `limit` was never honoured there and the documented order
did not hold. Adding `skip` on top would have skipped that many rows *per member*: three wrong answers at once, none of
them an error.

The page is now computed over the **merged** set — first `skip + limit` from each member, merged into the documented
order, then the window. Same defect class as the report, so it is fixed here rather than left for the next one.

## The paging tests assert TILING, not "page two differs"

Two different pages can both be wrong, and a sweep that re-reads or drops a row still returns plausible pages — which is
precisely how the fabricated number was produced. So the assertion is that concatenated pages equal one unpaged read:
same ids, same order, every id exactly once. Asserted over REST, over MCP, and over a two-member proxy space.

`compareQueryOrder` is a second expression of the sort `queryBrain` hands MongoDB, which is the drift this repo keeps
paying for, so a test sorts the same documents both ways and demands the same sequence.

## The new gate caught my own mistake, which is why it grew a third check

`brain-read-bodies-are-strict.test.js` enumerates the POST routes **from source** and asserts each one:

1. refuses unknown keys via the shared helper against a named field set;
2. **returns** the refusal it computed — the proxy-lens near-miss of computing a value and discarding it, which #811
   shipped on three routes;
3. allows **every key the handler actually READS**.

Check 3 exists because the first version of this fix built `RECALL_BODY_FIELDS` from recall's destructuring line and so
refused `includeFreshWrites` and `includeContent` — both real parameters, read 120 lines further down as
`(req.body as {...}).includeFreshWrites`. `recall-fresh-writes.test.js` caught it, which was **luck**: that test exists
because fresh-write recall was worth testing, not because anything guarded this.

**Making a body strict converts every key the author failed to notice into a 400.** The allowed set has to be the keys the
handler reads, and a handler that reads its body in two places is described by whichever place you happened to look at.

All three checks are mutation-tested — removing a refusal, removing only its `return`, and removing the two late-read keys
each turn exactly the intended assertion red. An earlier version of check 1 flagged two *correct* routes because its
regex forbade a comma in the first argument; a gate that reports correct code gets relaxed under pressure, and the
relaxation is what ships, so that is fixed and noted in the file.

## Verification

- 10 assertions in `query-paging-db.test.js` against a real Mongo (tiling, skip-before-limit, past-the-end, comparator
  agreement, missing-sort-key ordering).
- 16 in `query-skip-and-strict-bodies.test.js` across REST, MCP and a proxy space.
- 7 in the gate.
- Re-ran every existing suite touching the four routes — 12 files, all green on a **rebuilt** image.

**One process note.** The two suites that failed after the field-set fix were both the **stale test image**, not the code:
`test:up` reuses `ythril-test:latest`, so the container was running the previous compile. One of them presented as a
120-second *timeout* rather than a failure, which is a convincing disguise. Confirmed the fix was in the image by grepping
the compiled output inside the container before trusting any result — second time in this session that trap cost a wrong
conclusion.

🤖 Generated with Claude Code
