### PR TITLE
release: 2.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.1] — 2026-08-13
+
 ### Fixed
 - **`POST /query` returned an EMPTY page for any `skip` past 100, while `total` reported the true count.** Shipped in
   2.8.0 and fixed here. The route fetched a window capped at 100 rows and then sliced it at `skip`, so a caller sweeping a

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/client",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ythril",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ythril",
-      "version": "2.8.0",
+      "version": "2.8.1",
       "license": "PolyForm-Small-Business-1.0.0",
       "workspaces": [
         "server",
@@ -18,7 +18,7 @@
     },
     "client": {
       "name": "@ythril/client",
-      "version": "2.8.0",
+      "version": "2.8.1",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@angular/animations": "^21.0.0",
@@ -21022,7 +21022,7 @@
     },
     "server": {
       "name": "@ythril/server",
-      "version": "2.8.0",
+      "version": "2.8.1",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ythril",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "type": "module",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/server",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "license": "PolyForm-Small-Business-1.0.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
**One fix, in the feature 2.8.0 led with.**

`POST /query` returned an **empty page for any `skip` past 100** while `total` reported the true count. A caller sweeping a large collection stopped silently at row 100 and held a number telling them there was more. Both surfaces.

2.8.0 was **twenty minutes old** when an audit of its own new surface found it. **2.8.0 should be skipped in favour of this tag.**

- A single space pushes `skip` to MongoDB — correct at any depth.
- Only a proxy with several members merges, bounded, with a `400` naming the ceiling rather than a silent empty page.
- The regression guard is at HTTP level, because the first one was not: asserted against `queryBrain` it passed on the broken code, since that function was always correct and the window existed only in the route.

Detail in #872 and in `CHANGELOG.md` under `[2.8.1]`.

## Release checks

- `npm run release:gate` — green, CHANGELOG carries 2.8.1
- `npm run preflight` — green
- Version bump is the same five-file, 9/7-line shape; the lockfile diff is exactly the four workspace-root `version` fields

🤖 Generated with Claude Code