### PR TITLE
test(docs): the env-var gate now checks the variable is on its FEATURE's page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     asserted.
 
 ### Fixed
+- **`env-var-docs-coverage` now asserts a variable is documented on the page that owns its FEATURE, not merely somewhere
+  under `docs/`.** The gate was green while `FACE_RECOGNITION_EXTERNAL_MODEL` sat in `02-hosting.md`'s egress matrix and
+  was absent from `05c-face-recognition.md` — so breituai-platform, reading the face-recognition page while configuring
+  face recognition, reported the variable as nonexistent and we agreed with them. A variable on a page nobody has reason
+  to open is as good as absent, and "documented" and "findable where it is needed" are different properties.
+  - A small prefix→owner-pages map covers the families where a wrong page is a real discoverability failure. A prefix that
+    is not listed keeps the old rule rather than having an owner invented for it.
+  - Mutation-tested, and the weaker mutation is recorded in the file: deleting the variable's table row does *not* fail the
+    check, because 05c also names it in prose — which legitimately satisfies "a reader searching this page finds it".
+    Stripping all six mentions reproduces the original state and fails.
+  - My first version of the map named `02-hosting.md` as owner for the embedding, rerank and NLI families and failed on
+    nine variables that were all on the right page (`05b-media-embedding.md`). The map was wrong, not the docs — worth
+    recording, because the tempting repair for that failure is to loosen the check into uselessness.
 - **Deleting a brain record now retires its embed job, including one that had already gone terminal `failed`.**
   Cleanup was entirely lazy and lived in the worker: it claims a job, finds the record gone, and treats `gone` as success.
   That covers a `pending` job and **only** a `pending` job, because `claimNextEmbedJob` filters on `status: 'pending'` — so

--- a/testing/standalone/env-var-docs-coverage.test.js
+++ b/testing/standalone/env-var-docs-coverage.test.js
@@ -202,6 +202,58 @@ function collectDocumented(used) {
   return docs;
 }
 
+/**
+ * A variable belongs on the page that documents the FEATURE it configures — not merely somewhere under `docs/`.
+ *
+ * ## Why "documented somewhere" was not enough
+ *
+ * `FACE_RECOGNITION_EXTERNAL_MODEL` was in `02-hosting.md`'s egress matrix and absent from `05c-face-recognition.md`.
+ * This gate was green throughout, and it was right to be — it asked whether the variable was documented, and it was.
+ * breituai-platform, reading the face-recognition page while configuring face recognition, could not find it, told us it
+ * did not exist, and we agreed with them. A variable on a page nobody has reason to open is as good as absent.
+ *
+ * So the prefix decides the page. The map is small on purpose: it covers the families where a wrong page is a real
+ * discoverability failure, and a prefix that is not listed keeps the old "documented anywhere" rule rather than inventing
+ * an owner for it.
+ *
+ * ## Mutation-tested, and the first attempt was too weak
+ *
+ * Deleting the variable's TABLE ROW from 05c does **not** fail this check, because the page also names it in prose — and
+ * that is correct: the property is *"a reader searching the page they are configuring finds it"*, which a prose mention
+ * satisfies. Stripping all six mentions from 05c reproduces the original state exactly and fails with
+ * `documented in 02-hosting.md but on none of 05c-face-recognition.md`.
+ *
+ * Recorded because the weaker mutation passing looks like a broken gate until you see what the check actually claims.
+ *
+ * ## The direction this must fail in
+ *
+ * Stricter, always. If a variable is on the right page, this passes and says nothing new; the only way to make it green
+ * by weakening it is to delete a row, which is visible in a diff. Widening what counts as documented would be the wrong
+ * repair — the failure being prevented is a green gate over a variable an operator cannot find.
+ */
+const OWNER_PAGES = {
+  // Single owner, and the case this check exists for: a face variable belongs on the face page.
+  'FACE_RECOGNITION_': ['integration-guide/05c-face-recognition.md'],
+  // These families are configured from more than one page for real reasons -- the hosting matrix carries the egress
+  // policy, the pipeline pages carry the per-stage settings -- so the owner is a SET.
+  //
+  // A set is not a loophole: it says "one of the pages that documents this feature", and every entry had to be justified
+  // when it was added. A prefix that needs three pages is a hint the docs could be tightened, not permission to add a
+  // fourth. Adding a page here to make a failure go away is the one edit this check cannot defend against, so it should
+  // be visible in review as exactly that.
+  // 05b is the SETTINGS page for these three; 02-hosting carries the egress matrix, which is a different question about
+  // the same slots. Naming 02-hosting alone was my first attempt and it failed on nine variables that were all on the
+  // right page -- the map was wrong, not the docs, which is the failure mode a check like this has to survive without
+  // being loosened into uselessness.
+  'EMBEDDING_': ['integration-guide/05b-media-embedding.md', 'integration-guide/02-hosting.md'],
+  'RERANK_': ['integration-guide/05b-media-embedding.md', 'integration-guide/02-hosting.md'],
+  'NLI_': ['integration-guide/05b-media-embedding.md', 'integration-guide/02-hosting.md'],
+  'DOC_': ['integration-guide/02-hosting.md', 'integration-guide/05a-conversion-pipeline.md',
+    'integration-guide/05b-media-embedding.md'],
+  'STT_': ['integration-guide/02-hosting.md', 'integration-guide/05b-media-embedding.md'],
+  'MONGO_': ['integration-guide/02-hosting.md', 'dependencies.md'],
+};
+
 describe('env vars — docs and code agree', () => {
   const used = collectUsage();
   const documented = collectDocumented(used);
@@ -212,6 +264,45 @@ describe('env vars — docs and code agree', () => {
     const ours = [...used.keys()].filter(n => OURS(n));
     assert.ok(ours.length >= 25, `expected the scan to find our env vars, found ${ours.length}`);
     assert.ok(documented.size >= 15, `expected docs to name our env vars, found ${documented.size}`);
+  });
+
+  it('every variable whose prefix names an owner page is documented ON that page', () => {
+    // The check `FACE_RECOGNITION_EXTERNAL_MODEL` needed. Not "is it documented" — "is it where somebody configuring this
+    // feature will look".
+    const misplaced = [];
+    for (const [name, files] of documented) {
+      const prefix = Object.keys(OWNER_PAGES).find(p => name.startsWith(p));
+      if (!prefix) continue;
+      const pages = OWNER_PAGES[prefix];
+      // `split/join` rather than a regex: the escaping for a backslash-matching literal is exactly what got mangled
+      // writing this line, and a broken regex here is a syntax error rather than a wrong answer only by luck.
+      const onPage = [...files].some(f => pages.includes(f.split('\\').join('/')));
+      if (!onPage) misplaced.push(`${name} is documented in ${[...files].join(', ')} but on none of ${pages.join(', ')}`);
+    }
+    assert.deepEqual(misplaced, [],
+      'these variables are documented on a page nobody configuring their feature would open, which is how '
+      + 'FACE_RECOGNITION_EXTERNAL_MODEL came to be reported to us as nonexistent while this gate was green');
+  });
+
+  it('the owner pages all exist, so a typo cannot silently exempt a whole family', () => {
+    // A misspelled page name would make `onPage` false for every variable in that family and produce a wall of failures
+    // -- loud, so not the dangerous direction. A page that exists but is renamed later is the quiet one: the map would
+    // point at nothing and the check above would fail for a real reason nobody could act on. Assert the paths resolve.
+    for (const [prefix, pages] of Object.entries(OWNER_PAGES)) {
+      for (const page of pages) {
+        assert.ok(existsSync(join(ROOT, 'docs', page)), `${prefix} names a page that does not exist: ${page}`);
+      }
+    }
+  });
+
+  it('the placement check actually covers something (it is not vacuous)', () => {
+    // Without this, a change to `documented`'s shape could make the loop iterate nothing and the assertion above would
+    // pass for ever while measuring zero variables.
+    const covered = [...documented.keys()].filter(n => Object.keys(OWNER_PAGES).some(p => n.startsWith(p)));
+    assert.ok(covered.length >= 10,
+      `expected the owner-page map to cover a meaningful number of variables, it covers ${covered.length}`);
+    assert.ok(covered.includes('FACE_RECOGNITION_EXTERNAL_MODEL'),
+      'the variable this check exists for must be among the ones it covers');
   });
 
   it('every variable the code reads is documented', () => {


### PR DESCRIPTION
## The gate was green over a variable an operator could not find

`FACE_RECOGNITION_EXTERNAL_MODEL` was documented in `02-hosting.md`'s egress matrix and **absent from
`05c-face-recognition.md`**. `env-var-docs-coverage` was green throughout, and it was **right** to be — it asks whether a
variable is documented, and it was.

breituai-platform, reading the face-recognition page while configuring face recognition, reported the variable as
nonexistent. **We agreed with them and said so in writing**, then found it on the hosting page and had to send a
correction.

A variable on a page nobody has reason to open is as good as absent. *"Documented"* and *"findable where it is needed"* are
different properties, and only the first was measured.

## The check

A small prefix → owner-pages map. A prefix that is not listed keeps the old *"documented anywhere"* rule rather than having
an owner invented for it, and the owner is a **set** where a feature genuinely spans pages — the hosting matrix carries
egress policy, the pipeline pages carry per-stage settings.

Plus three supporting assertions, each guarding a way this check could quietly stop working:

| assertion | the failure it prevents |
|---|---|
| every owner page exists | a typo silently exempts a whole family |
| covers ≥10 variables, including the one it exists for | the loop iterates nothing and passes for ever |
| stated direction: any change must be **stricter** | the tempting repair is to loosen it |

## My first map was wrong and failed on nine innocent variables

I named `02-hosting.md` as owner for the embedding, rerank and NLI families. All nine are documented in
`05b-media-embedding.md`, which is their real settings page. **The map was wrong, not the docs.**

Recorded in the file, because the tempting repair for that failure is to loosen the check until it passes — and a gate that
reports correct code is one that gets deleted.

## Mutation-tested, and the first mutation was too weak

| mutation | result |
|---|---|
| delete the variable's **table row** from 05c | **passes** — the page still names it in prose |
| strip **all six** mentions from 05c | **fails**: `documented in 02-hosting.md but on none of 05c-face-recognition.md` |

The weak one passing is correct behaviour, not a broken gate: the property is *"a reader searching the page they are
configuring finds it"*, which a prose mention satisfies. Both results are in the file header, because the weak mutation
passing looks like a broken gate until you see what the check actually claims.

## Left for a follow-up, deliberately

`config-key-docs-coverage`, `metric-docs-coverage` and `route-path-docs-coverage` ask the same *"mentioned somewhere"*
question and will have the same hole. Each needs its own owner map and its own mutation test — sweeping them in here would
have shipped three unverified maps on the strength of one that worked.

🤖 Generated with Claude Code
