### PR TITLE
fix(mcp): reindex state reaches the door that is told to poll it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **The `reindex` tool told MCP callers to poll something MCP could not reach.** Its own description said the
+  job *"runs in the background and may take minutes, so poll `get_space_meta` or the REST reindex-status route
+  rather than waiting on this call"* — and `get_space_meta` did not carry the reindex state. `needsReindex` was
+  read by one route and by **no tool at all**, so a client with no HTTP door (Claude Desktop, any pure-MCP
+  agent) could start a multi-minute job and never learn it had finished.
+
+  Worse than a missing capability: a schema description is what a caller reads *while constructing arguments*,
+  and one that names a door the reader does not have is the same shape as `recall`'s filter description claiming
+  a post-filter — the wrong sentence was the one being read.
+  - `get_space_meta` and `GET /api/spaces/:id/meta` both report **`needsReindex`** now, `.some()` over the
+    member spaces exactly as `GET /reindex-status` computes it, so a proxy is `true` when any member is.
+  - The `reindex` description names that field instead of a route. The smaller of the two available fixes, and
+    the one that makes the existing sentence true rather than adding a second one.
+  - `GET /api/brain/spaces/:spaceId/reindex-status` is unchanged — this adds a field, it does not move a route.
+  - **Found by the capability × surface matrix**, not by a report: the generator put `reindex-status` in the
+    REST-only column, and reading why turned up the description pointing at it.
+
+### Added
+- **A gate on what a tool description may tell a caller to do.** `tool-descriptions-name-reachable-things.test.js`
+  fails when any of the 41 tool descriptions *directs* the reader to a REST route or a `curl`.
+  - It distinguishes **directing** from **describing**: `create_space` says *"Refusals match POST /api/spaces
+    exactly"*, which is a true parity statement useful to anyone holding both doors. `reindex` said *"poll … the
+    REST reindex-status route"*, which is an instruction half its callers cannot carry out. The check is
+    per-sentence, and a sentence about equivalence is allowed.
+  - Two false positives shaped it before it was right: the parity statement above, and `help` describing its own
+    contents (*"how to choose between query / recall … and the REST API map"*) — where a verb list containing
+    `query` swallowed a tool name. A gate that fires on correct prose gets deleted rather than obeyed.
+  - **Mutation-tested against the sentence that shipped**: restoring it turns the gate red and names `reindex`.
+
+### Fixed
 - **A truncated graph traversal was indistinguishable from a complete one.** `traverseRecallSeeds` ended with
   `collected.slice(0, limit)` and nothing in the response said the slice had happened, so `graphNodes: 7` at
   `topK: 1, traverse: 1` might be the whole neighbourhood or the first 7 of 40. `degraded` does not cover it —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The `reindex` description names that field instead of a route. The smaller of the two available fixes, and
     the one that makes the existing sentence true rather than adding a second one.
   - `GET /api/brain/spaces/:spaceId/reindex-status` is unchanged — this adds a field, it does not move a route.
+  - **The new field had to join `SERVER_OWNED_META_FIELDS`, and CI is what said so.** A caller who `GET`s a
+    space, edits one field and `PATCH`es it back would otherwise get `unrecognized_keys` for a field they
+    never wrote — the exact report that strip exists to answer. `type-schema-crud.test.js` round-trips a real
+    response rather than a hand-built body, so it went red the moment the response grew.
+  - `meta-response-round-trips.test.js` now holds the agreement in seconds rather than in a four-minute
+    Docker suite: every field the meta response emits must be an envelope field or a stripped one.
   - **Found by the capability × surface matrix**, not by a report: the generator put `reindex-status` in the
     REST-only column, and reading why turned up the description pointing at it.
 

--- a/docs/integration-guide/06-spaces-api.md
+++ b/docs/integration-guide/06-spaces-api.md
@@ -433,11 +433,21 @@ type schemas are readable only by tokens that may reach the space.
     }
   },
   "tagSuggestions": ["backend", "frontend"],
-  "stats": { "memories": 142, "entities": 53, "edges": 87, "chrono": 12, "files": 31 }
+  "stats": { "memories": 142, "entities": 53, "edges": 87, "chrono": 12, "files": 31 },
+  "needsReindex": false
 }
 ```
 
-> **MCP tool:** `get_space_meta` — returns the same information. Available to all tokens (not admin-only).
+`needsReindex` is `true` when the space holds embeddings from a different model than the one configured — the
+state `POST /reindex` clears. On a **proxy space** it is `true` when **any** member needs one, matching
+[`GET /reindex-status`](04d-brain-ops-api.md).
+
+It is here because `reindex` returns as soon as the job *starts*: this is the field you poll to learn it
+finished. The dedicated `GET /api/brain/spaces/:spaceId/reindex-status` route still exists and is unchanged.
+
+> **MCP tool:** `get_space_meta` — returns the same information, `needsReindex` included. Available to all
+> tokens (not admin-only). Before this field existed, the `reindex` tool's own description told MCP callers to
+> poll the REST status route — which a client with no HTTP door cannot do.
 
 ---
 

--- a/docs/integration-guide/16-mcp.md
+++ b/docs/integration-guide/16-mcp.md
@@ -182,7 +182,7 @@ row survives its own tool being built, so the list cannot keep advertising a gap
 | `query` | Structured MongoDB filter query (read-only) — supports `memories`, `entities`, `edges`, `chrono`, and `files` collections |
 | `find_similar` | Find entries with high vector similarity to an existing entry by ID — no re-embedding step. Provide `space` to scope to one space, or omit it to search across all accessible spaces (like `recall`). Supports `traverse` (graph expansion). The legacy `crossSpace` flag is deprecated — omit `space` instead |
 | `get_stats` | Return counts of memories, entities, edges, chrono entries, and files |
-| `get_space_meta` | Return the full space schema definition, purpose, usage notes, and stats |
+| `get_space_meta` | Return the full space schema definition, purpose, usage notes, stats, and `needsReindex` — the field to poll after `reindex`, which returns as soon as the job starts |
 | `upsert_entity` | Create or update a named entity (with optional properties) |
 | `update_entity` | Update an existing entity by ID (name, type, description, tags, properties, `excludeFromVectorSearch`); supports `deleteFields` for field removal |
 | `delete_entity` | Delete an entity by ID. Refused when the space has `strictLinkage` and another record still references it — the same rule the REST route enforces. Face labels are unlabelled rather than blocking |

--- a/docs/userguide/02-brain.md
+++ b/docs/userguide/02-brain.md
@@ -20,6 +20,9 @@ it returns you to the tab you were on. The cog is greyed out until a space is se
 The admin list at **Settings → Spaces** is unchanged and remains the place to create, reorder and compare
 spaces; the cog is the shortcut for the one you are working in.
 
+The same state is on both APIs as `needsReindex` on a space's meta, so an agent can check it without watching
+the screen.
+
 If the search index needs rebuilding (for example after the embedding model changes), a banner appears reading *"Embeddings are stale — the embedding model has changed and this space needs reindexing."* Click **Reindex now** to rebuild it.
 
 > **Reindex and rebuild are different repairs.** *Reindex* re-embeds your content against the current model. It does **not** help when the search index itself is missing or broken — the symptom there is search quietly returning nothing at all, with no error. That one needs **Rebuild search indexes** on the space's **Danger** tab (see below).

--- a/docs/userguide/02-brain.md
+++ b/docs/userguide/02-brain.md
@@ -49,6 +49,10 @@ Click **Save**. The memory is indexed immediately and available for search.
 
 **Sorting:** Click a column header with a caret (▾) to sort the list by that column — click again to flip the direction, and a third time to return to the default order. The caret fills in and points up or down to show the active sort. Sorting happens on the server, so it orders the **whole** list across every page, not just the rows currently on screen. Sortable columns vary by tab: **Entities** — Name, Type, Created · **Edges** — From, Relation, To, Weight, Created · **Memories** — Created · **Chrono** — Title, Kind, Status, Starts, Ends, Created.
 
+**Editing:** Click the **⊙ view-details** button on any row to open the full editable drawer — the same drawer
+the entity and edge tabs use. Every field you can set when creating a memory can be changed there, including
+tags, linked entities and properties.
+
 **Deleting:** Each row has a **✕** button. A small inline confirmation appears — click **Yes** to confirm, **No** to cancel.
 
 **Wiping everything:** There is no "Wipe all" button on the Brain toolbar. To clear a space's data, go to **Settings → Spaces → (space) → Danger tab** and use **Wipe all data**. You will be asked to type the space ID to confirm.
@@ -104,6 +108,9 @@ Chrono stores time-anchored entries: events, deadlines, plans, predictions, and 
 **Searching:** The top search bar is **Semantic** (ranks entries by meaning). Plain-text matching (title / description) is the **freetext box under the Title column**.
 
 **Filtering:** The filter bar above the table lets you narrow by tag text and status. Filters apply immediately.
+
+**Editing:** Click the **⊙ view-details** button on any row to open the editable drawer, as on the other record
+tabs. Title, type, dates, status, tags, description and properties can all be changed there.
 
 **Deleting:** Inline ✕ confirmation per row.
 

--- a/scripts/surface-matrix-audit.mjs
+++ b/scripts/surface-matrix-audit.mjs
@@ -1,0 +1,276 @@
+/**
+ * Audit the surface matrix against RUNNING code, not against the regex that produced it.
+ *
+ * `surface-matrix.mjs` finds routes by scanning source for `router.verb('path')`. That is a heuristic, and a
+ * heuristic is exactly what should not be trusted when the answer is "this table is complete". So this script
+ * builds the Express app in process and walks its router stack — the same object the server dispatches on — and
+ * compares the two sets in both directions.
+ *
+ * Three independent claims, each checked against a runtime source of truth:
+ *
+ * 1. **Route completeness.** Every route Express actually serves appears in the static extraction, and every
+ *    route the extraction claims is one Express actually serves. A miss in either direction is a real bug in
+ *    the table: the first hides a route, the second invents one.
+ * 2. **Tool completeness.** Every name in `ALL_TOOLS` appears in the hand-written map. Already enforced by the
+ *    generator, re-checked here so the audit stands alone.
+ * 3. **Mapping soundness.** For each mapped pair, the tool handler and the route handler must reach the same
+ *    underlying module — a shared function, not two implementations. Verified by comparing the imports each
+ *    side pulls from `brain/`, `files/` and `spaces/`; a pair with no shared module is reported for a human to
+ *    look at rather than silently blessed.
+ *
+ * Exit code is non-zero when any claim fails, so this can gate.
+ *
+ * Run: node scripts/surface-matrix-audit.mjs
+ */
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const read = p => readFileSync(join(ROOT, p), 'utf8');
+/**
+ * Comments out, LINE comments first.
+ *
+ * Order is not cosmetic. `api/data.ts:281` reads `// Follow the symlink — useful for /mnt/* or volume-mount
+ * points`, and stripping block comments first treats that `/*` as an opener: it swallows 5,907 characters
+ * through the next `*​/`, taking three route registrations with it. That is how this matrix reported 202 routes
+ * when the routers serve 207. Removing line comments first makes the phantom opener disappear with its line.
+ *
+ * Two files in the tree hit it today (`api/data.ts`, `files/converters/pipeline.ts`), and 33 gates still carry
+ * the other order — tracked as its own item rather than swept here.
+ */
+const strip = s => s.replace(/(^|[^:])\/\/.*/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
+
+const problems = [];
+const note = m => problems.push(m);
+
+// ── 1 · what the STATIC extractor sees (the matrix's own method) ─────────────
+const APP = strip(read('server/src/app.ts'));
+const routerFile = new Map();
+for (const m of APP.matchAll(/import \{ (\w+) \} from '\.\/(api\/[^']+)\.js'/g)) routerFile.set(m[1], `server/src/${m[2]}.ts`);
+const mounts = [];
+for (const m of APP.matchAll(/app\.use\('(\/[^']*)',\s*(\w+)\)/g)) {
+  const file = routerFile.get(m[2]);
+  if (file) mounts.push({ mount: m[1], file });
+}
+const filesFor = file => {
+  if (!file.endsWith('/index.ts')) return [file];
+  const dir = file.slice(0, -'/index.ts'.length);
+  return execFileSync('git', ['ls-files', dir], { cwd: ROOT, encoding: 'utf8' })
+    .split('\n').map(l => l.trim()).filter(l => l.endsWith('.ts'));
+};
+/**
+ * Every route, attributed by the ROUTER IDENTIFIER rather than by which file it sits in.
+ *
+ * `POST /api/spaces/:id/reembed` is registered in `api/spaces-reembed.ts` by a function that takes the router
+ * as a parameter — `registerReembedRoute(spacesRouter)` — so scanning only the router's own file missed it, and
+ * `activity/reset` the same way. The parameter is named after the router, which is what makes identifier
+ * attribution work: `spacesRouter.post('/:id/reembed', …)` maps to the `/api/spaces` mount wherever it lives.
+ */
+const API_ALL = execFileSync('git', ['ls-files', 'server/src/api'], { cwd: ROOT, encoding: 'utf8' })
+  .split('\n').map(l => l.trim()).filter(l => l.endsWith('.ts'));
+
+/**
+ * Router identifier -> mount path, following `use()` chains.
+ *
+ * `app.use('/api/brain', brainRouter)` is only the first hop: `brainRouter.use(memoriesRouter)` and seven
+ * siblings sit inside `api/brain/index.ts`, each with no prefix, so their routes are served under `/api/brain`
+ * while nothing in `app.ts` names them. Stopping at the first hop attributed 115 of 207 routes and called the
+ * other 92 unattributed.
+ *
+ * A PREFIXED nesting (`x.use('/y', sub)`) would need the prefix carried; none exists, and the loop reports one
+ * loudly if it appears rather than quietly mis-attributing its routes.
+ */
+const mountFor = new Map();
+for (const m of APP.matchAll(/app\.use\('(\/[^']*)',\s*(\w+)\)/g)) mountFor.set(m[2], m[1]);
+
+const nestings = [];
+for (const f of API_ALL) {
+  let code;
+  try { code = strip(read(f)); } catch { continue; }
+  for (const m of code.matchAll(/\b(\w*[Rr]outer)\.use\(\s*(?:'([^']*)',\s*)?(\w*[Rr]outer)\s*\)/g)) {
+    nestings.push({ parent: m[1], prefix: m[2] ?? '', child: m[3] });
+  }
+}
+for (let pass = 0; pass < 8; pass++) {
+  let changed = false;
+  for (const { parent, prefix, child } of nestings) {
+    const base = mountFor.get(parent);
+    if (base === undefined || mountFor.has(child)) continue;
+    if (prefix) console.log(`note: ${parent}.use('${prefix}', ${child}) — prefixed nesting, mount is ${base}${prefix}`);
+    mountFor.set(child, `${base}${prefix}`);
+    changed = true;
+  }
+  if (!changed) break;
+}
+
+const staticRoutes = new Set();
+const unattributed = [];
+for (const f of API_ALL) {
+  let code;
+  try { code = strip(read(f)); } catch { continue; }
+  for (const m of code.matchAll(/\b(\w*[Rr]outer)\.(get|post|patch|put|delete)\(\s*'(\/[^']*)'/g)) {
+    const mount = mountFor.get(m[1]);
+    if (!mount) { unattributed.push(`${f}: ${m[1]}.${m[2]}('${m[3]}')`); continue; }
+    staticRoutes.add(`${m[2].toUpperCase()} ${mount}${m[3] === '/' ? '' : m[3]}`);
+  }
+}
+
+// ── 2 · what EXPRESS actually serves ────────────────────────────────────────
+/**
+ * The live `Router` objects, walked directly.
+ *
+ * The first version of this walked `app._router.stack` and recovered each mount path from the layer's regexp.
+ * Express 5 builds those regexps differently (path-to-regexp v8), so it found **5 routes out of 202** and
+ * cheerfully reported the other 197 as "not served" — a completeness check that was itself the least complete
+ * thing in the repo. Reading `express/package.json` (5.2.1) is what settled it.
+ *
+ * Importing each mounted router and reading `router.stack[].route.path` needs no regexp archaeology: the paths
+ * come from the objects the app dispatches on. The MOUNT prefixes still come from `app.use('/api/x', router)`
+ * in source — they are literal strings, and the audit says so rather than implying otherwise.
+ */
+const routerExport = new Map();
+for (const m of APP.matchAll(/import \{ (\w+) \} from '\.\/(api\/[^']+)\.js'/g)) {
+  routerExport.set(m[1], `server/dist/${m[2]}.js`);
+}
+
+/**
+ * Routes on a router, INCLUDING the sub-routers it mounts with a bare `use()`.
+ *
+ * `brainRouter` is an aggregate: `brainRouter.use(memoriesRouter)` and seven siblings, each mounted with no
+ * prefix so their own paths are already complete (`/spaces/:spaceId/memories`). `syncRouter` and
+ * `networksRouter` do the same. Reading only the top-level `.route` layers therefore saw 115 of 202 routes and
+ * reported the other 87 as unserved — the first version of this audit did exactly that.
+ *
+ * A prefixed `use('/x', sub)` would need its mount recovered; none exists today, and if one is added the
+ * `pathPrefix` guard below turns it into a loud failure rather than a silent undercount.
+ */
+function collect(router, mount, out) {
+  for (const layer of router.stack ?? []) {
+    if (layer.route) {
+      const path = layer.route.path;
+      if (typeof path !== 'string') continue;
+      const full = `${mount}${path === '/' ? '' : path}`;
+      for (const [method, on] of Object.entries(layer.route.methods ?? {})) {
+        if (on && method !== '_all') out.add(`${method.toUpperCase()} ${full}`);
+      }
+      continue;
+    }
+    const sub = layer.handle;
+    if (typeof sub === 'function' && Array.isArray(sub.stack)) {
+      // `layer.path` is '/' for a bare use(); anything else means a prefix this walk would drop.
+      const prefix = typeof layer.path === 'string' && layer.path !== '/' ? layer.path : '';
+      if (prefix) {
+        note(`a sub-router is mounted at '${prefix}' under ${mount} — this walk assumes bare use(); `
+          + 'the count below is not trustworthy until it handles the prefix');
+      }
+      collect(sub, `${mount}${prefix}`, out);
+    }
+  }
+}
+
+let runtimeRoutes = new Set();
+let runtimeOk = true;
+for (const m of APP.matchAll(/app\.use\('(\/[^']*)',\s*(\w+)\)/g)) {
+  const [, mount, ident] = m;
+  const dist = routerExport.get(ident);
+  if (!dist) continue;                       // not a router import (middleware, etc.)
+  try {
+    const mod = await import(`file://${join(ROOT, dist)}`);
+    const router = mod[ident];
+    if (!router?.stack) { note(`${ident} exported no router stack — ${mount} is UNVERIFIED`); runtimeOk = false; continue; }
+    collect(router, mount, runtimeRoutes);
+  } catch (err) {
+    note(`importing ${dist} failed (${err.message}) — ${mount} is UNVERIFIED, which is a gap and not a pass`);
+    runtimeOk = false;
+  }
+}
+
+if (runtimeRoutes.size === 0) {
+  note('no routes were enumerated at runtime — the comparison below would be vacuous');
+  runtimeOk = false;
+}
+
+if (runtimeOk) {
+  const onlyRuntime = [...runtimeRoutes].filter(r => !staticRoutes.has(r)).sort();
+  const onlyStatic = [...staticRoutes].filter(r => !runtimeRoutes.has(r)).sort();
+  if (onlyRuntime.length) note(`routes the router SERVES that the matrix misses (${onlyRuntime.length}):\n    ${onlyRuntime.join('\n    ')}`);
+  if (onlyStatic.length) note(`routes the matrix claims that no router serves (${onlyStatic.length}):\n    ${onlyStatic.join('\n    ')}`);
+  console.log(`routes — live routers ${runtimeRoutes.size}, static extraction ${staticRoutes.size}, `
+    + `disagreement ${onlyRuntime.length + onlyStatic.length}`);
+}
+
+// ── 3 · tool completeness, from the registry ────────────────────────────────
+const { ALL_TOOLS } = await import(`file://${join(ROOT, 'server/dist/mcp/tools/index.js')}`);
+const matrixSrc = read('scripts/surface-matrix.mjs');
+const mapped = new Set([...matrixSrc.matchAll(/\['[^']*', '([a-z_0-9]+)',/g)].map(m => m[1]));
+const unmapped = ALL_TOOLS.map(t => t.name).filter(n => !mapped.has(n));
+if (unmapped.length) note(`tools absent from the map: ${unmapped.join(', ')}`);
+console.log(`tools — registry ${ALL_TOOLS.length}, mapped ${mapped.size}`);
+
+// ── 4 · mapping soundness: do the two doors reach the same module? ──────────
+const TOOL_FILES = execFileSync('git', ['ls-files', 'server/src/mcp/tools'], { cwd: ROOT, encoding: 'utf8' })
+  .split('\n').map(l => l.trim()).filter(l => l.endsWith('.ts'));
+const API_FILES = execFileSync('git', ['ls-files', 'server/src/api'], { cwd: ROOT, encoding: 'utf8' })
+  .split('\n').map(l => l.trim()).filter(l => l.endsWith('.ts'));
+
+/** Modules under brain/ files/ spaces/ that a source file imports. */
+const DOMAIN_DIRS = 'brain|files|spaces|auth|sync|networks|config|metrics|quota';
+/**
+ * Static AND dynamic imports.
+ *
+ * `list_tokens` reaches its implementation with `await import('../../auth/tokens.js')` inside the handler, so a
+ * `from '…'`-only regex reported it as sharing nothing with `GET /api/tokens` — which imports the same module
+ * statically. One flagged pair, entirely the detector's fault.
+ */
+const domainImports = src => new Set(
+  [...src.matchAll(new RegExp(`(?:from|import\\()\\s*'(?:\\.\\./)+(${DOMAIN_DIRS})/([\\w-]+)\\.js'`, 'g'))]
+    .map(m => `${m[1]}/${m[2]}`));
+
+const toolImports = new Map();
+for (const f of TOOL_FILES) {
+  const src = read(f);
+  for (const m of src.matchAll(/^\s*name: '([a-z_0-9]+)',$/gm)) toolImports.set(m[1], domainImports(src));
+}
+const apiImports = new Map();
+for (const f of API_FILES) apiImports.set(f, domainImports(read(f)));
+
+/** Which api file registers a given route path? */
+function apiFileFor(route) {
+  const [, path] = route.split(' ');
+  for (const { mount, file } of mounts) {
+    if (!path.startsWith(mount)) continue;
+    const sub = path.slice(mount.length) || '/';
+    for (const f of filesFor(file)) {
+      const code = strip(read(f));
+      if (code.includes(`'${sub}'`)) return f;
+    }
+  }
+  return null;
+}
+
+const pairs = [...matrixSrc.matchAll(/\['[^']*', '([a-z_0-9]+)', (?:'([A-Z]+ [^']+)'|null)/g)]
+  .map(m => ({ tool: m[1], route: m[2] ?? null }));
+const noShared = [];
+for (const { tool, route } of pairs) {
+  if (!route) continue;
+  const f = apiFileFor(route);
+  if (!f) { noShared.push(`${tool} -> ${route} (route file not found)`); continue; }
+  const a = toolImports.get(tool) ?? new Set();
+  const b = apiImports.get(f) ?? new Set();
+  const shared = [...a].filter(x => b.has(x));
+  if (shared.length === 0) noShared.push(`${tool} -> ${route} (no shared brain/files/spaces module)`);
+}
+if (noShared.length) {
+  console.log(`\npairs with no shared implementation module (${noShared.length}) — each needs a human look, `
+    + 'they are not necessarily wrong:');
+  for (const n of noShared) console.log(`    ${n}`);
+}
+
+// ── verdict ─────────────────────────────────────────────────────────────────
+if (problems.length) {
+  console.error(`\nAUDIT FAILED — ${problems.length} problem(s):`);
+  for (const p of problems) console.error(`  · ${p}`);
+  process.exit(1);
+}
+console.log('\nAUDIT PASSED — routes agree with Express, every tool is mapped.');

--- a/scripts/surface-matrix.mjs
+++ b/scripts/surface-matrix.mjs
@@ -14,14 +14,25 @@ import { join } from 'node:path';
 
 const ROOT = process.cwd();
 const read = p => readFileSync(join(ROOT, p), 'utf8');
-const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*/gm, '$1');
+/**
+ * Comments out, LINE comments first.
+ *
+ * Order is not cosmetic. `api/data.ts:281` reads `// Follow the symlink — useful for /mnt/* or volume-mount
+ * points`, and stripping block comments first treats that `/*` as an opener: it swallows 5,907 characters
+ * through the next `*​/`, taking three route registrations with it. That is how this matrix reported 202 routes
+ * when the routers serve 207. Removing line comments first makes the phantom opener disappear with its line.
+ *
+ * Two files in the tree hit it today (`api/data.ts`, `files/converters/pipeline.ts`), and 33 gates still carry
+ * the other order — tracked as its own item rather than swept here.
+ */
+const strip = s => s.replace(/(^|[^:])\/\/.*/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 
 // ── routes, as before ───────────────────────────────────────────────────────
 const APP = strip(read('server/src/app.ts'));
 const routerFile = new Map();
 for (const m of APP.matchAll(/import \{ (\w+) \} from '\.\/(api\/[^']+)\.js'/g)) routerFile.set(m[1], `server/src/${m[2]}.ts`);
 const mounts = [];
-for (const m of APP.matchAll(/app\.use\('(\/api\/[^']*)',\s*(\w+)\)/g)) {
+for (const m of APP.matchAll(/app\.use\('(\/[^']*)',\s*(\w+)\)/g)) {
   const file = routerFile.get(m[2]);
   if (file) mounts.push({ mount: m[1], file });
 }
@@ -31,22 +42,81 @@ const filesFor = file => {
   return execFileSync('git', ['ls-files', dir], { cwd: ROOT, encoding: 'utf8' })
     .split('\n').map(l => l.trim()).filter(l => l.endsWith('.ts'));
 };
+const API_ALL = execFileSync('git', ['ls-files', 'server/src/api'], { cwd: ROOT, encoding: 'utf8' })
+  .split('\n').map(l => l.trim()).filter(l => l.endsWith('.ts'));
+
+/**
+ * Router identifier -> mount path, following `use()` chains.
+ *
+ * `app.use('/api/brain', brainRouter)` is only the first hop: `brainRouter.use(memoriesRouter)` and seven
+ * siblings sit inside `api/brain/index.ts`, each with no prefix, so their routes are served under `/api/brain`
+ * while nothing in `app.ts` names them. Stopping at the first hop attributed 115 of 207 routes and called the
+ * other 92 unattributed.
+ *
+ * A PREFIXED nesting (`x.use('/y', sub)`) would need the prefix carried; none exists, and the loop reports one
+ * loudly if it appears rather than quietly mis-attributing its routes.
+ */
+const mountFor = new Map();
+for (const m of APP.matchAll(/app\.use\('(\/[^']*)',\s*(\w+)\)/g)) mountFor.set(m[2], m[1]);
+
+const nestings = [];
+for (const f of API_ALL) {
+  let code;
+  try { code = strip(read(f)); } catch { continue; }
+  for (const m of code.matchAll(/\b(\w*[Rr]outer)\.use\(\s*(?:'([^']*)',\s*)?(\w*[Rr]outer)\s*\)/g)) {
+    nestings.push({ parent: m[1], prefix: m[2] ?? '', child: m[3] });
+  }
+}
+for (let pass = 0; pass < 8; pass++) {
+  let changed = false;
+  for (const { parent, prefix, child } of nestings) {
+    const base = mountFor.get(parent);
+    if (base === undefined || mountFor.has(child)) continue;
+    if (prefix) console.log(`note: ${parent}.use('${prefix}', ${child}) — prefixed nesting, mount is ${base}${prefix}`);
+    mountFor.set(child, `${base}${prefix}`);
+    changed = true;
+  }
+  if (!changed) break;
+}
+
 const routes = new Set();
 const routeArea = new Map();
-for (const { mount, file } of mounts) {
-  for (const f of filesFor(file)) {
-    let code;
-    try { code = strip(read(f)); } catch { continue; }
-    for (const m of code.matchAll(/\b\w*[Rr]outer\.(get|post|patch|put|delete)\(\s*'(\/[^']*)'/g)) {
-      const key = `${m[1].toUpperCase()} ${mount}${m[2] === '/' ? '' : m[2]}`;
-      routes.add(key);
-      routeArea.set(key, mount);
-    }
+const unattributed = [];
+for (const f of API_ALL) {
+  let code;
+  try { code = strip(read(f)); } catch { continue; }
+  for (const m of code.matchAll(/\b(\w*[Rr]outer)\.(get|post|patch|put|delete)\(\s*'(\/[^']*)'/g)) {
+    const mount = mountFor.get(m[1]);
+    if (!mount) { unattributed.push(`${f}: ${m[1]}.${m[2]}('${m[3]}')`); continue; }
+    const key = `${m[2].toUpperCase()} ${mount}${m[3] === '/' ? '' : m[3]}`;
+    routes.add(key);
+    routeArea.set(key, mount);
   }
+}
+if (unattributed.length) {
+  console.error(`route registrations on an unknown router (${unattributed.length}) — the table is INCOMPLETE:`);
+  for (const u of unattributed) console.error(`    ${u}`);
+  process.exit(1);
 }
 
 const { ALL_TOOLS } = await import(`file://${join(ROOT, 'server/dist/mcp/tools/index.js')}`);
 const tools = new Set(ALL_TOOLS.map(t => t.name));
+const { ROUTE_RIGHTS, NOT_AREA_SCOPED } = await import(`file://${join(ROOT, 'server/dist/auth/space-rights.js')}`);
+
+/** `METHOD route` -> the rung a token needs, from the rights matrix that actually gates the request. */
+const RUNG = new Map(ROUTE_RIGHTS.map(r => [`${r.method} ${r.route}`, r.needs]));
+const AREA_OF = new Map(ROUTE_RIGHTS.map(r => [`${r.method} ${r.route}`, r.area]));
+const EXEMPT_ROUTES = new Set(NOT_AREA_SCOPED.map(r => r.route));
+
+/**
+ * What a TOKEN needs, per door.
+ *
+ * REST comes from `ROUTE_RIGHTS` — the per-space area and rung the middleware enforces. MCP has a coarser gate:
+ * `mutating` tools are hidden from a read-only token and `admin` tools from a non-admin one, which maps onto the
+ * same three rungs. Reporting both is the point: a tool hidden from a token whose REST route would have accepted
+ * it (or the reverse) is a real asymmetry, and it is invisible unless the two are put side by side.
+ */
+const toolRung = t => (t.admin ? 'admin' : t.mutating ? 'write' : 'read');
 
 // ── the mapping, by hand and verified ───────────────────────────────────────
 // `null` REST means the capability exists on MCP only; a note says why.
@@ -122,21 +192,47 @@ function hits(list, tool, route) {
   return out;
 }
 
-const rows = MAP.map(([area, tool, route, note]) => ({
-  area, tool, route, note,
-  guide: hits(GUIDE, tool, route),
-  user: hits(USER, tool, route),
-  changelog: hits(CHANGELOG, tool, route).length > 0 || hits(ARCHIVE, tool, route).length > 0,
-}));
+const rows = MAP.map(([area, tool, route, note]) => {
+  const t = ALL_TOOLS.find(x => x.name === tool);
+  const mcpRung = toolRung(t);
+  const restRung = route ? (RUNG.get(route) ?? (EXEMPT_ROUTES.has(route.split(' ').slice(1).join(' ')) ? 'exempt' : null)) : null;
+  return {
+    area, tool, route, note, mcpRung, restRung,
+    restArea: route ? (AREA_OF.get(route) ?? null) : null,
+    guide: hits(GUIDE, tool, route),
+    user: hits(USER, tool, route),
+    changelog: hits(CHANGELOG, tool, route).length > 0 || hits(ARCHIVE, tool, route).length > 0,
+  };
+});
 
 const cell = a => (a.length ? a.join(', ') : '**—**');
+
+/**
+ * One cell for the token requirement.
+ *
+ * `read` / `write` / `admin` when both doors agree — the common case, and what a reader wants at a glance. When
+ * they differ, BOTH are named with the door, because that difference is the interesting thing: it means the same
+ * capability is reachable by tokens of different strength depending on which client you happen to hold.
+ */
+function rungCell(r) {
+  if (!r.route) return `${r.mcpRung} (MCP)`;
+  // The per-space rights matrix governs SPACE-scoped areas. `/api/spaces`, `/api/tokens` and `/api/networks`
+  // are instance-level and deliberately outside it, so 'no row' there is the design rather than a gap.
+  if (r.restRung === null) return `${r.mcpRung} (MCP) · instance-level`;
+  if (r.restRung === 'exempt') return `${r.mcpRung} (MCP) · REST exempt`;
+  const area = r.restArea ? ` \`${r.restArea}\`` : '';
+  if (r.restRung === r.mcpRung) return `${r.restRung}${area}`;
+  return `**REST ${r.restRung}${area} · MCP ${r.mcpRung}**`;
+}
+
 const out = [];
-out.push('| capability | MCP tool | REST route | integration guide | userguide | CHANGELOG |');
-out.push('|---|---|---|---|---|---|');
+out.push('| capability | MCP tool | REST route | token needs | integration guide | userguide | CHANGELOG |');
+out.push('|---|---|---|---|---|---|---|');
 let area = null;
 for (const r of rows) {
-  if (r.area !== area) { area = r.area; out.push(`| **${area}** | | | | | |`); }
-  out.push(`| | \`${r.tool}\` | ${r.route ? `\`${r.route}\`` : '**MCP only**'} | ${cell(r.guide)} | ${cell(r.user)} | ${r.changelog ? 'y' : '**—**'} |`);
+  if (r.area !== area) { area = r.area; out.push(`| **${area}** | | | | | | |`); }
+  out.push(`| | \`${r.tool}\` | ${r.route ? `\`${r.route}\`` : '**MCP only**'} | ${rungCell(r)} `
+    + `| ${cell(r.guide)} | ${cell(r.user)} | ${r.changelog ? 'y' : '**—**'} |`);
 }
 
 // ── REST routes no tool covers ──────────────────────────────────────────────
@@ -156,9 +252,13 @@ for (const [a, list] of [...byArea].sort((x, y) => y[1].length - x[1].length)) {
 
 writeFileSync(join(ROOT, 'todo/_matrix-capabilities.md'), out.join('\n'), 'utf8');
 writeFileSync(join(ROOT, 'todo/_matrix-rest-only.md'), rest.join('\n'), 'utf8');
+const rungMismatch = rows.filter(r => r.route && r.restRung && r.restRung !== 'exempt' && r.restRung !== r.mcpRung);
+const noRightsRow = rows.filter(r => r.route && r.restRung === null);
 console.log(JSON.stringify({
   capabilities: rows.length, routes: routes.size, restOnly: restOnly.length,
   noGuide: rows.filter(r => !r.guide.length).length,
   noUser: rows.filter(r => !r.user.length).length,
   noChangelog: rows.filter(r => !r.changelog).length,
+  rungMismatch: rungMismatch.map(r => `${r.tool}: REST ${r.restRung} vs MCP ${r.mcpRung}`),
+  noRightsRow: noRightsRow.map(r => `${r.tool} -> ${r.route}`),
 }));

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -6,7 +6,7 @@ import { requireAuth, requireSpaceAuthScoped, requireAdmin, requireAdminMfa, req
 import { globalRateLimit } from '../rate-limit/middleware.js';
 import { getConfig, saveConfig, getSecrets, getDataRoot, getSchemaLibrary, getDocumentProcessingConfig, getMediaEmbeddingConfig, getStorageConfig } from '../config/loader.js';
 import { capDocExtractionMode } from '../files/converters/extraction-level.js';
-import { slugify, SPACE_PURPOSE_MAX } from '../spaces/_shared.js';
+import { slugify, SPACE_PURPOSE_MAX, needsReindex } from '../spaces/_shared.js';
 import { createSpace, removeSpace } from '../spaces/lifecycle.js';
 import { renameSpace } from '../spaces/rename.js';
 import { updateSpace, reorderSpaces, spaceDescriptionAlias, spaceResponse } from '../spaces/spaces.js';
@@ -406,7 +406,17 @@ spacesRouter.get('/:id/meta', globalRateLimit, requireSpaceAuthScoped('id'), asy
     files: counts.reduce((s, c) => s + c.files, 0),
   };
 
+  // Reindex state travels with the meta on BOTH doors. The `reindex` tool's own description tells a caller to
+  // "poll `get_space_meta` or the REST reindex-status route" after starting a job — and `get_space_meta` did not
+  // carry it, so for an MCP-only client (Claude Desktop, any agent with no HTTP door) the sentence named
+  // something unreachable. A schema description is read while arguments are being constructed; one that points
+  // at a door the reader does not have is worse than silence.
+  //
+  // `.some()` over the members, matching `GET /reindex-status`: a proxy needs a reindex when any member does.
+  const reindexNeeded = memberIds.some(mid => needsReindex(mid));
+
   // Strip previousVersions from public response (available via dedicated endpoint if needed)
+  // (`needsReindex` is attached where the response is assembled, just below.)
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { previousVersions: _pv, ...metaPublic } = meta;
 
@@ -415,6 +425,7 @@ spacesRouter.get('/:id/meta', globalRateLimit, requireSpaceAuthScoped('id'), asy
     spaceName: space.label,
     ...metaPublic,
     stats,
+    needsReindex: reindexNeeded,
   });
 });
 

--- a/server/src/mcp/tools/spaces.ts
+++ b/server/src/mcp/tools/spaces.ts
@@ -5,7 +5,7 @@ import { resolveMemberSpaces } from '../../spaces/proxy.js';
 import { memberSpacesWithin } from '../../spaces/proxy-scoped.js';
 import { WIPE_COLLECTION_TYPES, type WipeCollectionType, wipeSpace } from '../../spaces/lifecycle.js';
 import { updateSpace, spacePurpose } from '../../spaces/spaces.js';
-import { SPACE_PURPOSE_MAX } from '../../spaces/_shared.js';
+import { SPACE_PURPOSE_MAX, needsReindex } from '../../spaces/_shared.js';
 
 export const list_spacesTool: ToolHandler = {
   name: 'list_spaces',
@@ -91,7 +91,11 @@ export const get_statsTool: ToolHandler = {
 export const get_space_metaTool: ToolHandler = {
   name: 'get_space_meta',
   description:
-        'Returns the schema, purpose, usage notes, validation mode, and entry counts for this space. ' +
+        // Deliberately NOT the words "reindex state": `mcp-help.test.js` holds that a read-only token is never told
+        // the name of a tool it cannot call, and `reindex` is one. Naming the STATE rather than the repair is also
+        // the more useful sentence for a reader who cannot perform the repair — `needsReindex` still names the field.
+        'Returns the schema, purpose, usage notes, validation mode, entry counts and whether the stored '
+        + 'embeddings are stale (`needsReindex`) for this space. ' +
         'Call this before writing to an unfamiliar space to learn what entity types, edge labels, ' +
         'required properties, and naming patterns are expected.',
   spaceRequired: true,
@@ -133,6 +137,10 @@ export const get_space_metaTool: ToolHandler = {
         chrono: metaCounts.reduce((s, c) => s + c.chrono, 0),
         files: metaCounts.reduce((s, c) => s + c.files, 0),
       },
+      // The field `reindex`'s description has always told callers to poll for. It was only ever on the REST
+      // route, so an MCP-only client could START a multi-minute job and never learn it had finished. Same
+      // `.some()` over members the REST side uses: a proxy needs a reindex when any member does.
+      needsReindex: metaMemberIds.some(mid => needsReindex(mid)),
     };
     return {
       content: [{
@@ -463,7 +471,7 @@ export const reindexTool: ToolHandler = {
   name: 'reindex',
   description: 'Re-embed every record in a space with the currently configured embedding model — the recovery path '
     + 'after changing embedder or model. Requires an admin token. Returns as soon as the job STARTS: it runs in the '
-    + 'background and may take minutes, so poll `get_space_meta` or the REST reindex-status route rather than waiting '
+    + 'background and may take minutes, so poll `get_space_meta` — its `needsReindex` field — rather than waiting '
     + 'on this call. One job per instance at a time; a second call while one is running is refused. A PROXY space is '
     + 'refused by name — it has no index of its own, and its members are listed in the error so you can reindex them '
     + 'instead. Idempotent: re-embedding a record that is already current is harmless.',

--- a/server/src/spaces/body-schemas.ts
+++ b/server/src/spaces/body-schemas.ts
@@ -136,7 +136,7 @@ export const SpaceMetaBody = z.object({
 }).strict();
 
 /**
- * The three fields the server OWNS: it writes them, `GET` returns them, and a caller may not set them.
+ * The fields the server OWNS: it writes them, `GET` returns them, and a caller may not set them.
  *
  * They are stripped from an incoming `meta` rather than rejected by `.strict()`. Reported by an integrator
  * doing the obvious thing — `GET` a space, edit one field of `meta.typeSchemas`, `PATCH` it back — and getting
@@ -144,16 +144,27 @@ export const SpaceMetaBody = z.object({
  * *"either merge, or do not return what you will not accept"*, and this is the second half; the merge half
  * already shipped as `mergeSpaceMeta`.
  *
- * **Only these three, and `.strict()` still rejects everything else.** That distinction is the whole design:
+ * **Only these, and `.strict()` still rejects everything else.** That distinction is the whole design:
  * a key the server itself emitted is echo-back noise and dropping it costs the caller nothing, while an
  * unknown key is a typo — and silently ignoring `validationMdoe` would let someone believe they had turned
  * validation on. Stripping everything would trade a real diagnostic for a convenience.
  *
- * The dry-run endpoint has stripped exactly these three since it was written, so before this the two endpoints
+ * The dry-run endpoint has stripped exactly these since it was written, so before this the two endpoints
  * disagreed about whether a round-tripped body was acceptable. One of them had to be wrong; the one that
  * accepted it was right.
+ *
+ * ## `needsReindex` joined the list, and the round-trip test is why
+ *
+ * It is derived state on the meta response — whether the space holds embeddings from a different model — added
+ * so an MCP caller can poll after `reindex`. The moment `GET` returned it, a caller doing the obvious thing
+ * (`GET`, edit one field, `PATCH` it back) got `unrecognized_keys` for a field they never wrote, which is
+ * exactly the report this strip exists to answer. CI caught it: `type-schema-crud.test.js` round-trips a real
+ * response rather than a hand-built body, so it fails the moment the response grows a field the PATCH refuses.
+ *
+ * The rule for anything added to this response in future: **derived, server-written, and echoed back means it
+ * belongs here** — otherwise "do not return what you will not accept" is broken again.
  */
-export const SERVER_OWNED_META_FIELDS = ['version', 'updatedAt', 'previousVersions'] as const;
+export const SERVER_OWNED_META_FIELDS = ['version', 'updatedAt', 'previousVersions', 'needsReindex'] as const;
 
 /** Drop the server-owned housekeeping fields from an incoming `meta`, leaving everything else to Zod. */
 export function stripServerOwnedMeta(meta: unknown): unknown {

--- a/server/src/spaces/meta-update.ts
+++ b/server/src/spaces/meta-update.ts
@@ -170,9 +170,9 @@ export function planSpaceMetaUpdate(input: {
   }
 
   // Accept what we emit: a caller who GETs a space, edits one field and PATCHes it back is doing the obvious
-  // thing, and `version`/`updatedAt`/`previousVersions` come straight out of our own response. Stripped, not
-  // rejected — and ONLY these three, so `.strict()` still catches a typo like `validationMdoe`, which someone
-  // would otherwise believe had turned validation on. See SERVER_OWNED_META_FIELDS.
+  // thing, and `version`/`updatedAt`/`previousVersions`/`needsReindex` come straight out of our own response.
+  // Stripped, not rejected — and ONLY those, so `.strict()` still catches a typo like `validationMdoe`, which
+  // someone would otherwise believe had turned validation on. See SERVER_OWNED_META_FIELDS.
   const bodyForParse = body != null && typeof body === 'object' && !Array.isArray(body)
     ? { ...(body as Record<string, unknown>), ...('meta' in (body as object) ? { meta: stripServerOwnedMeta((body as { meta?: unknown }).meta) } : {}) }
     : body;

--- a/testing/integration/schema-validation.test.js
+++ b/testing/integration/schema-validation.test.js
@@ -19,6 +19,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { INSTANCES, post, get, patch, put } from '../sync/helpers.js';
+import { openMcpSession } from '../sync/mcp-session.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
@@ -395,6 +396,43 @@ describe('Schema validation — GET /api/spaces/:id/meta', () => {
     assert.ok(typeof r.body.stats === 'object', 'Response should have stats');
     // previousVersions should be stripped from public response
     assert.equal(r.body.previousVersions, undefined, 'previousVersions should be stripped');
+  });
+
+  it('reports needsReindex, the field the reindex tool tells callers to poll', async () => {
+    // `reindex` returns as soon as the job STARTS, and its description says to poll `get_space_meta`. That was
+    // only true over REST until now: `needsReindex` reached no tool, so a client with no HTTP door could start a
+    // multi-minute job and never learn it finished. Asserted as a BOOLEAN rather than for truthiness — an
+    // absent field and a `false` one are the same to `if (!x)` and opposite to a caller polling for a change.
+    const r = await get(INSTANCES.a, token(), `/api/spaces/${TEST_SPACE}/meta`);
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal(typeof r.body.needsReindex, 'boolean', `needsReindex must be present: ${JSON.stringify(r.body.needsReindex)}`);
+
+    // And it agrees with the dedicated route, which is the thing it was added to replace polling.
+    const status = await get(INSTANCES.a, token(), `/api/brain/spaces/${TEST_SPACE}/reindex-status`);
+    assert.equal(status.status, 200, JSON.stringify(status.body));
+    assert.equal(r.body.needsReindex, status.body.needsReindex,
+      'two answers to one question must not disagree');
+  });
+
+  it('MCP get_space_meta reports the same field', async (t) => {
+    // The whole point: the door that was told to poll can now poll.
+    let session;
+    try {
+      session = await openMcpSession(token());
+    } catch (e) {
+      return t.skip(`MCP session unavailable: ${e.message}`);
+    }
+    try {
+      const res = await session.callTool('get_space_meta', { space: TEST_SPACE });
+      const text = res?.content?.[0]?.text ?? '';
+      const meta = JSON.parse(text);
+      assert.equal(typeof meta.needsReindex, 'boolean',
+        `get_space_meta must carry needsReindex: ${text.slice(0, 200)}`);
+      const status = await get(INSTANCES.a, token(), `/api/brain/spaces/${TEST_SPACE}/reindex-status`);
+      assert.equal(meta.needsReindex, status.body.needsReindex, 'both doors, one answer');
+    } finally {
+      session.close();
+    }
   });
 });
 

--- a/testing/standalone/meta-response-round-trips.test.js
+++ b/testing/standalone/meta-response-round-trips.test.js
@@ -1,0 +1,84 @@
+/**
+ * Every field `GET /api/spaces/:id/meta` emits can be PATCHed straight back.
+ *
+ * ## The report this answers, and the way it keeps coming back
+ *
+ * An integrator did the obvious thing — `GET` a space, edit one field of `meta.typeSchemas`, `PATCH` it back —
+ * and got `unrecognized_keys` for three fields they never wrote and could not have known to remove. Their ask
+ * was *"either merge, or do not return what you will not accept"*, and `SERVER_OWNED_META_FIELDS` is the second
+ * half of the answer: those fields are stripped from an incoming body rather than refused.
+ *
+ * **It broke again the moment the response grew a field.** `needsReindex` was added so an MCP caller could poll
+ * after `reindex`, and `type-schema-crud.test.js` went red in CI — it round-trips a real response rather than a
+ * hand-built body, which is the only reason it noticed. That is a good test and a slow signal: it needs Docker,
+ * Mongo, and four minutes.
+ *
+ * This gate is the fast half. It reads the fields the handler assembles and requires each one to be either a
+ * known envelope field or a member of the strip list — so adding a field to the response and forgetting the
+ * strip fails in seconds, at the desk, instead of in CI.
+ *
+ * ## Why the envelope list is spelled out here
+ *
+ * `spaceId`, `spaceName` and `stats` sit OUTSIDE `meta` in the response, and a caller peels them off before
+ * PATCHing `{meta}` back — the integration test's own `metaFrom` does exactly that. They are not in the strip
+ * list and must not be: `.strict()` refusing `spaceId` inside `meta` is correct.
+ *
+ * Run: node --test testing/standalone/meta-response-round-trips.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const { SERVER_OWNED_META_FIELDS } = await import('../../server/dist/spaces/body-schemas.js');
+
+/** Line comments first — see `Q-1`: a `/*` inside a `//` comment otherwise opens a phantom block. */
+const strip = s => s.replace(/(^|[^:])\/\/.*/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
+
+/** Fields that live outside `meta` in the response, which a caller peels off rather than sending back. */
+const ENVELOPE = new Set(['spaceId', 'spaceName', 'stats']);
+
+/** The `res.json({...})` the meta GET handler assembles, as a list of top-level keys. */
+function metaResponseKeys() {
+  const src = strip(readFileSync('server/src/api/spaces.ts', 'utf8'));
+  const at = src.indexOf("spacesRouter.get('/:id/meta'");
+  assert.ok(at > -1, 'the meta route moved — this gate reads it by name');
+  // The handler's own res.json, not a later one.
+  const body = src.slice(at, src.indexOf('spacesRouter.', at + 30));
+  const json = body.slice(body.indexOf('res.json({'));
+  const close = json.indexOf('});');
+  assert.ok(close > 0, 'could not find the end of the response object');
+  const literal = json.slice('res.json({'.length, close);
+  return [...literal.matchAll(/^\s*(?:\.\.\.)?(\w+)\s*[:,]/gm)].map(m => m[1]);
+}
+
+describe('the meta response and the PATCH strip agree', () => {
+  const keys = metaResponseKeys();
+
+  it('the extraction found the response, not an empty string', () => {
+    // Without this the loop below passes for ever on a regex that stopped matching.
+    assert.ok(keys.length >= 4, `expected several response fields, got ${JSON.stringify(keys)}`);
+    assert.ok(keys.includes('spaceId'), `expected spaceId among ${JSON.stringify(keys)}`);
+  });
+
+  it('every emitted field is an envelope field, the meta spread, or stripped on the way back in', () => {
+    const stripped = new Set(SERVER_OWNED_META_FIELDS);
+    const offenders = keys.filter(k => !ENVELOPE.has(k) && !stripped.has(k) && k !== 'metaPublic' && k !== 'meta');
+    assert.deepEqual(offenders, [], `these fields are returned but would be refused on PATCH: ${offenders.join(', ')}. `
+      + 'Add each to SERVER_OWNED_META_FIELDS (derived and server-written) or to the envelope, or stop returning it '
+      + '— "do not return what you will not accept".');
+  });
+
+  it('needsReindex specifically, because it is the one that broke this', () => {
+    assert.ok(keys.includes('needsReindex'), 'the reindex state must still be on the response — `reindex` tells '
+      + 'callers to poll it');
+    assert.ok(SERVER_OWNED_META_FIELDS.includes('needsReindex'), 'and must still be stripped on the way back in');
+  });
+
+  it('the strip stays SMALL — it is not a licence to ignore unknown keys', () => {
+    // The distinction is the whole design: an echoed-back field costs the caller nothing to drop, while
+    // silently ignoring `validationMdoe` would let someone believe they had turned validation on.
+    assert.ok(SERVER_OWNED_META_FIELDS.length <= 6,
+      `${SERVER_OWNED_META_FIELDS.length} stripped fields is heading towards "accept anything": `
+      + SERVER_OWNED_META_FIELDS.join(', '));
+  });
+});

--- a/testing/standalone/tool-descriptions-name-reachable-things.test.js
+++ b/testing/standalone/tool-descriptions-name-reachable-things.test.js
@@ -1,0 +1,100 @@
+/**
+ * A tool description must not send an MCP caller to a REST route.
+ *
+ * ## The defect this was written for
+ *
+ * `reindex`'s description said: *"it runs in the background and may take minutes, so poll `get_space_meta` or
+ * the REST reindex-status route rather than waiting on this call."*
+ *
+ * `get_space_meta` did not carry the reindex state. `needsReindex` was read by one route and by no tool at all.
+ * So the only actually-working half of that sentence was the REST one — and for a pure-MCP client (Claude
+ * Desktop, any agent with no HTTP door) the description named something it could not reach.
+ *
+ * That is worse than a missing capability. A schema description is what a caller reads *while constructing
+ * arguments*, `help()` says so in as many words, and nobody reports a capability they were told to get
+ * elsewhere. It is the same shape as `recall`'s filter description claiming a post-filter: the wrong sentence
+ * was the one being read.
+ *
+ * ## What this gate holds
+ *
+ * 1. No tool description tells the reader to use a REST route or a `curl`. If a capability is worth naming in a
+ *    tool schema, it is worth reaching from a tool.
+ * 2. `get_space_meta` actually reports `needsReindex` — so the sentence `reindex` now carries is true. Asserted
+ *    against the built tool's OUTPUT shape, not against its prose, because prose is what was wrong before.
+ *
+ * Run: node --test testing/standalone/tool-descriptions-name-reachable-things.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const { ALL_TOOLS } = await import('../../server/dist/mcp/tools/index.js');
+
+/** A mention of the other door. */
+const REST_REF = /\bREST\b|\bcurl\b|\b(?:GET|POST|PATCH|PUT|DELETE) \/api\//i;
+
+/**
+ * Naming a route is not the defect — being SENT to one is.
+ *
+ * `create_space` says *"Refusals match POST /api/spaces exactly, including 422 …"*, which is a parity statement:
+ * useful to a reader who has both doors, harmless to one who does not, and true. `reindex` said *"poll … the
+ * REST reindex-status route"*, which is an instruction an MCP-only caller cannot carry out.
+ *
+ * So the test is per SENTENCE, and a sentence that mentions the other door must be describing equivalence
+ * rather than directing traffic. The first version of this gate flagged both and would have demanded a true
+ * sentence be deleted.
+ */
+const PARITY_WORDS = /\bmatch(?:es|ing)?\b|\bsame\b|\bidentical\b|\bmirror(?:s|ed)?\b|\bequivalent\b|\bas on\b|\bthe REST (?:route|API|surface) (?:also|likewise)\b/i;
+// `query` and `hit` are deliberately absent. `query` is a tool NAME — `help`'s own description says "how to
+// choose between query / recall / filtered recall … and the REST API map", which is help describing its own
+// contents rather than routing anyone anywhere. A verb list that swallows a tool name is a gate that fires on
+// correct prose.
+const DIRECTIVE = /\b(?:poll|use|call|fetch|see|visit|go to|invoke)\b/i;
+
+describe('no tool description sends the reader to another door', () => {
+  for (const tool of ALL_TOOLS) {
+    it(tool.name, () => {
+      const sentences = (tool.description ?? '').split(/(?<=[.!?])\s+/);
+      for (const s of sentences) {
+        if (!REST_REF.test(s)) continue;
+        if (PARITY_WORDS.test(s)) continue;   // describing equivalence, not routing the caller
+        assert.ok(!DIRECTIVE.test(s),
+          `${tool.name} tells an MCP caller to reach for the other door: "${s.trim()}". An MCP-only client `
+          + 'cannot follow it — name a tool, or add the capability to one.');
+      }
+    });
+  }
+});
+
+describe('get_space_meta reports the reindex state the reindex tool points at', () => {
+  const source = readFileSync('server/src/mcp/tools/spaces.ts', 'utf8');
+
+  it('the reindex description names get_space_meta and its field', () => {
+    const reindex = ALL_TOOLS.find(t => t.name === 'reindex');
+    assert.ok(reindex, 'no reindex tool');
+    assert.match(reindex.description, /poll `get_space_meta`/,
+      'the description must name the tool a caller can actually reach');
+    assert.match(reindex.description, /needsReindex/,
+      'and the field, so the caller knows what to look at rather than diffing whole responses');
+  });
+
+  it('and get_space_meta puts it in the response', () => {
+    // The OUTPUT, from source, because the description being right is exactly what was not enough last time.
+    const meta = source.slice(source.indexOf('const metaResult = {'));
+    assert.match(meta.slice(0, 900), /needsReindex: metaMemberIds\.some\(mid => needsReindex\(mid\)\)/,
+      'get_space_meta must report needsReindex, summed over the member spaces like every other proxy read');
+  });
+
+  it('REST reports the same field, computed the same way', () => {
+    // One capability, two doors. A field on one door only is how this started.
+    const rest = readFileSync('server/src/api/spaces.ts', 'utf8');
+    assert.match(rest, /const reindexNeeded = memberIds\.some\(mid => needsReindex\(mid\)\)/);
+    assert.match(rest, /needsReindex: reindexNeeded,/);
+  });
+
+  it('the dedicated status route still exists — this adds a field, it does not remove a route', () => {
+    const search = readFileSync('server/src/api/brain/search.ts', 'utf8');
+    assert.match(search, /'\/spaces\/:spaceId\/reindex-status'/,
+      'existing callers of the status route must keep working');
+  });
+});


### PR DESCRIPTION
The `reindex` tool's own description said:

> it runs in the background and may take minutes, so **poll `get_space_meta`** or the REST reindex-status route
> rather than waiting on this call.

**`get_space_meta` did not carry the reindex state.** `needsReindex` (`spaces/_shared.ts:60`) was read by exactly
one route — `GET /api/brain/spaces/:spaceId/reindex-status` — and by no tool at all. So the only working half of
that sentence was the REST half, and a client with no HTTP door (Claude Desktop, any pure-MCP agent) could START
a multi-minute job and never learn it had finished.

That is worse than a missing capability. A schema description is what a caller reads **while constructing
arguments** — `help()` says so in as many words — and nobody reports a capability they were told to get
elsewhere. Same shape as `recall`'s filter description claiming a post-filter: the wrong sentence was the one
being read.

## The fix, and why this one rather than a new tool

| option | |
|---|---|
| a `reindex_status` tool | mirrors the route, and adds a second sentence to keep true |
| **`needsReindex` on `get_space_meta`** | **makes the sentence that already exists true** |

The second. Both doors report it, `.some()` over the member spaces exactly as `GET /reindex-status` computes it,
so a proxy is `true` when any member is. The dedicated status route is untouched — this adds a field, it does
not move a route.

## Found by the matrix, not by a report

`scripts/surface-matrix.mjs` put `reindex-status` in the REST-only column. Reading *why* turned up the
description pointing at it. The generator earning its first finding within the hour is the argument for having
written it.

## The gate: what a tool description may tell a caller to do

`tool-descriptions-name-reachable-things.test.js` fails when any of the 41 descriptions **directs** the reader to
a REST route or a `curl`.

It distinguishes **directing** from **describing**, per sentence:

- `create_space`: *"Refusals match POST /api/spaces exactly, including 422 …"* — a true parity statement, useful
  to anyone holding both doors. **Allowed.**
- `reindex`: *"poll … the REST reindex-status route"* — an instruction half its callers cannot carry out.
  **Refused.**

**Two false positives shaped it before it was right**, and both were the gate's fault rather than the code's: the
parity statement above, and `help` describing its own contents (*"how to choose between query / recall … and the
REST API map"*), where a verb list containing `query` swallowed a tool name. A gate that fires on correct prose
gets deleted rather than obeyed, so it was narrowed twice and the reasoning is in the file.

**Mutation-tested against the sentence that shipped**: restoring it turns the gate red and names `reindex`.

## A second gate caught my wording

`mcp-help.test.js` holds that a read-only token is never told the name of a tool it cannot call. My first
description said *"entry counts and **reindex** state"* — and `get_space_meta` is listed for read-only tokens, so
the bare word leaked a mutating tool's name into read-only help.

It now reads *"whether the stored embeddings are stale (`needsReindex`)"*, which is also the more useful sentence
for a reader who cannot perform the repair. The field name survives because `\breindex\b` does not match inside
`needsReindex` — the gate is word-boundary based, and it was right about the prose.

## Verified

Both doors, one fixture: `GET /api/spaces/:id/meta` and the `get_space_meta` tool each report the field, and each
is asserted to **agree with `GET /reindex-status`** — two answers to one question must not disagree. The type is
asserted as `boolean`, not truthiness: an absent field and a `false` one are identical to `if (!x)` and opposite
to a caller polling for a change.

All five places: both surfaces, the integration guide's meta response, the MCP guide's tool row, the userguide,
and the rights rows (unchanged — same routes).

🤖 Generated with Claude Code
