### PR TITLE
feat(brain): every declared surface is checked against the one enforcement set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     place.
 
 ### Fixed
+- **`find_similar` accepted `traverse` and `includeContent` on MCP and refused them over REST.** The tool schema
+  advertised both and its handler implemented both; the REST route read neither, and the integration guide described the
+  gap as intended behaviour (*"the MCP tool ... adds `traverse`"*). A caller who read the tool schema and switched door
+  got a `400` for a documented parameter — and before the read bodies were made strict, got a `200` with an unexpanded
+  answer, which is why it survived this long.
+  - REST `/find-similar` now implements both, using recall's item shape, cap formula and `stripContentIfAsked` helper
+    rather than a second copy of them, so the two graph-augmented responses cannot drift.
+  - Bad values are refused rather than coerced, in recall's exact words: `traverse` must be an integer 0–5,
+    `includeContent` must be a boolean.
+  - **Found by a gate, not by a report.** The measurement that found it was wrong on its first run — `inputSchema` is a
+    function of the token-scoped schemas, and read as a literal it reports every REST field as missing from MCP, the
+    opposite of the truth. The gate now asserts the schema is materialised before comparing anything.
+- **The integration guide's accepted-fields table had drifted from what the routes enforce.** It still said *"there is no
+  `sort` on `/query`. It is refused rather than ignored"* after `sort` and `dir` had been added, so the authoritative
+  reference told integrators a working parameter would be rejected. The table is now compared against the enforced sets
+  by the same gate.
+
+### Added
+- **A gate that compares every declared surface against the one enforcement set.** `client-bodies-match-server.test.js`
+  takes the four strict brain read routes and checks the Angular client's request bodies, the MCP tool schemas and the
+  integration guide's table against `QUERY_BODY_FIELDS`, `RECALL_BODY_FIELDS`, `TRAVERSE_BODY_FIELDS` and
+  `FIND_SIMILAR_BODY_FIELDS`.
+  - Strictness moved the failure rather than removing it: an unknown key used to be a wrong answer with a `200`, and is
+    now a `400` in whatever is asking. The client's bodies were verified by hand and were correct — which is exactly when
+    to write the gate, because a hand-check does not survive the next edit to either side.
+  - The client call sites are DISCOVERED by sweeping the tracked sources for a POST to one of the four, so a component
+    posting directly instead of through `BrainApi` is covered the day it is written. A hand-maintained file list would
+    have shared the blind spot with the code it audits.
+  - It refuses to pass vacuously: an opaque body type (`Record<string, unknown>`, an index signature, a named interface
+    it cannot read) is a failure naming the file, and the routes are asserted BY NAME rather than by count.
+
+### Fixed
 - **The brain LIST endpoints report a `total`, refuse `offset`, and page a proxy space correctly.** aigents, 2026-08-13T1020Z
   (corrected 1036Z): they paged `/memories?limit=300&offset=N` in a loop and it never came back short. `offset` is not a
   parameter we have — the routes read `skip` — so it was accepted and ignored, every page was the same newest-300, and **67

--- a/docs/integration-guide/04a-recall-api.md
+++ b/docs/integration-guide/04a-recall-api.md
@@ -512,7 +512,7 @@ POST /api/brain/spaces/:spaceId/find-similar
 
 Given an existing entry's `_id`, find other entries with high vector similarity. Unlike `recall` (which re-embeds a text query), `find_similar` uses the entry's **stored embedding vector** directly — no re-embedding step. Ideal for deduplication, "more like this", and merge detection.
 
-> **Also available as MCP tool:** `find_similar` — note the MCP tool makes `space` optional (omit it to search all accessible spaces, like `recall`) and adds `traverse`; its `crossSpace` flag is deprecated in favour of omitting `space`. This REST endpoint keeps `spaceId` in the path and the `crossSpace` body flag.
+> **Also available as MCP tool:** `find_similar` — note the MCP tool makes `space` optional (omit it to search all accessible spaces, like `recall`); its `crossSpace` flag is deprecated in favour of omitting `space`. This REST endpoint keeps `spaceId` in the path and the `crossSpace` body flag. Every other parameter, including `traverse` and `includeContent`, is identical on both doors.
 
 **Request body:**
 
@@ -523,6 +523,8 @@ Given an existing entry's `_id`, find other entries with high vector similarity.
   "targetTypes": ["memory", "entity"],
   "topK": 10,
   "minScore": 0.7,
+  "traverse": 0,
+  "includeContent": true,
   "crossSpace": false
 }
 ```
@@ -534,6 +536,8 @@ Given an existing entry's `_id`, find other entries with high vector similarity.
 | `targetTypes` | — | all types | Which knowledge types to search in |
 | `topK` | — | `10` | Maximum results (1–100) |
 | `minScore` | — | `0.0` | Minimum cosine similarity threshold |
+| `traverse` | — | `0` | Graph-expansion depth (0–5). With `traverse > 0` each match is expanded along edges and the connected entities come back alongside it — see the response shape below |
+| `includeContent` | — | `true` | Whether file-chunk results carry their passage `content`. `false` returns locations and metadata only, exactly as on `recall` |
 | `crossSpace` | — | `false` | If `true`, search across all spaces the token can access |
 
 **Response** `200`:
@@ -551,6 +555,23 @@ Given an existing entry's `_id`, find other entries with high vector similarity.
 - `source` echoes the input entry with `score: 1.0` (self-match) — excluded from `results`
 - Results sorted by `score` descending
 - `spaceId` included on each result when `crossSpace: true`
+
+**With `traverse > 0`** the response carries the same graph-augmented shape `recall` uses — `results` becomes a list of
+`{score, source, hops, path, spaceId, type, record}` items, plus `count` and `traverseDepth`. Similarity matches are
+`source: "recall"` at `hops: 0`; records reached by following edges are `source: "traverse"` with a null `score` and the
+connecting `path`. The combined output is capped at `topK × (traverse + 1) × 4`.
+
+```json
+{
+  "source": { "_id": "...", "type": "entity", "name": "auth-service", "score": 1.0 },
+  "results": [
+    { "score": 0.91, "source": "recall", "hops": 0, "path": [], "spaceId": "dev-apps", "type": "entity", "record": { "_id": "..." } },
+    { "score": null, "source": "traverse", "hops": 1, "path": [{ "from": "...", "label": "depends_on", "to": "..." }], "spaceId": "dev-apps", "type": "entity", "record": { "_id": "..." } }
+  ],
+  "count": 2,
+  "traverseDepth": 1
+}
+```
 
 **Common use cases:**
 

--- a/docs/integration-guide/04d-brain-ops-api.md
+++ b/docs/integration-guide/04d-brain-ops-api.md
@@ -584,15 +584,15 @@ keys:
 
 | Route | Accepted fields |
 |---|---|
-| `POST /query` | `collection`, `filter`, `projection`, `limit`, `skip`, `maxTimeMS` |
+| `POST /query` | `collection`, `filter`, `projection`, `limit`, `skip`, `sort`, `dir`, `maxTimeMS` |
 | `POST /recall` | `query`, `topK`, `types`, `minScore`, `filter`, `traverse`, `tags`, `minPerType`, `maxPerType`, `maxTimeMS`, `includeFreshWrites`, `includeContent` |
 | `POST /traverse` | `startId`, `direction`, `edgeLabels`, `maxDepth`, `limit`, `includeChrono`, `includeMemories`, `includeFiles`, `includeEdges` |
-| `POST /find-similar` | `entryId`, `entryType`, `topK`, `minScore`, `targetTypes`, `crossSpace` *(deprecated, still accepted)* |
+| `POST /find-similar` | `entryId`, `entryType`, `topK`, `minScore`, `targetTypes`, `traverse`, `includeContent`, `crossSpace` *(deprecated, still accepted)* |
 
 ```json
 {
-  "error": "Unknown field(s): sort. Allowed: collection, filter, projection, limit, skip, maxTimeMS",
-  "unrecognized_keys": ["sort"]
+  "error": "Unknown field(s): orderBy. Allowed: collection, filter, projection, limit, skip, sort, dir, maxTimeMS",
+  "unrecognized_keys": ["orderBy"]
 }
 ```
 
@@ -601,7 +601,10 @@ honour the ones they recognised. aigents paged a sweep with `skip` before it was
 counted page one repeatedly as if it had advanced — *"it cost us a fabricated number"*. A parameter the server cannot
 honour is now an error rather than a wrong answer that looks right.
 
-There is **no `sort`** on `/query`. It is refused rather than ignored for exactly that reason.
+`sort` and `dir` **are** accepted on `/query` — they were added after this refusal shipped, and this table is the
+authoritative list rather than a summary of it. `client-bodies-match-server.test.js` compares every row here against the
+sets the routes enforce, so a parameter cannot be added to a route and left undocumented, or documented as refused while
+being accepted.
 
 ---
 

--- a/server/src/api/brain/search.ts
+++ b/server/src/api/brain/search.ts
@@ -569,6 +569,29 @@ searchRouter.post('/spaces/:spaceId/find-similar', globalRateLimit, requireSpace
     ? (body['targetTypes'] as unknown[]).filter((t): t is RecallKnowledgeType => typeof t === 'string' && VALID_ENTRY_TYPES.has(t))
     : undefined;
 
+  // `traverse` and `includeContent`: MCP `find_similar` has implemented both since it shipped — the tool schema
+  // advertises them and the handler reads them — while this route read neither. Same shape as the `includeContent`
+  // asymmetry an integrator reported on `recall`, one route over.
+  //
+  // Strictness is what made it visible: before the body was strict, sending `traverse: 2` here returned an unexpanded
+  // answer with a 200. It is a 400 now, which is better and still wrong — the parameter is supposed to work.
+  //
+  // Validated exactly as recall validates them, refusing rather than coercing, so the two routes cannot disagree
+  // about what a bad value is.
+  const traverseRaw = body['traverse'];
+  if (traverseRaw !== undefined
+    && (typeof traverseRaw !== 'number' || !Number.isInteger(traverseRaw) || traverseRaw < 0 || traverseRaw > MAX_RECALL_TRAVERSE)) {
+    res.status(400).json({ error: `traverse must be an integer between 0 and ${MAX_RECALL_TRAVERSE}` });
+    return;
+  }
+  const safeTraverse = typeof traverseRaw === 'number' ? traverseRaw : 0;
+  const includeContentRaw = body['includeContent'];
+  if (includeContentRaw !== undefined && typeof includeContentRaw !== 'boolean') {
+    res.status(400).json({ error: '`includeContent` must be a boolean' });
+    return;
+  }
+  const safeIncludeContent = includeContentRaw !== false;
+
   if (!entryId || !UUID_V4_RE.test(entryId)) {
     res.status(400).json({ error: 'entryId must be a valid UUID v4' });
     return;
@@ -597,7 +620,28 @@ searchRouter.post('/spaces/:spaceId/find-similar', globalRateLimit, requireSpace
       minScore,
       crossSpaceIds,
     );
-    res.json(result);
+    if (safeTraverse === 0) {
+      res.json({ ...result, results: stripContentIfAsked(result.results, safeIncludeContent) });
+      return;
+    }
+
+    // Graph-augmented: expand the similar seeds along edges. Deliberately the SAME item shape, the same cap formula
+    // and the same helper recall's traverse uses — a caller who can read one response can read the other, and a
+    // second copy of the shape is how the two would drift.
+    const traverseSpaces = crossSpaceIds ?? [spaceId];
+    const totalCap = topK * (safeTraverse + 1) * 4;
+    const neighbours = await traverseRecallSeeds(
+      traverseSpaces,
+      result.results.map(r => ({ _id: r._id, spaceId: r.spaceId })),
+      safeTraverse,
+      Math.max(0, totalCap - result.results.length),
+    );
+    const items: RecallTraverseItem[] = [
+      ...stripContentIfAsked(result.results, safeIncludeContent)
+        .map(r => ({ score: r.score, source: 'recall' as const, hops: 0, path: [], spaceId: r.spaceId, type: r.type, record: r })),
+      ...neighbours.map(n => ({ score: null, source: 'traverse' as const, hops: n.hops, path: n.path, spaceId: n.spaceId, type: 'entity' as const, record: n.record })),
+    ];
+    res.json({ source: result.source, results: items, count: items.length, traverseDepth: safeTraverse });
   } catch (err: unknown) {
     if (err instanceof NotFoundError) {
       res.status(404).json({ error: err.message });

--- a/server/src/brain/query.ts
+++ b/server/src/brain/query.ts
@@ -111,6 +111,10 @@ export const RECALL_BODY_FIELDS: ReadonlySet<string> = new Set([
 
 export const FIND_SIMILAR_BODY_FIELDS: ReadonlySet<string> = new Set([
   'entryId', 'entryType', 'topK', 'minScore', 'targetTypes', 'crossSpace',
+  // `traverse` and `includeContent` were on the MCP tool's schema and read by its handler while this route read
+  // neither. Found by the gate that compares every declared surface against these sets, not by a report — the
+  // strict body turned a silently-ignored parameter into a 400, which is how it surfaced at all.
+  'traverse', 'includeContent',
 ]);
 
 /**

--- a/testing/integration/find-similar-parity.test.js
+++ b/testing/integration/find-similar-parity.test.js
@@ -1,0 +1,187 @@
+/**
+ * `find_similar` takes the same parameters through both doors, and they DO something.
+ *
+ * ## What was wrong
+ *
+ * The MCP tool has advertised `traverse` and `includeContent` since it shipped, and its handler reads both.
+ * The REST route read neither. A caller who read the tool schema and switched door got a 400 for a
+ * documented parameter — and before the body was made strict, got a 200 with an unexpanded answer, which is
+ * worse.
+ *
+ * Found by a gate comparing every declared surface against the server's allowed sets, not by a report.
+ *
+ * ## Why these assertions
+ *
+ * Accepting a parameter and ignoring it is the same defect wearing a 200, so acceptance is not the claim
+ * here: the traversed neighbour must actually come back, annotated, with the connecting edge. And the two
+ * doors are asked the SAME question in the same fixture, so "parity" is a measured property rather than two
+ * schemas that happen to list the same words.
+ *
+ * ## Seeding
+ *
+ * Source and match are written through the brain API so they are embedded and `$vectorSearch`-visible. The
+ * neighbour is written through the sync endpoint, so it is NOT embedded: it can only be reached structurally,
+ * which is what makes its presence proof that traversal ran rather than that similarity was generous.
+ *
+ * Run: node --test testing/integration/find-similar-parity.test.js
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, get, waitForIndexed } from '../sync/helpers.js';
+import { openMcpSession } from '../sync/mcp-session.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+const RUN = Date.now();
+const SPACE = `fs-parity-${RUN}`;
+const NEIGHBOUR = `fs-neighbour-${RUN}`;
+
+let tokenA;
+let sourceId = null;
+let matchId = null;
+let embeddingAvailable = false;
+
+const token = () => tokenA;
+
+async function syncPostEntity(id, name, seq) {
+  const { post: syncPost } = await import('../sync/helpers.js');
+  const now = new Date().toISOString();
+  await syncPost(INSTANCES.a, token(), `/api/sync/entities?spaceId=${SPACE}`, {
+    _id: id, spaceId: SPACE, name, type: 'service', tags: [],
+    seq, author: { instanceId: 'test', instanceLabel: 'Test' }, createdAt: now, updatedAt: now,
+  });
+}
+
+async function syncPostEdge(from, to, label, seq) {
+  const { post: syncPost } = await import('../sync/helpers.js');
+  const now = new Date().toISOString();
+  await syncPost(INSTANCES.a, token(), `/api/sync/edges?spaceId=${SPACE}`, {
+    _id: `edge-${from}-${to}-${RUN}`.slice(0, 120), spaceId: SPACE, from, to, label,
+    seq, author: { instanceId: 'test', instanceLabel: 'Test' }, createdAt: now, updatedAt: now,
+  });
+}
+
+const findSimilar = (body) =>
+  post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/find-similar`, body);
+
+before(async () => {
+  tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+
+  const created = await post(INSTANCES.a, token(), '/api/spaces', { id: SPACE, label: `FindSimilar Parity ${RUN}` });
+  assert.equal(created.status, 201, `failed to create space: ${JSON.stringify(created.body)}`);
+
+  const { body: statusBody } = await get(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/reindex-status`);
+  if (statusBody?.needsReindex) await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/reindex`, {});
+
+  const source = await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/entities`, {
+    name: `Vault Secret Service ${RUN}`, type: 'service',
+    description: 'Vault secret storage service handling authentication token scoping and rotation',
+    tags: [], properties: {},
+  });
+  embeddingAvailable = source.status === 201;
+  sourceId = source.body?._id ?? null;
+
+  // Deliberately close in meaning to the source, so it is the similarity match rather than noise.
+  const match = await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/entities`, {
+    name: `Credential Rotation Service ${RUN}`, type: 'service',
+    description: 'Secret storage and credential rotation service scoping authentication tokens',
+    tags: [], properties: {},
+  });
+  matchId = match.body?._id ?? null;
+
+  let seq = Date.now();
+  await syncPostEntity(NEIGHBOUR, `FS-Neighbour-${RUN}`, seq++);
+  // The edge hangs off the MATCH, not the source: traversal expands the results of the similarity search.
+  if (matchId) await syncPostEdge(matchId, NEIGHBOUR, 'depends_on', seq++);
+
+  if (embeddingAvailable && sourceId && matchId) await waitForIndexed(INSTANCES.a, token(), SPACE, [sourceId, matchId], ['entity']);
+});
+
+after(async () => {
+  await fetch(`${INSTANCES.a}/api/spaces/${SPACE}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token()}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ confirm: true }),
+  }).catch(() => {});
+});
+
+describe('REST find-similar refuses a bad value rather than coercing it', () => {
+  it('traverse above the cap is a 400 naming the bound', async () => {
+    const r = await findSimilar({ entryId: sourceId, entryType: 'entity', traverse: 6 });
+    assert.equal(r.status, 400, JSON.stringify(r.body));
+    assert.match(r.body.error, /traverse must be an integer between 0 and \d+/);
+  });
+
+  it('a non-integer traverse is a 400', async () => {
+    const r = await findSimilar({ entryId: sourceId, entryType: 'entity', traverse: 1.5 });
+    assert.equal(r.status, 400, JSON.stringify(r.body));
+  });
+
+  it('a non-boolean includeContent is a 400, in recall’s words', async () => {
+    // `"false"` is truthy. A flag whose whole purpose is to make a response smaller must not silently do
+    // nothing, and the message is recall's verbatim so the two routes cannot disagree about a bad value.
+    const r = await findSimilar({ entryId: sourceId, entryType: 'entity', includeContent: 'no' });
+    assert.equal(r.status, 400, JSON.stringify(r.body));
+    assert.match(r.body.error, /`includeContent` must be a boolean/);
+  });
+});
+
+describe('REST find-similar traverse actually expands', () => {
+  it('traverse: 0 keeps the original response shape', async (t) => {
+    if (!embeddingAvailable || !sourceId) return t.skip('embedding unavailable');
+    const r = await findSimilar({ entryId: sourceId, entryType: 'entity', topK: 5 });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal(r.body.source?._id, sourceId);
+    assert.ok(Array.isArray(r.body.results));
+    assert.equal(r.body.traverseDepth, undefined, 'an unasked-for traverse must not change the shape');
+  });
+
+  it('traverse: 1 returns the match AND its unembedded neighbour, annotated', async (t) => {
+    if (!embeddingAvailable || !sourceId || !matchId) return t.skip('embedding unavailable');
+    const r = await findSimilar({ entryId: sourceId, entryType: 'entity', topK: 5, traverse: 1 });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal(r.body.traverseDepth, 1);
+    assert.equal(r.body.count, r.body.results.length, 'count must describe the array it ships with');
+
+    const seeds = r.body.results.filter(x => x.source === 'recall');
+    const reached = r.body.results.filter(x => x.source === 'traverse');
+    assert.ok(seeds.some(s => s.record?._id === matchId), `the similarity match must be a seed: ${JSON.stringify(r.body.results.map(x => x.record?._id))}`);
+
+    // The neighbour is not embedded, so vector search cannot have found it. Its presence IS the traversal.
+    const n = reached.find(x => x.record?._id === NEIGHBOUR);
+    assert.ok(n, `the unembedded neighbour must be reached by traversal: ${JSON.stringify(reached.map(x => x.record?._id))}`);
+    assert.equal(n.hops, 1);
+    assert.equal(n.score, null, 'a structurally-reached record has no similarity score to report');
+    assert.equal(n.path.length, 1, 'one edge away means a one-edge path');
+    assert.equal(n.path[0].label, 'depends_on', 'the path must carry the edge label, not just the ids');
+  });
+});
+
+describe('both doors answer the same question the same way', () => {
+  it('MCP find_similar with traverse reaches the same neighbour', async (t) => {
+    if (!embeddingAvailable || !sourceId) return t.skip('embedding unavailable');
+    const session = await openMcpSession(token());
+    try {
+      const res = await session.callTool('find_similar', {
+        space: SPACE, entryId: sourceId, entryType: 'entity', topK: 5, traverse: 1,
+      });
+      // `callTool` already unwraps the JSON-RPC envelope down to `result`.
+      const text = res?.content?.[0]?.text ?? '';
+      const parsed = JSON.parse(text);
+      assert.equal(parsed.traverseDepth, 1, text.slice(0, 200));
+      const ids = parsed.results.map(x => x.record?._id);
+      assert.ok(ids.includes(NEIGHBOUR), `MCP must reach the same neighbour: ${JSON.stringify(ids)}`);
+      // The annotation keys are the contract a caller reads. Both doors ship the same four.
+      const reached = parsed.results.find(x => x.record?._id === NEIGHBOUR);
+      for (const key of ['source', 'hops', 'path', 'spaceId']) {
+        assert.ok(key in reached, `MCP item is missing ${key}, which REST ships`);
+      }
+    } finally {
+      session.close();
+    }
+  });
+});

--- a/testing/standalone/brain-read-bodies-are-strict.test.js
+++ b/testing/standalone/brain-read-bodies-are-strict.test.js
@@ -52,12 +52,21 @@ const EXEMPT = {
     + 'an empty body would be a check that can only ever pass.',
 };
 
-/** Source with comments stripped, so a gate cannot pass on the comment that explains the fix. */
+/**
+ * Source with comments stripped, so a gate cannot pass on the comment that explains the fix.
+ *
+ * No `$`. The lines are split on `\n`, and on a Windows checkout each one still ends with `\r` — which `$`
+ * cannot match past without the `m` flag, so this function silently stripped NOTHING locally while working
+ * in CI, where the checkout is LF. Every other gate in this directory got away with `/(^|[^:])\/\/.*$/gm`,
+ * where `\r` counts as a line terminator; this one split first and dropped the flag.
+ *
+ * `.*` stops at `\r` on its own, so leaving the anchor off is both shorter and correct on either checkout.
+ */
 function stripComments(src) {
   return src
     .replace(/\/\*[\s\S]*?\*\//g, '')
     .split('\n')
-    .map(l => l.replace(/(^|[^:])\/\/.*$/, '$1'))
+    .map(l => l.replace(/(^|[^:])\/\/.*/, '$1'))
     .join('\n');
 }
 
@@ -127,7 +136,11 @@ describe('brain read routes refuse unknown body keys', () => {
     //   const { a, b } = req.body ?? {}          — the destructure
     //   body['a'] / (req.body as X)['a']         — bracket access
     //   (req.body as { a?: unknown }).a          — cast-then-dot, which is how the two missed keys were read
-    const QUERY_SRC = readFileSync(join(ROOT, 'server', 'src', 'brain', 'query.ts'), 'utf8');
+    // `stripComments` here too, not only on the route file. The sets carry long comments explaining why each key is
+    // listed, and the member extraction below pairs single quotes — so one apostrophe in prose (`the MCP tool's
+    // schema`) pairs with the next real quote and swallows every key after it. That is exactly how this gate reported
+    // `traverse` and `includeContent` as missing from a set that listed them.
+    const QUERY_SRC = stripComments(readFileSync(join(ROOT, 'server', 'src', 'brain', 'query.ts'), 'utf8'));
     const missing = [];
 
     for (const { path, body } of postRoutes()) {

--- a/testing/standalone/client-bodies-match-server.test.js
+++ b/testing/standalone/client-bodies-match-server.test.js
@@ -1,0 +1,219 @@
+/**
+ * Every body key the CLIENT sends to a strict brain read route is a key the SERVER allows.
+ *
+ * ## Why this gate exists
+ *
+ * `/query`, `/recall`, `/traverse` and `/find-similar` were made strict because a silently dropped key
+ * produces a *wrong answer with a 200* — aigents sent `skip`, got page one, and it cost them a fabricated
+ * number. Strictness fixed the lying, but it moved the failure: a client key that is not in the server's
+ * allowed set is now a **400 in the UI**, and nothing checked that our own client stays inside those sets.
+ *
+ * Two copies of one rule, and only one of them was enforced. The client's body types were verified BY HAND
+ * on 2026-08-13 and were correct — which is exactly when to write the gate, because a hand-check does not
+ * survive the next edit to either side.
+ *
+ * ## Direction: client ⊆ server, never the reverse
+ *
+ * The server may allow more than the client sends (`skip`, `sort` and `dir` exist for API callers and no UI
+ * asks for them yet). A key the client sends and the server refuses is the defect.
+ *
+ * ## It reads the shipped call sites, not a list of files
+ *
+ * The routes are discovered by sweeping every tracked client source file for a `POST` to one of the four,
+ * so a component that posts directly instead of going through `BrainApi` is covered the day it is written.
+ * A hand-maintained file list would have shared the blind spot with the code it audits.
+ *
+ * Run: node --test testing/standalone/client-bodies-match-server.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+const {
+  QUERY_BODY_FIELDS, RECALL_BODY_FIELDS, TRAVERSE_BODY_FIELDS, FIND_SIMILAR_BODY_FIELDS,
+} = await import('../../server/dist/brain/query.js');
+const { ALL_TOOLS } = await import('../../server/dist/mcp/tools/index.js');
+
+/** The four strict routes, each pointing at the set the route actually gates on. */
+const SETS = new Map([
+  ['query', QUERY_BODY_FIELDS],
+  ['recall', RECALL_BODY_FIELDS],
+  ['traverse', TRAVERSE_BODY_FIELDS],
+  ['find-similar', FIND_SIMILAR_BODY_FIELDS],
+]);
+
+/** Comments are stripped: a doc comment inside a body type literal names keys it does not declare. */
+const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '');
+
+const clientSources = () =>
+  execFileSync('git', ['ls-files', 'client/src'], { encoding: 'utf8' })
+    .split('\n')
+    .filter(f => f.endsWith('.ts') && !f.endsWith('.spec.ts'));
+
+/** From the `{` at `open`, the matching `}` — inclusive of both braces. */
+function literalAt(src, open) {
+  let depth = 0;
+  for (let i = open; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}' && --depth === 0) return src.slice(open, i + 1);
+  }
+  return null;
+}
+
+/** The keys declared at the literal's TOP level. Nested literals raise the depth and are skipped. */
+function topLevelKeys(literal) {
+  const keys = [];
+  let depth = 0;
+  let word = '';
+  for (const c of literal) {
+    if (c === '{' || c === '[' || c === '(' || c === '<') { depth++; word = ''; continue; }
+    if (c === '}' || c === ']' || c === ')' || c === '>') { depth--; word = ''; continue; }
+    if (depth !== 1) continue;
+    if (/[A-Za-z0-9_$]/.test(c)) word += c;
+    else if (c === '?') continue;                  // an optional key keeps its name
+    else if (c === ':') { if (word) keys.push(word); word = ''; }
+    else word = '';
+  }
+  return keys;
+}
+
+/**
+ * Every `POST` to a strict brain route in the tracked client sources, with the body keys it sends.
+ *
+ * The second argument is either an inline object (keys read from it) or a parameter named `body`, whose
+ * inline type literal is the nearest `body:` declaration above the call — one per method, so nearest is its
+ * own.
+ */
+function clientPosts() {
+  const found = [];
+  for (const file of clientSources()) {
+    const src = strip(readFileSync(file, 'utf8'));
+    const call = /\.post\s*<[^(;]*?>\s*\(\s*`\/api\/brain\/spaces\/\$\{[^}]+\}\/([a-z-]+)`\s*,\s*/g;
+    for (let m = call.exec(src); m; m = call.exec(src)) {
+      const route = m[1];
+      if (!SETS.has(route)) continue;
+      const argAt = m.index + m[0].length;
+      if (src[argAt] === '{') {
+        found.push({ file, route, keys: topLevelKeys(literalAt(src, argAt)), how: 'inline object' });
+        continue;
+      }
+      const declared = src.lastIndexOf('body:', m.index);
+      assert.ok(declared > 0, `${file}: POST /${route} sends something this gate cannot read — pass an inline
+        object or a parameter named \`body\` with an inline type literal.`);
+      const brace = src.indexOf('{', declared);
+      const literal = brace > -1 && brace < declared + 8 ? literalAt(src, brace) : null;
+      assert.ok(literal, `${file}: the \`body\` for POST /${route} is not an inline type literal, so its keys
+        cannot be compared with the server's allowed set. Inline it.`);
+      assert.doesNotMatch(literal, /\[\s*\w+\s*:\s*string\s*\]\s*:/,
+        `${file}: the \`body\` for POST /${route} has an index signature, which admits any key and makes this
+        gate vacuous.`);
+      found.push({ file, route, keys: topLevelKeys(literal), how: 'body parameter' });
+    }
+  }
+  return found;
+}
+
+describe('the sweep itself found the call sites', () => {
+  // Every extraction happens INSIDE an `it`. Called at collection time, a body this gate cannot read throws
+  // before any test is registered, and `node --test` then reports zero tests — which reads like nothing was
+  // wrong rather than like a failure.
+  it('finds the three strict read routes the client actually calls', () => {
+    const posts = clientPosts();
+    // Asserted by IDENTITY, not by count: a regex that silently stops matching would otherwise report
+    // "no client key is wrong" while having looked at nothing.
+    const routes = new Set(posts.map(p => p.route));
+    for (const route of ['query', 'recall', 'traverse']) {
+      assert.ok(routes.has(route), `no client POST to /${route} was found — the extractor is broken, or the
+        call moved. This gate is worthless until it can see them.`);
+    }
+  });
+
+  it('reads real keys out of every site it found', () => {
+    for (const p of clientPosts()) {
+      assert.ok(p.keys.length > 0, `${p.file}: POST /${p.route} parsed to zero body keys (${p.how})`);
+    }
+  });
+});
+
+/** The MCP tool that is the same capability as each REST route. `find-similar` is `find_similar` there. */
+const MCP_TOOL = new Map([
+  ['query', 'query'], ['recall', 'recall'], ['traverse', 'traverse'], ['find-similar', 'find_similar'],
+]);
+
+/** What the router passes to every `inputSchema`. The `space` enum is token-scoped, so a stub is faithful. */
+const SCHEMA_STUB = { requiredSpace: { type: 'string' }, optionalSpace: { type: 'string' } };
+
+/** `space` is transport, not a query parameter: REST carries it in the path. */
+const TRANSPORT_ONLY = new Set(['space']);
+
+describe('MCP advertises the same parameters the REST route accepts', () => {
+  // The owner's standing rule is that the two doors take the same params, and `mcp-rest-parity` checks which
+  // TOOLS exist, not which parameters they take. This half was unenforced, and it was hiding a real gap:
+  // `find_similar` advertised `traverse` and `includeContent` — implemented in its handler — while the REST
+  // route read neither, so a caller who read the tool schema got a 400 from the other door.
+  for (const [route, tool] of MCP_TOOL) {
+    it(`${route} ↔ ${tool}`, () => {
+      const t = ALL_TOOLS.find(x => x.name === tool);
+      assert.ok(t, `no MCP tool named ${tool}`);
+
+      // `inputSchema` is a FUNCTION of the token-scoped schemas, not a literal. Reading it as an object gives
+      // `properties: undefined`, which silently reports every REST field as missing from MCP — the first
+      // version of this measurement did exactly that and concluded the opposite of the truth. So the
+      // materialised schema is asserted to be a real object with real properties before anything is compared.
+      assert.equal(typeof t.inputSchema, 'function', 'inputSchema must be materialised, not read as a literal');
+      const props = Object.keys(t.inputSchema(SCHEMA_STUB).properties ?? {});
+      assert.ok(props.length > 0, `${tool}'s materialised schema has no properties — the comparison below would
+        pass or fail for a reason that has nothing to do with parity`);
+
+      const allowed = SETS.get(route);
+      const mcpOnly = props.filter(p => !allowed.has(p) && !TRANSPORT_ONLY.has(p));
+      assert.deepEqual(mcpOnly, [], `${tool} advertises ${mcpOnly.join(', ')}, which POST /${route} answers 400
+        for. A caller who reads the tool schema and switches door gets a refusal for a documented parameter.`);
+
+      const restOnly = [...allowed].filter(p => !props.includes(p));
+      assert.deepEqual(restOnly, [], `POST /${route} accepts ${restOnly.join(', ')} and ${tool} does not offer
+        it. One API, two doors — a parameter reachable from only one of them is the gap this rule exists for.`);
+    });
+  }
+});
+
+describe('the integration guide lists exactly what each route accepts', () => {
+  // The guide calls this table the authoritative list, and a schema description or a reference table is
+  // treated as code here. It had drifted twice: `/query` gained `sort` and `dir` while the table still said
+  // "there is no sort on /query", and `/find-similar` gained nothing while MCP had two extra parameters.
+  const DOC = 'docs/integration-guide/04d-brain-ops-api.md';
+  const rowFor = (route, src) =>
+    src.split('\n').find(l => l.startsWith(`| \`POST /${route}\` |`));
+
+  for (const [route, allowed] of SETS) {
+    it(`${route} row`, () => {
+      const src = readFileSync(DOC, 'utf8');
+      const row = rowFor(route, src);
+      assert.ok(row, `${DOC} has no accepted-fields row for POST /${route}`);
+      const documented = new Set([...row.matchAll(/`([A-Za-z][\w]*)`/g)].map(m => m[1]).filter(k => k !== 'POST'));
+      const undocumented = [...allowed].filter(k => !documented.has(k));
+      assert.deepEqual(undocumented, [], `POST /${route} accepts ${undocumented.join(', ')} and the table does
+        not list them. An integrator reading the guide cannot know the parameter exists.`);
+      const overdocumented = [...documented].filter(k => !allowed.has(k));
+      assert.deepEqual(overdocumented, [], `the table lists ${overdocumented.join(', ')} for POST /${route},
+        which the route answers 400 for. Documenting a refused parameter is worse than omitting it.`);
+    });
+  }
+});
+
+describe('every key the client sends is a key the server allows', () => {
+  // The loop is over the four ROUTES, which are static, so each gets a named test whether or not the client
+  // calls it today. `find-similar` has no UI caller yet; the day one is added it is already covered.
+  for (const [route, allowed] of SETS) {
+    it(route, () => {
+      const sites = clientPosts().filter(p => p.route === route);
+      for (const p of sites) {
+        const rejected = p.keys.filter(k => !allowed.has(k));
+        assert.deepEqual(rejected, [], `${p.file} sends keys /${route} answers 400 unrecognized_keys for: `
+          + `${rejected.join(', ')}. Either the server's allowed set is missing them, or the client is `
+          + 'sending a parameter the route never read.');
+      }
+    });
+  }
+});


### PR DESCRIPTION
Making the brain read bodies strict fixed the lying — a key the server could not honour used to come back `200` with a
wrong answer — but it **moved** the failure rather than removing it. An unknown key is now a `400` in whatever is asking,
and nothing checked that our own declared surfaces stay inside the sets the routes enforce.

Three surfaces declare these parameters. One enforces them.

| surface | who reads it | was it checked? |
|---|---|---|
| `client/src/app/core/brain-api.service.ts` body types | the UI | no |
| MCP tool `inputSchema` | every agent integrator | capabilities only, never parameters |
| the integration guide's accepted-fields table | every human integrator | no |
| `*_BODY_FIELDS` in `brain/query.ts` | **the routes** | is the enforcement |

The client's bodies were verified **by hand** yesterday and were correct — which is exactly when to write the gate,
because a hand-check does not survive the next edit to either side. The other two surfaces were both wrong.

## What the gate found

**`find_similar` accepted `traverse` and `includeContent` on MCP and refused them over REST.** The tool schema advertises
both, its handler implements both, and the REST route read neither. The integration guide described the gap as intended
behaviour — *"the MCP tool … adds `traverse`"*.

So a caller who read the tool schema and switched door got a `400` for a documented parameter. Before the bodies were
strict they got a `200` with an unexpanded answer, which is why it survived this long.

REST implements both now, using **recall's** item shape, cap formula and `stripContentIfAsked` helper rather than a
second copy of them, so the two graph-augmented responses cannot drift. Bad values are refused in recall's exact words.

**The guide's table had drifted the other way too.** It still said *"there is no `sort` on `/query`. It is refused rather
than ignored"* after `sort` and `dir` had been added — the authoritative reference telling integrators a working
parameter would be rejected.

## The measurement was wrong on its first run

`inputSchema` is a **function** of the token-scoped schemas, not a literal. Read as an object it yields
`properties: undefined`, and the diff then reports every REST field as missing from MCP — the exact opposite of the
truth, with `mcp-only: -` on every row to make it look clean.

I believed it for about a minute. The gate now asserts the schema is **materialised**, with real properties, before it
compares anything, because that failure mode is silent and reads as a pass.

## It refuses to pass vacuously

- Call sites are **discovered** by sweeping tracked client sources for a POST to one of the four routes, so a component
  posting directly instead of through `BrainApi` is covered the day it is written. A hand-maintained file list would
  have shared the blind spot with the code it audits.
- An **opaque body** — `Record<string, unknown>`, an index signature, a named interface it cannot read — is a failure
  naming the file, not a silent skip.
- Routes are asserted **by name**, so a regex that stops matching cannot report "no client key is wrong" having looked
  at nothing.
- Every extraction happens **inside** an `it`. At collection time a throw registers zero tests, and `node --test` then
  reports no failures.

Mutation-tested in four places: a bogus client key, an opaque client body, the pre-fix allowed set (the shipped defect —
red, naming both parameters), and the pre-fix docs table.

## A gate that had never stripped a comment locally

`brain-read-bodies-are-strict` reported `traverse` and `includeContent` as missing from a set that lists them. Its
`stripComments` splits on `\n` and then anchors with `$` **without** the `m` flag — so on a Windows checkout every line
still ends with `\r`, `$` can never be reached, and the function returned its input unchanged. The set's prose contains
*"the MCP tool's schema"*, whose apostrophe pairs with the next real quote and swallows every key after it.

It worked in CI, where the checkout is LF, so it had gone unnoticed. The other 50-odd gates in that directory use
`/…$/gm`, where `\r` counts as a line terminator — this one split first and dropped the flag. Checked; it is the only
copy.

## Verified end to end

Six integration assertions against a rebuilt stack. The traversal neighbour is written through the **sync** endpoint, so
it is never embedded — vector search cannot have found it, and its presence *is* the traversal. Both doors are asked the
same question in the same fixture and both reach it, carrying `source`, `hops`, `path` and the edge `label`.

🤖 Generated with Claude Code
