### PR TITLE
test(docs): the route gate checks BOTH directions, and eight endpoints get documented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     asserted.
 
 ### Fixed
+- **`route-path-docs-coverage` now checks BOTH directions, and eight undocumented endpoints are documented.** The gate
+  verified *documented → exists* only, while `release-gate.mjs` printed **"every API route path is documented"** beside it
+  — a label for the opposite of what was measured, on the report an owner reads before cutting a tag.
+  - Building the missing direction found eight genuine gaps, now documented: `POST /api/spaces/reorder`,
+    `GET /api/brain/spaces/:id/token-access`, the **media** `embedding-queue` pair (`GET` and `POST .../retry-failed` —
+    the brain half was documented last week and its sibling was not), `GET /api/admin/data/browse-dirs`, and the three
+    local-connector routes (`local-agent/status`, `local-agent/bootstrap`, `enable-networks/execute`).
+  - **The first measurement said 33, and 25 of those were my scanner.** The doc extractor only recognised the prose form
+    `POST /api/x`, never the table form `| \`POST\` | \`/api/x\` |` where the verb and path are separate cells. Two spot
+    checks dissolved on reading the docs, which is exactly what this file's own header warns about — a naive extractor once
+    proposed 89 findings out of 182 here. The extractor learned the table form before any count was believed or filed.
+  - The label is corrected to what the test actually asserts, and the exemption list ships EMPTY: every `/api` route is
+    documented, so nothing had to be excused.
 - **`env-var-docs-coverage` now asserts a variable is documented on the page that owns its FEATURE, not merely somewhere
   under `docs/`.** The gate was green while `FACE_RECOGNITION_EXTERNAL_MODEL` sat in `02-hosting.md`'s egress matrix and
   was absent from `05c-face-recognition.md` — so breituai-platform, reading the face-recognition page while configuring

--- a/docs/integration-guide/04d-brain-ops-api.md
+++ b/docs/integration-guide/04d-brain-ops-api.md
@@ -191,6 +191,98 @@ discovering this by trying.
 > or if the database search process was not ready when the instance started. Reindexing every record
 > in the space will not create it. Use the rebuild endpoint below.
 
+### Reorder spaces
+
+```http
+POST /api/spaces/reorder
+```
+
+```json
+{ "ids": ["general", "research", "photos"] }
+```
+
+Admin + MFA. Sets the display order of spaces in the UI's sidebar and space pickers. `ids` must name **every** space you
+want ordered — a space whose id is absent keeps its existing position relative to the ones you did name.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `ids` | ✅ | Space ids in the desired order, 1–40 characters each, at least one entry |
+
+**Response** `200`: the reordered spaces as `{ id, label, builtIn, folders, … }`. `400` if any id names no space — the
+whole call is rejected rather than partially applied, so a typo cannot silently reorder a subset.
+
+---
+
+### Which tokens can reach a space
+
+```http
+GET /api/brain/spaces/:spaceId/token-access
+```
+
+**Admin only** (on top of the space's own read right), because it enumerates the instance's tokens. Powers the Overview
+tab's token-access matrix.
+
+**Response** `200`:
+
+```json
+{
+  "tokens": [
+    { "name": "ci-writer", "level": "full", "allSpaces": false, "peer": false, "expiresAt": null }
+  ]
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `level` | `admin`, `readOnly`, or `full` |
+| `allSpaces` | `true` when the token has no space allow-list, so it reaches every space |
+| `peer` | `true` for a token belonging to a peer instance rather than a person or client |
+
+It returns the **minimum** the matrix needs and **never** a hash, a prefix, or any other secret material. A token reaches
+this space when it has no allow-list or lists this space; `schemaLibrary` tokens have no space access at all and never
+appear.
+
+---
+
+### Media embedding queue for a space
+
+```http
+GET /api/brain/spaces/:spaceId/embedding-queue
+```
+
+The **media** half of the queue — file chunks produced by the conversion pipeline. For brain records (memories, entities,
+edges, chrono) see [Vectorless records](#vectorless-records--the-embed-queue-for-brain-records), which is a separate
+collection with a separate worker.
+
+**Response** `200`:
+
+```json
+{
+  "pending": 3, "processing": 1, "complete": 412, "failed": 2,
+  "failedSample": [ … ], "failedByReason": [ { "reason": "ffmpeg exited 1", "count": 2 } ]
+}
+```
+
+Summed across member spaces for a proxy space. `failedByReason` is grouped across the whole fleet before truncation, so a
+proxy's grouping describes its members rather than whichever one was read first.
+
+---
+
+### Retry every failed media job in a space
+
+```http
+POST /api/brain/spaces/:spaceId/embedding-queue/retry-failed
+```
+
+Re-queues **all** failed media jobs in the space (and across members for a proxy). Requires `files: write`.
+
+**Response** `202`: `{ "retried": 7 }`.
+
+Retry-all is offered here and deliberately **not** for brain records: a media failure is usually about the worker, where a
+brain record's failure is usually about that record. See the per-record retry above.
+
+---
+
 ### Vectorless records — the embed queue for brain records
 
 A brain record is written and its vector is computed **after** the response. If the embedder is unreachable or the text

--- a/docs/integration-guide/12-admin-api.md
+++ b/docs/integration-guide/12-admin-api.md
@@ -552,6 +552,69 @@ Content-Type: application/json
 
 ---
 
+### GET /api/admin/data/browse-dirs
+
+Admin only. Lists the **immediate child directories** of an absolute path on the server's filesystem. Powers the backup
+destination picker in the Settings UI.
+
+| Query param | Required | Description |
+|-------------|----------|-------------|
+| `path` | — | Absolute path to list. Defaults to `/` |
+
+`400` if the path is not absolute, or if any segment is still `..` after normalisation. It returns directories only — never
+file contents — and it is admin-gated because it discloses the server's directory layout.
+
+---
+
+## Local connector (workstation mode)
+
+These three exist for **workstation mode**, where Ythril runs on a machine an operator also uses directly and a small local
+agent performs the steps a container cannot: opening a firewall port, installing a service, starting a tunnel. All three
+require **admin + MFA**, and all three are a thin control plane over the agent's own `/v1` API — the agent is reached at
+`YTHRIL_LOCAL_AGENT_URL`.
+
+See [the workstation-mode guide](../workstation-mode-guide.md) for what the agent is and how it is installed.
+
+### GET /api/admin/local-agent/status
+
+Reports whether the connector is usable, and says why when it is not:
+
+```json
+{ "configured": true, "reachable": true, "canExecute": true }
+```
+
+| Field | Meaning |
+|---|---|
+| `configured` | The server has a local-agent URL |
+| `reachable` | The agent answered its `/v1/status` |
+| `canExecute` | The agent will run privileged actions |
+| `message` | Present when any of the above is false, in plain language |
+
+**This route answers `200` even when the connector is broken.** That is deliberate: "is the connector working" is the
+question being asked, so an unreachable agent is an *answer* rather than an error, and the UI renders the manual-commands
+fallback instead of a failure. A `5xx` here would be indistinguishable from the server itself being unwell.
+
+### POST /api/admin/local-agent/bootstrap
+
+```json
+{ "os": "windows" }
+```
+
+Installs and starts the connector. `os` is optional and inferred when omitted. Idempotent —
+`{ "ok": true, "message": "Local connector already running." }` when it is already up.
+
+### POST /api/admin/local-agent/enable-networks/execute
+
+```json
+{ "hostname": "ythril.example.com", "os": "windows" }
+```
+
+Performs the host-side steps that let this instance accept peer connections. `hostname` is validated against RFC 952 /
+1123 label rules, both fields are required, and the OS is not inferred here because the steps differ per platform and a
+wrong guess would run the wrong ones.
+
+---
+
 ### POST /api/admin/data/migrate
 
 > **Feature flag required.** This endpoint returns `403` unless the instance was started with `YTHRIL_DB_MIGRATION_ENABLED=true`. The flag is off by default so that a compromised admin token cannot be used to exfiltrate the entire database to an attacker-controlled server.

--- a/scripts/release-gate.mjs
+++ b/scripts/release-gate.mjs
@@ -164,7 +164,7 @@ const DOC_GATES = [
   ['metric-docs-coverage', 'every metric on /metrics is documented'],
   ['metric-docs-are-accurate', "every metric row says what the code's help says"],
   ['mcp-tool-docs-coverage', 'every MCP tool is documented'],
-  ['route-path-docs-coverage', 'every API route path is documented'],
+  ['route-path-docs-coverage', 'every route is documented, and every documented route exists'],
   ['help-docs-coverage', 'every in-product Help anchor resolves'],
   ['docs-tables-render', 'no docs table is malformed'],
   ['error-shape-is-json', 'the documented error shape holds'],

--- a/testing/standalone/config-key-docs-coverage.test.js
+++ b/testing/standalone/config-key-docs-coverage.test.js
@@ -148,6 +148,13 @@ function configExamples() {
       if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) continue;
       const roots = Object.keys(parsed);
       if (!roots.length || !roots.every(k => topLevel.has(k))) continue;
+      // An API RESPONSE example whose top-level key happens to collide with a config field is not a config example. The
+      // all-top-level-keys heuristic above is what tamed this file's original 36 false findings, and it is not enough on
+      // its own: `{"tokens": [...]}` is a token-access response AND `tokens` is a real config field, so a response example
+      // was reported as three undeclared config keys. The docs mark these unambiguously with a `**Response**` line
+      // immediately above the fence, so that marker is what to read.
+      const preamble = src.slice(Math.max(0, m.index - 220), m.index);
+      if (/\*\*Response\*\*/i.test(preamble)) continue;
       found.push({ doc: f, parsed });
     }
   }

--- a/testing/standalone/route-path-docs-coverage.test.js
+++ b/testing/standalone/route-path-docs-coverage.test.js
@@ -1,5 +1,10 @@
 /**
- * Every API path named in the docs exists in a router.
+ * Every API path named in the docs exists in a router, AND every `/api` route the code declares is named in the docs.
+ *
+ * The second direction was added on 2026-08-13 and did not exist before: this file checked docs -> code only, while
+ * `release-gate.mjs` printed *"every API route path is documented"* beside it — a label for the opposite of what was
+ * measured, on the report an owner reads before cutting a tag. Building the missing direction found eight genuinely
+ * undocumented endpoints; all eight are documented now.
  *
  * Slice 3 of the pre-release documentation audit. A documented endpoint that does not exist is the
  * most expensive doc bug there is: someone writes an integration against it, gets a 404, and has
@@ -112,12 +117,28 @@ function documentedEndpoints() {
   for (const full of mdFiles(join(ROOT, 'docs'))) {
     const f = full.split(/[\\/]docs[\\/]/)[1];
     const src = readFileSync(full, 'utf8');
-    for (const m of src.matchAll(new RegExp(`\\b(GET|POST|PUT|PATCH|DELETE)\\s+(/api/[A-Za-z0-9_\\-/:{},.]*)`, 'g'))) {
-      for (const path of expand(m[2])) {
-        const key = `${m[1]} ${norm(path)}`;
+    const record = (verb, rawPath) => {
+      for (const path of expand(rawPath)) {
+        const key = `${verb} ${norm(path)}`;
         if (!out.has(key)) out.set(key, new Set());
         out.get(key).add(f);
       }
+    };
+    // Prose and fenced form: `POST /api/duplicates/scan`.
+    for (const m of src.matchAll(new RegExp(`\\b(GET|POST|PUT|PATCH|DELETE)\\s+(/api/[A-Za-z0-9_\\-/:{},.]*)`, 'g'))) {
+      record(m[1], m[2]);
+    }
+    // TABLE form, where the verb and the path are separate cells. The adjacency pattern above cannot see it: it requires
+    // whitespace between the two, and a table puts a backtick, a pipe and more backticks there.
+    //
+    // Found by building the REVERSE check (route → docs) and getting 33 findings, two of which were spot-checked and
+    // turned out to be documented in exactly this form. Filing that count would have repeated the mistake this file's own
+    // header warns about — and the one that produced a wrong customer-facing claim earlier the same day: a scanner that
+    // under-detects usage manufactures findings, and a count from it is worse than no count.
+    for (const m of src.matchAll(
+      /\|\s*`?(GET|POST|PUT|PATCH|DELETE)`?\s*\|\s*`?(\/api\/[A-Za-z0-9_\-/:{},.]*)/g,
+    )) {
+      record(m[1], m[2]);
     }
   }
   return out;
@@ -146,6 +167,51 @@ describe('documented API paths exist', () => {
     // examining nothing — the failure mode where a gate silently stops gating.
     assert.ok(known.size > 150, `expected to resolve the routing table, found ${known.size} routes`);
     assert.ok(documented.size > 100, `expected documented endpoints, found ${documented.size}`);
+  });
+
+  /**
+   * Routes that exist and are deliberately not in the integration guide, each with the reason.
+   *
+   * Scoped to `/api/` on purpose: `/health`, `/ready`, `/metrics`, `/setup`, `/mcp` and the local agent's own `/v1` are
+   * documented as OPERATIONS or TRANSPORT rather than as REST endpoints, and the doc extractor only recognises `/api/`
+   * paths. Widening the extractor to chase them would trade a real check for a bigger one that reports noise.
+   */
+  const EXEMPT_UNDOCUMENTED = {};
+
+  it('every /api route is documented SOMEWHERE — the direction the release gate claims', () => {
+    // This direction did not exist. The file checked docs -> code only, while `release-gate.mjs` printed
+    // "every API route path is documented" beside it — a label for the opposite of what was measured, on the report an
+    // owner reads before cutting a tag.
+    //
+    // Building it found EIGHT genuinely undocumented endpoints: spaces/reorder, token-access, the media
+    // embedding-queue pair, browse-dirs, and the three local-connector routes. All eight are documented now, so this
+    // ships green rather than as a ratchet over a backlog.
+    const undocumented = [...known]
+      .filter(k => k.split(' ')[1]?.startsWith('/api/'))
+      .filter(k => !(k in EXEMPT_UNDOCUMENTED))
+      .filter(k => ![...documented.keys()].some(docKey => matches(new Set([k]), docKey)));
+
+    assert.deepEqual(undocumented.sort(), [],
+      'These routes exist and no doc names them. An integrator cannot use what they cannot find, and this is the '
+      + `direction the release gate has been claiming to check:\n  ${undocumented.sort().join('\n  ')}`);
+  });
+
+  it('the reverse check is not vacuous', () => {
+    // Both filters could go wrong quietly: `startsWith('/api/')` matching nothing, or `matches` returning true for
+    // everything. Either would make the assertion above pass for ever while measuring nothing.
+    const api = [...known].filter(k => k.split(' ')[1]?.startsWith('/api/'));
+    assert.ok(api.length > 150, `expected the /api surface, found ${api.length}`);
+    assert.ok(!api.some(k => matches(new Set([k]), 'GET /api/definitely-not-a-real-route')),
+      'the matcher accepts a route that is documented nowhere — it is matching too loosely to detect anything');
+  });
+
+  it('every exemption carries a reason, and names a route that exists', () => {
+    for (const [key, reason] of Object.entries(EXEMPT_UNDOCUMENTED)) {
+      assert.ok(reason && reason.length > 30, `${key}: an exemption needs a reason, not a placeholder`);
+      assert.ok(!/todo|later|for now|not yet/i.test(reason),
+        `${key}: "${reason}" is a deferral, not a reason`);
+      assert.ok(known.has(key), `${key} is exempted but no router declares it — a stale exemption covers nothing`);
+    }
   });
 
   it('every documented endpoint resolves to a real route', () => {


### PR DESCRIPTION
## The release gate was printing a claim its test did not check

`route-path-docs-coverage` verified **documented → exists** only. `release-gate.mjs` printed
**"every API route path is documented"** beside it — a label for the *opposite* of what was measured, on the report an
owner reads before cutting a tag.

## Eight endpoints were genuinely undocumented

Building the missing direction found them. All eight are documented in this PR, so the check ships **green with an empty
exemption list** rather than as a ratchet over a backlog:

| endpoint | now in |
|---|---|
| `POST /api/spaces/reorder` | `04d-brain-ops-api.md` |
| `GET /api/brain/spaces/:id/token-access` | `04d` |
| `GET /api/brain/spaces/:id/embedding-queue` | `04d` |
| `POST /api/brain/spaces/:id/embedding-queue/retry-failed` | `04d` |
| `GET /api/admin/data/browse-dirs` | `12-admin-api.md` |
| `GET /api/admin/local-agent/status` | `12` |
| `POST /api/admin/local-agent/bootstrap` | `12` |
| `POST /api/admin/local-agent/enable-networks/execute` | `12` |

The media `embedding-queue` pair is the sharpest of them: its **brain** sibling was documented last week and its twin was
left undocumented in the same file.

## My first count said 33. Twenty-five of those were my own scanner.

The doc extractor recognised the prose form `POST /api/x` and **never the table form** — `| \`POST\` | \`/api/x\` |`, where
the verb and the path are separate cells with backticks and a pipe between them.

Two spot checks dissolved on reading the docs. This file's own header warns about exactly this: a naive extractor once
proposed **89 findings out of 182** here. And I had made the same mistake hours earlier, telling a customer a variable was
documented nowhere after grepping the two files they named.

**So the extractor learned the table form before any count was believed, filed, or sent.**

## Scope, stated

The reverse check covers `/api/` only. `/health`, `/ready`, `/metrics`, `/setup`, `/mcp` and the local agent's own `/v1`
are documented as **operations** or **transport** rather than as REST endpoints, and widening the extractor to chase them
would trade a real check for a bigger one that reports noise.

Three supporting assertions guard the ways this could stop working: the reverse check is not vacuous (the `/api` filter
finds a real surface, and the matcher rejects a route documented nowhere), every exemption carries a reason and names a
route that exists, and the label now states what is asserted.

**Mutation-tested**: un-documenting `browse-dirs` makes the gate name it.

## Also fixed, because my own new docs tripped it

`config-key-docs-coverage` read an API **response** example as a `config.json` example. Its heuristic accepts a json block
whose top-level keys are all real config fields — and `{"tokens": [...]}` is a token-access response while `tokens` is
*also* a real config field, so three response fields were reported as undeclared config keys.

That heuristic is what tamed the file's original 36 false findings and it is not sufficient alone. Response blocks are now
excluded by the `**Response**` marker the docs already put above them.

## One process note

Mutation-testing the new direction meant un-documenting `browse-dirs`, and `git checkout --` on that file reverted my
**unstaged** admin docs along with the mutation — four endpoints silently back to undocumented, with the suite reporting
one failure that read exactly like the mutation still being in place. Re-inserted from the scratchpad copy and staged
immediately.

Restore a mutation by putting the original string back, never with git.

🤖 Generated with Claude Code
