### PR TITLE
docs(face): the external path exists, and 05c described only half the product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,9 +135,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   documented behaviour that exists only for the **external** path. The external face endpoint is a real, shipped feature
   and it was **absent from its own configuration reference**, which is why they asked two questions that should have been
   lookups.
-  - `FACE_RECOGNITION_EXTERNAL_MODEL` is now in the env-var table. It existed all along (`config/loader.ts`), documented
-    nowhere. They explicitly refused to guess a name, on the grounds that an unrecognised env var is ignored silently and
-    a wrong guess leaves a field unpinned while looking pinned — which is exactly right.
+  - `FACE_RECOGNITION_EXTERNAL_MODEL` is now in **05c's** env-var table. **Correction to an earlier draft of this entry:
+    it was not undocumented.** It was in `02-hosting.md`'s egress matrix all along — and absent from the face-recognition
+    page, which is where anyone configuring face recognition looks. So the defect is discoverability, not absence, and
+    `env-var-docs-coverage` was right to be green: it asks whether a variable is documented *somewhere*, which a variable
+    on the wrong page satisfies. Filed as a gate gap.
+  - They explicitly refused to guess a name, on the grounds that an unrecognised env var is ignored silently and a wrong
+    guess leaves a field unpinned while looking pinned — which is exactly right, and the reason a variable documented on
+    a page they had no reason to open was as good as absent to them.
   - The egress claim is now conditional and states which setting decides it: unset means nothing leaves the machine; set
     means face crops are sent per image, gated behind an acknowledged host.
   - **`faceDescriptorDims` at space creation is documented**, with the supported order for bringing your own recogniser:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     asserted.
 
 ### Fixed
+- **`docs/integration-guide/05c-face-recognition.md` described a pipeline that is only half of what ships.** Reported by
+  breituai-platform, 2026-08-12: the page opened by saying face recognition runs *"entirely in-process — no GPU, no
+  sidecar, no Python"* and its ISO note said *"No face data is transmitted to any external service"* — while the same file
+  documented behaviour that exists only for the **external** path. The external face endpoint is a real, shipped feature
+  and it was **absent from its own configuration reference**, which is why they asked two questions that should have been
+  lookups.
+  - `FACE_RECOGNITION_EXTERNAL_MODEL` is now in the env-var table. It existed all along (`config/loader.ts`), documented
+    nowhere. They explicitly refused to guess a name, on the grounds that an unrecognised env var is ignored silently and
+    a wrong guess leaves a field unpinned while looking pinned — which is exactly right.
+  - The egress claim is now conditional and states which setting decides it: unset means nothing leaves the machine; set
+    means face crops are sent per image, gated behind an acknowledged host.
+  - **`faceDescriptorDims` at space creation is documented**, with the supported order for bringing your own recogniser:
+    create the space at the right width *first*, then point the endpoint at it. The reverse embeds at one width against a
+    128-wide gallery, and every descriptor is skipped — a silent no-op that reads as *"these photographs contain no
+    faces"*.
+  - A source comment claimed an infra deployment could *"forbid biometric egress outright by pinning it empty"*. **It
+    could not** — an empty env var is deliberately not a pin, because `docker compose` passes `${VAR:-}` and leaves
+    variables defined-but-empty, so reading "defined" as "pinned" would lock every field on every Compose deployment. The
+    comment promised a lever that does not exist on the one setting with biometric consequences, which is worse than
+    saying nothing; it now documents the real behaviour and points at `FACE_RECOGNITION_ENABLED=false`.
 - **`PATCH /api/brain/spaces/:spaceId/memories/:id` silently ignored `type`.** `POST` read it; the update handler never
   destructured it, so changing a memory's type answered **200 and changed nothing**.
   - `updateMemory` had accepted `type` and written `$set.type` all along, so the field was plumbed the whole way down

--- a/docs/integration-guide/05c-face-recognition.md
+++ b/docs/integration-guide/05c-face-recognition.md
@@ -10,7 +10,7 @@ The face recognition pipeline detects and embeds faces in uploaded images, build
 
 It can instead call an **external face-embedding endpoint** (`faceRecognition.externalModel`, env var `FACE_RECOGNITION_EXTERNAL_MODEL`), which is how you use a recogniser we do not bundle — ArcFace, AdaFace, FaceNet, buffalo_l. **When that is configured, face crops leave the Ythril process**, so the egress policy marks it guarded ALWAYS with an operator acknowledgement REQUIRED regardless of locality — unlike the `nli` and `rerank` slots, which exempt local URLs. A biometric payload is treated as biometric whether the endpoint is on the same cluster or not.
 
-> This page previously described the pipeline as in-process only while documenting behaviour that exists for the external path — reported by breituai-platform on 2026-08-12, who could not find `FACE_RECOGNITION_EXTERNAL_MODEL` because it was absent from its own configuration reference. Both are corrected below.
+> This page previously described the pipeline as in-process only while documenting behaviour that exists for the external path — reported by breituai-platform on 2026-08-12, who could not find `FACE_RECOGNITION_EXTERNAL_MODEL` because it was absent from THIS page. It was documented in [02-hosting.md](02-hosting.md)'s egress matrix, which is not where anyone configuring face recognition would look. Both are corrected below.
 
 **Faces are governed by the image LEVEL, not by a switch of their own.** They run only where the effective
 image level is `recognition` (or `auto`, which resolves to the most the instance allows). The instance

--- a/docs/integration-guide/05c-face-recognition.md
+++ b/docs/integration-guide/05c-face-recognition.md
@@ -6,7 +6,11 @@
 
 ### Face Recognition Pipeline
 
-The face recognition pipeline detects and embeds faces in uploaded images, builds a per-space face gallery, and automatically links images to person entities when a match exceeds a configurable confidence threshold. It runs **entirely in-process** on the CPU — no GPU, no sidecar, no Python — using `@vladmandic/human` (TF.js CPU backend).
+The face recognition pipeline detects and embeds faces in uploaded images, builds a per-space face gallery, and automatically links images to person entities when a match exceeds a configurable confidence threshold. **By default** it runs entirely in-process on the CPU — no GPU, no sidecar, no Python — using `@vladmandic/human` (TF.js CPU backend).
+
+It can instead call an **external face-embedding endpoint** (`faceRecognition.externalModel`, env var `FACE_RECOGNITION_EXTERNAL_MODEL`), which is how you use a recogniser we do not bundle — ArcFace, AdaFace, FaceNet, buffalo_l. **When that is configured, face crops leave the Ythril process**, so the egress policy marks it guarded ALWAYS with an operator acknowledgement REQUIRED regardless of locality — unlike the `nli` and `rerank` slots, which exempt local URLs. A biometric payload is treated as biometric whether the endpoint is on the same cluster or not.
+
+> This page previously described the pipeline as in-process only while documenting behaviour that exists for the external path — reported by breituai-platform on 2026-08-12, who could not find `FACE_RECOGNITION_EXTERNAL_MODEL` because it was absent from its own configuration reference. Both are corrected below.
 
 **Faces are governed by the image LEVEL, not by a switch of their own.** They run only where the effective
 image level is `recognition` (or `auto`, which resolves to the most the instance allows). The instance
@@ -75,7 +79,26 @@ Set `reprocessSyncedImages: false` to restrict gallery building to images upload
 
 #### MongoDB Atlas Vector Index
 
-Face recognition requires a dedicated Atlas vector search index per space. Name: `{spaceId}_files_faceEmbedding`, field: `faceEmbedding`, dimensions: `128`, similarity: `cosine`. This is distinct from the text embedding index used by `recall`.
+Face recognition requires a dedicated Atlas vector search index per space. Name: `{spaceId}_files_faceEmbedding`, field: `faceEmbedding`, similarity: `cosine`. This is distinct from the text embedding index used by `recall`.
+
+#### Choosing the gallery width: `faceDescriptorDims` at space creation
+
+The index is created at **128 dimensions by default**, which is what the bundled in-process model produces. A different recogniser produces a different width, and **a descriptor of the wrong width is skipped** — the symptom is indistinguishable from *"these photographs contain no faces"*, with one warning per process as the only signal.
+
+So the width is chosen **when the space is created**, with `faceDescriptorDims`:
+
+```http
+POST /api/spaces
+{ "id": "photos", "label": "Photos", "faceDescriptorDims": 512 }
+```
+
+Also available as `faceDescriptorDims` on the `create_space` MCP tool. Use **128** for MobileFaceNet-class models (including the bundled one) and **512** for ArcFace / AdaFace / FaceNet / EdgeFace / buffalo_l.
+
+**It is create-only and permanent.** A populated gallery cannot be re-dimensioned: its stored vectors have not moved, so re-declaring the width would leave every existing descriptor unmatchable. There is no admin call to change it afterwards, and that is deliberate rather than missing — a space whose width is wrong is re-created, not migrated.
+
+**The supported order for bringing your own recogniser** is therefore: create the space with the right `faceDescriptorDims` **first**, then point `FACE_RECOGNITION_EXTERNAL_MODEL` at your endpoint. Doing it the other way round embeds at your width against a 128-wide gallery, and every descriptor is skipped.
+
+The matcher reads the width from **the space's own index**, not from an instance-wide constant, so a space is judged against the vectors it actually holds and a later change of default cannot invalidate an existing gallery.
 
 **This index is never re-dimensioned automatically, and that is deliberate.** Ythril rebuilds other vector indexes when their definition changes, because re-embedding the records makes the vectors catch up. Face vectors live on already-stored face-chunk records and nothing re-derives them, so a rebuild at a new width would leave the stored vectors indexed as if they were the new width — every similarity score wrong, with no error reported. If the configured width ever differs from an existing space's index, Ythril **refuses the change, keeps the existing width, and logs both numbers**. To move a populated gallery, re-embed its faces at the new width first. A filter-field change still applies, at the existing width.
 
@@ -92,6 +115,7 @@ Each field can also be **pinned by an infra admin** through the env var below, w
 | Field | Env var | Default | Description |
 |---|---|---|---|
 | `enabled` | `FACE_RECOGNITION_ENABLED` | `false` | Master switch. When false, face detection is completely skipped. |
+| `externalModel` | `FACE_RECOGNITION_EXTERNAL_MODEL` | *(unset)* | External face-embedding endpoint. **Unset means all inference is in-process and no face data leaves the machine.** Set it to use a recogniser we do not bundle; face crops are then sent there per image, and the egress policy requires an acknowledged host. Pin it when instance admins must not be able to point face processing at an endpoint of their own. |
 | `confidenceThreshold` | `FACE_RECOGNITION_CONFIDENCE_THRESHOLD` | `0.6` | Cosine similarity score (0–1) required for auto-labeling. Lower values label more aggressively; higher values require a closer match. Tune upward as your gallery grows. |
 | `minFaceSizeFraction` | `FACE_RECOGNITION_MIN_FACE_SIZE_FRACTION` | `0.05` | Minimum face bounding-box size as a fraction of the image's shorter side. Faces smaller than this are skipped (avoids noise from crowd shots or background faces). |
 | `modelPath` | `FACE_RECOGNITION_MODEL_PATH` | `"human-models"` | Path relative to `DATA_ROOT` where the BlazeFace and FaceRes model files are located. |
@@ -99,6 +123,8 @@ Each field can also be **pinned by an infra admin** through the env var below, w
 | `reprocessSyncedImages` | `FACE_RECOGNITION_REPROCESS_SYNCED_IMAGES` | `true` | When true, images received via network sync are automatically re-enqueued for face processing if they haven't been processed yet. Set to false to keep gallery building local-origin only. |
 
 > Booleans accept `true` or `1`; anything else reads as false. Pinning `FACE_RECOGNITION_ENABLED=false` is the way to guarantee no face processing happens on an instance regardless of what is in `config.json` — including after a restore from a backup taken on an instance where it was on.
+>
+> **An env var set to the EMPTY STRING is not a pin.** `docker compose` passes variables as `FACE_RECOGNITION_ENABLED: ${FACE_RECOGNITION_ENABLED:-}`, which leaves them *defined but empty* when the operator set nothing — so reading "defined" as "pinned" would lock all six fields on every Compose deployment and render controls read-only that nobody had chosen to fix. Pin the **value** you want enforced instead: `FACE_RECOGNITION_ENABLED=false`, not `FACE_RECOGNITION_EXTERNAL_MODEL=`. There is currently no way to express *"fixed, and fixed at nothing"* for a field whose empty value is itself meaningful.
 
 **Example `config.json` excerpt:**
 
@@ -120,6 +146,8 @@ Each field can also be **pinned by an infra admin** through the env var below, w
 
 #### ISO 27001 Note
 
-Face embeddings (128d float vectors) are stored in MongoDB. They are not reversible to images; they cannot reconstruct a face. No face data is transmitted to any external service — all inference is in-process. If your data residency policy classifies biometric-derived data, ensure your MongoDB instance and backup destinations comply.
+Face embeddings (128d float vectors by default) are stored in MongoDB. They are not reversible to images; they cannot reconstruct a face.
+
+**Whether face data leaves the process depends on one setting.** With `faceRecognition.externalModel` **unset** — the default — all inference is in-process and no face data is transmitted anywhere. With it **configured**, face crops are sent to that endpoint on every image processed. That is a deliberate operator choice, gated behind an egress acknowledgement, and it is the one setting on this page with biometric consequences: pin it with `FACE_RECOGNITION_EXTERNAL_MODEL` if an instance's admins must not be able to change it. To guarantee no face processing at all, pin `FACE_RECOGNITION_ENABLED=false` — an **empty** env var is deliberately not a pin (see the env-var note below). If your data residency policy classifies biometric-derived data, ensure your MongoDB instance and backup destinations comply.
 
 ---

--- a/server/src/config/loader.ts
+++ b/server/src/config/loader.ts
@@ -1261,8 +1261,19 @@ const FACE_RECOGNITION_DEFAULTS: Required<FaceRecognitionConfig> = {
  * except whether faces are processed at all. That is the setting with the clearest privacy weight.
  */
 const FACE_RECOGNITION_ENV: Record<keyof Required<FaceRecognitionConfig>, string> = {
-  // Env-pinnable as a whole, so an infra-managed deployment can forbid biometric egress outright by
-  // pinning it empty — the same lever the other providers have.
+  // Env-pinnable as a whole, so an infra-managed deployment can pin the biometric endpoint the same way it pins every
+  // other provider.
+  //
+  // CORRECTION, 2026-08-13: this comment used to end "...by pinning it empty". That is NOT what happens, and saying so
+  // was worse than saying nothing — an operator following it would believe biometric egress was locked when the field
+  // was still editable. An EMPTY env var is deliberately not a pin: docker-compose passes
+  // `FACE_RECOGNITION_ENABLED: ${FACE_RECOGNITION_ENABLED:-}`, which leaves the variable defined-but-empty when the
+  // operator set nothing, so reading "defined" as "pinned" would lock all six fields on every Compose deployment and
+  // report controls the operator cannot use and could not explain. `face-recognition-env.test.js` pins that reasoning.
+  //
+  // To forbid the egress, pin the value that forbids it: `FACE_RECOGNITION_ENABLED=false`. There is currently no way to
+  // express "fixed, and fixed at nothing" for a field whose empty value is meaningful — breituai-platform asked for
+  // exactly that on 2026-08-12 and it needs a mechanism that cannot be confused with a Compose default.
   externalModel: 'FACE_RECOGNITION_EXTERNAL_MODEL',
   enabled: 'FACE_RECOGNITION_ENABLED',
   confidenceThreshold: 'FACE_RECOGNITION_CONFIDENCE_THRESHOLD',


### PR DESCRIPTION
## Three questions from breituai-platform, and one of them nearly got a wrong answer shipped

They asked (2026-08-12T1238Z / 1245Z) three things. Two should have been lookups and were not, because the page they
looked in described only half the product.

## Q1 — the env var exists

```
FACE_RECOGNITION_EXTERNAL_MODEL
```

In `config/loader.ts` alongside the six they found. **Absent from 05c, from 05-files-api.md, and from everywhere else they
looked.**

They explicitly refused to guess a name, because *"an unrecognised env var is ignored silently, so a wrong guess leaves
the field unpinned while looking pinned to us"* — on the biometric slot, the worst available failure mode. Correct, and
the answer was in a file they could not read.

## 05c described half the product — their §4 was right

The page opened with *"entirely in-process — no GPU, no sidecar, no Python"* and its ISO note said *"No face data is
transmitted to any external service"*, while the **same file** documented per-space width behaviour that exists only
because of the external path.

Both claims are now conditional and name the setting that decides them: unset → nothing leaves the machine; set → face
crops go to that endpoint per image, gated behind an acknowledged host.

## Q2′ — `faceDescriptorDims` at space creation

```http
POST /api/spaces { "id": "photos", "label": "Photos", "faceDescriptorDims": 512 }
```

Create-only and permanent — a populated gallery cannot be re-dimensioned because its stored vectors have not moved.

**The supported ORDER is the part that would have bitten them**, and it is now documented: create the space at 512
**first**, then point the endpoint at it. The reverse embeds buffalo_l's 512 against a 128-wide gallery and every
descriptor is skipped — which, as they predicted, reads exactly like *"these photographs contain no faces"*.

## Q3 — no, an empty env var does not pin. **I nearly shipped the opposite.**

I read the provider slots, found `if (rerankApiKeyEnv) locked.push(…)`, read a different helper thirty lines away keyed off
`!== undefined`, and concluded the codebase gave two answers depending on the block. **I converted all twenty pins to
presence checks and wrote a test asserting the new rule.**

Then `face-recognition-env.test.js` failed, carrying the reason the old behaviour is correct:

> `docker compose` passes `FACE_RECOGNITION_ENABLED: ${FACE_RECOGNITION_ENABLED:-}`, which leaves the variable **defined
> but empty** when the operator set nothing. Reading "defined" as "pinned" would lock all six fields on every Compose
> deployment and report controls as infra-locked that nobody had chosen to fix.

**The change is reverted in full.** What is left is the part that was genuinely wrong.

### What was wrong: a comment promising a lever that does not exist

A comment on `FACE_RECOGNITION_EXTERNAL_MODEL` claimed an infra deployment could *"forbid biometric egress outright by
pinning it empty"*. **It could not.** An operator following it would believe egress was locked while the field stayed
editable — on the one setting on that page with biometric consequences. It now states the real behaviour and points at
`FACE_RECOGNITION_ENABLED=false`.

### And I probed instead of asserting

I was about to tell them *"yes, `RERANK_API_KEY=` already pins"* on the strength of reading one helper. One `node -e`
against the loader returned `lockedByInfra: ["rerank.model"]` — no `rerank.apiKey`. The measurement cost a minute; the
wrong answer would have gone into a customer record.

## What remains unmet, and is parked rather than guessed

Their owner's point stands: *"once the URL is infra-pinned to an in-cluster unauthenticated endpoint, an editable key field
is a control with nothing behind it."* There is no way to express **"fixed, and fixed at nothing"** for a field whose empty
value is meaningful.

Parked as **P-7** with a recommendation: an explicit pin list (`YTHRIL_PINNED_FIELDS=rerank.apiKey,…`), which cannot be
confused with a Compose default, works uniformly for every field, and does not overload the value channel. Owner's call —
and they have been told it is parked with that recommendation, so it is not a silent park.

## Diff

Documentation, plus a comment correction in `loader.ts`. **No behaviour change** — the behaviour change I wrote is the one
that got reverted.

🤖 Generated with Claude Code
