### PR TITLE
fix(brain): the embed-job listing pages, and both listings now page through one function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- **The embed-job listing takes `skip`, so a reported failure is always reachable.** `getEmbedJobCounts` aggregates every
+  job while the listing returned one capped page, so a space reporting `failed: 500` had no way to reach failure #201 — an
+  accurate total beside an unreachable tail, on the one surface whose justification is that its failures are actionable.
+  - Same asymmetry that cost aigents a fabricated number on `/query`, found by auditing the surface in the same pass that
+    found the deep-skip defect.
+  - **Both listings now page through ONE function**, `spaces/page-across-members.ts`, rather than the same shape written
+    twice: a single space pushes `skip` to MongoDB, and only a multi-member proxy merges, bounded, with an explicit refusal
+    instead of an empty page. `/query` had that logic inline, which is how it shipped a window that truncated deep pages.
+  - Tested with a **250-job** fixture, because the cap is 200 and a fixture inside the cap cannot see this — exactly how the
+    same defect shipped on `/query` behind tests that paged 12 and 25 rows. Mutation-tested by removing the `skip`.
 
 ## [2.8.1] — 2026-08-13
 

--- a/docs/integration-guide/04d-brain-ops-api.md
+++ b/docs/integration-guide/04d-brain-ops-api.md
@@ -301,6 +301,7 @@ GET /api/brain/spaces/:spaceId/embedding-queue/records
 |-------------|-------------|
 | `status` | `pending`, `processing`, or `failed`. Omit for all three. An unknown value is a `400`, never a silently ignored filter |
 | `limit` | Default `50`, max `200`. `0`, a negative, or a non-integer is a `400` |
+| `skip` | Rows to discard before the page (default `0`). A negative or non-integer is a `400` |
 
 **Response** `200`:
 
@@ -323,7 +324,12 @@ GET /api/brain/spaces/:spaceId/embedding-queue/records
 }
 ```
 
-Newest-first by `updatedAt`. `attempts === maxAttempts` with `status: "failed"` means the queue has **given up** — it
+`counts` aggregates **every** job in the space; `jobs` is one page of them. Page with `skip` — without it a space reporting
+`failed: 500` would have no way to reach failure #201, and the point of this endpoint is that its failures are actionable.
+`limit` and `skip` are echoed so a draining loop can tell what was applied, and a `skip` past the end returns an empty
+`jobs` array with the counts intact, which is how the loop terminates.
+
+Newest-first by `updatedAt`, with the record id breaking ties so the order is **total** and pages cannot overlap. `attempts === maxAttempts` with `status: "failed"` means the queue has **given up** — it
 will not retry on its own, and the record stays unfindable until you retry it or rewrite it. Each row carries its own
 `spaceId`, which for a **proxy space** is the member space the record actually lives in — that is the space to retry it
 in. `counts` is returned whether or not you filtered, so a caller can filter to `failed` and still see the whole picture.

--- a/server/src/api/brain/embed-jobs.ts
+++ b/server/src/api/brain/embed-jobs.ts
@@ -30,6 +30,11 @@ import { resolveWriteTarget } from '../../spaces/proxy.js';
 import {
   listEmbedJobs, getEmbedJobCounts, retryEmbedJob, EMBED_RECORD_TYPES, isEmbedRecordType,
 } from '../../brain/embed-queue.js';
+import { pageAcrossMembers } from '../../spaces/page-across-members.js';
+import { PROXY_PAGE_CEILING } from '../../brain/query.js';
+
+/** Page size when the caller names none. Matches `listEmbedJobs`'s own default, so one number governs. */
+const DEFAULT_JOB_PAGE = 50;
 import type { BrainEmbedJobDoc } from '../../config/types.js';
 
 export const embedJobsRouter = Router();
@@ -90,19 +95,47 @@ embedJobsRouter.get('/spaces/:spaceId/embedding-queue/records', globalRateLimit,
     limit = n;
   }
 
+  const rawSkip = req.query['skip'];
+  let skip = 0;
+  if (rawSkip !== undefined && rawSkip !== '') {
+    const n = Number(rawSkip);
+    if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
+      res.status(400).json({ error: 'skip must be a non-negative integer' });
+      return;
+    }
+    skip = n;
+  }
+
+  const members = memberSpacesForRequest(req, spaceId);
   const counts = { pending: 0, processing: 0, failed: 0 };
-  const jobs: ReturnType<typeof toWire>[] = [];
-  for (const mid of memberSpacesForRequest(req, spaceId)) {
+  for (const mid of members) {
     const c = await getEmbedJobCounts(mid);
     counts.pending += c.pending; counts.processing += c.processing; counts.failed += c.failed;
-    for (const j of await listEmbedJobs(mid, { ...(status ? { status } : {}), ...(limit ? { limit } : {}) })) {
-      jobs.push(toWire(j, mid));
-    }
   }
-  // Re-sorted after the merge, or a proxy space's page would be ordered by member and only then by time.
-  jobs.sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : a.updatedAt > b.updatedAt ? -1 : 0));
 
-  res.json({ counts, jobs: limit ? jobs.slice(0, limit) : jobs, ...(status ? { status } : {}) });
+  // `counts` aggregates EVERY job while the listing returns a page, so without `skip` a caller could be told
+  // `failed: 500` and never reach failure #201 — an accurate total beside an unreachable tail, on the one surface whose
+  // justification is that its failures are actionable. Same asymmetry that cost aigents a fabricated number on `/query`,
+  // and paged here by the same function rather than by the same shape written twice.
+  const effectiveLimit = limit ?? DEFAULT_JOB_PAGE;
+  const page = await pageAcrossMembers<ReturnType<typeof toWire>>({
+    members,
+    limit: effectiveLimit,
+    skip,
+    ceiling: PROXY_PAGE_CEILING,
+    // Newest-first by `updatedAt`, with `_id` breaking every tie so the order is TOTAL and the pages cannot overlap.
+    compare: (a, b) => (a.updatedAt === b.updatedAt
+      ? (a.recordId < b.recordId ? 1 : a.recordId > b.recordId ? -1 : 0)
+      : (a.updatedAt < b.updatedAt ? 1 : -1)),
+    readMember: async (mid, lim, sk) =>
+      (await listEmbedJobs(mid, { ...(status ? { status } : {}), limit: lim, skip: sk })).map(j => toWire(j, mid)),
+  });
+  if (!page.ok) { res.status(400).json({ error: page.error }); return; }
+
+  res.json({
+    counts, jobs: page.rows, limit: effectiveLimit, skip,
+    ...(status ? { status } : {}),
+  });
 });
 
 // POST /api/brain/spaces/:spaceId/embedding-queue/records/retry — re-queue ONE record's embed job.

--- a/server/src/api/brain/search.ts
+++ b/server/src/api/brain/search.ts
@@ -8,6 +8,7 @@ import { requireSpaceAuth, denyReadOnly } from '../../auth/middleware.js';
 import { summariseActivity } from '../../metrics/space-activity-store.js';
 import { globalRateLimit } from '../../rate-limit/middleware.js';
 import { parseSortParam, toMongoSort, SORTABLE_FIELDS } from '../../brain/list-sort.js';
+import { pageAcrossMembers } from '../../spaces/page-across-members.js';
 import { NotFoundError } from '../../util/errors.js';
 import { countMemories } from '../../brain/memory.js';
 import { getEmbedJobCounts } from '../../brain/embed-queue.js';
@@ -271,41 +272,26 @@ searchRouter.post('/spaces/:spaceId/query', globalRateLimit, requireSpaceAuth, a
   const order = sortParse.sort ? toMongoSort(sortParse.sort) : DEFAULT_QUERY_SORT;
 
   try {
-    // A SINGLE space pushes `skip` down to MongoDB, which is correct at any depth. Only a PROXY with several members
-    // needs the merge, and only then does a deep page cost a larger read.
-    //
-    // The previous version always merged, with the per-member fetch capped at 100 — so `skip: 100` sliced past the end of
-    // a 100-row window and returned NOTHING, on a collection whose `total` said 120. The tests tiled 12 and 25 rows, both
-    // entirely inside the window, so the suite was green over exactly the defect this route exists to prevent.
+    // One paging rule, shared with the embed-job listing. It used to be inline here, and being inline is how it shipped
+    // a window capped at 100 that sliced deep pages to nothing — see `spaces/page-across-members.ts`.
     const members = memberSpacesForRequest(req, spaceId);
-    let merged: unknown[];
+    const page = await pageAcrossMembers({
+      members,
+      limit: safeLimit,
+      skip: safeSkip,
+      ceiling: PROXY_PAGE_CEILING,
+      compare: compareBySort(order),
+      readMember: (mid, lim, sk) => queryBrain(
+        mid, collection as typeof validCollections[number],
+        safeFilter, safeProjection, lim, safeMaxTimeMS, sk, order,
+      ),
+    });
+    if (!page.ok) { res.status(400).json({ error: page.error }); return; }
+    const merged = page.rows;
+
     let total = 0;
-    if (members.length === 1) {
-      merged = await queryBrain(
-        members[0] as string, collection as typeof validCollections[number],
-        safeFilter, safeProjection, safeLimit, safeMaxTimeMS, safeSkip, order,
-      );
-      total = await countBrain(members[0] as string, collection as typeof validCollections[number], safeFilter, safeMaxTimeMS);
-    } else {
-      // Rows [skip, skip+limit) of the merged set need skip+limit from each member. Bounded, because a deep page on a
-      // fleet multiplies: a 400 naming the ceiling beats a silent empty page, which is the failure being fixed.
-      const window = safeSkip + safeLimit;
-      if (window > PROXY_PAGE_CEILING) {
-        res.status(400).json({
-          error: `skip + limit must not exceed ${PROXY_PAGE_CEILING} on a proxy space (got ${window}). `
-            + 'Page a member space directly for a deeper sweep.',
-        });
-        return;
-      }
-      const perMember: unknown[] = [];
-      for (const mid of members) {
-        perMember.push(...await queryBrain(
-          mid, collection as typeof validCollections[number],
-          safeFilter, safeProjection, window, safeMaxTimeMS, 0, order,
-        ));
-        total += await countBrain(mid, collection as typeof validCollections[number], safeFilter, safeMaxTimeMS);
-      }
-      merged = perMember.sort(compareBySort(order)).slice(safeSkip, safeSkip + safeLimit);
+    for (const mid of members) {
+      total += await countBrain(mid, collection as typeof validCollections[number], safeFilter, safeMaxTimeMS);
     }
     res.json({
       results: merged, collection,

--- a/server/src/brain/embed-queue.ts
+++ b/server/src/brain/embed-queue.ts
@@ -326,7 +326,7 @@ export function isEmbedRecordType(v: unknown): v is BrainEmbedRecordType {
  */
 export async function listEmbedJobs(
   spaceId: string,
-  opts: { status?: 'pending' | 'processing' | 'failed'; limit?: number } = {},
+  opts: { status?: 'pending' | 'processing' | 'failed'; limit?: number; skip?: number } = {},
 ): Promise<BrainEmbedJobDoc[]> {
   // A non-positive or non-numeric limit falls back to the DEFAULT rather than being clamped up to 1. `Math.max(n, 1)`
   // would answer a caller who computed `limit: 0` with a single row, and one row out of a hundred failures reads as a
@@ -334,9 +334,15 @@ export async function listEmbedJobs(
   const asked = Number(opts.limit);
   const limit = Number.isFinite(asked) && asked >= 1 ? Math.min(Math.floor(asked), 200) : 50;
   const filter = opts.status ? { status: opts.status } : {};
+  // `skip` before `limit`, pushed to MongoDB. Without it a caller could be told `counts.failed: 500` and never reach
+  // failure #201 — an accurate total beside an unreachable tail, on the one surface whose justification is that its
+  // failures are actionable. Same asymmetry that cost aigents a fabricated number on `/query`.
+  const askedSkip = Number(opts.skip);
+  const skip = Number.isFinite(askedSkip) && askedSkip >= 1 ? Math.floor(askedSkip) : 0;
   return await jobs(spaceId)
     .find(asFilter<BrainEmbedJobDoc>(filter), { projection: { claimToken: 0 } })
     .sort({ updatedAt: -1 })
+    .skip(skip)
     .limit(limit)
     .toArray() as BrainEmbedJobDoc[];
 }

--- a/server/src/mcp/tools/search.ts
+++ b/server/src/mcp/tools/search.ts
@@ -17,6 +17,7 @@ import {
 import { parseSortParam, toMongoSort, SORTABLE_FIELDS } from '../../brain/list-sort.js';
 import { type RecallKnowledgeType, type RecallResult, findSimilar, recall, recallGlobal } from '../../brain/recall.js';
 import { memberSpacesWithin } from '../../spaces/proxy-scoped.js';
+import { pageAcrossMembers } from '../../spaces/page-across-members.js';
 import { NotFoundError } from '../../util/errors.js';
 import { rankOf, mergeRecallResults } from '../../brain/recall-shape.js';
 
@@ -413,35 +414,22 @@ export const queryTool: ToolHandler = {
         ? (a['projection'] as Record<string, unknown>)
         : undefined;
 
-    // Same shape as the REST route, and for the same reason: a SINGLE space pushes `skip` to MongoDB, which is correct at
-    // any depth, and only a PROXY with several members needs the merge. The previous version always merged with the
-    // per-member fetch capped at 100, so `skip: 100` sliced past the end of the window and returned NOTHING while the
-    // total reported the true count.
-    // SCOPED, not `resolveMemberSpaces`: a token holding some of a proxy's members must read those and no others. The
-    // first version of this fix called the unscoped resolver and `proxy-fanout-inventory.test.js` caught it — that gate
-    // exists because flipping a proxy read to the full member list leaks records from every member with a well-formed 200.
+    // The SAME function the REST route pages with, not the same shape written twice.
     const members = memberSpacesWithin(callSpace, ctx.accessibleSpaces.map(sp => sp.id));
-    let docs: unknown[];
-    let total = 0;
     const coll = collName as 'memories' | 'entities' | 'edges' | 'chrono' | 'files';
-    if (members.length === 1) {
-      docs = await queryBrain(members[0] as string, coll, filter, projection, limit, maxTimeMS, skip, order);
-      total = await countBrain(members[0] as string, coll, filter, maxTimeMS);
-    } else {
-      const window = skip + limit;
-      if (window > PROXY_PAGE_CEILING) {
-        throw new Error(
-          `skip + limit must not exceed ${PROXY_PAGE_CEILING} on a proxy space (got ${window}). `
-          + 'Query a member space directly for a deeper sweep.',
-        );
-      }
-      const perMember: unknown[] = [];
-      for (const mid of members) {
-        perMember.push(...await queryBrain(mid, coll, filter, projection, window, maxTimeMS, 0, order));
-        total += await countBrain(mid, coll, filter, maxTimeMS);
-      }
-      docs = perMember.sort(compareBySort(order)).slice(skip, skip + limit);
-    }
+    const page = await pageAcrossMembers({
+      members,
+      limit,
+      skip,
+      ceiling: PROXY_PAGE_CEILING,
+      compare: compareBySort(order),
+      readMember: (mid, lim, sk) => queryBrain(mid, coll, filter, projection, lim, maxTimeMS, sk, order),
+    });
+    if (!page.ok) throw new Error(page.error);
+    const docs = page.rows;
+
+    let total = 0;
+    for (const mid of members) total += await countBrain(mid, coll, filter, maxTimeMS);
 
     // `structuredContent` carries the paging facts; `content` stays the bare array it has always been, so a client
     // parsing the text is unaffected. Without `total` a caller sweeping with `skip` cannot tell a short last page from a

--- a/server/src/spaces/page-across-members.ts
+++ b/server/src/spaces/page-across-members.ts
@@ -1,0 +1,71 @@
+/**
+ * One paging rule for every listing that spans the members of a proxy space.
+ *
+ * ## Why this is a shared function and not a pattern to copy
+ *
+ * `/query` shipped its own version of this in 2.8.0 and got it wrong: it fetched a window capped at 100 rows and then
+ * sliced it at `skip`, so every page past row 100 came back EMPTY while the response's own `total` reported the true
+ * count. A caller sweeping a large collection stopped silently at 100.
+ *
+ * The embed-job listing then needed the same paging, and copying the shape would have meant two implementations of one
+ * rule — this codebase's most repeated defect, with the weaker copy winning silently. So the rule lives here and both
+ * callers pass their own fetch function.
+ *
+ * ## The rule
+ *
+ * **One member: push `skip` down to the database.** Correct at any depth, no window, no slicing. This is the case for
+ * every non-proxy space, which is nearly every request.
+ *
+ * **Several members: fetch `skip + limit` from each, merge, sort, take the window.** Rows `[skip, skip+limit)` of a merged
+ * set genuinely require `skip + limit` from every member — there is no way to know which member holds row 200 without
+ * reading the first 200 of each. That multiplies, so it is bounded, and exceeding the bound is an explicit refusal rather
+ * than the empty page that made this necessary.
+ */
+
+export interface PageRequest<T> {
+  /** The member spaces to read, already narrowed to what the caller may see. */
+  members: readonly string[];
+  /**
+   * Read one member. `skip`/`limit` are what THIS member should be asked for — the caller does not compute the window.
+   * For the single-member case `skip` is the caller's skip; for the merge it is 0 and `limit` is `skip + limit`.
+   *
+   * Named `readMember` rather than `fetch`: in this codebase `fetch` means HTTP egress, and the egress gate reads it that
+   * way — it flagged this file the moment it existed. A name that misleads a gate misleads a reader too.
+   */
+  readMember: (memberId: string, limit: number, skip: number) => Promise<T[]>;
+  /** Comparator for the merge, which must match the order `readMember` applies, or a proxy page is ordered differently. */
+  compare: (a: T, b: T) => number;
+  limit: number;
+  skip: number;
+  /** Max `skip + limit` for the MULTI-member case. Ignored when there is one member, which has no window. */
+  ceiling: number;
+}
+
+export type PageResult<T> =
+  | { ok: true; rows: T[] }
+  /** Over the ceiling. The caller turns this into a 400 (REST) or an Error (MCP) with the same text. */
+  | { ok: false; error: string };
+
+export async function pageAcrossMembers<T>(req: PageRequest<T>): Promise<PageResult<T>> {
+  const { members, readMember, compare, limit, skip, ceiling } = req;
+
+  if (members.length === 0) return { ok: true, rows: [] };
+
+  if (members.length === 1) {
+    // No window and no slice: the database applies both bounds, so depth costs nothing extra and cannot truncate.
+    return { ok: true, rows: await readMember(members[0] as string, limit, skip) };
+  }
+
+  const window = skip + limit;
+  if (window > ceiling) {
+    return {
+      ok: false,
+      error: `skip + limit must not exceed ${ceiling} on a proxy space (got ${window}). `
+        + 'Page a member space directly for a deeper sweep.',
+    };
+  }
+
+  const merged: T[] = [];
+  for (const mid of members) merged.push(...await readMember(mid, window, 0));
+  return { ok: true, rows: merged.sort(compare).slice(skip, skip + limit) };
+}

--- a/testing/integration/brain-embed-jobs-both-surfaces.test.js
+++ b/testing/integration/brain-embed-jobs-both-surfaces.test.js
@@ -260,3 +260,33 @@ describe('rights: reading the queue is knowledge:read, retrying is knowledge:wri
     assert.ok(r.status === 403 || r.status === 404, `a scoped token read another space's queue: ${r.status}`);
   });
 });
+
+describe('the listing pages, and echoes what it applied', () => {
+  // The queue is empty on this stack (the embedder works), so what HTTP can prove here is the CONTRACT: the parameters are
+  // accepted, refused correctly, and echoed. The tiling across the 200-row cap is asserted in
+  // `embed-jobs-are-visible-db.test.js`, where jobs can be made to fail — that is the only place a 250-job backlog exists.
+  it('echoes limit and skip', async () => {
+    const r = await listRest('?limit=5&skip=10');
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal(r.body.limit, 5);
+    assert.equal(r.body.skip, 10);
+  });
+
+  it('defaults skip to 0 and reports it', async () => {
+    const r = await listRest();
+    assert.equal(r.body.skip, 0, 'a caller must be able to tell where the page started without guessing');
+  });
+
+  it('refuses a negative or fractional skip rather than reading it as 0', async () => {
+    for (const bad of ['-1', '2.5', 'lots']) {
+      assert.equal((await listRest(`?skip=${bad}`)).status, 400, `skip=${bad} was accepted`);
+    }
+  });
+
+  it('a skip past the end is an empty page, not the last one', async () => {
+    const r = await listRest('?skip=100000');
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.deepEqual(r.body.jobs, []);
+    assert.ok(r.body.counts, 'and the counts still come back, so the caller knows whether there was anything at all');
+  });
+});

--- a/testing/standalone/embed-jobs-are-visible-db.test.js
+++ b/testing/standalone/embed-jobs-are-visible-db.test.js
@@ -178,6 +178,32 @@ describe('the embed queue is readable and retryable (real MongoDB, no reachable 
     assert.ok(!JSON.stringify(listed).includes('super-secret-lease'));
   });
 
+  it('pages past the 200-row cap, so a reported failure is always reachable', async () => {
+    // `getEmbedJobCounts` aggregates EVERY job while the listing returns a page. Without `skip` a caller was told
+    // `failed: 250` and could never reach failure #201 — an accurate total beside an unreachable tail, on the one surface
+    // whose justification is that its failures are actionable.
+    //
+    // 250 rows, because the cap is 200: a fixture inside the cap cannot see this, which is exactly how the same defect
+    // shipped on `/query` behind tests that paged 12 and 25 rows.
+    const N = 250;
+    for (let i = 0; i < N; i++) await writeRecord(`bulk ${String(i).padStart(3, '0')}`);
+    assert.equal((await queue.getEmbedJobCounts(SPACE)).pending, N, 'precondition: the counts see all of them');
+
+    const seen = [];
+    for (let skip = 0; skip < N; skip += 100) {
+      const rows = await queue.listEmbedJobs(SPACE, { limit: 100, skip });
+      seen.push(...rows.map(r => r.recordId));
+    }
+    assert.equal(seen.length, N, `expected every job across the pages, got ${seen.length}`);
+    assert.equal(new Set(seen).size, N, 'and each exactly once — no repeats, no gaps across the cap boundary');
+  });
+
+  it('a page past the END is empty rather than the tail', async () => {
+    await writeRecord('only one');
+    assert.deepEqual(await queue.listEmbedJobs(SPACE, { limit: 10, skip: 5 }), [],
+      'returning the tail here would make a draining loop run for ever');
+  });
+
   it('a retry re-queues a failed job and clears what it failed with', async () => {
     const { id, jobId } = await writeRecord('retry me');
     await jobs().updateOne({ _id: jobId }, {


### PR DESCRIPTION
`getEmbedJobCounts` aggregates **every** job while the listing returned one capped page — so a space reporting `failed: 500` had **no way to reach failure #201**. An accurate total beside an unreachable tail, on the one surface whose entire justification is that its failures are actionable: an operator draining a backlog could not drain it through the API that exists to drain it.

Same asymmetry that cost aigents a fabricated number on `/query`, found by auditing the surface in the same pass that found the deep-skip defect. **Two defects of one class on one surface, neither caught by the tests that shipped with it.**

## One paging rule, one implementation

`spaces/page-across-members.ts`:

- **one member** → push `skip` to MongoDB; correct at any depth, no window, no slice
- **several members** → fetch `skip + limit` from each, merge, take the window; bounded, with an explicit refusal rather than an empty page

`/query` had that logic **inline**, which is how it shipped a window capped at 100 that sliced deep pages to nothing. Copying the shape into a second route was therefore not an option — both listings and both surfaces now call the same function.

## The fixture size is the point

Tested with **250 jobs**, because the cap is 200 and a fixture inside the cap cannot see this. That is exactly how the same defect shipped on `/query` behind tests that paged 12 and 25 rows. **Mutation-tested** by removing the `.skip()`, which turns both new assertions red.

The HTTP tests assert the **contract** only — parameters accepted, refused, echoed — and say so in the file, because the integration stack has a working embedder and cannot hold a 250-job backlog. The tiling lives in the DB suite where jobs can be made to fail. Naming which layer proves what is the lesson from #872, where a test at the wrong layer passed against the broken code.

## One naming note

The helper's callback is `readMember`, not `fetch`. In this codebase `fetch` means HTTP egress, and the egress gate read it that way and flagged the file the moment it existed. A name that misleads a gate misleads a reader too.

🤖 Generated with Claude Code