### PR TITLE
feat(brain): /query takes sort and dir, and reports the match total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- **`POST /query` takes `sort`/`dir` and reports a match `total`.** aigents asked for both alongside the `skip` finding
+  (2026-08-11T1045Z); #863 honoured `skip` and turned `sort` from silently ignored into an explicit `400`, which was the
+  right direction and still not what they asked for.
+  - **`total` is the more important half.** `count` is the page length, so a caller sweeping with `skip` could not tell a
+    short last page from a truncated one without an extra request that returned nothing — that total was the number they
+    were computing by hand, which is how it got fabricated. Always returned, summed across members on a proxy space, and
+    bounded by the same `maxTimeMS` as the read. `count` keeps its meaning.
+  - **`sort` reuses the list endpoints' allowlist, parser and error text** (`parseSortParam` / `SORTABLE_FIELDS` /
+    `toMongoSort`), so a caller who knows one knows the other and an unlisted field is refused with the sortable ones
+    named. Inventing an object form here would have been a second way to say one thing.
+  - **`_id` is appended to every order**, including a caller's, which is what keeps it total and therefore pageable. A
+    sort that dropped it would re-create the fabricated-number defect on a different axis.
+  - **The proxy merge comparator is now built FROM the sort handed to MongoDB.** It previously hardcoded the default keys,
+    which was correct only while `/query` had no `sort`: the moment a caller could choose an order, a proxy space would
+    have merged its members by the old one and returned a page in an order nobody asked for — with a `200`.
+  - Both on the **MCP `query` tool** in the same commit, with `count`/`total`/`limit`/`skip` in `structuredContent` and
+    `content` left as the bare array it has always been.
 - **`help` takes a `query` now: only the matching sections instead of the whole guide.** Owner, 2026-08-12: *"help needs
   a searchfunction"*. It took no arguments and returned the entire instance explanation — every visible tool, the
   knowledge model, retrieval guidance, schema authoring and the REST map — which is a large payload to read in full when

--- a/docs/integration-guide/04d-brain-ops-api.md
+++ b/docs/integration-guide/04d-brain-ops-api.md
@@ -416,6 +416,8 @@ Run a constrained Mongo-style read query against one logical collection. Intende
 | `projection` | — | Projection object (`1` include / `0` exclude) |
 | `limit` | — | Max rows (default `20`, capped at `100`) |
 | `skip` | — | Rows to discard before the page (default `0`) — see below |
+| `sort` | — | Field to order by. Per-collection allowlist; an unlisted field is a `400` naming the allowed ones. Omit for newest-first |
+| `dir` | — | `asc` or `desc` (default `desc`). Only meaningful with `sort` |
 | `maxTimeMS` | — | Query timeout in milliseconds (default `5000`) |
 
 Any other field is a `400`. See **Unknown body fields are refused** below.
@@ -427,10 +429,33 @@ Any other field is a `400`. See **Unknown body fields are refused** below.
   "results": [ ... ],
   "collection": "entities",
   "count": 12,
+  "total": 4831,
   "limit": 20,
   "skip": 0
 }
 ```
+
+`count` is **this page**. `total` is **every document the filter matches**, ignoring `limit` and `skip` — that is the
+number you need to know whether a sweep is finished, and without it a short last page is indistinguishable from a
+truncated one. On a proxy space it is the sum across member spaces. It costs one count per member per call, bounded by
+`maxTimeMS`, and it is always returned: a caller who does not know to ask for it is exactly the caller who ends up
+guessing.
+
+When you pass `sort`, the applied `sort` and `dir` are echoed back too.
+
+#### Sortable fields, per collection
+
+| Collection | Fields |
+|---|---|
+| `entities` | `createdAt`, `name`, `type` |
+| `edges` | `createdAt`, `label`, `from`, `to`, `type`, `weight` |
+| `memories` | `createdAt`, `type` |
+| `chrono` | `createdAt`, `title`, `startsAt`, `endsAt`, `status`, `type` |
+| `files` | `createdAt`, `updatedAt`, `path` |
+
+The same allowlist, parser and error text as [Sorting](04-brain-api.md#sorting-all-brain-list-endpoints) on the list
+endpoints. **`_id` is appended to every order**, including one you choose — that is what keeps the order *total*, so
+`skip` pages through it without a row drifting between pages and being seen twice or missed.
 
 #### Paging with `skip`
 

--- a/server/src/api/brain/search.ts
+++ b/server/src/api/brain/search.ts
@@ -7,12 +7,13 @@ import { Router } from 'express';
 import { requireSpaceAuth, denyReadOnly } from '../../auth/middleware.js';
 import { summariseActivity } from '../../metrics/space-activity-store.js';
 import { globalRateLimit } from '../../rate-limit/middleware.js';
+import { parseSortParam, toMongoSort, SORTABLE_FIELDS } from '../../brain/list-sort.js';
 import { NotFoundError } from '../../util/errors.js';
 import { countMemories } from '../../brain/memory.js';
 import { getEmbedJobCounts } from '../../brain/embed-queue.js';
 import {
-  queryBrain, QUERY_BODY_FIELDS, TRAVERSE_BODY_FIELDS, RECALL_BODY_FIELDS, FIND_SIMILAR_BODY_FIELDS,
-  unknownBodyFields, compareQueryOrder,
+  queryBrain, countBrain, QUERY_BODY_FIELDS, TRAVERSE_BODY_FIELDS, RECALL_BODY_FIELDS, FIND_SIMILAR_BODY_FIELDS,
+  unknownBodyFields, compareBySort, DEFAULT_QUERY_SORT,
 } from '../../brain/query.js';
 import { findSimilar, recall, type RecallKnowledgeType, type RecallResult } from '../../brain/recall.js';
 import { validateFilterExpression, type FilterExpression } from '../../brain/filter.js';
@@ -261,6 +262,13 @@ searchRouter.post('/spaces/:spaceId/query', globalRateLimit, requireSpaceAuth, a
   }
   const safeSkip = typeof skip === 'number' ? skip : 0;
 
+  // Same `sort`/`dir` the brain LIST endpoints take, with the same allowlist and the same 400 text — a caller who knows
+  // one knows the other, and inventing an object form here would have been a second way to say one thing.
+  // `toMongoSort` appends `_id`, which is what keeps a caller-chosen order total and therefore pageable.
+  const sortParse = parseSortParam(body['sort'], body['dir'], SORTABLE_FIELDS[collection as keyof typeof SORTABLE_FIELDS]);
+  if ('error' in sortParse) { res.status(400).json({ error: sortParse.error }); return; }
+  const order = sortParse.sort ? toMongoSort(sortParse.sort) : DEFAULT_QUERY_SORT;
+
   try {
     // A PROXY space needs the page computed over the MERGED set, not per member.
     //
@@ -282,12 +290,28 @@ searchRouter.post('/spaces/:spaceId/query', globalRateLimit, requireSpaceAuth, a
         window,
         safeMaxTimeMS,
         0,
+        order,
       ),
     );
-    const merged = perMember.sort(compareQueryOrder).slice(safeSkip, safeSkip + safeLimit);
+    // The match TOTAL, summed across members. aigents fabricated a number because `count` is the PAGE length: a sweep
+    // cannot tell a short last page from a truncated one without an extra request that returns nothing. It costs one
+    // count per member per call, bounded by the same deadline as the read, and it is returned unconditionally because a
+    // caller who does not know to ask for it is exactly the caller who ends up guessing.
+    const total = (await collectAcrossMembers(spaceId, async mid =>
+      [await countBrain(mid, collection as typeof validCollections[number], safeFilter, safeMaxTimeMS)]))
+      .reduce((a, b) => a + b, 0);
+    // Merged with a comparator built from the SAME order given to MongoDB, so a proxy space's page is in the order the
+    // caller asked for rather than in the default one.
+    const merged = perMember.sort(compareBySort(order)).slice(safeSkip, safeSkip + safeLimit);
     // `limit` and `skip` are echoed so a caller paging in a loop can tell "the page you asked for" from "what I
     // capped it to", which is exactly the distinction the fabricated number came from.
-    res.json({ results: merged, collection, count: merged.length, limit: safeLimit, skip: safeSkip });
+    res.json({
+      results: merged, collection,
+      // `count` is this page; `total` is the whole match. Both, because renaming `count` would break every caller that
+      // already reads it and dropping it would break them silently.
+      count: merged.length, total, limit: safeLimit, skip: safeSkip,
+      ...(sortParse.sort ? { sort: sortParse.sort.field, dir: sortParse.sort.dir === 1 ? 'asc' : 'desc' } : {}),
+    });
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     res.status(400).json({ error: msg });

--- a/server/src/brain/query.ts
+++ b/server/src/brain/query.ts
@@ -68,7 +68,7 @@ const ALLOWED_COLLECTIONS = new Set(['memories', 'entities', 'edges', 'chrono', 
  * a parameter to the query and forgetting to allow it in the body is one edit rather than two.
  */
 export const QUERY_BODY_FIELDS: ReadonlySet<string> = new Set([
-  'collection', 'filter', 'projection', 'limit', 'skip', 'maxTimeMS',
+  'collection', 'filter', 'projection', 'limit', 'skip', 'sort', 'dir', 'maxTimeMS',
 ]);
 
 /**
@@ -124,28 +124,45 @@ export function unknownBodyFields(
 }
 
 /**
- * The documented result order — `seq` desc, then `updatedAt`, `createdAt`, `_id` — as a comparator, for merging pages
- * across the members of a proxy space.
+ * The default result order, as DATA so the same value can go to MongoDB and to the merge comparator.
  *
- * A second expression of the sort is exactly the drift risk this repo keeps paying for, so it is defined next to the
- * `.sort()` it mirrors and `query-order-matches-the-sort.test.js` asserts the two agree on the same documents rather
- * than on my reading of them.
+ * `_id` last is not decoration: it makes the order TOTAL, which is what lets `skip` page without a row drifting between
+ * pages and being seen twice or missed. Any caller-supplied sort gets `_id` appended for the same reason — see
+ * `toMongoSort` in list-sort.ts, which has always done this for the list endpoints.
  */
-export function compareQueryOrder(a: unknown, b: unknown): number {
-  const A = a as Record<string, unknown>;
-  const B = b as Record<string, unknown>;
-  for (const key of ['seq', 'updatedAt', 'createdAt', '_id'] as const) {
-    const av = A[key];
-    const bv = B[key];
-    // A record missing the key sorts LAST rather than first: `undefined` in a descending sort must not win, or a
-    // partially projected document would lead a page it has no claim to.
-    if (av === bv) continue;
-    if (av === undefined || av === null) return 1;
-    if (bv === undefined || bv === null) return -1;
-    return av > bv ? -1 : 1;
-  }
-  return 0;
+export const DEFAULT_QUERY_SORT: Record<string, 1 | -1> = {
+  seq: -1, updatedAt: -1, createdAt: -1, _id: -1,
+};
+
+/**
+ * A comparator for a given sort document, for merging pages across the members of a proxy space.
+ *
+ * Built FROM the sort that was handed to MongoDB rather than written out separately. The previous version hardcoded the
+ * default keys, which was correct only for as long as `/query` had no `sort` parameter: the moment a caller could choose
+ * an order, a proxy space would have merged its members by the OLD one and returned a page in an order it did not ask
+ * for — a wrong answer with a 200, which is the defect class this route was just fixed for.
+ */
+export function compareBySort(sort: Record<string, 1 | -1>): (a: unknown, b: unknown) => number {
+  const keys = Object.entries(sort);
+  return (a, b) => {
+    const A = a as Record<string, unknown>;
+    const B = b as Record<string, unknown>;
+    for (const [key, dir] of keys) {
+      const av = A[key];
+      const bv = B[key];
+      if (av === bv) continue;
+      // A record missing the key sorts LAST in either direction: `undefined` must not win a descending sort, or a
+      // partially projected document would lead a page it has no claim to.
+      if (av === undefined || av === null) return 1;
+      if (bv === undefined || bv === null) return -1;
+      return (av > bv ? -1 : 1) * (dir === -1 ? 1 : -1);
+    }
+    return 0;
+  };
 }
+
+/** The default order, as a comparator. Kept as a named export because most callers want exactly this. */
+export const compareQueryOrder = compareBySort(DEFAULT_QUERY_SORT);
 
 /** Structured read-only query (operator whitelist enforced) */
 export async function queryBrain(
@@ -165,6 +182,12 @@ export async function queryBrain(
    * pages and be seen twice or missed.
    */
   skip = 0,
+  /**
+   * Order to apply, defaulting to `DEFAULT_QUERY_SORT`. Passed in rather than chosen here so the caller can hand the
+   * SAME value to `compareBySort` when merging a proxy space's members — two expressions of one order is the drift this
+   * codebase keeps paying for.
+   */
+  sort: Record<string, 1 | -1> = DEFAULT_QUERY_SORT,
 ) {
   if (!ALLOWED_COLLECTIONS.has(collectionName)) {
     throw new Error(`Unknown collection '${collectionName}'`);
@@ -175,9 +198,9 @@ export async function queryBrain(
   const cursor = col(collName)
     .find(safeFilter)
     .maxTimeMS(safeMaxTime)
-    // Deterministic newest-first ordering keeps recent writes visible under
-    // the default limit even when historical datasets grow large.
-    .sort({ seq: -1, updatedAt: -1, createdAt: -1, _id: -1 })
+    // Deterministic newest-first ordering by default, which keeps recent writes visible under the default limit even
+    // when historical datasets grow large. Every order ends in `_id`, so it is total and pageable.
+    .sort(sort)
     // Skip BEFORE limit, which is the order the driver applies regardless of call order — spelled out here because
     // the reverse reading (limit the page, then drop rows from it) would silently return short pages.
     .skip(Math.max(Math.floor(skip) || 0, 0))
@@ -188,6 +211,31 @@ export async function queryBrain(
     // caller's projection entirely.
     .project(mergeEmbeddingExclusion(projection) as Record<string, never>);
   return cursor.toArray();
+}
+
+/**
+ * How many documents the filter matches, ignoring `limit` and `skip`.
+ *
+ * aigents had to fabricate a number because `count` on the response is the PAGE length: a caller sweeping with `skip`
+ * cannot tell a short last page from a truncated one without an extra request that returns nothing. This is the number
+ * they were computing by hand.
+ *
+ * Same `sanitizeFilter` and same deadline as the read, so a filter that is safe to query is safe to count and a count
+ * cannot outlive the query it belongs to.
+ */
+export async function countBrain(
+  spaceId: string,
+  collectionName: 'memories' | 'entities' | 'edges' | 'chrono' | 'files',
+  filter: Record<string, unknown>,
+  maxTimeMS = 5000,
+): Promise<number> {
+  if (!ALLOWED_COLLECTIONS.has(collectionName)) {
+    throw new Error(`Unknown collection '${collectionName}'`);
+  }
+  return await col(`${spaceId}_${collectionName}`).countDocuments(
+    sanitizeFilter(filter) as Record<string, never>,
+    { maxTimeMS: Math.min(maxTimeMS, 10_000) },
+  );
 }
 
 /**

--- a/server/src/mcp/tools/search.ts
+++ b/server/src/mcp/tools/search.ts
@@ -11,7 +11,8 @@ import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.
 import { UUID_V4_RE, entityDocToRecord, formatRecallSummary, toRecallRecord, uuidSchema, unitScoreSchema, QUERY_FILTER_OPERATORS, RECALL_FILTER_KEY_PATTERN, type McpRecallTraverseItem } from './shared.js';
 import { MAX_RECALL_TRAVERSE, traverseRecallSeeds } from '../../brain/edges.js';
 import { type FilterExpression, validateFilterExpression } from '../../brain/filter.js';
-import { queryBrain, compareQueryOrder } from '../../brain/query.js';
+import { queryBrain, countBrain, compareBySort, DEFAULT_QUERY_SORT } from '../../brain/query.js';
+import { parseSortParam, toMongoSort, SORTABLE_FIELDS } from '../../brain/list-sort.js';
 import { type RecallKnowledgeType, type RecallResult, findSimilar, recall, recallGlobal } from '../../brain/recall.js';
 import { collectAcrossMembers } from '../../spaces/proxy.js';
 import { memberSpacesWithin } from '../../spaces/proxy-scoped.js';
@@ -376,6 +377,8 @@ export const queryTool: ToolHandler = {
             },
             limit: { type: 'number', minimum: 1, maximum: 100, default: 20, description: 'Max documents to return (clamped to 1–100). Default 20.' },
             skip: { type: 'number', minimum: 0, description: 'Rows to discard before the page, for paging. The result order is total (`_id` breaks every tie), so no row can be seen twice or missed between pages. On a proxy space the page is computed over the MERGED set, not per member.' },
+            sort: { type: 'string', description: 'Field to order by. Allowed values depend on the collection (entities: createdAt, name, type; edges: createdAt, label, from, to, type, weight; memories: createdAt, type; chrono: createdAt, title, startsAt, endsAt, status, type; files: createdAt, updatedAt, path). An unknown field is refused and names the allowed ones. Omit for newest-first.' },
+            dir: { type: 'string', enum: ['asc', 'desc'], description: "Sort direction, default desc. Only meaningful with `sort`." },
             maxTimeMS: { type: 'number', minimum: 1, maximum: 10000, default: 5000, description: 'Server-side query timeout in ms. Default 5000, hard-capped at 10000.' },
           },
           required: ['space', 'collection', 'filter'],
@@ -398,6 +401,11 @@ export const queryTool: ToolHandler = {
       throw new Error('skip must be a non-negative integer');
     }
     const skip = typeof a['skip'] === 'number' ? a['skip'] : 0;
+
+    // The same parser, allowlist and error text the REST route and the list endpoints use.
+    const sortParse = parseSortParam(a['sort'], a['dir'], SORTABLE_FIELDS[collName as keyof typeof SORTABLE_FIELDS]);
+    if ('error' in sortParse) throw new Error(sortParse.error);
+    const order = sortParse.sort ? toMongoSort(sortParse.sort) : DEFAULT_QUERY_SORT;
     const maxTimeMS = typeof a['maxTimeMS'] === 'number' ? a['maxTimeMS'] : 5000;
     const projection =
       a['projection'] != null && typeof a['projection'] === 'object'
@@ -417,8 +425,15 @@ export const queryTool: ToolHandler = {
         window,
         maxTimeMS,
         0,
+        order,
       ));
-    const docs = perMember.sort(compareQueryOrder).slice(skip, skip + limit);
+    const docs = perMember.sort(compareBySort(order)).slice(skip, skip + limit);
+    const total = (await collectAcrossMembers(callSpace, async mid =>
+      [await countBrain(mid, collName as 'memories' | 'entities' | 'edges' | 'chrono' | 'files', filter, maxTimeMS)]))
+      .reduce((x, y) => x + y, 0);
+    // `structuredContent` carries the paging facts; `content` stays the bare array it has always been, so a client
+    // parsing the text is unaffected. Without `total` a caller sweeping with `skip` cannot tell a short last page from a
+    // truncated one, which is the number aigents ended up fabricating.
     return {
       content: [
         {
@@ -426,6 +441,10 @@ export const queryTool: ToolHandler = {
           text: JSON.stringify(docs),
         },
       ],
+      structuredContent: {
+        count: docs.length, total, limit, skip,
+        ...(sortParse.sort ? { sort: sortParse.sort.field, dir: sortParse.sort.dir === 1 ? 'asc' : 'desc' } : {}),
+      },
     };
   },
 };

--- a/testing/integration/query-skip-and-strict-bodies.test.js
+++ b/testing/integration/query-skip-and-strict-bodies.test.js
@@ -151,7 +151,10 @@ describe('REST: skip paginates instead of being ignored', () => {
 
 describe('REST: the four read routes refuse a key they cannot honour', () => {
   const cases = [
-    ['/query', { collection: 'memories', filter: {}, sort: { seq: 1 } }, 'sort'],
+    // `orderBy`, not `sort`: this case originally used `sort` when it was unimplemented, and became a false alarm the day
+    // it shipped. A plausible ALIAS is the better test anyway — it is what a caller actually reaches for, and it is the
+    // one that would otherwise be accepted and ignored.
+    ['/query', { collection: 'memories', filter: {}, orderBy: 'seq' }, 'orderBy'],
     ['/recall', { query: 'anything', topk: 5 }, 'topk'],
     ['/traverse', { startId: '00000000-0000-4000-8000-000000000000', depth: 2 }, 'depth'],
     ['/find-similar', { entryId: '00000000-0000-4000-8000-000000000000', entryType: 'memory', limit: 5 }, 'limit'],
@@ -216,5 +219,76 @@ describe('MCP: query offers skip too, rather than it becoming REST-only', () => 
     // rather than as a silently ignored argument, which is the REST defect arriving on the other surface.
     const r = await session.callTool('query', { space: SPACE, collection: 'memories', filter: {}, sort: { seq: 1 } });
     assert.ok(r?.isError, `MCP accepted an unknown argument: ${JSON.stringify(r)}`);
+  });
+});
+
+describe('the match TOTAL and a caller-chosen order, on both surfaces', () => {
+  it('REST reports total separately from the page count', async () => {
+    // The number aigents had to fabricate: `count` is the page, `total` is the match. Without the second one a sweep
+    // cannot tell a short last page from a truncated one except by making a request that returns nothing.
+    const r = await query({ collection: 'memories', filter: {}, limit: 5 });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal(r.body.count, 5, 'count is the page');
+    assert.equal(r.body.total, TOTAL, 'total is every match');
+  });
+
+  it('total is unaffected by skip', async () => {
+    const r = await query({ collection: 'memories', filter: {}, limit: 3, skip: 9 });
+    assert.equal(r.body.total, TOTAL);
+    assert.equal(r.body.count, 3);
+  });
+
+  it('total respects the filter', async () => {
+    const r = await query({ collection: 'memories', filter: { fact: `paged 00 ${RUN}` } });
+    assert.equal(r.body.total, 1, JSON.stringify(r.body));
+  });
+
+  it('REST orders by a chosen field and echoes it', async () => {
+    const r = await query({ collection: 'memories', filter: {}, sort: 'createdAt', dir: 'asc', limit: 100 });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal(r.body.sort, 'createdAt');
+    assert.equal(r.body.dir, 'asc');
+    const times = r.body.results.map(d => d.createdAt);
+    assert.deepEqual(times, [...times].sort(), 'ascending must actually be ascending');
+  });
+
+  it('refuses an unsortable field and NAMES the sortable ones', async () => {
+    // The same allowlist and the same message the brain list endpoints give, so a caller who knows one knows the other.
+    const r = await query({ collection: 'memories', filter: {}, sort: 'fact' });
+    assert.equal(r.status, 400, `sorting by an unlisted field was accepted: ${JSON.stringify(r.body)}`);
+    assert.match(r.body.error, /Sortable fields/);
+  });
+
+  it('refuses a bad dir', async () => {
+    const r = await query({ collection: 'memories', filter: {}, sort: 'createdAt', dir: 'sideways' });
+    assert.equal(r.status, 400, JSON.stringify(r.body));
+  });
+
+  it('pages a custom order on a PROXY space in that order', async () => {
+    // The comparator is built from the sort handed to Mongo. Hardcoded to the default keys it would merge the members by
+    // the wrong order and return a page nobody asked for -- with a 200.
+    const all = await query({ collection: 'memories', filter: {}, sort: 'createdAt', dir: 'asc', limit: 100 }, PROXY);
+    assert.equal(all.status, 200, JSON.stringify(all.body));
+    const times = all.body.results.map(d => d.createdAt);
+    assert.deepEqual(times, [...times].sort(), 'a proxy page must honour the caller order across members');
+    assert.equal(all.body.total, 12, 'and the total sums both members');
+  });
+
+  it('MCP carries the same total and takes the same sort', async () => {
+    const r = await session.callTool('query', {
+      space: SPACE, collection: 'memories', filter: {}, limit: 4, sort: 'createdAt', dir: 'asc',
+    });
+    assert.ok(!r?.isError, JSON.stringify(r));
+    assert.equal(r.structuredContent.total, TOTAL, 'the total must be on the MCP surface too, not REST-only');
+    assert.equal(r.structuredContent.count, 4);
+    assert.equal(r.structuredContent.sort, 'createdAt');
+    const times = JSON.parse(r.content[0].text).map(d => d.createdAt);
+    assert.deepEqual(times, [...times].sort());
+  });
+
+  it('MCP refuses an unsortable field with the same message', async () => {
+    const r = await session.callTool('query', { space: SPACE, collection: 'memories', filter: {}, sort: 'fact' });
+    assert.ok(r?.isError, `MCP accepted an unlisted sort field: ${JSON.stringify(r)}`);
+    assert.match(JSON.stringify(r), /Sortable fields/);
   });
 });

--- a/testing/standalone/query-paging-db.test.js
+++ b/testing/standalone/query-paging-db.test.js
@@ -142,9 +142,15 @@ describe('query paging (real MongoDB)', { skip }, () => {
     // The two halves of this fix have to agree: honouring `skip` while the strict body rejects it as unknown would turn
     // a silently ignored parameter into a 400 for the caller who reported it.
     assert.ok(query.QUERY_BODY_FIELDS.has('skip'));
-    for (const k of ['collection', 'filter', 'projection', 'limit', 'maxTimeMS']) {
+    for (const k of ['collection', 'filter', 'projection', 'limit', 'maxTimeMS', 'sort', 'dir']) {
       assert.ok(query.QUERY_BODY_FIELDS.has(k), `${k} must stay allowed`);
     }
-    assert.ok(!query.QUERY_BODY_FIELDS.has('sort'), 'sort is not implemented, so it must not be quietly accepted');
+    // This line used to assert `sort` was ABSENT, which was true when it was unimplemented and became a false alarm the
+    // day it shipped. The invariant is not "sort is missing" — it is that a key is allowed only if the route honours it,
+    // so a plausible ALIAS nobody implemented must still be refused. Those are the ones a caller reaches for.
+    for (const alias of ['order', 'orderBy', 'sortBy', 'direction', 'offset', 'page']) {
+      assert.ok(!query.QUERY_BODY_FIELDS.has(alias),
+        `'${alias}' is not implemented, so accepting it would silently ignore it — the original defect`);
+    }
   });
 });

--- a/testing/standalone/query-sort-and-total-db.test.js
+++ b/testing/standalone/query-sort-and-total-db.test.js
@@ -1,0 +1,146 @@
+/**
+ * `/query` orders by a caller-chosen field and reports the MATCH TOTAL — against a real MongoDB.
+ *
+ * ## The ask
+ *
+ * aigents, 2026-08-11T1045Z, alongside the `skip` finding: `sort` on `/query`, and an explicit way to fetch everything.
+ * #863 honoured `skip` and turned `sort` from silently ignored into an explicit `400` naming it — the right direction, and
+ * still not the thing they asked for.
+ *
+ * ## Why `total` is the more important half
+ *
+ * `count` on the response is the PAGE length. A caller sweeping with `skip` cannot distinguish a short last page from a
+ * truncated one without an extra request that returns nothing — so the total was the number they were computing by hand,
+ * which is how it got fabricated in the first place.
+ *
+ * ## What the sort has to preserve
+ *
+ * Paging works because the order is TOTAL: `_id` breaks every tie, so no row drifts between pages. A caller-supplied sort
+ * that dropped that would re-create the original defect on a different axis, so `toMongoSort` appends `_id` and the
+ * assertions below page through a custom order and demand the same tiling property as the default one.
+ *
+ * And the proxy merge comparator is built FROM the sort handed to MongoDB. The previous version hardcoded the default
+ * keys, which was correct only while `/query` had no `sort`: the moment a caller could choose, a proxy space would have
+ * merged its members by the old order and returned a page in an order nobody asked for.
+ *
+ * Run: `npm run test:up` first, then
+ *      node --test testing/standalone/query-sort-and-total-db.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+
+const SPACE = 'general';
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ythril-query-sort-'));
+const CONFIG_PATH = path.join(tmpDir, 'config.json');
+process.env['CONFIG_PATH'] = CONFIG_PATH;
+const EMPTY_CACHE = path.join(tmpDir, 'empty-model-cache');
+fs.mkdirSync(EMPTY_CACHE, { recursive: true });
+process.env['YTHRIL_MODELS_OFFLINE'] = '1';
+process.env['MODEL_CACHE_DIR'] = EMPTY_CACHE;
+
+let mongo, query, entities;
+const NAMES = ['delta', 'alpha', 'charlie', 'echo', 'bravo'];
+
+describe('query sort and total (real MongoDB)', { skip }, () => {
+  before(async () => {
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify(
+      { spaces: [{ id: SPACE, label: 'General' }], networks: [], tokens: [] }, null, 2,
+    ));
+    mongo = await openTestMongo('querysort');
+    const loader = await import('../../server/dist/config/loader.js');
+    loader.loadConfig();
+    query = await import('../../server/dist/brain/query.js');
+    entities = await import('../../server/dist/brain/entities.js');
+
+    await mongo.col(`${SPACE}_entities`).deleteMany({});
+    // Insertion order deliberately NOT alphabetical, so a name sort cannot pass by accident on insertion order.
+    for (const n of NAMES) await entities.upsertEntity(SPACE, n, 'thing');
+  });
+
+  after(async () => {
+    await closeTestMongo();
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  const q = (opts = {}) => query.queryBrain(
+    SPACE, 'entities', opts.filter ?? {}, undefined,
+    opts.limit ?? 100, 5000, opts.skip ?? 0, opts.sort,
+  );
+
+  it('the fixture is unsorted on purpose', async () => {
+    const rows = await q();
+    assert.equal(rows.length, NAMES.length);
+    const names = rows.map(r => r.name);
+    assert.notDeepEqual(names, [...names].sort(), 'the default order must not already be alphabetical');
+  });
+
+  it('orders ascending by a chosen field', async () => {
+    const rows = await q({ sort: { name: 1, _id: 1 } });
+    assert.deepEqual(rows.map(r => r.name), [...NAMES].sort());
+  });
+
+  it('orders descending by a chosen field', async () => {
+    const rows = await q({ sort: { name: -1, _id: -1 } });
+    assert.deepEqual(rows.map(r => r.name), [...NAMES].sort().reverse());
+  });
+
+  it('pages through a CUSTOM order without repeats or gaps', async () => {
+    // The property that matters: a caller-chosen order must page as reliably as the default, or the fabricated-number
+    // defect returns on a different axis.
+    const sort = { name: 1, _id: 1 };
+    const all = await q({ sort });
+    const stitched = [];
+    for (let s = 0; s < NAMES.length; s += 2) stitched.push(...await q({ sort, limit: 2, skip: s }));
+    assert.deepEqual(stitched.map(r => r.name), all.map(r => r.name));
+    assert.equal(new Set(stitched.map(r => r._id)).size, NAMES.length);
+  });
+
+  it('compareBySort reproduces the database order for the SAME sort', async () => {
+    // The proxy merge depends on this. Asserted for a custom order, because the old hardcoded comparator was correct for
+    // the default one and would have silently mis-merged every other.
+    for (const sort of [{ name: 1, _id: 1 }, { name: -1, _id: -1 }, query.DEFAULT_QUERY_SORT]) {
+      const fromDriver = await q({ sort });
+      const shuffled = [...fromDriver].reverse().sort(query.compareBySort(sort));
+      assert.deepEqual(shuffled.map(r => r._id), fromDriver.map(r => r._id),
+        `comparator disagreed with the driver for ${JSON.stringify(sort)}`);
+    }
+  });
+
+  it('compareBySort still puts a record missing the key LAST, in both directions', () => {
+    for (const dir of [1, -1]) {
+      const sorted = [{ _id: 'a' }, { _id: 'b', name: 'x' }].sort(query.compareBySort({ name: dir }));
+      assert.equal(sorted[0]._id, 'b', `dir ${dir}: the record with the field must come first`);
+    }
+  });
+
+  it('countBrain counts MATCHES, not the page', async () => {
+    assert.equal(await query.countBrain(SPACE, 'entities', {}), NAMES.length);
+    // The distinction the whole ask is about: a page of 2 out of 5.
+    assert.equal((await q({ limit: 2 })).length, 2);
+    assert.equal(await query.countBrain(SPACE, 'entities', {}), NAMES.length, 'the total ignores limit and skip');
+  });
+
+  it('countBrain honours the filter it is given', async () => {
+    assert.equal(await query.countBrain(SPACE, 'entities', { name: 'alpha' }), 1);
+    assert.equal(await query.countBrain(SPACE, 'entities', { name: 'nobody' }), 0);
+  });
+
+  it('countBrain refuses an unknown collection rather than counting nothing', async () => {
+    // Returning 0 for a typo'd collection is a wrong answer that looks like an empty space.
+    await assert.rejects(() => query.countBrain(SPACE, 'memoriez', {}));
+  });
+
+  it('the default sort is still the documented one', () => {
+    // It is now a value rather than an inline literal, so a reordering of these keys would change every page silently.
+    assert.deepEqual(query.DEFAULT_QUERY_SORT, { seq: -1, updatedAt: -1, createdAt: -1, _id: -1 });
+    assert.equal(Object.keys(query.DEFAULT_QUERY_SORT).at(-1), '_id',
+      '`_id` must be LAST, which is what makes the order total and therefore pageable');
+  });
+});


### PR DESCRIPTION
## The ask

aigents, **2026-08-11T1045Z**, alongside the `skip` finding: `sort` on `/query`, and an explicit way to fetch everything.

#863 honoured `skip` and turned `sort` from *silently ignored* into an explicit `400` naming it. That was the right
direction and still not what they asked for.

## `total` is the more important half

`count` is the **page** length. A caller sweeping with `skip` could not tell a short last page from a truncated one
without an extra request that returned nothing — **that total is the number they were computing by hand**, which is how it
came to be fabricated.

```json
{ "results": [ … ], "collection": "entities", "count": 12, "total": 4831, "limit": 20, "skip": 0 }
```

Summed across members on a proxy space, bounded by the same `maxTimeMS` as the read, and returned **unconditionally**
rather than behind an opt-in: a caller who does not know to ask for it is exactly the caller who ends up guessing.
`count` keeps its meaning — renaming it would break every caller that reads it, and dropping it would break them
silently.

## `sort` reuses the list endpoints' machinery

`parseSortParam`, `SORTABLE_FIELDS`, `toMongoSort` — same per-collection allowlist, same `400` text naming the sortable
fields. A caller who knows one endpoint knows the other, and inventing an object form here would have been a second way
to say one thing.

**`_id` is appended to every order, including a caller's.** `toMongoSort` has always done that for the list endpoints and
it is not cosmetic: it makes the order **total**, which is what lets `skip` page without a row drifting between pages and
being seen twice or missed. A sort that dropped it would re-create the fabricated-number defect on a different axis, so
the tests page through a *custom* order and demand the same tiling property as the default one.

## The proxy merge comparator was about to become wrong

It hardcoded the default sort keys — correct only for as long as `/query` had no `sort`. **The moment a caller could
choose an order, a proxy space would have merged its members by the old one and returned a page in an order nobody asked
for, with a `200`** — the defect class this route was fixed for two commits ago.

So the default order is now a value (`DEFAULT_QUERY_SORT`) handed to both the driver and `compareBySort`, and a test
asserts the comparator reproduces the database ordering for **three** different sorts rather than for the one it was
written against.

## Both surfaces, same commit

MCP `query` gains `sort`/`dir` and carries `count`/`total`/`limit`/`skip` in `structuredContent`. `content` stays the bare
array it has always been, so a client parsing the text is unaffected.

## Two of my own assertions encoded a point in time

Both said *"`sort` is not implemented, so it must not be accepted"* — true when written, a false alarm the day it shipped.
They now assert the **invariant**: a key is allowed only if the route honours it, so plausible aliases nobody implemented
(`order`, `orderBy`, `sortBy`, `direction`, `offset`, `page`) must still be refused. Those are the ones a caller actually
reaches for, which makes them the better test anyway.

## Verification

- 10 assertions in `query-sort-and-total-db.test.js` against a real Mongo — ascending, descending, paging a custom order,
  comparator agreement across three sorts, missing-key ordering in both directions, and that `countBrain` counts matches
  rather than the page and refuses an unknown collection instead of answering `0`.
- 25 in `query-skip-and-strict-bodies.test.js` across REST, MCP and a two-member proxy space.
- `npm run preflight` green; the integration run was against a **rebuilt** image, verified by grepping the compiled
  output inside the container.

🤖 Generated with Claude Code
