### PR TITLE
fix(files): a derived description cannot overwrite one a person wrote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Documented in all five places the parity rule now names: both APIs, the integration guide, the userguide's Brain →
     Search page, and the rights rows (unchanged — same routes, same rights).
 ### Fixed
+- **A derived file description could overwrite one a person had written.** The media worker read the stored description,
+  computed `operatorWrote` from it, and then wrote its derived text on that decision — a read-modify-write, which cannot
+  win the race it exists to win. An operator `PATCH` landing between the read and the write was silently replaced: no field
+  missing, no status wrong, the description simply somebody else's. Same shape as the 2.5.1 defect that computed a vector
+  from the record *as the write had read it*.
+  - The condition now lives in the **update filter**, so MongoDB arbitrates in one operation:
+    `setDerivedDescriptionIfUnset` matches only while the stored description is absent, null or whitespace-only. If it
+    became non-empty in the meantime, the update matches nothing and the operator's text stands.
+  - The `excerpt` half keeps writing unconditionally, which the original comment was right about: it is the document's own
+    text rather than a competing summary, and it is what makes a remembered phrase find the record.
+  - `descriptionSource` keeps its old semantics exactly — a derived description with no known provenance UNSETS it rather
+    than inheriting the previous label. Ported deliberately: mislabelling where text came from would be a worse bug than
+    the race.
+  - **Found chasing a CI failure**, and the mechanism came from source rather than from a reproduction — the race does not
+    reproduce on an idle machine, which is stated in the test rather than implied. The assertions force the interleaving
+    instead of hoping to lose a race, and are mutation-tested by neutralising the filter.
+  - The whitespace case earned its keep immediately: the first version of the filter used `'^\s*$'` as a **string**, which
+    in JavaScript is `^s*$` — it matched "sss" and not whitespace. It is a `RegExp` literal now, which cannot lose the
+    escape.
+### Fixed
 - **The embed-job listing takes `skip`, so a reported failure is always reachable.** `getEmbedJobCounts` aggregates every
   job while the listing returned one capped page, so a space reporting `failed: 500` had no way to reach failure #201 — an
   accurate total beside an unreachable tail, on the one surface whose justification is that its failures are actionable.

--- a/server/src/files/file-meta.ts
+++ b/server/src/files/file-meta.ts
@@ -105,6 +105,58 @@ export async function upsertFileMeta(
  * record does not exist.
  */
 /**
+ * Write a DERIVED description only if the operator has not written one — decided by the DATABASE, in one operation.
+ *
+ * ## Why this is not `updateFileMeta` with a read in front of it
+ *
+ * The media worker used to do exactly that: `findOne`, compute `operatorWrote` from the result, then write on that
+ * decision. The intent was right and documented — *"Only the description itself is theirs to keep"* — but a read-modify-write
+ * cannot win the race it exists to win. An operator PATCH landing between the read and the write was silently overwritten
+ * by the derived text, and nothing reported it: no field is missing, no status is wrong, the description is simply somebody
+ * else's.
+ *
+ * Same shape as the 2.5.1 embedding defect, which computed a vector from the record *as the write had read it*.
+ *
+ * The filter carries the condition, so MongoDB arbitrates: if the stored description became non-empty in the meantime, the
+ * update matches nothing and the operator's text stands. `^\s*$` rather than `''` because the guard it replaces used
+ * `.trim()`, and a whitespace-only description was treated as absent.
+ *
+ * Returns whether it wrote, so a caller can log the difference rather than infer it.
+ */
+export async function setDerivedDescriptionIfUnset(
+  spaceId: string,
+  filePath: string,
+  description: string,
+  /**
+   * Optional, and its ABSENCE is meaningful: `updateFileMeta` unsets `descriptionSource` when a description arrives
+   * without one, so a derived description with no known provenance must not inherit the previous one's. Ported
+   * faithfully rather than defaulted — mislabelling where a description came from is a worse bug than the race being
+   * fixed here.
+   */
+  descriptionSource?: 'generated' | 'extracted',
+): Promise<boolean> {
+  const _id = toDocId(filePath);
+  const r = await col<FileMetaDoc>(`${spaceId}_files`).updateOne(
+    asFilter<FileMetaDoc>({
+      _id,
+      $or: [
+        { description: { $exists: false } },
+        { description: null },
+        // Built from a RegExp rather than a string literal, because `'^\s*$'` in a JS string is `^s*$` — the backslash
+        // is dropped and the pattern matches "sss" instead of whitespace. It did exactly that here, and the
+        // whitespace-only assertion is what caught it. A RegExp literal cannot lose the escape.
+        { description: { $regex: /^\s*$/ } },
+      ],
+    } as never),
+    asUpdate<FileMetaDoc>({
+      $set: { description, updatedAt: new Date().toISOString(), ...(descriptionSource ? { descriptionSource } : {}) },
+      ...(descriptionSource ? {} : { $unset: { descriptionSource: '' } }),
+    }),
+  );
+  return r.modifiedCount > 0;
+}
+
+/**
  * Read one file-metadata record by path, or null.
  *
  * Exists for the audit before-snapshot: `updateFileMeta` reads the same document internally but returns

--- a/server/src/files/media/worker.ts
+++ b/server/src/files/media/worker.ts
@@ -43,7 +43,7 @@ import { embedAudio } from './audio-embedder.js';
 import { embedVideo } from './video-embedder.js';
 import { col, asFilter } from '../../db/mongo.js';
 import type { FileMetaDoc } from '../../config/types.js';
-import { updateFileMeta, markFileMetaDeleted } from '../file-meta.js';
+import { updateFileMeta, markFileMetaDeleted, setDerivedDescriptionIfUnset } from '../file-meta.js';
 import { mimeTypeForPath } from '../mime.js';
 import { describeDocument } from '../converters/describe.js';
 import {
@@ -526,20 +526,23 @@ async function processJob(
     // Write the derived description to the parent file meta if the user has not set one.
     // This also re-embeds the parent file meta so the description is searchable on the file itself.
     if (derivedDescription || derivedExcerpt) {
-      const parentMeta = await col<FileMetaDoc>(`${spaceId}_files`).findOne(
-        asFilter<FileMetaDoc>({ _id: fileId }),
-        { projection: { description: 1 } },
-      );
-      const operatorWrote = !!parentMeta?.description?.trim();
       // The excerpt goes in even when a person has written their own description: it is the document's own
       // text, not a competing summary, and it is what makes a remembered phrase find this record. Only the
       // description itself is theirs to keep.
-      const update = {
-        ...(operatorWrote || !derivedDescription ? {} : { description: derivedDescription, descriptionSource: derivedSource }),
-        ...(derivedExcerpt ? { excerpt: derivedExcerpt } : {}),
-      };
-      if (Object.keys(update).length > 0) {
-        await updateFileMeta(spaceId, filePath, update).catch(err =>
+      if (derivedExcerpt) {
+        await updateFileMeta(spaceId, filePath, { excerpt: derivedExcerpt }).catch(err =>
+          log.warn(`Media worker: failed to write excerpt to file meta ${spaceId}/${fileId}: ${err instanceof Error ? err.message : String(err)}`),
+        );
+      }
+      // The description is a CONDITIONAL write, decided by the database in one operation.
+      //
+      // This used to read the stored description, compute `operatorWrote`, and then write on that decision. The intent
+      // was right and the implementation could not deliver it: a read-modify-write loses to anything that lands in
+      // between, so an operator PATCH issued while the worker was mid-flight was silently replaced by the derived text.
+      // Nothing reported it — no field missing, no status wrong, the description simply somebody else's. Same shape as
+      // the 2.5.1 defect that computed a vector from the record as the write had read it.
+      if (derivedDescription) {
+        await setDerivedDescriptionIfUnset(spaceId, filePath, derivedDescription, derivedSource).catch(err =>
           log.warn(`Media worker: failed to write description to file meta ${spaceId}/${fileId}: ${err instanceof Error ? err.message : String(err)}`),
         );
       }

--- a/testing/standalone/derived-description-loses-to-the-operator-db.test.js
+++ b/testing/standalone/derived-description-loses-to-the-operator-db.test.js
@@ -1,0 +1,128 @@
+/**
+ * A derived file description never overwrites one a person wrote — decided by the database, in one write.
+ *
+ * ## The defect
+ *
+ * The media worker read the stored description, computed `operatorWrote` from it, and then wrote its derived text on that
+ * decision. The intent was right and documented — *"Only the description itself is theirs to keep"* — but a
+ * read-modify-write cannot win the race it exists to win: an operator PATCH landing between the read and the write was
+ * silently replaced. No field missing, no status wrong, the description simply somebody else's.
+ *
+ * Same shape as the 2.5.1 embedding defect, which computed a vector from the record *as the write had read it*.
+ *
+ * ## Why the window is held open ARTIFICIALLY, and why that is the honest test
+ *
+ * On an idle machine the worker wins the race comfortably; I could not reproduce the loss locally in either order. The
+ * only evidence of the symptom is a CI run under load. So a test that races and hopes to lose would pass on the broken
+ * code most of the time — which is worse than no test.
+ *
+ * Instead these assertions call the write path directly with the interleaving forced: set an operator description, THEN
+ * ask for the derived write, and require it to decline. That is exactly what the conditional filter guarantees and it is
+ * deterministic.
+ *
+ * Run: `npm run test:up` first, then
+ *      node --test testing/standalone/derived-description-loses-to-the-operator-db.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+
+const SPACE = 'general';
+const FILE = 'docs/report.md';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ythril-derived-desc-'));
+const CONFIG_PATH = path.join(tmpDir, 'config.json');
+process.env['CONFIG_PATH'] = CONFIG_PATH;
+
+let mongo, meta;
+
+const files = () => mongo.col(`${SPACE}_files`);
+const stored = async () => await files().findOne({ _id: FILE });
+
+describe('a derived description never beats the operator (real MongoDB)', { skip }, () => {
+  before(async () => {
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify(
+      { spaces: [{ id: SPACE, label: 'General' }], networks: [], tokens: [] }, null, 2,
+    ));
+    mongo = await openTestMongo('deriveddesc');
+    const loader = await import('../../server/dist/config/loader.js');
+    loader.loadConfig();
+    meta = await import('../../server/dist/files/file-meta.js');
+  });
+
+  after(async () => {
+    await closeTestMongo();
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  beforeEach(async () => {
+    await files().deleteMany({});
+  });
+
+  it('writes the derived description when the field is ABSENT', async () => {
+    // The ordinary case, and the reason the guard cannot simply refuse: a file nobody has described should get one.
+    // `upsertFileMeta` CREATES; `updateFileMeta` only updates an existing record and silently does nothing without
+    // one. And its third parameter is `sizeBytes`, not the opts bag — passing the opts third made it the SIZE and
+    // dropped every option without complaint. Both mistakes were mine, in sequence, and each produced a test that
+    // failed for a reason unrelated to the code under test.
+    await meta.upsertFileMeta(SPACE, FILE, 64, { tags: ['rma'] });
+    assert.equal(await meta.setDerivedDescriptionIfUnset(SPACE, FILE, 'Derived summary', 'generated'), true);
+    const d = await stored();
+    assert.equal(d.description, 'Derived summary');
+    assert.equal(d.descriptionSource, 'generated');
+  });
+
+  it('DECLINES when the operator already wrote one — the defect', async () => {
+    await meta.upsertFileMeta(SPACE, FILE, 64, { description: 'MINE' });
+    assert.equal(await meta.setDerivedDescriptionIfUnset(SPACE, FILE, 'Derived summary', 'generated'), false,
+      'the derived write must report that it did nothing');
+    assert.equal((await stored()).description, 'MINE',
+      'an operator description was overwritten by derived text — the exact loss this exists to prevent');
+  });
+
+  it('declines even when the operator wrote AFTER the caller decided to write', async () => {
+    // The interleaving, forced. This is the race: the worker resolves its intent, the operator writes, and only then does
+    // the worker's write land. The condition lives in the filter, so the late write loses rather than the operator.
+    await meta.upsertFileMeta(SPACE, FILE, 64, { tags: ['rma'] });
+    const intent = { description: 'Derived summary', source: 'generated' };   // decided while the field was empty
+
+    await meta.updateFileMeta(SPACE, FILE, { description: 'MINE, written in the window' });
+
+    assert.equal(await meta.setDerivedDescriptionIfUnset(SPACE, FILE, intent.description, intent.source), false);
+    assert.equal((await stored()).description, 'MINE, written in the window');
+  });
+
+  it('treats a WHITESPACE-ONLY description as absent, matching the guard it replaces', async () => {
+    // The old check was `!!parentMeta?.description?.trim()`, so "   " counted as unwritten. Preserved deliberately: a
+    // fix that quietly changed which values count as "described" would be a second behaviour change smuggled in.
+    await meta.upsertFileMeta(SPACE, FILE, 64, { description: '   ' });
+    assert.equal(await meta.setDerivedDescriptionIfUnset(SPACE, FILE, 'Derived summary', 'extracted'), true);
+    assert.equal((await stored()).description, 'Derived summary');
+  });
+
+  it('UNSETS descriptionSource when the derived write has no provenance', async () => {
+    // `updateFileMeta` unsets it in that case, so a description with unknown provenance must not inherit the previous
+    // one's label. Ported rather than defaulted — mislabelling where text came from is worse than the race.
+    await meta.upsertFileMeta(SPACE, FILE, 64, { description: 'old' });
+    await files().updateOne({ _id: FILE }, { $set: { descriptionSource: 'generated' } });
+    await files().updateOne({ _id: FILE }, { $set: { description: '' } });
+
+    assert.equal(await meta.setDerivedDescriptionIfUnset(SPACE, FILE, 'Derived, source unknown'), true);
+    const d = await stored();
+    assert.equal(d.description, 'Derived, source unknown');
+    assert.ok(!('descriptionSource' in d), `descriptionSource must be unset, got ${JSON.stringify(d.descriptionSource)}`);
+  });
+
+  it('does not create a record for a file that has no meta at all', async () => {
+    // The filter matches on `_id`, so a missing record means no match. Creating one here would invent a file-meta record
+    // for a path the operator may have deleted mid-conversion.
+    assert.equal(await meta.setDerivedDescriptionIfUnset(SPACE, 'docs/never-existed.md', 'Derived', 'generated'), false);
+    assert.equal(await files().countDocuments({}), 0);
+  });
+});

--- a/testing/standalone/document-description.test.js
+++ b/testing/standalone/document-description.test.js
@@ -147,8 +147,16 @@ describe('provenance is recorded, not assumed', () => {
 
   it('the worker writes the excerpt even when an operator owns the description', () => {
     // The excerpt is the document's own text, not a competing summary: only the description is theirs.
+    //
+    // This used to assert the shape `operatorWrote … derivedExcerpt ? { excerpt: derivedExcerpt }` — the excerpt riding
+    // along in the same object as the guarded description. That guard was a read-modify-write and is gone; the excerpt is
+    // now written on its own, unconditionally, which is STRICTLY STRONGER than "even when an operator owns the
+    // description". So the assertion is the property: an excerpt write that no description condition can reach.
     const workerSrc = src('server/src/files/media/worker.ts');
-    assert.match(workerSrc, /operatorWrote[\s\S]{0,200}?derivedExcerpt \? \{ excerpt: derivedExcerpt \}/);
+    assert.match(workerSrc, /updateFileMeta\(spaceId, filePath, \{ excerpt: derivedExcerpt \}\)/,
+      'the excerpt must be written by itself, not inside a description-conditional object');
+    assert.ok(!/operatorWrote/.test(workerSrc),
+      'the read-modify-write guard is gone — if it is back, the excerpt may be gated on it again');
   });
 
   it('an image caption is labelled generated too — it always was model output', () => {

--- a/testing/standalone/document-summary.test.js
+++ b/testing/standalone/document-summary.test.js
@@ -157,10 +157,23 @@ describe('the worker wires it to the parent record', () => {
   });
 
   it('through the SAME writer images use, which respects an operator-set description', () => {
-    // Not a second write path: an operator-written description must outrank a generated one, and that
-    // rule already lives in the existing block.
-    assert.match(w, /const operatorWrote = !!parentMeta\?\.description\?\.trim\(\)/);
-    assert.match(w, /updateFileMeta\(spaceId, filePath, update\)/);
-    assert.match(w, /operatorWrote \|\| !derivedDescription \? \{\} : \{ description: derivedDescription/);
+    // Not a second write path: an operator-written description must outrank a generated one.
+    //
+    // The RULE is unchanged; where it lives has moved. It used to be `operatorWrote`, computed from a read and then acted
+    // on — a read-modify-write that lost anything landing in between. It is now a condition in the update FILTER, so the
+    // database arbitrates. Asserting the old three lines would demand the defect back.
+    assert.match(w, /setDerivedDescriptionIfUnset\(spaceId, filePath, derivedDescription, derivedSource\)/,
+      'the description must go through the conditional writer, not a plain update');
+    assert.ok(!/operatorWrote/.test(w),
+      'a read-then-decide guard is back; the condition belongs in the write, not in a snapshot');
+
+    // And the condition itself, at the writer, so this cannot pass against a function that ignores its own name.
+    const meta = strip(readFileSync('server/src/files/file-meta.ts', 'utf8'));
+    assert.match(meta, /export async function setDerivedDescriptionIfUnset/);
+    assert.match(meta, /description: \{ \$exists: false \}/, 'absent counts as unwritten');
+    // An exact substring, not a regex. Writing a regex that matches a regex literal is where this assertion went wrong
+    // once already — the `\s` collapsed and it stopped meaning what it read as.
+    assert.ok(meta.includes('$regex: /^\\s*$/'),
+      'the whitespace-only case must be in the filter, matching the `.trim()` guard it replaced');
   });
 });


### PR DESCRIPTION
The media worker read the stored description, computed `operatorWrote` from it, then wrote its derived text on that
decision. The intent was right and documented — *"Only the description itself is theirs to keep"* — but **a
read-modify-write cannot win the race it exists to win.**

An operator `PATCH` landing between the read and the write was silently replaced. No field missing, no status wrong, the
description simply somebody else's. Same shape as the 2.5.1 defect that computed a vector from the record *as the write had
read it*.

## The fix

The condition lives in the **update filter** now, so MongoDB arbitrates in one operation:

```
_id, $or: [ description absent | null | /^\s*$/ ]
```

If the stored description became non-empty in the meantime, the update matches nothing and the operator's text stands.

- The **excerpt** keeps writing unconditionally — the original comment was right that it is the document's own text rather
  than a competing summary, and it is what makes a remembered phrase find the record.
- **`descriptionSource` keeps its exact old semantics**, including *unsetting* when a derived description arrives with no
  known provenance. Ported deliberately: mislabelling where text came from is a worse bug than the race.

## Found chasing CI, with the mechanism from source and no local repro

This surfaced as a `traverse-chrono` assertion in #876 — the file's excerpt where a PATCHed description should have been.
**I could not reproduce the race locally in either order**, because the worker wins comfortably on an idle machine. The
mechanism is read from `worker.ts:528`; the symptom is from CI. The test says that rather than implying otherwise.

So the assertions **force the interleaving** instead of racing: set a description, then ask for the derived write, and
require it to decline. A racing test would pass on the broken code most of the time, which is worse than no test.

**Mutation-tested** by neutralising the filter — exactly the two race assertions go red.

## The whitespace case earned its place immediately

My first filter used `'^\s*$'` as a **string**. In JavaScript that is `^s*$` — it matched `"sss"` and not whitespace, and
the whitespace-only assertion is the only thing that caught it. It is a `RegExp` literal now, which cannot lose the escape.

## Two gates asserted the old shape and failed on correct code

`document-description` required the excerpt to ride along inside the guarded object; `document-summary` required the three
`operatorWrote` lines verbatim. Both now assert the **property**: that the excerpt write is reachable by no description
condition, and that the description goes through the conditional writer with the condition visible at the writer.

Demanding the old lines back would have demanded the defect back. Third time today a gate needed correcting rather than
satisfying.

## Two mistakes of mine, recorded in the test

`updateFileMeta` does not create a record, and `upsertFileMeta`'s third parameter is `sizeBytes` — passing the options
object third made it the file size and dropped every option without complaint. Each produced a test that failed for a
reason unrelated to the code under test.

🤖 Generated with Claude Code
