### PR TITLE
fix(brain): an embed job dies with its record, including one that already failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     asserted.
 
 ### Fixed
+- **Deleting a brain record now retires its embed job, including one that had already gone terminal `failed`.**
+  Cleanup was entirely lazy and lived in the worker: it claims a job, finds the record gone, and treats `gone` as success.
+  That covers a `pending` job and **only** a `pending` job, because `claimNextEmbedJob` filters on `status: 'pending'` — so
+  a job that had exhausted its attempts was never claimed again and outlived its record for ever.
+  - **Invisible until the queue got a surface, which is why it lasted.** Since the embed-queue listing shipped, that row is
+    reported by `GET /api/brain/spaces/:id/embedding-queue/records`, by `list_embed_jobs`, and in `getEmbedJobCounts` — so
+    an operator saw a permanent failure naming a `recordId` that returns 404, on a surface whose entire justification is
+    that its failures are actionable.
+  - Retired eagerly from all four delete paths rather than filtered out at read time: hiding an orphan leaves it in the
+    collection, costs a lookup per listed row, and makes the counts disagree with the rows they are counting.
+  - Retirement sits **after** the `deletedCount === 0` check, so a delete that matches nothing cannot drop the job of a
+    record that is still there — asserted, because that is the way this fix breaks.
+  - `pending` jobs are retired too rather than left to the worker. One rule beats "eagerly for failed, lazily for
+    pending", which is the kind of split nobody remembers.
 - **`docs/integration-guide/05c-face-recognition.md` described a pipeline that is only half of what ships.** Reported by
   breituai-platform, 2026-08-12: the page opened by saying face recognition runs *"entirely in-process — no GPU, no
   sidecar, no Python"* and its ISO note said *"No face data is transmitted to any external service"* — while the same file

--- a/server/src/brain/chrono.ts
+++ b/server/src/brain/chrono.ts
@@ -17,7 +17,7 @@ import { stampExpiryOnCreate, applyExpiryToUpdate } from './ttl.js';
 import { stampSkewOnCreate } from './stamp-skew.js';
 import { getSpaceMeta } from '../spaces/schema-validation.js';
 import { mergeTags, mergeProperties, mergePropertiesOrKeep } from './merge-fields.js';
-import { enqueueEmbedJob } from './embed-queue.js';
+import { enqueueEmbedJob, retireEmbedJob } from './embed-queue.js';
 import { emitWebhookEvent, type WebhookActor } from '../webhooks/dispatcher.js';
 import type { ChronoEntry, ChronoType, ChronoStatus, TombstoneDoc } from '../config/types.js';
 import { writeFilterFor, writeOutcome } from './write-precondition.js';
@@ -416,6 +416,11 @@ export async function deleteChrono(
     spaceId,
   });
   if (result.deletedCount === 0) return false;
+  // The record is gone, so its embed job has nothing left to embed. Eager rather than left to the worker: the
+  // worker only claims `pending` jobs, so a job that had already gone terminal `failed` would never be claimed
+  // again and would outlive the record for ever — visible since #861 as a permanent failure naming a recordId
+  // that 404s.
+  await retireEmbedJob(spaceId, 'chrono', chronoId);
 
   const tombstone: TombstoneDoc = {
     _id: chronoId,

--- a/server/src/brain/edges.ts
+++ b/server/src/brain/edges.ts
@@ -14,7 +14,7 @@ import { stampSkewOnCreate } from './stamp-skew.js';
 import { getSpaceMeta } from '../spaces/schema-validation.js';
 import { applyDeleteFields, setUnlessDeleted } from './delete-fields.js';
 import { mergePropertiesOrKeep, mergeTagsOrKeep } from './merge-fields.js';
-import { enqueueEmbedJob } from './embed-queue.js';
+import { enqueueEmbedJob, retireEmbedJob } from './embed-queue.js';
 import { getEntityById } from './entities.js';
 import { emitWebhookEvent, type WebhookActor } from '../webhooks/dispatcher.js';
 import type { EdgeDoc, EntityDoc, TombstoneDoc, ChronoEntry, MemoryDoc, FileMetaDoc } from '../config/types.js';
@@ -234,6 +234,11 @@ export async function deleteEdge(spaceId: string, edgeId: string, actor?: Webhoo
     spaceId,
   });
   if (result.deletedCount === 0) return false;
+  // The record is gone, so its embed job has nothing left to embed. Eager rather than left to the worker: the
+  // worker only claims `pending` jobs, so a job that had already gone terminal `failed` would never be claimed
+  // again and would outlive the record for ever — visible since #861 as a permanent failure naming a recordId
+  // that 404s.
+  await retireEmbedJob(spaceId, 'edge', edgeId);
 
   const tombstone: TombstoneDoc = {
     _id: edgeId,

--- a/server/src/brain/embed-queue.ts
+++ b/server/src/brain/embed-queue.ts
@@ -192,6 +192,34 @@ export async function completeEmbedJob(
   await jobs(spaceId).deleteOne(asFilter<BrainEmbedJobDoc>({ _id: embedJobId(recordType, recordId) }));
 }
 
+/**
+ * Retire the job for a record that is being DELETED.
+ *
+ * Same deletion as `completeEmbedJob`, named for the other reason it happens — a caller reading `completeEmbedJob` in a
+ * delete path would reasonably wonder what completed.
+ *
+ * ## Why the delete path has to do this at all
+ *
+ * Cleanup used to be entirely lazy: the worker claims the job, finds the record gone, and treats `gone` as success. That
+ * covers a `pending` job and only a `pending` job — `claimNextEmbedJob` filters on `status: 'pending'`, so a job that
+ * exhausted its attempts and went terminal `failed` is **never claimed again**. Delete the record at that moment and the
+ * job row outlived it for ever.
+ *
+ * Invisible until #861, which is exactly why it lasted: the listing and `getEmbedJobCounts` now report that row, so an
+ * operator sees a permanent failure naming a `recordId` that 404s. A surface whose whole purpose is that its failures are
+ * actionable cannot carry phantoms.
+ *
+ * Deliberately eager rather than filtered out at read time: hiding an orphan leaves it in the collection, costs a lookup
+ * per listed row, and makes the counts disagree with the rows they are counting.
+ */
+export async function retireEmbedJob(
+  spaceId: string,
+  recordType: BrainEmbedRecordType,
+  recordId: string,
+): Promise<void> {
+  await jobs(spaceId).deleteOne(asFilter<BrainEmbedJobDoc>({ _id: embedJobId(recordType, recordId) }));
+}
+
 /** Requeue with backoff, or leave `failed` once the attempt budget is spent. */
 export async function failEmbedJob(
   spaceId: string,

--- a/server/src/brain/entities.ts
+++ b/server/src/brain/entities.ts
@@ -15,7 +15,7 @@ import { getSpaceMeta } from '../spaces/schema-validation.js';
 import { writeFilterFor, writeOutcome } from './write-precondition.js';
 import { applyDeleteFields, setUnlessDeleted } from './delete-fields.js';
 import { mergeTagsAndProperties, mergePropertiesOrKeep, mergeTagsOrKeep } from './merge-fields.js';
-import { enqueueEmbedJob } from './embed-queue.js';
+import { enqueueEmbedJob, retireEmbedJob } from './embed-queue.js';
 import { checkDuplicates, type SimilarMatch, type DupeCheckOpts } from './recall.js';
 import { emitWebhookEvent, type WebhookActor } from '../webhooks/dispatcher.js';
 import { log } from '../util/log.js';
@@ -414,6 +414,11 @@ export async function deleteEntity(
     spaceId,
   });
   if (result.deletedCount === 0) return false;
+  // The record is gone, so its embed job has nothing left to embed. Eager rather than left to the worker: the
+  // worker only claims `pending` jobs, so a job that had already gone terminal `failed` would never be claimed
+  // again and would outlive the record for ever — visible since #861 as a permanent failure naming a recordId
+  // that 404s.
+  await retireEmbedJob(spaceId, 'entity', entityId);
 
   const tombstone: TombstoneDoc = {
     _id: entityId,

--- a/server/src/brain/memory.ts
+++ b/server/src/brain/memory.ts
@@ -21,7 +21,7 @@ import { stampSkewOnCreate } from './stamp-skew.js';
 import { getSpaceMeta } from '../spaces/schema-validation.js';
 import { applyDeleteFields } from './delete-fields.js';
 import { mergeTags, mergeProperties, mergePropertiesOrKeep } from './merge-fields.js';
-import { enqueueEmbedJob } from './embed-queue.js';
+import { enqueueEmbedJob, retireEmbedJob } from './embed-queue.js';
 import { emitWebhookEvent, type WebhookActor } from '../webhooks/dispatcher.js';
 import type { MemoryDoc, EntityDoc, TombstoneDoc } from '../config/types.js';
 import { SimilarMatch, DupeCheckOpts, checkDuplicates } from './recall.js';
@@ -339,6 +339,11 @@ export async function deleteMemory(
     spaceId,
   });
   if (result.deletedCount === 0) return false;
+  // The record is gone, so its embed job has nothing left to embed. Eager rather than left to the worker: the
+  // worker only claims `pending` jobs, so a job that had already gone terminal `failed` would never be claimed
+  // again and would outlive the record for ever — visible since #861 as a permanent failure naming a recordId
+  // that 404s.
+  await retireEmbedJob(spaceId, 'memory', memoryId);
 
   const tombstone: TombstoneDoc = {
     _id: memoryId,

--- a/testing/standalone/embed-job-dies-with-its-record-db.test.js
+++ b/testing/standalone/embed-job-dies-with-its-record-db.test.js
@@ -1,0 +1,161 @@
+/**
+ * Deleting a record retires its embed job — including a job that had already gone terminal `failed`.
+ *
+ * ## The defect
+ *
+ * Cleanup used to be entirely lazy and lived in the worker: it claims a job, finds the record gone, and treats `gone` as
+ * success. That covers a `pending` job and **only** a `pending` job, because `claimNextEmbedJob` filters on
+ * `status: 'pending'`. A job that exhausted its attempts and went terminal `failed` is never claimed again — so deleting
+ * the record at that moment left the job row behind for ever.
+ *
+ * ## Why it lasted, and why it stopped being tolerable
+ *
+ * The row was invisible. Until #861 nothing exposed the brain embed queue, so an orphan cost one document and nobody
+ * could see it. Now `GET /api/brain/spaces/:id/embedding-queue/records` and `list_embed_jobs` report it and
+ * `getEmbedJobCounts` counts it, so an operator sees a permanent `failed` entry naming a `recordId` that returns 404 —
+ * on a surface whose entire justification is that its failures are actionable.
+ *
+ * ## The `failed` case is the whole test
+ *
+ * A `pending` job was already cleaned up by the worker, so a test that only deletes a freshly written record passes
+ * against the broken code. Every case below drives the job to `failed` FIRST, which is the state the old behaviour could
+ * not recover from.
+ *
+ * Run: `npm run test:up` first, then
+ *      node --test testing/standalone/embed-job-dies-with-its-record-db.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+
+const SPACE = 'general';
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ythril-job-orphan-'));
+const CONFIG_PATH = path.join(tmpDir, 'config.json');
+process.env['CONFIG_PATH'] = CONFIG_PATH;
+
+// Unreachable model: a genuinely failed job cannot be produced against a working embedder.
+const EMPTY_CACHE = path.join(tmpDir, 'empty-model-cache');
+fs.mkdirSync(EMPTY_CACHE, { recursive: true });
+process.env['YTHRIL_MODELS_OFFLINE'] = '1';
+process.env['MODEL_CACHE_DIR'] = EMPTY_CACHE;
+
+let mongo, memory, entities, edges, chrono, queue;
+
+const jobs = () => mongo.col(`${SPACE}_embed_jobs`);
+
+/** Force a record's job to the terminal state the old code could not recover from. */
+const failJob = async (recordType, recordId) => {
+  const _id = `${recordType}:${recordId}`;
+  const r = await jobs().updateOne({ _id }, {
+    $set: { status: 'failed', attempts: 5, lastError: 'model unreachable' },
+  });
+  assert.equal(r.matchedCount, 1, `no job was enqueued for ${_id} — the fixture is wrong, not the code`);
+  return _id;
+};
+
+describe('an embed job dies with its record (real MongoDB, no reachable model)', { skip }, () => {
+  before(async () => {
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify(
+      { spaces: [{ id: SPACE, label: 'General' }], networks: [], tokens: [] }, null, 2,
+    ));
+    mongo = await openTestMongo('joborphan');
+    const loader = await import('../../server/dist/config/loader.js');
+    loader.loadConfig();
+    memory = await import('../../server/dist/brain/memory.js');
+    entities = await import('../../server/dist/brain/entities.js');
+    edges = await import('../../server/dist/brain/edges.js');
+    chrono = await import('../../server/dist/brain/chrono.js');
+    queue = await import('../../server/dist/brain/embed-queue.js');
+  });
+
+  after(async () => {
+    await closeTestMongo();
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  beforeEach(async () => {
+    for (const c of ['memories', 'entities', 'edges', 'chrono', 'embed_jobs']) {
+      await mongo.col(`${SPACE}_${c}`).deleteMany({});
+    }
+  });
+
+  it('a memory: the FAILED job goes when the record goes', async () => {
+    const doc = await memory.remember(SPACE, 'delete me while failed', [], []);
+    const _id = await failJob('memory', doc._id);
+
+    assert.equal(await memory.deleteMemory(SPACE, doc._id), true);
+    assert.equal(await jobs().findOne({ _id }), null,
+      'the job outlived its record — nothing will ever claim it again, and the listing reports it for ever');
+  });
+
+  it('an entity', async () => {
+    const e = await entities.upsertEntity(SPACE, `orphan entity ${Date.now()}`, 'thing');
+    const _id = await failJob('entity', e.entity._id);
+    assert.equal(await entities.deleteEntity(SPACE, e.entity._id), true);
+    assert.equal(await jobs().findOne({ _id }), null);
+  });
+
+  it('an edge', async () => {
+    const a = await entities.upsertEntity(SPACE, `edge-a ${Date.now()}`, 'thing');
+    const b = await entities.upsertEntity(SPACE, `edge-b ${Date.now()}`, 'thing');
+    const edge = await edges.upsertEdge(SPACE, a.entity._id, b.entity._id, 'relates_to');
+    const _id = await failJob('edge', edge._id);
+    assert.equal(await edges.deleteEdge(SPACE, edge._id), true);
+    assert.equal(await jobs().findOne({ _id }), null);
+  });
+
+  it('a chrono entry', async () => {
+    const c = await chrono.createChrono(SPACE, { title: `orphan chrono ${Date.now()}`, type: 'event' });
+    const _id = await failJob('chrono', c._id);
+    assert.equal(await chrono.deleteChrono(SPACE, c._id), true);
+    assert.equal(await jobs().findOne({ _id }), null);
+  });
+
+  it('the counts and the listing stop reporting the phantom', async () => {
+    // The user-visible symptom, asserted through the surface an operator actually reads rather than on the collection.
+    const doc = await memory.remember(SPACE, 'phantom failure', [], []);
+    await failJob('memory', doc._id);
+    assert.equal((await queue.getEmbedJobCounts(SPACE)).failed, 1, 'precondition: one failure is reported');
+
+    await memory.deleteMemory(SPACE, doc._id);
+
+    assert.equal((await queue.getEmbedJobCounts(SPACE)).failed, 0);
+    assert.deepEqual(await queue.listEmbedJobs(SPACE), [],
+      'the listing must not name a recordId that now 404s — that is what makes its failures actionable');
+  });
+
+  it('deleting a record with NO job is not an error', async () => {
+    // The common case by far: a successfully embedded record has no job, because a completed job is deleted. The retire
+    // must be a no-op rather than throwing on a missing row.
+    const doc = await memory.remember(SPACE, 'no job here', [], []);
+    await jobs().deleteMany({});
+    assert.equal(await memory.deleteMemory(SPACE, doc._id), true);
+  });
+
+  it('a delete that matches NOTHING does not retire a job', async () => {
+    // The guard: retirement must sit after the `deletedCount === 0` check, or deleting a nonexistent id would drop the
+    // job of a record that is still there. Constructed by writing a record, then deleting a DIFFERENT id.
+    const doc = await memory.remember(SPACE, 'keep my job', [], []);
+    const _id = await failJob('memory', doc._id);
+
+    assert.equal(await memory.deleteMemory(SPACE, 'no-such-record-id'), false);
+    assert.ok(await jobs().findOne({ _id }),
+      'a failed delete must not retire anything — the record and its job are both still there');
+  });
+
+  it('a PENDING job is retired too, not only a failed one', async () => {
+    // The worker would have got to this one, but not for an unbounded time. Retiring both keeps one rule instead of
+    // "eagerly for failed, lazily for pending", which is the kind of split nobody remembers.
+    const doc = await memory.remember(SPACE, 'pending then deleted', [], []);
+    const _id = `memory:${doc._id}`;
+    assert.equal((await jobs().findOne({ _id })).status, 'pending');
+    await memory.deleteMemory(SPACE, doc._id);
+    assert.equal(await jobs().findOne({ _id }), null);
+  });
+});


### PR DESCRIPTION
## The defect

Cleanup of a deleted record's embed job was entirely **lazy** and lived in the worker: it claims a job, finds the record
gone, and treats `gone` as success.

That covers a `pending` job and **only** a `pending` job — `claimNextEmbedJob` filters on `status: 'pending'`. A job that
exhausted its attempts and went terminal `failed` is **never claimed again**, so deleting the record at that moment left
the job row behind for ever. None of the four brain delete functions touched the queue at all.

## Why it lasted, and why shipping a feature turned it into a wrong answer

While nothing exposed the brain embed queue, an orphan cost one document and nobody could see it.

Since #861 that row is reported by `GET /api/brain/spaces/:id/embedding-queue/records`, by `list_embed_jobs`, and in
`getEmbedJobCounts` — so an operator now sees a **permanent `failed` entry naming a `recordId` that returns 404**, on a
surface whose entire justification is that its failures are actionable.

Found by the data-integrity audit lens run against the surface I had just built, and confirmed in source before it was
written down.

## The fix, and two decisions inside it

**Eager retirement from all four delete paths**, not a filter at read time. Hiding an orphan leaves it in the collection,
costs a lookup per listed row, and makes the counts disagree with the rows they are counting.

**Retirement sits after the `deletedCount === 0` check.** That is the way this fix breaks — retire before it and deleting
a nonexistent id drops the job of a record that is still there. Asserted rather than reasoned about: a test deletes a
missing id and demands the real record's failed job survive.

**`pending` jobs are retired too**, rather than left to the worker. One rule beats *"eagerly for failed, lazily for
pending"*, which is the kind of split nobody remembers six months later.

`retireEmbedJob` is the same deletion `completeEmbedJob` performs, named for the other reason it happens — a reader
finding `completeEmbedJob` in a delete path would reasonably wonder what completed.

## Tests

8 assertions against a real MongoDB with the model deliberately unreachable, since a genuinely failed job cannot be
produced against a working embedder.

**Every case drives the job to `failed` first.** A test that only deletes a freshly written record passes against the
broken code — the worker would have cleaned that one up. The terminal state *is* the defect.

Plus the user-visible symptom asserted through the surface an operator reads: `getEmbedJobCounts().failed` goes 1 → 0 and
the listing empties, rather than only checking the collection.

**Mutation-tested** by removing the `memory.ts` call site: exactly the memory assertion and the counts assertion go red.

🤖 Generated with Claude Code
