### PR TITLE
release: 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.8.0] — 2026-08-13
 ### Added
 - **`POST /query` takes `sort`/`dir` and reports a match `total`.** aigents asked for both alongside the `skip` finding
   (2026-08-11T1045Z); #863 honoured `skip` and turned `sort` from silently ignored into an explicit `400`, which was the

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/client",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ythril",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ythril",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "workspaces": [
         "server",
@@ -18,7 +18,7 @@
     },
     "client": {
       "name": "@ythril/client",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@angular/animations": "^21.0.0",
@@ -21022,7 +21022,7 @@
     },
     "server": {
       "name": "@ythril/server",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ythril",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "type": "module",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/server",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump and CHANGELOG date for **2.8.0**. Ten changes since 2.7.0; full detail in `CHANGELOG.md`.

## What is in it

| | |
|---|---|
| #861 | brain embed queue readable + retryable, REST **and** MCP in one commit |
| #862 | a record's own timestamp checked against the server's (`stampSkew`) |
| #863 | `skip` honoured on `/query`; four read routes refuse keys they cannot honour |
| #864 | `help({query})` returns only the matching sections |
| #865 | `sort`/`dir` and a match `total` on `/query` |
| #866 | the external face path documented; 05c described half the product |
| #867 | an embed job dies with its record, `failed` included |
| #868 | env-var docs gate checks the variable is on its feature's page |
| #869 | route docs gate checks both directions; 8 endpoints documented |
| #870 | the metrics reference is signposted from the index |

## The through-line

Most of these were found by **building a surface and then looking at what it exposed**. #861 made the embed queue visible, which is what turned #867's orphaned job from a harmless leak into a permanent phantom failure. #866's documentation fix is what made #868's gate gap visible.

Three documentation gates were **measuring less than their labels claimed**, and each first measurement was mostly my own scanner — 33 route findings of which 25 were a table form the extractor could not read; nine env vars that were on the right page all along. None of those counts were filed or sent.

## Release checks

- `npm run release:gate` — green: docs match code, CHANGELOG carries 2.8.0, NOTICE complete
- `npm run preflight` — green
- Version bump is the same five-file, 9/7-line shape as 2.7.0. The `package-lock.json` diff is **exactly the four workspace-root `version` fields** — verified, because a global replace of the old version once rewrote dependencies that happened to share it

🤖 Generated with Claude Code