### PR TITLE
fix(brain): the list endpoints report a total, refuse offset, and page a proxy correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
+- **The brain LIST endpoints report a `total`, refuse `offset`, and page a proxy space correctly.** aigents, 2026-08-13T1020Z
+  (corrected 1036Z): they paged `/memories?limit=300&offset=N` in a loop and it never came back short. `offset` is not a
+  parameter we have — the routes read `skip` — so it was accepted and ignored, every page was the same newest-300, and **67
+  identical pages summed to 10,184 matching records in a space holding 300 with 152 matches**. They were about to delete
+  records on that number; what caught it was `get_stats` disagreeing, not anything the paging response said.
+  - **`total` in the envelope** — their ranked #1, *"the one we would take if you only do one"*: the caller compares its
+    running sum against what the server counted and stops. Plus `truncated`, their #3, so a partial page says so rather
+    than being derived.
+  - **An unsupported pagination name is a `400` naming the one to use** — their #2, in their words: *"accepting a parameter
+    and ignoring it is worse than rejecting it, because the caller writes a loop around it."* `offset`, `page`, `per_page`,
+    `pageSize`, `sortBy`, `orderBy`, `order`, `direction`. Deliberately a short list of plausible-but-wrong names rather
+    than a strict allowlist over the whole query string, which would refuse the cache-busters and analytics params a GET
+    picks up in the wild.
+  - **All five list endpoints now page through `pageAcrossMembers`** — memories, entities, edges, chrono, file-meta — so a
+    proxy space's page is the page of the merged set instead of `skip` rows dropped from each member. That was a second,
+    quieter instance of the same defect.
+  - Documented in all five places the parity rule now names: both APIs, the integration guide, the userguide's Brain →
+    Search page, and the rights rows (unchanged — same routes, same rights).
 ### Fixed
 - **The embed-job listing takes `skip`, so a reported failure is always reachable.** `getEmbedJobCounts` aggregates every
   job while the listing returned one capped page, so a space reporting `failed: 500` had no way to reach failure #201 — an

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,28 @@ expressed against two different sources of scope — it is not one surface offer
 `400` on one door and a silent default on the other is worse than either alone, because it makes the behaviour depend on
 which client the caller happened to pick.
 
+## The five places a capability lives — all of them, same commit
+
+Owner rule, extended 2026-08-13. "MCP and REST" is not the whole list. A capability change is not done until all five
+agree:
+
+1. **the REST route**
+2. **the MCP tool** — same parameters, same defaults, same caps, same refusals
+3. **`docs/integration-guide/`** — the integrator's reference
+4. **`docs/userguide/02-brain.md` → Brain → Search** — what an operator reads in the product. A parameter that exists on
+   both APIs and is absent from that page is a capability nobody using the UI knows about; a control described there that
+   no longer matches the API is worse
+5. **token rights** — `auth/space-rights.ts`. A new route with no rights row is either unreachable or ungoverned, and both
+   fail silently
+
+The failure this prevents is not "documentation drift". It is that **each of these is somebody's authoritative source**,
+and the one that is wrong is invisible to whoever reads it: aigents designed around a stale sentence in an MCP schema;
+breituai-platform could not find an env var that was documented on the wrong page; a user reading the Search page cannot
+discover a `skip` that only the API has.
+
+**Check all five when you change any one.** If one genuinely does not apply, say which and why in the commit — not in your
+head.
+
 ## A schema description is the authoritative reference — treat it as code
 
 An MCP tool's `inputSchema` description is what a caller reads *while constructing arguments*, and `help()` says so in as

--- a/docs/integration-guide/04-brain-api.md
+++ b/docs/integration-guide/04-brain-api.md
@@ -424,7 +424,7 @@ Optional filters:
 | `fromName` / `toName` | *(edges)* Filter the From/To endpoint by entity name, same resolution |
 | `entity` | Filter by linked entity ID |
 | `limit` | Results per page (default 100, max 500) |
-| `skip` | Offset for pagination |
+| `skip` | Rows to discard before the page. **The parameter is `skip`** — `offset`, `page`, `per_page`, `pageSize`, `sortBy`, `orderBy`, `order` and `direction` are refused with a `400` naming the one to use, rather than accepted and ignored |
 
 Both `tag` and `entity` can be combined (AND logic). Results are sorted newest-first.
 
@@ -434,11 +434,27 @@ Both `tag` and `entity` can be combined (AND logic). Results are sorted newest-f
 {
   "memories": [ ... ],
   "limit": 100,
-  "skip": 0
+  "skip": 0,
+  "total": 4831,
+  "truncated": true
 }
 ```
 
-Default limit: 100, max: 500. Use `skip` for offset pagination.
+| Field | Meaning |
+|---|---|
+| `limit` / `skip` | The values actually applied, echoed so a loop can tell what it got from what it asked for |
+| `total` | Every record the filter matches, ignoring `limit` and `skip`. Summed across members on a proxy space |
+| `truncated` | `true` when this page is not the end of the match set — i.e. `skip + returned < total` |
+
+**Compare your running sum against `total` and stop.** That is what `total` is for. aigents paged this endpoint with
+`offset`, which was not a parameter we had: it was accepted and ignored, every page was the same newest-300, and 67
+identical pages summed to 10,184 matching records in a space holding 300 with 152 matches. They were about to delete
+records on that number, and what caught it was a *different* endpoint disagreeing — not anything the paging response said.
+Both halves of that are fixed here: the total is in the envelope, and an unsupported pagination name is a `400`.
+
+On a **proxy space** the page is computed over the merged set of member spaces, not per member, so `skip` means the same
+thing it does on a plain space. `skip + limit` is bounded there — a deep page needs that many rows from every member — and
+exceeding the bound is a `400` naming the ceiling.
 
 ---
 

--- a/docs/userguide/02-brain.md
+++ b/docs/userguide/02-brain.md
@@ -72,7 +72,7 @@ When a **type** is selected and the space has a schema defined for that type, th
 
 **Deleting:** Each row has an inline **✕ → confirm** flow.
 
-Results are paginated — use **← Prev / Next →** to page through them.
+Results are paginated — use **← Prev / Next →** to page through them. The list also reports the **total** number of matching records, not just the ones on screen, so "first page of 4,831" is visible rather than something you have to page to the end to discover.
 
 ---
 
@@ -158,6 +158,8 @@ So a **topK** of 10 can legitimately show fewer than ten rows — the passage co
 #### Advanced Query
 
 Runs a structured MongoDB-style query against one collection. Select a collection (`memories`, `entities`, `edges`, `chrono`, or `files`), optionally set a **limit** and **max time (ms)**, enter a filter as JSON, and click **Run**. Results appear below.
+
+The API behind this tab also takes **`skip`** (page through the results), **`sort`** and **`dir`** (order by a field), and returns a **`total`** — every record the filter matches, not just the page. Those are useful when you are driving it from a script rather than this form; see [Structured Query](../integration-guide/04d-brain-ops-api.md#structured-query-read-only) for the parameters and the sortable fields per collection.
 
 Example — find all entities of type `service`:
 

--- a/server/src/api/brain/chrono.ts
+++ b/server/src/api/brain/chrono.ts
@@ -8,8 +8,11 @@ import { requireSpaceAuth, denyReadOnly } from '../../auth/middleware.js';
 import { globalRateLimit, bulkWipeRateLimit } from '../../rate-limit/middleware.js';
 import { createChrono, updateChrono, getChronoById, listChrono, deleteChrono, bulkDeleteChrono, parseRecurrence, ChronoFilter } from '../../brain/chrono.js';
 import { getConfig } from '../../config/loader.js';
-import { parseLimit, parseSkip, capPage } from '../../util/pagination.js';
-import { parseSortParam, SORTABLE_FIELDS } from '../../brain/list-sort.js';
+import { parseLimit, parseSkip, unsupportedPageParam } from '../../util/pagination.js';
+import { pageAcrossMembers } from '../../spaces/page-across-members.js';
+import { countBrain, compareBySort, PROXY_PAGE_CEILING } from '../../brain/query.js';
+import { memberSpacesForRequest } from '../../spaces/proxy-scoped.js';
+import { parseSortParam, SORTABLE_FIELDS, toMongoSort } from '../../brain/list-sort.js';
 import { resolveWriteTarget, isProxySpace, isStrictLinkage, findFirstAcrossMembers, collectAcrossMembers } from '../../spaces/proxy.js';
 import { validateChrono, getAllowedChronoTypes } from '../../spaces/schema-validation.js';
 import type { ChronoStatus } from '../../config/types.js';
@@ -373,6 +376,10 @@ chronoRouter.get('/spaces/:spaceId/chrono', globalRateLimit, requireSpaceAuth, a
     return;
   }
   const limit = parseLimit(req.query['limit'], 50, 500);
+  // A pagination name we do not have is a 400 naming the one we do — aigents paged with `offset`, which was accepted
+  // and ignored, and summed 67 identical pages into a count 67x the truth.
+  const badParam = unsupportedPageParam(req.query as Record<string, unknown>);
+  if (badParam) { res.status(400).json(badParam); return; }
   const skip = parseSkip(req.query['skip']);
   const sortParse = parseSortParam(req.query['sort'], req.query['dir'], SORTABLE_FIELDS.chrono);
   if ('error' in sortParse) {
@@ -410,12 +417,21 @@ chronoRouter.get('/spaces/:spaceId/chrono', globalRateLimit, requireSpaceAuth, a
   // as edges: an id belongs to the member that owns it. An empty resolution filters to nothing, which is
   // correct — "no entity by that name" must not fall back to showing everything.
   const entityName = typeof req.query['entityName'] === 'string' ? req.query['entityName'] : undefined;
-  const all = await collectAcrossMembers(spaceId, async mid => {
+  const filterFor = async (mid: string): Promise<Record<string, unknown>> => {
     const perMember: Record<string, unknown> = { ...filter };
     if (entityName) perMember['entityIds'] = { $in: await resolveEntityIdsByName(mid, entityName) };
-    return listChrono(mid, perMember, limit, skip, sortParse.sort);
+    return perMember;
+  };
+  const members = memberSpacesForRequest(req, spaceId);
+  const page = await pageAcrossMembers<Record<string, unknown>>({
+    members, limit, skip, ceiling: PROXY_PAGE_CEILING,
+    compare: compareBySort(sortParse.sort ? toMongoSort(sortParse.sort) : { createdAt: -1, _id: -1 }),
+    readMember: async (mid, lim, sk) => await listChrono(mid, await filterFor(mid), lim, sk, sortParse.sort) as unknown as Record<string, unknown>[],
   });
-  res.json({ chrono: capPage(all, limit, sortParse.sort), limit, skip });
+  if (!page.ok) { res.status(400).json({ error: page.error }); return; }
+  let total = 0;
+  for (const mid of members) total += await countBrain(mid, 'chrono', await filterFor(mid));
+  res.json({ chrono: page.rows, limit, skip, total, truncated: skip + page.rows.length < total });
 });
 
 

--- a/server/src/api/brain/edges.ts
+++ b/server/src/api/brain/edges.ts
@@ -11,8 +11,11 @@ import { listEdges, deleteEdge, upsertEdge, getEdgeById, updateEdgeById, bulkDel
 import { validateDeleteFields, applyDeleteFields as applyDeleteFieldsPaths } from '../../brain/delete-fields.js';
 import { getConfig } from '../../config/loader.js';
 import { col, asFilter } from '../../db/mongo.js';
-import { parseLimit, parseSkip, capPage } from '../../util/pagination.js';
-import { parseSortParam, SORTABLE_FIELDS } from '../../brain/list-sort.js';
+import { parseLimit, parseSkip, unsupportedPageParam } from '../../util/pagination.js';
+import { pageAcrossMembers } from '../../spaces/page-across-members.js';
+import { countBrain, compareBySort, PROXY_PAGE_CEILING } from '../../brain/query.js';
+import { memberSpacesForRequest } from '../../spaces/proxy-scoped.js';
+import { parseSortParam, SORTABLE_FIELDS, toMongoSort } from '../../brain/list-sort.js';
 import { resolveMemberSpaces, resolveWriteTarget, isProxySpace, isStrictLinkage, findFirstAcrossMembers, collectAcrossMembers } from '../../spaces/proxy.js';
 import { validateEdge } from '../../spaces/schema-validation.js';
 import { UUID_V4_RE, webhookToken, getSpaceMeta, ttlDaysFromBody, ttlDaysError, ifMatchFromRequest, preconditionFailedBody } from './_shared.js';
@@ -118,6 +121,9 @@ edgesRouter.get('/spaces/:spaceId/edges', globalRateLimit, requireSpaceAuth, asy
     return;
   }
   const limit = parseLimit(req.query['limit'], 50, 200);
+  // A pagination name we do not have is a 400 naming the one we do.
+  const badParam = unsupportedPageParam(req.query as Record<string, unknown>);
+  if (badParam) { res.status(400).json(badParam); return; }
   const skip = parseSkip(req.query['skip']);
   const sortParse = parseSortParam(req.query['sort'], req.query['dir'], SORTABLE_FIELDS.edges);
   if ('error' in sortParse) {
@@ -137,12 +143,23 @@ edgesRouter.get('/spaces/:spaceId/edges', globalRateLimit, requireSpaceAuth, asy
   // member that owns it, so resolving against another's entities would match nothing while looking fine.
   const fromName = typeof req.query['fromName'] === 'string' ? req.query['fromName'] : undefined;
   const toName = typeof req.query['toName'] === 'string' ? req.query['toName'] : undefined;
-  const all = await collectAcrossMembers(spaceId, async mid => {
+  const filterFor = async (mid: string) => {
     const perMember = { ...filter };
     if (fromName) perMember.fromIds = await resolveEntityIdsByName(mid, fromName);
     if (toName) perMember.toIds = await resolveEntityIdsByName(mid, toName);
-    return listEdges(mid, perMember, limit, skip, sortParse.sort);
+    return perMember;
+  };
+  const members = memberSpacesForRequest(req, spaceId);
+  const page = await pageAcrossMembers<Record<string, unknown>>({
+    members, limit, skip, ceiling: PROXY_PAGE_CEILING,
+    compare: compareBySort(sortParse.sort ? toMongoSort(sortParse.sort) : { createdAt: -1, _id: -1 }),
+    readMember: async (mid, lim, sk) =>
+      await listEdges(mid, await filterFor(mid), lim, sk, sortParse.sort) as unknown as Record<string, unknown>[],
   });
+  if (!page.ok) { res.status(400).json({ error: page.error }); return; }
+  // Names are resolved for the PAGE, not for a whole per-member fetch: enriching rows that the window discards is work
+  // whose result is thrown away.
+  const all = page.rows as unknown as Awaited<ReturnType<typeof listEdges>>;
   // Batch-resolve entity names for from/to so the client can display names instead of raw UUIDs
   const allEntityIds = [...new Set(all.flatMap(e => [e.from, e.to]))];
   const nameMap = new Map<string, string>();
@@ -154,7 +171,9 @@ edgesRouter.get('/spaces/:spaceId/edges', globalRateLimit, requireSpaceAuth, asy
     for (const d of nameDocs) nameMap.set(String(d._id), d.name);
   }
   const enriched = all.map(e => ({ ...e, fromName: nameMap.get(e.from), toName: nameMap.get(e.to) }));
-  res.json({ edges: capPage(enriched, limit, sortParse.sort), limit, skip });
+  let total = 0;
+  for (const mid of members) total += await countBrain(mid, 'edges', await filterFor(mid));
+  res.json({ edges: enriched, limit, skip, total, truncated: skip + enriched.length < total });
 });
 
 

--- a/server/src/api/brain/entities.ts
+++ b/server/src/api/brain/entities.ts
@@ -11,8 +11,10 @@ import { listEntities, deleteEntity, upsertEntity, getEntityById, updateEntityBy
 import { computeMergePlan, applyResolutions, executeMerge, validateResolution, type PropertyResolution } from '../../brain/merge.js';
 import { validateDeleteFields, applyDeleteFields as applyDeleteFieldsPaths } from '../../brain/delete-fields.js';
 import { getConfig } from '../../config/loader.js';
-import { parseLimit, parseSkip, capPage } from '../../util/pagination.js';
-import { parseSortParam, SORTABLE_FIELDS } from '../../brain/list-sort.js';
+import { parseLimit, parseSkip, unsupportedPageParam } from '../../util/pagination.js';
+import { pageAcrossMembers } from '../../spaces/page-across-members.js';
+import { countBrain, compareBySort, PROXY_PAGE_CEILING } from '../../brain/query.js';
+import { parseSortParam, SORTABLE_FIELDS, toMongoSort } from '../../brain/list-sort.js';
 import { textSearchOr, SEARCHABLE_FIELDS } from '../../brain/text-search.js';
 import { resolveMemberSpaces, resolveWriteTarget, isProxySpace, isStrictLinkage, findFirstAcrossMembers, collectAcrossMembers } from '../../spaces/proxy.js';
 import { memberSpacesForRequest } from '../../spaces/proxy-scoped.js';
@@ -120,6 +122,10 @@ entitiesRouter.get('/spaces/:spaceId/entities', globalRateLimit, requireSpaceAut
     return;
   }
   const limit = parseLimit(req.query['limit'], 50, 500);
+  // A pagination name we do not have is a 400 naming the one we do — aigents paged with `offset`, which was accepted
+  // and ignored, and summed 67 identical pages into a count 67x the truth.
+  const badParam = unsupportedPageParam(req.query as Record<string, unknown>);
+  if (badParam) { res.status(400).json(badParam); return; }
   const skip = parseSkip(req.query['skip']);
   const sortParse = parseSortParam(req.query['sort'], req.query['dir'], SORTABLE_FIELDS.entities);
   if ('error' in sortParse) {
@@ -135,8 +141,16 @@ entitiesRouter.get('/spaces/:spaceId/entities', globalRateLimit, requireSpaceAut
   if (typeof req.query['properties'] === 'string') Object.assign(filter, propertiesValueContains(req.query['properties']));
   const search = textSearchOr(req.query['search'] as string | undefined, SEARCHABLE_FIELDS.entities);
   if (search) Object.assign(filter, search);
-  const all = await collectAcrossMembers(spaceId, mid => listEntities(mid, filter, limit, skip, sortParse.sort));
-  res.json({ entities: capPage(all, limit, sortParse.sort), limit, skip });
+  const members = memberSpacesForRequest(req, spaceId);
+  const page = await pageAcrossMembers<Record<string, unknown>>({
+    members, limit, skip, ceiling: PROXY_PAGE_CEILING,
+    compare: compareBySort(sortParse.sort ? toMongoSort(sortParse.sort) : { createdAt: -1, _id: -1 }),
+    readMember: async (mid, lim, sk) => await listEntities(mid, filter, lim, sk, sortParse.sort) as unknown as Record<string, unknown>[],
+  });
+  if (!page.ok) { res.status(400).json({ error: page.error }); return; }
+  let total = 0;
+  for (const mid of members) total += await countBrain(mid, 'entities', filter);
+  res.json({ entities: page.rows, limit, skip, total, truncated: skip + page.rows.length < total });
 });
 
 

--- a/server/src/api/brain/file-meta.ts
+++ b/server/src/api/brain/file-meta.ts
@@ -20,7 +20,9 @@ import { fileExists, readFile } from '../../files/files.js';
 import { log } from '../../util/log.js';
 import { getConfig } from '../../config/loader.js';
 import { col, asFilter } from '../../db/mongo.js';
-import { parseLimit, parseSkip, capPage } from '../../util/pagination.js';
+import { parseLimit, parseSkip, unsupportedPageParam } from '../../util/pagination.js';
+import { pageAcrossMembers } from '../../spaces/page-across-members.js';
+import { countBrain, compareBySort, PROXY_PAGE_CEILING } from '../../brain/query.js';
 import { parseSortParam, toMongoSort, SORTABLE_FIELDS } from '../../brain/list-sort.js';
 import { textSearchOr, SEARCHABLE_FIELDS } from '../../brain/text-search.js';
 import { resolveMemberSpaces, resolveWriteTarget, findFirstAcrossMembers, collectAcrossMembers, isStrictLinkage } from '../../spaces/proxy.js';
@@ -72,6 +74,8 @@ fileMetaRouter.get('/spaces/:spaceId/files', globalRateLimit, requireSpaceAuth, 
     return;
   }
   const limit = parseLimit(req.query['limit'], 50, 200);
+  const badParam = unsupportedPageParam(req.query as Record<string, unknown>);
+  if (badParam) { res.status(400).json(badParam); return; }
   const skip = parseSkip(req.query['skip']);
   const sortParse = parseSortParam(req.query['sort'], req.query['dir'], SORTABLE_FIELDS.files);
   if ('error' in sortParse) {
@@ -90,21 +94,29 @@ fileMetaRouter.get('/spaces/:spaceId/files', globalRateLimit, requireSpaceAuth, 
   // Distinct from the exact `?path=` filter above; the client's docked freetext box feeds this.
   const search = textSearchOr(req.query['search'] as string | undefined, SEARCHABLE_FIELDS.files);
   if (search) Object.assign(filter, search);
-  const all = await collectAcrossMembers(spaceId, async mid => {
-    const files = await col(`${mid}_files`)
-      .find(asFilter(filter))
-      .sort(mongoSort)
-      .skip(skip)
-      .limit(limit)
-      .toArray();
-    // Attach step progress for files still in flight, so the UI can draw which stage is running
-    // instead of a spinner that never resolves. Joined per MEMBER: on a proxy space the ids belong
-    // to that member's job collection, and looking them up in another's would silently find nothing.
-    return attachJobProgress(mid, files as Array<Record<string, unknown>>);
+  const members = memberSpacesForRequest(req, spaceId);
+  const page = await pageAcrossMembers<Record<string, unknown>>({
+    members, limit, skip, ceiling: PROXY_PAGE_CEILING,
+    compare: compareBySort(sortParse.sort ? toMongoSort(sortParse.sort) : { createdAt: -1, _id: -1 }),
+    readMember: async (mid, lim, sk) => {
+      const rows = await col(`${mid}_files`)
+        .find(asFilter(filter))
+        .sort(mongoSort)
+        .skip(sk)
+        .limit(lim)
+        .toArray();
+      // Attach step progress for files still in flight, so the UI can draw which stage is running
+      // instead of a spinner that never resolves. Joined per MEMBER: on a proxy space the ids belong
+      // to that member's job collection, and looking them up in another's would silently find nothing.
+      return attachJobProgress(mid, rows as Array<Record<string, unknown>>);
+    },
   });
-  const files = capPage(all, limit, sortParse.sort);
+  if (!page.ok) { res.status(400).json({ error: page.error }); return; }
 
-  res.json({ files, limit, skip });
+  let total = 0;
+  for (const mid of members) total += await countBrain(mid, 'files', filter);
+
+  res.json({ files: page.rows, limit, skip, total, truncated: skip + page.rows.length < total });
 });
 
 /**

--- a/server/src/api/brain/memories.ts
+++ b/server/src/api/brain/memories.ts
@@ -11,8 +11,11 @@ import { listMemories, deleteMemory, bulkDeleteMemories, remember, updateMemory 
 import { validateDeleteFields, applyDeleteFields as applyDeleteFieldsPaths } from '../../brain/delete-fields.js';
 import { getConfig } from '../../config/loader.js';
 import { col, asFilter } from '../../db/mongo.js';
-import { parseLimit, parseSkip, capPage } from '../../util/pagination.js';
-import { parseSortParam, SORTABLE_FIELDS } from '../../brain/list-sort.js';
+import { parseLimit, parseSkip, unsupportedPageParam } from '../../util/pagination.js';
+import { pageAcrossMembers } from '../../spaces/page-across-members.js';
+import { memberSpacesForRequest } from '../../spaces/proxy-scoped.js';
+import { countBrain, compareBySort, PROXY_PAGE_CEILING } from '../../brain/query.js';
+import { parseSortParam, SORTABLE_FIELDS, toMongoSort } from '../../brain/list-sort.js';
 import { checkQuota, QuotaError } from '../../quota/quota.js';
 import { resolveMemberSpaces, resolveWriteTarget, isProxySpace, isStrictLinkage, findFirstAcrossMembers, collectAcrossMembers } from '../../spaces/proxy.js';
 import { validateMemory } from '../../spaces/schema-validation.js';
@@ -158,6 +161,11 @@ memoriesRouter.get('/spaces/:spaceId/memories', globalRateLimit, requireSpaceAut
     res.status(404).json({ error: `Space '${spaceId}' not found` });
     return;
   }
+  // A pagination name we do not have is a 400 naming the one we do. aigents paged this endpoint with `offset`, which was
+  // accepted and ignored, and summed 67 identical pages into a count 67x the truth.
+  const badParam = unsupportedPageParam(req.query as Record<string, unknown>);
+  if (badParam) { res.status(400).json(badParam); return; }
+
   const limit = parseLimit(req.query['limit'], 100, 500);
   const skip = parseSkip(req.query['skip']);
   const sortParse = parseSortParam(req.query['sort'], req.query['dir'], SORTABLE_FIELDS.memories);
@@ -170,12 +178,35 @@ memoriesRouter.get('/spaces/:spaceId/memories', globalRateLimit, requireSpaceAut
   // as edges: an id belongs to the member that owns it. An empty resolution filters to nothing, which is
   // correct — "no entity by that name" must not fall back to showing everything.
   const entityName = typeof req.query['entityName'] === 'string' ? req.query['entityName'] : undefined;
-  const all = await collectAcrossMembers(spaceId, async mid => {
+  // Paged through the shared helper, so a proxy space's page is the page of the MERGED set rather than `skip` rows
+  // dropped from each member. Same function `/query` and the embed-job listing use.
+  const members = memberSpacesForRequest(req, spaceId);
+  const filterFor = async (mid: string): Promise<Record<string, unknown>> => {
     const perMember: Record<string, unknown> = { ...filter };
     if (entityName) perMember['entityIds'] = { $in: await resolveEntityIdsByName(mid, entityName) };
-    return listMemories(mid, perMember, limit, skip, sortParse.sort);
+    return perMember;
+  };
+  const page = await pageAcrossMembers<Record<string, unknown>>({
+    members, limit, skip, ceiling: PROXY_PAGE_CEILING,
+    // The comparator is built FROM the sort handed to MongoDB, so a proxy merge cannot order by a different rule.
+    compare: compareBySort(sortParse.sort ? toMongoSort(sortParse.sort) : { createdAt: -1, _id: -1 }),
+    readMember: async (mid, lim, sk) =>
+      await listMemories(mid, await filterFor(mid), lim, sk, sortParse.sort) as Record<string, unknown>[],
   });
-  res.json({ memories: capPage(all, limit, sortParse.sort), limit, skip });
+  if (!page.ok) { res.status(400).json({ error: page.error }); return; }
+
+  // `total` is the whole match, and it is the ONE thing aigents said they would take if we only did one: a caller
+  // compares what it summed against what the server counted and stops. Without it, 67 identical pages summed to a
+  // plausible number with nothing in any response contradicting it.
+  let total = 0;
+  for (const mid of members) total += await countBrain(mid, 'memories', await filterFor(mid));
+
+  res.json({
+    memories: page.rows, limit, skip, total,
+    // Explicit rather than left to be derived from `total`: their third ask, and a caller that knows it received a
+    // partial page does not need to work out whether it did.
+    truncated: skip + page.rows.length < total,
+  });
 });
 
 

--- a/server/src/util/pagination.ts
+++ b/server/src/util/pagination.ts
@@ -40,3 +40,42 @@ export function capPage<T>(rows: T[], limit: number, sort?: { field: string; dir
   const val = (r: T) => String((r as Record<string, unknown>)[field] ?? '');
   return [...rows].sort((a, b) => dir * val(a).localeCompare(val(b))).slice(0, limit);
 }
+
+/**
+ * Pagination parameter names we do NOT have, mapped to the one we do.
+ *
+ * aigents paged `/memories?limit=300&offset=N` in a loop. `offset` is not a parameter of ours — the routes read `skip` —
+ * so it was accepted and ignored, every page was the same newest-300, and the loop ran until their own guard stopped it.
+ * They summed 67 identical pages into 10,184 matching records where 152 exist, and were about to delete records on that
+ * number. What caught it was `get_stats` disagreeing, not anything the paging response said.
+ *
+ * Their words, and the reason this is a refusal rather than an alias: *"accepting a parameter and ignoring it is worse
+ * than rejecting it, because the caller writes a loop around it."*
+ *
+ * DELIBERATELY NOT a strict allowlist over the whole query string. A GET is reached by browsers, proxies and cache
+ * busters (`?_=1699…`), so refusing every unknown key would break traffic that never asked for pagination. This list is
+ * the plausible-but-wrong names a caller reaches for on purpose — each one a loop waiting to be written.
+ */
+export const UNSUPPORTED_PAGE_PARAMS: Readonly<Record<string, string>> = {
+  offset: 'skip',
+  page: 'skip',
+  per_page: 'limit',
+  perPage: 'limit',
+  pageSize: 'limit',
+  sortBy: 'sort',
+  orderBy: 'sort',
+  order: 'dir',
+  direction: 'dir',
+};
+
+/** The 400 body for an unsupported pagination alias, or `null` when the query is clean. */
+export function unsupportedPageParam(
+  query: Record<string, unknown>,
+): { error: string; unrecognized_keys: string[] } | null {
+  const bad = Object.keys(UNSUPPORTED_PAGE_PARAMS).filter(k => query[k] !== undefined);
+  if (bad.length === 0) return null;
+  return {
+    error: bad.map(k => `'${k}' is not a parameter of this endpoint — use '${UNSUPPORTED_PAGE_PARAMS[k]}'`).join('; '),
+    unrecognized_keys: bad,
+  };
+}

--- a/testing/integration/traverse-chrono.test.js
+++ b/testing/integration/traverse-chrono.test.js
@@ -79,10 +79,39 @@ before(async () => {
   const content = ['# Carrier report', '', 'The unit was lost in transit.', ''].join('\n');
   const w = await P(`/api/files/${SPACE}?path=${encodeURIComponent(ids.file)}`, { content });
   assert.ok(w.status < 300, `write file: ${w.status} ${JSON.stringify(w.body)}`);
-  const meta = await reqJson(INSTANCES.a, token(),
+  // PATCH, then CONFIRM IT STUCK — re-patching until it does, bounded.
+  //
+  // The file write kicks off the conversion pipeline, which writes the brain's file-meta record itself and derives
+  // `description` from the document's own opening prose. A PATCH issued before that write lands is silently overwritten:
+  // in CI on 2026-08-13 this fixture's description came back as "Carrier report The unit was lost in transit." — the
+  // excerpt — and the assertion 170 lines later reported it as a traverse defect. Locally the pipeline finishes first, so
+  // the race only ever shows up under load.
+  //
+  // Asserting the fixture is what it claims to be, HERE, is the difference between a one-line failure at setup and a
+  // misleading failure in the test body. The product question of whether the pipeline should overwrite an operator's own
+  // description at all is filed separately — this loop does not depend on the answer.
+  const wantDescription = 'Carrier incident report';
+  const patchMeta = () => reqJson(INSTANCES.a, token(),
     `/api/brain/spaces/${SPACE}/files?path=${encodeURIComponent(ids.file)}`,
-    { method: 'PATCH', body: JSON.stringify({ description: 'Carrier incident report', tags: ['rma'], entityIds: [ids.inc] }) });
+    { method: 'PATCH', body: JSON.stringify({ description: wantDescription, tags: ['rma'], entityIds: [ids.inc] }) });
+
+  let meta = await patchMeta();
   assert.ok(meta.status < 300, `link file to entity: ${meta.status} ${JSON.stringify(meta.body)}`);
+
+  const deadline = Date.now() + 20_000;
+  let readBack;
+  for (;;) {
+    readBack = await reqJson(INSTANCES.a, token(),
+      `/api/brain/spaces/${SPACE}/files?path=${encodeURIComponent(ids.file)}`, { method: 'GET' });
+    const got = readBack.body?.files?.[0]?.description ?? readBack.body?.description;
+    if (got === wantDescription) break;
+    if (Date.now() > deadline) {
+      assert.fail(`the file-meta PATCH never stuck: description reads ${JSON.stringify(got)} rather than `
+        + `${JSON.stringify(wantDescription)} — the conversion pipeline is overwriting it`);
+    }
+    await new Promise(r => setTimeout(r, 500));
+    meta = await patchMeta();
+  }
 });
 
 after(async () => {

--- a/testing/standalone/column-filters.test.js
+++ b/testing/standalone/column-filters.test.js
@@ -152,8 +152,16 @@ describe('entity-NAME column filters (From / To / Entities)', () => {
     // nothing while looking like it worked.
     for (const f of ['edges.ts', 'memories.ts', 'chrono.ts']) {
       const src = readFileSync(new URL(`../../server/src/api/brain/${f}`, import.meta.url), 'utf8');
-      assert.match(src, /collectAcrossMembers\(spaceId, async mid =>/, `${f} must resolve inside the member loop`);
+      // The PROPERTY, not the shape that used to express it. This line required
+      // `collectAcrossMembers(spaceId, async mid =>` until the list routes moved onto the shared pager, at which point the
+      // resolution moved into a `filterFor(mid)` helper — still per member, and the gate failed on correct code.
+      //
+      // Asserting the ARGUMENT is stronger than asserting the enclosing loop: the old pattern would have passed a
+      // `resolveEntityIdsByName(spaceId, …)` written inside the loop, which is the actual mistake being guarded against.
       assert.match(src, /resolveEntityIdsByName\(mid,/, `${f} must resolve against the MEMBER id`);
+      assert.ok(!/resolveEntityIdsByName\(spaceId,/.test(src),
+        `${f} resolves an entity name against the PROXY space id — ids belong to the member that owns them, so this `
+        + 'matches nothing while looking like it worked');
     }
   });
 

--- a/testing/standalone/proxy-fanout-inventory.test.js
+++ b/testing/standalone/proxy-fanout-inventory.test.js
@@ -113,7 +113,17 @@ const RECLASSIFIED = 1;
  * backwards — the arithmetic says the opposite — and lowering a conserved total on a plausible story is exactly the move
  * this invariant exists to catch. It caught it.
  */
-const TOTAL = 33;
+/**
+ * 33 -> 38: all five brain LIST routes now name their narrowing.
+ *
+ * They paged through `collectAcrossMembers`, which the counter does not see, and each now calls
+ * `memberSpacesForRequest` by name so it can hand the member list to the shared pager — memories, entities, edges, chrono
+ * and file-meta. Five more visible sites, the same reads, and the same narrowing they always had.
+ *
+ * The number moving UP as narrowing becomes explicit is the healthy direction for this invariant. It moved down once in
+ * my hands, on a plausible story about consolidation, and the arithmetic said otherwise.
+ */
+const TOTAL = 38;
 
 const GUARDS = {
   'server/src/auth/middleware.ts': 2,

--- a/testing/sync/braintree.test.js
+++ b/testing/sync/braintree.test.js
@@ -11,7 +11,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import {
-  INSTANCES, post, postRetry429, get, del, delWithBody, triggerSync, waitFor, getInstanceId,
+  INSTANCES, post, postRetry429, get, del, delWithBody, triggerSync, waitFor, getInstanceId, makeTriggerProbe,
 } from './helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -20,6 +20,31 @@ const CONFIGS = path.join(__dirname, 'configs');
 let tokenA, tokenB, tokenC;
 let networkId;
 let testSpaceId;
+
+/**
+ * Wait for a peer to deliver something, RE-TRIGGERING sync while we wait.
+ *
+ * A single up-front trigger races a slow gossip cycle: the trigger is accepted, the push is queued behind other work, and
+ * the wait expires having asked once. That is what `makeTriggerProbe`'s own docstring warns about, and it is what failed
+ * in CI on 2026-08-13 — the FIRST propagation of a run, 15.2s against a 15s budget, with no container error and the same
+ * assertions passing locally in 2.7s.
+ *
+ * So the budget is not the fix. Re-triggering is, and the probe makes a persistently-rejected trigger report itself
+ * ("429 Too Many Requests") instead of arriving as a bare timeout with nothing to act on.
+ */
+// 20s, matching the one hand-rolled re-triggered wait this codebase already had rather than inventing a number. The
+// MECHANISM is the fix -- re-triggering -- and the budget is deliberately not raised far, so a genuinely hung sync
+// still reports in a reasonable time instead of being papered over.
+async function waitForSynced(instance, token, networkId, label, check, timeoutMs = 20_000) {
+  await triggerSync(instance, token, networkId);
+  const probe = makeTriggerProbe(instance, token, networkId, label);
+  const retrigger = setInterval(() => { void probe(); }, 3_000);
+  try {
+    await waitFor(check, timeoutMs, 500, probe.diagnose);
+  } finally {
+    clearInterval(retrigger);
+  }
+}
 
 describe('Braintree topology (A -> B -> C)', () => {
   before(async () => {
@@ -111,16 +136,14 @@ describe('Braintree topology (A -> B -> C)', () => {
     const memId = write.body._id ?? write.body.id;
 
     // A pushes to B
-    await triggerSync(INSTANCES.a, tokenA, networkId);
-    await waitFor(async () => {
+    await waitForSynced(INSTANCES.a, tokenA, networkId, 'A', async () => {
       const r = await get(INSTANCES.b, tokenB, `/api/brain/spaces/${testSpaceId}/memories/${memId}`);
       return r.status === 200;
     });
     console.log(`  Root fact appeared on B ✓`);
 
     // B pushes to C
-    await triggerSync(INSTANCES.b, tokenB, networkId);
-    await waitFor(async () => {
+    await waitForSynced(INSTANCES.b, tokenB, networkId, 'B', async () => {
       const r = await get(INSTANCES.c, tokenC, `/api/brain/spaces/${testSpaceId}/memories/${memId}`);
       return r.status === 200;
     });

--- a/testing/sync/closed-network.test.js
+++ b/testing/sync/closed-network.test.js
@@ -51,6 +51,29 @@ process.stdout.write('ok');
 
 // ── Setup ────────────────────────────────────────────────────────────────────
 
+/**
+ * Wait for a peer to deliver something, RE-TRIGGERING sync while we wait.
+ *
+ * One test in this file already did this by hand (the A-pulls-from-B case) and the others did not. The tombstone test was
+ * one of the two that failed in CI on 2026-08-13 — the wait expires having asked once, because a single up-front trigger
+ * races a slow gossip cycle, which is exactly what `makeTriggerProbe`'s docstring warns about.
+ *
+ * `probe.diagnose` makes a persistently-rejected trigger report itself instead of arriving as a bare timeout.
+ */
+// 20s, matching the one hand-rolled re-triggered wait this codebase already had rather than inventing a number. The
+// MECHANISM is the fix -- re-triggering -- and the budget is deliberately not raised far, so a genuinely hung sync
+// still reports in a reasonable time instead of being papered over.
+async function waitForSynced(instance, token, networkId, label, check, timeoutMs = 20_000) {
+  await triggerSync(instance, token, networkId);
+  const probe = makeTriggerProbe(instance, token, networkId, label);
+  const retrigger = setInterval(() => { void probe(); }, 3_000);
+  try {
+    await waitFor(check, timeoutMs, 500, probe.diagnose);
+  } finally {
+    clearInterval(retrigger);
+  }
+}
+
 describe('Closed Network (A <-> B)', () => {
   before(async () => {
     loadTokens();
@@ -118,12 +141,8 @@ describe('Closed Network (A <-> B)', () => {
     const memId = write.body._id ?? write.body.id;
     console.log(`  Wrote memory ${memId} on A`);
 
-    // Trigger sync on A (A pushes to B)
-    await triggerSync(INSTANCES.a, tokenA, networkId);
-    console.log(`  Triggered sync on A`);
-
-    // Wait for B to have the memory (lookup by direct ID to avoid pagination)
-    await waitFor(async () => {
+    // Wait for B to have the memory (lookup by direct ID to avoid pagination), re-triggering while we wait.
+    await waitForSynced(INSTANCES.a, tokenA, networkId, 'A', async () => {
       const r = await get(INSTANCES.b, tokenB, `/api/brain/spaces/${testSpaceId}/memories/${memId}`);
       return r.status === 200;
     });
@@ -163,9 +182,8 @@ describe('Closed Network (A <-> B)', () => {
     assert.equal(write.status, 201);
     const memId = write.body._id ?? write.body.id;
 
-    await triggerSync(INSTANCES.a, tokenA, networkId);
     // Wait for B to have the memory (direct ID lookup)
-    await waitFor(async () => {
+    await waitForSynced(INSTANCES.a, tokenA, networkId, 'A', async () => {
       const r = await get(INSTANCES.b, tokenB, `/api/brain/spaces/${testSpaceId}/memories/${memId}`);
       return r.status === 200;
     });
@@ -175,11 +193,10 @@ describe('Closed Network (A <-> B)', () => {
     assert.equal(del_.status, 204, `Delete: ${JSON.stringify(del_.body)}`);
     console.log(`  Deleted memory ${memId} on A`);
 
-    // Trigger sync
-    await triggerSync(INSTANCES.a, tokenA, networkId);
-
-    // Wait for tombstone to arrive on B (memory disappears — direct ID lookup returns 404)
-    await waitFor(async () => {
+    // Wait for the tombstone to arrive on B (memory disappears — direct ID lookup returns 404), re-triggering while we
+    // wait. This is the assertion that timed out in CI on 2026-08-13: a tombstone push queued behind other work, asked
+    // for once.
+    await waitForSynced(INSTANCES.a, tokenA, networkId, 'A', async () => {
       const r = await get(INSTANCES.b, tokenB, `/api/brain/spaces/${testSpaceId}/memories/${memId}`);
       return r.status === 404;
     });


### PR DESCRIPTION
aigents, **2026-08-13T1020Z** (corrected 1036Z). They paged `/memories?limit=300&offset=N` in a loop and **it never came
back short**.

`offset` is not a parameter we have — the routes read `skip` — so it was accepted and ignored, every page was the same
newest-300, and **67 identical pages summed to 10,184 matching records in a space holding 300 with 152 matches.** They were
about to delete records on that number. What caught it was `get_stats` disagreeing with the listing, not anything the
paging response said.

## Their three asks, in their ranking

| # | ask | what ships |
|---|---|---|
| 1 | *"a total in the response envelope"* — **the one we would take if you only do one** | `total` beside the array, summed across members on a proxy; plus `truncated` |
| 2 | `offset` honoured **or** a refusal | a `400` naming the parameter to use |
| 3 | a truncation flag when a cap applied | `truncated: skip + returned < total` |

> *"accepting a parameter and ignoring it is worse than rejecting it, because the caller writes a loop around it."*

Refused names: `offset`, `page`, `per_page`, `pageSize`, `sortBy`, `orderBy`, `order`, `direction`. **Deliberately a short
list of plausible-but-wrong names, not a strict allowlist over the whole query string** — a GET picks up cache busters and
analytics params in the wild, and refusing those would break traffic that never asked for pagination.

## A second, quieter instance of the same defect

All five list endpoints fetched `limit` rows per member with `skip` applied **per member**, then capped — so on a proxy
space `skip` never meant what it means on a plain space. They now page through `pageAcrossMembers`, the same function
`/query` and the embed-job listing use.

## All five places, per the extended rule

Both APIs, the integration guide, **the userguide's Brain → Search page** (which had no mention of `skip`, `sort` or
`total` at all), and the rights rows — unchanged, because these are the same routes with the same rights. `CLAUDE.md` now
carries the rule.

## One gate needed correcting rather than satisfying

`column-filters.test.js` asserted the source contained `collectAcrossMembers(spaceId, async mid =>` as a proxy for *"entity
names are resolved per member"*. The resolution moved into a `filterFor(mid)` helper — still per member — and **the gate
failed on correct code**.

It now asserts the **argument** is `mid` and that `spaceId` is never passed, which is strictly stronger: the old pattern
would have accepted a `resolveEntityIdsByName(spaceId, …)` written inside the loop, which is the actual mistake being
guarded against.

## Verification

Probed live on all five endpoints: `total` correct, `truncated` flipping at the boundary, `offset` refused with a `400` on
every one. `chrono` first showed `total: 0` — my probe's creates were failing on a missing `startsAt`, not a bug in the
change. Full standalone suite green at 3719, plus 317 integration assertions across the list-touching suites.

🤖 Generated with Claude Code
