### PR TITLE
docs: signpost the metrics reference from the guide index

### DIFF
--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -26,7 +26,8 @@ stands on its own.
    Sync API
 10. [MFA & Conflicts APIs](integration-guide/10-mfa-and-conflicts.md)
    Conflicts API
-11. [Setup API](integration-guide/11-setup-api.md)
+11. [Setup API](integration-guide/11-setup-api.md) — first-run setup, health and readiness probes, and the
+    **Prometheus metrics reference** (every series `/metrics` exposes, with what each one means)
 12. [Admin & Data Management APIs](integration-guide/12-admin-api.md)
    Reference integrity · Data Management API
 13. [Audit Log API](integration-guide/13-audit-log-api.md)


### PR DESCRIPTION
The Prometheus metrics table lives in `11-setup-api.md`, beside the `/metrics` endpoint it describes — the right home. The index listed that file as just **"Setup API"**, so nothing told an operator looking for metrics to open a page named for first-run setup.

Same discoverability shape as `FACE_RECOGNITION_EXTERNAL_MODEL` one level up: **the content was in the right place and the signpost was missing**, which is indistinguishable from absent to whoever is looking.

## Why there is no placement gate for metrics

Found while deciding whether `metric-docs-coverage` needed the check #868 and #869 added to the env-var and route gates. **It does not.** It already asserts both directions *and* that no metric is documented twice, and `metric-docs-are-accurate` compares each documented row against the code's own `help` string — strictly more than either of the other two had. A placement map would only ask whether that single home is the right page, and it is, by construction: the table sits with the endpoint.

The reasoning is recorded in `_REFERENCE.md` rather than deleted along with the tracker item, because an unexplained disappearance reads as forgotten.

Docs-only diff — one line.

🤖 Generated with Claude Code