### PR TITLE
fix(brain): /query returned an empty page past skip=100 while total said otherwise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`POST /query` returned an EMPTY page for any `skip` past 100, while `total` reported the true count.** Shipped in
+  2.8.0 and fixed here. The route fetched a window capped at 100 rows and then sliced it at `skip`, so a caller sweeping a
+  large collection stopped silently at row 100 — a wrong answer that looked right, which is the exact defect class the
+  `skip` work existed to remove.
+  - **A single space now pushes `skip` to MongoDB**, which is correct at any depth. Only a **proxy** with several members
+    needs the merge, and only then does a deep page cost a larger read — bounded by `PROXY_PAGE_CEILING` (1000) with a
+    `400` naming the limit rather than a silent empty page.
+  - The caller-facing page cap (100) moved out of `queryBrain` and into the routes. Inside `queryBrain` it also bounded the
+    proxy merge's internal fetch, which is what truncated deep pages to nothing.
+  - Both surfaces. The MCP tool had the identical bug.
+  - **Found by auditing the surface I had just shipped, not by the tests** — they tiled 12 and 25 rows, entirely inside the
+    window, so the suite was green over it. Verified against a running instance with 120 records before and after.
+  - **My first regression test guarded nothing**, and the mutation test is what showed it: asserted against `queryBrain`
+    directly, it passes on the broken code, because that function pushes `skip` down and the window only ever existed in
+    the route. The guard is at HTTP level now, and mutating the route's `skip` pass-through turns five assertions red.
+- **The MCP `/query` path narrowed a proxy read with the UNSCOPED resolver** in the first draft of this fix — caught by
+  `proxy-fanout-inventory.test.js`, which exists because a proxy read flipped to the full member list leaks records from
+  every member with a well-formed `200`.
+
 ## [2.8.0] — 2026-08-13
 ### Added
 - **`POST /query` takes `sort`/`dir` and reports a match `total`.** aigents asked for both alongside the `skip` finding

--- a/server/src/api/brain/search.ts
+++ b/server/src/api/brain/search.ts
@@ -13,7 +13,7 @@ import { countMemories } from '../../brain/memory.js';
 import { getEmbedJobCounts } from '../../brain/embed-queue.js';
 import {
   queryBrain, countBrain, QUERY_BODY_FIELDS, TRAVERSE_BODY_FIELDS, RECALL_BODY_FIELDS, FIND_SIMILAR_BODY_FIELDS,
-  unknownBodyFields, compareBySort, DEFAULT_QUERY_SORT,
+  unknownBodyFields, compareBySort, DEFAULT_QUERY_SORT, QUERY_PAGE_MAX, PROXY_PAGE_CEILING,
 } from '../../brain/query.js';
 import { findSimilar, recall, type RecallKnowledgeType, type RecallResult } from '../../brain/recall.js';
 import { validateFilterExpression, type FilterExpression } from '../../brain/filter.js';
@@ -24,7 +24,6 @@ import { col, asFilter } from '../../db/mongo.js';
 import { needsReindex } from '../../spaces/_shared.js';
 import { planReindex, startReindex } from '../../brain/reindex.js';
 import { log } from '../../util/log.js';
-import { collectAcrossMembers } from '../../spaces/proxy.js';
 import { memberSpacesForRequest } from '../../spaces/proxy-scoped.js';
 import type { MemoryDoc, EntityDoc, EdgeDoc, ChronoEntry, FileMetaDoc } from '../../config/types.js';
 import { reindexInProgress } from '../../metrics/registry.js';
@@ -251,7 +250,9 @@ searchRouter.post('/spaces/:spaceId/query', globalRateLimit, requireSpaceAuth, a
     projection != null && typeof projection === 'object' && !Array.isArray(projection)
       ? (projection as Record<string, unknown>)
       : undefined;
-  const safeLimit = typeof limit === 'number' ? limit : 20;
+  // The caller-facing page cap. It used to live inside `queryBrain`, where it also bounded the proxy merge's internal
+  // fetch and silently truncated deep pages to nothing.
+  const safeLimit = Math.min(typeof limit === 'number' ? limit : 20, QUERY_PAGE_MAX);
   const safeMaxTimeMS = typeof maxTimeMS === 'number' ? maxTimeMS : 5000;
 
   // A non-integer or negative `skip` is refused rather than floored to 0. Silently reading it as "start from the
@@ -270,41 +271,42 @@ searchRouter.post('/spaces/:spaceId/query', globalRateLimit, requireSpaceAuth, a
   const order = sortParse.sort ? toMongoSort(sortParse.sort) : DEFAULT_QUERY_SORT;
 
   try {
-    // A PROXY space needs the page computed over the MERGED set, not per member.
+    // A SINGLE space pushes `skip` down to MongoDB, which is correct at any depth. Only a PROXY with several members
+    // needs the merge, and only then does a deep page cost a larger read.
     //
-    // `collectAcrossMembers` concatenates, so asking each member for rows `[skip, skip+limit)` and flattening would
-    // return up to `limit × members` rows, ordered by member rather than by the documented sort, having skipped `skip`
-    // rows in each — three wrong answers at once, and none of them an error. That is the same class as the defect this
-    // route is being fixed for, so it is fixed here rather than left for the next report.
-    //
-    // Correct paging over a union: take the first `skip + limit` from each member, merge, sort by the documented key,
-    // then slice the window. The per-member fetch is bounded by the page the caller asked for, so a deep page costs
-    // more but never the whole collection.
-    const window = Math.min(safeSkip + Math.min(safeLimit, 100), 100);
-    const perMember = await collectAcrossMembers(spaceId, mid =>
-      queryBrain(
-        mid,
-        collection as typeof validCollections[number],
-        safeFilter,
-        safeProjection,
-        window,
-        safeMaxTimeMS,
-        0,
-        order,
-      ),
-    );
-    // The match TOTAL, summed across members. aigents fabricated a number because `count` is the PAGE length: a sweep
-    // cannot tell a short last page from a truncated one without an extra request that returns nothing. It costs one
-    // count per member per call, bounded by the same deadline as the read, and it is returned unconditionally because a
-    // caller who does not know to ask for it is exactly the caller who ends up guessing.
-    const total = (await collectAcrossMembers(spaceId, async mid =>
-      [await countBrain(mid, collection as typeof validCollections[number], safeFilter, safeMaxTimeMS)]))
-      .reduce((a, b) => a + b, 0);
-    // Merged with a comparator built from the SAME order given to MongoDB, so a proxy space's page is in the order the
-    // caller asked for rather than in the default one.
-    const merged = perMember.sort(compareBySort(order)).slice(safeSkip, safeSkip + safeLimit);
-    // `limit` and `skip` are echoed so a caller paging in a loop can tell "the page you asked for" from "what I
-    // capped it to", which is exactly the distinction the fabricated number came from.
+    // The previous version always merged, with the per-member fetch capped at 100 — so `skip: 100` sliced past the end of
+    // a 100-row window and returned NOTHING, on a collection whose `total` said 120. The tests tiled 12 and 25 rows, both
+    // entirely inside the window, so the suite was green over exactly the defect this route exists to prevent.
+    const members = memberSpacesForRequest(req, spaceId);
+    let merged: unknown[];
+    let total = 0;
+    if (members.length === 1) {
+      merged = await queryBrain(
+        members[0] as string, collection as typeof validCollections[number],
+        safeFilter, safeProjection, safeLimit, safeMaxTimeMS, safeSkip, order,
+      );
+      total = await countBrain(members[0] as string, collection as typeof validCollections[number], safeFilter, safeMaxTimeMS);
+    } else {
+      // Rows [skip, skip+limit) of the merged set need skip+limit from each member. Bounded, because a deep page on a
+      // fleet multiplies: a 400 naming the ceiling beats a silent empty page, which is the failure being fixed.
+      const window = safeSkip + safeLimit;
+      if (window > PROXY_PAGE_CEILING) {
+        res.status(400).json({
+          error: `skip + limit must not exceed ${PROXY_PAGE_CEILING} on a proxy space (got ${window}). `
+            + 'Page a member space directly for a deeper sweep.',
+        });
+        return;
+      }
+      const perMember: unknown[] = [];
+      for (const mid of members) {
+        perMember.push(...await queryBrain(
+          mid, collection as typeof validCollections[number],
+          safeFilter, safeProjection, window, safeMaxTimeMS, 0, order,
+        ));
+        total += await countBrain(mid, collection as typeof validCollections[number], safeFilter, safeMaxTimeMS);
+      }
+      merged = perMember.sort(compareBySort(order)).slice(safeSkip, safeSkip + safeLimit);
+    }
     res.json({
       results: merged, collection,
       // `count` is this page; `total` is the whole match. Both, because renaming `count` would break every caller that

--- a/server/src/brain/query.ts
+++ b/server/src/brain/query.ts
@@ -124,6 +124,18 @@ export function unknownBodyFields(
 }
 
 /**
+ * The caller-facing page cap for `/query`, and the ceiling on a PROXY space's merged window.
+ *
+ * A proxy page needs `skip + limit` rows from EACH member, so a deep page on a fleet multiplies. The ceiling makes that
+ * cost bounded and, more importantly, makes exceeding it an explicit 400 naming the limit — the alternative, which shipped
+ * in 2.8.0, was an empty page for any `skip` past the window while `total` reported the true count.
+ *
+ * A single space is not subject to it: `skip` goes to MongoDB and is correct at any depth.
+ */
+export const QUERY_PAGE_MAX = 100;
+export const PROXY_PAGE_CEILING = 1000;
+
+/**
  * The default result order, as DATA so the same value can go to MongoDB and to the merge comparator.
  *
  * `_id` last is not decoration: it makes the order TOTAL, which is what lets `skip` page without a row drifting between
@@ -204,7 +216,14 @@ export async function queryBrain(
     // Skip BEFORE limit, which is the order the driver applies regardless of call order — spelled out here because
     // the reverse reading (limit the page, then drop rows from it) would silently return short pages.
     .skip(Math.max(Math.floor(skip) || 0, 0))
-    .limit(Math.min(limit, 100))
+    // Clamped by the CALLERS (both routes cap the caller-facing page at 100) rather than here, because the proxy merge
+    // legitimately needs a larger internal fetch: to return rows [skip, skip+limit) of a MERGED set it must read
+    // skip+limit from each member. Clamping at 100 here is what made every page past row 100 come back EMPTY while
+    // `total` reported the true count — a wrong answer that looked right, shipped in 2.8.0 and caught by auditing the
+    // surface rather than by any test, because the tests tiled 12 and 25 rows entirely inside the window.
+    //
+    // A floor of 1 so a computed 0 cannot mean "no rows"; the ceiling is the callers' business and is documented there.
+    .limit(Math.max(1, Math.floor(limit)))
     // The embedding vector is never returned. This is MERGED with the caller's
     // projection rather than applied as a second `.project()` — a second call
     // replaces the first in the MongoDB driver, which previously discarded the

--- a/server/src/mcp/tools/search.ts
+++ b/server/src/mcp/tools/search.ts
@@ -11,10 +11,11 @@ import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.
 import { UUID_V4_RE, entityDocToRecord, formatRecallSummary, toRecallRecord, uuidSchema, unitScoreSchema, QUERY_FILTER_OPERATORS, RECALL_FILTER_KEY_PATTERN, type McpRecallTraverseItem } from './shared.js';
 import { MAX_RECALL_TRAVERSE, traverseRecallSeeds } from '../../brain/edges.js';
 import { type FilterExpression, validateFilterExpression } from '../../brain/filter.js';
-import { queryBrain, countBrain, compareBySort, DEFAULT_QUERY_SORT } from '../../brain/query.js';
+import {
+  queryBrain, countBrain, compareBySort, DEFAULT_QUERY_SORT, QUERY_PAGE_MAX, PROXY_PAGE_CEILING,
+} from '../../brain/query.js';
 import { parseSortParam, toMongoSort, SORTABLE_FIELDS } from '../../brain/list-sort.js';
 import { type RecallKnowledgeType, type RecallResult, findSimilar, recall, recallGlobal } from '../../brain/recall.js';
-import { collectAcrossMembers } from '../../spaces/proxy.js';
 import { memberSpacesWithin } from '../../spaces/proxy-scoped.js';
 import { NotFoundError } from '../../util/errors.js';
 import { rankOf, mergeRecallResults } from '../../brain/recall-shape.js';
@@ -394,7 +395,7 @@ export const queryTool: ToolHandler = {
       a['filter'] != null && typeof a['filter'] === 'object'
         ? (a['filter'] as Record<string, unknown>)
         : {};
-    const limit = typeof a['limit'] === 'number' ? a['limit'] : 20;
+    const limit = Math.min(typeof a['limit'] === 'number' ? a['limit'] : 20, QUERY_PAGE_MAX);
     // Same refusal as the REST route: a non-integer or negative skip is an error, not a silent 0. Reading it as "start
     // from the beginning" returns a page that is not the page asked for, with no sign that anything went wrong.
     if (a['skip'] !== undefined && (typeof a['skip'] !== 'number' || !Number.isInteger(a['skip']) || a['skip'] < 0)) {
@@ -412,25 +413,36 @@ export const queryTool: ToolHandler = {
         ? (a['projection'] as Record<string, unknown>)
         : undefined;
 
-    // The proxy-merge is the same as the REST route's, and for the same reason: asking each member for rows
-    // [skip, skip+limit) and concatenating skips that many rows PER MEMBER and orders the result by member. Take the
-    // first skip+limit from each, merge by the documented order, then slice the window.
-    const window = Math.min(skip + Math.min(limit, 100), 100);
-    const perMember = await collectAcrossMembers(callSpace, mid =>
-      queryBrain(
-        mid,
-        collName as 'memories' | 'entities' | 'edges' | 'chrono' | 'files',
-        filter,
-        projection,
-        window,
-        maxTimeMS,
-        0,
-        order,
-      ));
-    const docs = perMember.sort(compareBySort(order)).slice(skip, skip + limit);
-    const total = (await collectAcrossMembers(callSpace, async mid =>
-      [await countBrain(mid, collName as 'memories' | 'entities' | 'edges' | 'chrono' | 'files', filter, maxTimeMS)]))
-      .reduce((x, y) => x + y, 0);
+    // Same shape as the REST route, and for the same reason: a SINGLE space pushes `skip` to MongoDB, which is correct at
+    // any depth, and only a PROXY with several members needs the merge. The previous version always merged with the
+    // per-member fetch capped at 100, so `skip: 100` sliced past the end of the window and returned NOTHING while the
+    // total reported the true count.
+    // SCOPED, not `resolveMemberSpaces`: a token holding some of a proxy's members must read those and no others. The
+    // first version of this fix called the unscoped resolver and `proxy-fanout-inventory.test.js` caught it — that gate
+    // exists because flipping a proxy read to the full member list leaks records from every member with a well-formed 200.
+    const members = memberSpacesWithin(callSpace, ctx.accessibleSpaces.map(sp => sp.id));
+    let docs: unknown[];
+    let total = 0;
+    const coll = collName as 'memories' | 'entities' | 'edges' | 'chrono' | 'files';
+    if (members.length === 1) {
+      docs = await queryBrain(members[0] as string, coll, filter, projection, limit, maxTimeMS, skip, order);
+      total = await countBrain(members[0] as string, coll, filter, maxTimeMS);
+    } else {
+      const window = skip + limit;
+      if (window > PROXY_PAGE_CEILING) {
+        throw new Error(
+          `skip + limit must not exceed ${PROXY_PAGE_CEILING} on a proxy space (got ${window}). `
+          + 'Query a member space directly for a deeper sweep.',
+        );
+      }
+      const perMember: unknown[] = [];
+      for (const mid of members) {
+        perMember.push(...await queryBrain(mid, coll, filter, projection, window, maxTimeMS, 0, order));
+        total += await countBrain(mid, coll, filter, maxTimeMS);
+      }
+      docs = perMember.sort(compareBySort(order)).slice(skip, skip + limit);
+    }
+
     // `structuredContent` carries the paging facts; `content` stays the bare array it has always been, so a client
     // parsing the text is unaffected. Without `total` a caller sweeping with `skip` cannot tell a short last page from a
     // truncated one, which is the number aigents ended up fabricating.

--- a/testing/integration/query-skip-and-strict-bodies.test.js
+++ b/testing/integration/query-skip-and-strict-bodies.test.js
@@ -292,3 +292,64 @@ describe('the match TOTAL and a caller-chosen order, on both surfaces', () => {
     assert.match(JSON.stringify(r), /Sortable fields/);
   });
 });
+
+describe('paging PAST the window — the defect 2.8.0 shipped', () => {
+  // The route fetched a window capped at 100 and then sliced it at `skip`, so every page past row 100 came back EMPTY
+  // while `total` reported the true count. A caller sweeping a large collection stopped silently at 100.
+  //
+  // This has to run through HTTP. The same assertion against `queryBrain` directly PASSES on the broken code, because
+  // that function pushes `skip` to MongoDB and is correct at any depth — the window only ever existed in the route. I
+  // wrote that version first and the mutation test is what showed it guarded nothing.
+  const DEEP = `qdeep-${RUN}`;
+  const N = 120;
+
+  before(async () => {
+    await makeSpace(DEEP);
+    for (let i = 0; i < N; i++) {
+      const r = await post(INSTANCES.a, token, `/api/brain/spaces/${DEEP}/memories`, {
+        fact: `deep ${String(i).padStart(3, '0')} ${RUN}`,
+      });
+      assert.equal(r.status, 201, JSON.stringify(r.body));
+    }
+  });
+
+  const q = (body) => post(INSTANCES.a, token, `/api/brain/spaces/${DEEP}/query`, body);
+
+  it('reports the real total', async () => {
+    const r = await q({ collection: 'memories', filter: {}, limit: 5 });
+    assert.equal(r.body.total, N, 'the total must be the whole match, which is what made the empty pages contradictory');
+  });
+
+  it('returns rows past row 100', async () => {
+    for (const skip of [95, 100, 105, 119]) {
+      const r = await q({ collection: 'memories', filter: {}, limit: 5, skip });
+      assert.ok(r.body.results.length > 0,
+        `skip=${skip} returned nothing on a ${N}-row collection while total says ${r.body.total}`);
+    }
+  });
+
+  it('still tiles exactly across the boundary — no repeats, no gaps', async () => {
+    // A deep page that returns SOMETHING is not enough: it has to return the right something. 120 rows in pages of 25
+    // crosses the old window twice.
+    const seen = [];
+    for (let skip = 0; skip < N; skip += 25) {
+      const r = await q({ collection: 'memories', filter: {}, limit: 25, skip });
+      seen.push(...r.body.results.map(d => d._id));
+    }
+    assert.equal(seen.length, N, `expected ${N} rows across the pages, got ${seen.length}`);
+    assert.equal(new Set(seen).size, N, 'every row exactly once');
+  });
+
+  it('past the END is still empty, so a paging loop terminates', async () => {
+    const r = await q({ collection: 'memories', filter: {}, limit: 5, skip: N });
+    assert.deepEqual(r.body.results, []);
+    assert.equal(r.body.total, N, 'and the total still tells the caller where the end was');
+  });
+
+  it('caps the caller-facing page at 100 rather than refusing it', async () => {
+    const r = await q({ collection: 'memories', filter: {}, limit: 500 });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal(r.body.results.length, 100, 'a page larger than the cap is clamped, not rejected');
+    assert.equal(r.body.limit, 100, 'and the applied limit is echoed so the caller knows it was clamped');
+  });
+});

--- a/testing/standalone/proxy-fanout-inventory.test.js
+++ b/testing/standalone/proxy-fanout-inventory.test.js
@@ -101,7 +101,19 @@ const RECLASSIFIED = 1;
  * accounted for, not that the number never moves. Lowering it, or leaving it at 30 and letting the new site sit in
  * PENDING, are the two ways this gate gets quietly defeated.
  */
-const TOTAL = 31;
+/**
+ * 31 -> 33: the two `/query` paths now name their narrowing EXPLICITLY.
+ *
+ * They used to fan out through `collectAcrossMembers`, which this gate does not count as a narrowed call — it resolves
+ * the member list internally. Fixing the deep-skip defect meant resolving that list in the route, so each path now calls
+ * `memberSpacesForRequest` (REST) or `memberSpacesWithin` (MCP) by name and the counter sees two sites it could not see
+ * before. Narrowed went 28 -> 30; guards and reclassified are unchanged, so the total is 33.
+ *
+ * My first attempt at this number was 30, on the reasoning that two fan-outs had been consolidated into one. That was
+ * backwards — the arithmetic says the opposite — and lowering a conserved total on a plausible story is exactly the move
+ * this invariant exists to catch. It caught it.
+ */
+const TOTAL = 33;
 
 const GUARDS = {
   'server/src/auth/middleware.ts': 2,

--- a/testing/standalone/query-paging-db.test.js
+++ b/testing/standalone/query-paging-db.test.js
@@ -138,6 +138,35 @@ describe('query paging (real MongoDB)', { skip }, () => {
     assert.equal(sorted[0]._id, 'b', 'the record with a seq comes first');
   });
 
+  it('queryBrain itself pages past 100 — necessary, and NOT the regression guard', async () => {
+    // Stated plainly because I got it wrong: this asserts a property of `queryBrain`, which pushes `skip` to MongoDB and
+    // is correct at any depth. It PASSES against the 2.8.0 code, so it does not guard the defect.
+    //
+    // The defect was in the ROUTE: it fetched a window capped at 100 and then sliced it at `skip`, so every page past row
+    // 100 came back empty while `total` reported the true count. `query-skip-and-strict-bodies.test.js` guards that,
+    // through HTTP, because that is the layer where the window exists. A test at the wrong layer is worse than none — it
+    // reads like coverage.
+    const EXTRA = 120 - TOTAL;
+    for (let i = 0; i < EXTRA; i++) await memory.remember(SPACE, `deep record ${String(i).padStart(3, '0')}`, [], []);
+    const all = await mongo.col(`${SPACE}_memories`).countDocuments({});
+    assert.equal(all, 120, 'precondition: the fixture must exceed the 100-row window');
+
+    for (const s of [95, 100, 110, 119]) {
+      const rows = await query.queryBrain(SPACE, 'memories', {}, undefined, 5, 5000, s);
+      assert.ok(rows.length > 0, `skip=${s} returned nothing on a 120-row collection — the deep-page defect is back`);
+    }
+    assert.equal((await query.queryBrain(SPACE, 'memories', {}, undefined, 5, 5000, 120)).length, 0,
+      'and past the END is still empty, which is how a paging loop terminates');
+  });
+
+  it('the page size cap lives with the CALLERS now, not inside queryBrain', () => {
+    // The clamp used to be `.limit(Math.min(limit, 100))` inside queryBrain, which also bounded the proxy merge's
+    // internal fetch — that is what truncated deep pages to nothing. The routes cap the caller-facing page instead.
+    assert.equal(query.QUERY_PAGE_MAX, 100);
+    assert.ok(query.PROXY_PAGE_CEILING > query.QUERY_PAGE_MAX,
+      'a proxy page needs skip+limit per member, so its ceiling must exceed the per-page cap or deep pages break again');
+  });
+
   it('QUERY_BODY_FIELDS names skip, or the route would refuse the parameter it just gained', async () => {
     // The two halves of this fix have to agree: honouring `skip` while the strict body rejects it as unknown would turn
     // a silently ignored parameter into a 400 for the caller who reported it.


### PR DESCRIPTION
**Shipped in 2.8.0, twenty minutes old, found by auditing the surface I had just built.**

The route fetched a window capped at 100 rows and then **sliced it at `skip`**. For `skip >= 100` the slice began past the end of the window and returned **nothing** — on a collection whose `total`, added in the same release, reported the real count.

```
total reported: 120 | page 1 rows: 10
skip=90  -> 10 rows
skip=100 -> 0 rows   <<< EMPTY
skip=110 -> 0 rows   <<< EMPTY
```

Verified against a running instance **before** touching anything, and again after. A caller sweeping a large collection stopped silently at row 100 while holding a number that said there was more — the exact defect class the `skip` work existed to remove.

## The fix

- **A single space pushes `skip` to MongoDB**, correct at any depth, no window.
- Only a **proxy** with several members needs the merge — rows `[skip, skip+limit)` of a merged set require `skip+limit` from each member. Bounded by `PROXY_PAGE_CEILING` (1000) with a **400 naming the limit**, because a silent empty page is the thing being fixed.
- The caller-facing page cap (100) moved **out of `queryBrain`** and into the routes. Inside `queryBrain` it also bounded the proxy merge's internal fetch, and that dual duty is what truncated deep pages to nothing.
- Both surfaces — the MCP tool had the identical bug.

## My first regression test guarded nothing

It asserted against `queryBrain` directly, where `skip` goes to Mongo and is correct at any depth — **so it passed against the broken code.** Restoring the 2.8.0 clamp left it green.

The window only ever existed in the **route**, so the guard has to go through HTTP. Mutating the route's `skip` pass-through now turns **five** assertions red, including the deep-page tiling. The standalone assertion is kept and **relabelled** as a property of `queryBrain` rather than as the guard it is not.

A test at the wrong layer is worse than no test, because it reads like coverage. The mutation test is the only reason I know which layer I was on.

## Also caught by a gate, in my own first draft

The MCP path resolved the proxy's members with the **unscoped** resolver. `proxy-fanout-inventory.test.js` named the site immediately — that gate exists because a proxy read flipped to the full member list leaks records from every member with a well-formed `200`. It uses `memberSpacesWithin` now, like every other read in that file.

The conserved total goes **31 → 33**: both `/query` paths now name their narrowing explicitly where they previously went through `collectAcrossMembers`, which the counter cannot see. My first attempt at that number was **30**, on a plausible story about consolidating two fan-outs into one. The arithmetic said the opposite — and lowering a conserved total on a plausible story is precisely the move that invariant exists to catch.

## Release

2.8.0 is published and carries the bug, so **2.8.1 follows immediately**. The release notice to breituai is held until then rather than announcing a version whose paging stops at 100.

🤖 Generated with Claude Code