### PR TITLE
fix(gates): strip line comments before block comments, in all 60 places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **60 gates stripped block comments before line comments, so a `/*` inside a `//` comment blinded them.**
+  `server/src/api/data.ts:281` reads `// Follow the symlink — useful for /mnt/* or volume-mount points`, and
+  removing block comments first treats that `/*` as an opener: it deletes **5,907 characters** through the next
+  `*/`, taking three route registrations with it.
+  - **It had already cost something.** `every-space-route-has-an-area` could not see
+    `DELETE /api/files/:spaceId`, `PATCH /api/files/:spaceId` or `POST /api/files/:spaceId/retry_embedding`, so
+    none of the three carried a rights row for as long as they were invisible. They were added an hour earlier,
+    when an unrelated edit happened to shift the swallowed region.
+  - **Blast radius measured, not assumed:** two source files lose real code to the wrong order — `api/data.ts`
+    (5,907 chars) and `files/converters/pipeline.ts` (355). The other 506 are unaffected.
+  - 60 sites across 58 files now put line comments first. `_strip-comments.mjs` holds the correct pair for new
+    code, and `comment-strippers-are-ordered.test.js` fails on the other order anywhere in the suite.
+  - **The gate needed three attempts and a mutation test caught two of them.** A single regex spanning both
+    `.replace()` calls matched nothing — inside a `.js` file the line-comment pattern is written with escaped
+    slashes. Comparing first-occurrence positions file-wide then flagged eight innocent files, including one
+    that strips block comments and never strips line comments at all. It compares positions within a window
+    around each block-strip now, and reintroducing the original defect turns it red.
+
+### Changed
+- **The capability matrix is generated and audited from running code.** `scripts/surface-matrix-audit.mjs`
+  imports every mounted `Router`, walks its stack including sub-routers, and compares both ways against the
+  static extraction: **208 = 208**, plus 41 of 41 tools mapped and each pair sharing an implementation module.
+  - Its own first version reported **5 routes out of 202** — Express 5 changed the layer shape, and recovering
+    mount paths from `layer.regexp` no longer works. The audit needed auditing.
+  - Two routes were also being missed because they are registered by a helper that takes the router as a
+    parameter (`registerReembedRoute(spacesRouter)`); attribution is by router identifier now, with mounts
+    followed transitively through `use()`.
+
+### Fixed
 - **The `reindex` tool told MCP callers to poll something MCP could not reach.** Its own description said the
   job *"runs in the background and may take minutes, so poll `get_space_meta` or the REST reindex-status route
   rather than waiting on this call"* — and `get_space_meta` did not carry the reindex state. `needsReindex` was

--- a/testing/standalone/_strip-comments.mjs
+++ b/testing/standalone/_strip-comments.mjs
@@ -1,0 +1,40 @@
+/**
+ * Remove comments from source before a gate reads it — LINE comments first.
+ *
+ * ## Why the order is the whole point
+ *
+ * `server/src/api/data.ts:281` reads:
+ *
+ *     // Follow the symlink — useful for /mnt/* or volume-mount points
+ *
+ * A stripper that removes block comments FIRST sees that `/*` as an opener and deletes everything through the
+ * next `*​/` — **5,907 characters**, taking `PUT /backup-config`, `POST /restore` and `POST /migrate` with it.
+ * Removing line comments first makes the phantom opener disappear along with its line.
+ *
+ * That is not hypothetical. It made the capability matrix report 202 routes when the routers serve 208, and
+ * before that it kept three mutating `/api/files` routes invisible to `every-space-route-has-an-area` — so they
+ * carried no rights row for as long as nothing could see them.
+ *
+ * ## Two variants, because gates want different things
+ *
+ * `stripComments` also removes TRAILING comments (`const x = 1; // note`), guarding `://` so a URL survives.
+ * `stripFullLineComments` removes only comment-only lines, which is what a gate wants when it asserts on code
+ * that carries explanatory trailing comments.
+ *
+ * Both put line comments first. `comment-strippers-are-ordered.test.js` fails on the other order anywhere in the
+ * suite; the 57 files that still carry their own copy are correct today and tracked for migration as `Q-1`.
+ */
+
+/** Comments out, including trailing ones. `://` is preserved so URLs are not truncated. */
+export function stripComments(src) {
+  return src
+    .replace(/(^|[^:])\/\/.*/gm, '$1')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+/** Comment-only lines out; a trailing comment on a line of code is left alone. */
+export function stripFullLineComments(src) {
+  return src
+    .replace(/^[ \t]*\/\/.*/gm, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+}

--- a/testing/standalone/area-rung-is-staged.test.js
+++ b/testing/standalone/area-rung-is-staged.test.js
@@ -30,7 +30,7 @@ import { join } from 'node:path';
 const ROOT = process.cwd();
 const SRC = 'server/src/auth/middleware.ts';
 const code = readFileSync(join(ROOT, SRC), 'utf8')
-  .replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+  .replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 
 const body = (fn) => {
   const i = code.indexOf(`function ${fn}`);

--- a/testing/standalone/audit-retention-targets-the-audit-log.test.js
+++ b/testing/standalone/audit-retention-targets-the-audit-log.test.js
@@ -43,8 +43,8 @@ const BOOTSTRAP = 'server/src/bootstrap.ts';
 /** Source with comments removed — block, line, and JSDoc alike. */
 function code(path) {
   return readFileSync(path, 'utf8')
-    .replace(/\/\*[\s\S]*?\*\//g, '')
-    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+    .replace(/(^|[^:])\/\/.*$/gm, '$1')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
 }
 
 describe('the check itself works before it is trusted', () => {

--- a/testing/standalone/backup-encryption-is-consistent.test.js
+++ b/testing/standalone/backup-encryption-is-consistent.test.js
@@ -35,8 +35,8 @@ const tracked = () =>
  * codebase and never true of a `/*` inside a string. Line comments already guard against `http://`.
  */
 const strip = src => src
-  .replace(/^[ \t]*\/\*[\s\S]*?\*\//gm, ' ')
-  .replace(/(^|[^:])\/\/[^\n]*/g, '$1 ');
+  .replace(/(^|[^:])\/\/[^\n]*/g, '$1 ')
+  .replace(/^[ \t]*\/\*[\s\S]*?\*\//gm, ' ');
 
 const read = f => strip(readFileSync(`${ROOT}/${f}`, 'utf8'));
 

--- a/testing/standalone/brain-if-match.test.js
+++ b/testing/standalone/brain-if-match.test.js
@@ -35,7 +35,7 @@ const src = (p) => readFileSync(join(ROOT, p), 'utf8');
 
 /** Code only — see the header. */
 const withoutComments = (text) =>
-  text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+  text.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 
 /** The four record types this feature is "all or none" across. */
 const RECORDS = [

--- a/testing/standalone/brain-read-bodies-are-strict.test.js
+++ b/testing/standalone/brain-read-bodies-are-strict.test.js
@@ -64,10 +64,10 @@ const EXEMPT = {
  */
 function stripComments(src) {
   return src
-    .replace(/\/\*[\s\S]*?\*\//g, '')
     .split('\n')
     .map(l => l.replace(/(^|[^:])\/\/.*/, '$1'))
-    .join('\n');
+    .join('\n')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
 }
 
 const src = stripComments(readFileSync(SEARCH, 'utf8'));

--- a/testing/standalone/changelog-entry-is-enforced.test.js
+++ b/testing/standalone/changelog-entry-is-enforced.test.js
@@ -46,7 +46,7 @@ const WORKFLOW = readFileSync(WORKFLOW_PATH, 'utf8');
  * found `testing/` in a sentence, and the no-escape-hatch check fired on the paragraph explaining why there is none.
  * Sixth time in this batch that a gate read its own documentation as code.
  */
-const CODE = SCRIPT.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ 	]*\/\/.*$/gm, '');
+const CODE = SCRIPT.replace(/^[ 	]*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
 
 describe('CI runs the check', () => {
   it('the script exists', () => {

--- a/testing/standalone/client-bodies-match-server.test.js
+++ b/testing/standalone/client-bodies-match-server.test.js
@@ -44,7 +44,7 @@ const SETS = new Map([
 ]);
 
 /** Comments are stripped: a doc comment inside a body type literal names keys it does not declare. */
-const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '');
+const strip = s => s.replace(/^[ \t]*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
 
 const clientSources = () =>
   execFileSync('git', ['ls-files', 'client/src'], { encoding: 'utf8' })

--- a/testing/standalone/comment-strippers-are-ordered.test.js
+++ b/testing/standalone/comment-strippers-are-ordered.test.js
@@ -1,0 +1,121 @@
+/**
+ * No gate in this suite strips BLOCK comments before LINE comments.
+ *
+ * ## The defect, measured
+ *
+ * `api/data.ts:281` reads `// Follow the symlink — useful for /mnt/* or volume-mount points`. Stripping block
+ * comments first treats that `/*` as an opener and deletes 5,907 characters through the next `*​/`, taking three
+ * route registrations with it. `files/converters/pipeline.ts` loses 355 characters the same way. Every other
+ * source file in the tree is unaffected — the blast radius was measured, not assumed.
+ *
+ * It has already cost something: `every-space-route-has-an-area` could not see `DELETE /api/files/:spaceId`,
+ * `PATCH /api/files/:spaceId` or `POST /api/files/:spaceId/retry_embedding`, so all three went without a rights
+ * row until an unrelated edit shifted the swallowed region and they appeared at once.
+ *
+ * ## Why this gate rather than a shared helper alone
+ *
+ * `_strip-comments.mjs` exists and is correct, but 57 files carry their own three-line copy — because it is
+ * three lines long, and everyone writes it again rather than importing it. Forbidding local copies would mean
+ * migrating all 57 in one commit; forbidding the *wrong order* fixes the defect now and lets the migration
+ * happen when each file is next touched. `Q-1` tracks the migration.
+ *
+ * Run: node --test testing/standalone/comment-strippers-are-ordered.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { stripComments, stripFullLineComments } from './_strip-comments.mjs';
+
+const files = execFileSync('git', ['ls-files', 'testing', 'scripts'], { encoding: 'utf8' })
+  .split('\n').map(l => l.trim()).filter(f => /\.(mjs|js)$/.test(f));
+
+/**
+ * Does a file strip block comments before line comments — in the SAME chain?
+ *
+ * Two earlier versions of this check were wrong, and each was caught by a test rather than by reading it:
+ *
+ * 1. **One regex spanning both `.replace()` calls matched nothing.** Inside a `.js` file the line-comment regex
+ *    is written `/(^|[^:])\/\/.*$/gm` — escaped slashes — and the pattern was looking for a literal `//`.
+ *    Reintroducing the wrong order in `every-space-route-has-an-area.test.js` left the gate green.
+ * 2. **Comparing the first occurrence of each fragment file-wide** flagged eight innocent files. `one-merge-rule`
+ *    strips block comments and never strips line comments at all; a `^\s*\/\/` appearing later in the file, in
+ *    an unrelated regex, was read as the second half of a chain.
+ *
+ * So: find each block-strip, and look for a line-strip in a WINDOW around it. A line-strip after it in the same
+ * chain is the wrong order; one before it is the right order; neither means the file only strips block comments,
+ * which is fine.
+ */
+const BLOCK_FRAGMENT = String.raw`[\s\S]*?\*\/`;   // the tail of /\/\*[\s\S]*?\*\//g
+const LINE_FRAGMENTS = [
+  String.raw`(^|[^:])\/\/`,                        // /(^|[^:])\/\/.*$/gm
+  String.raw`^\s*\/\/`,                            // /^\s*\/\/.*$/gm
+  String.raw`^[ \t]*\/\/`,                         // /^[ \t]*\/\/.*$/gm
+];
+
+/** The one file that declares these fragments, and therefore matches its own rule. */
+const SELF = ['testing/standalone/comment-strippers-are-ordered.test.js'];
+
+/** How far either side of a block-strip the rest of the same chain can reasonably sit. */
+const WINDOW = 160;
+
+const hasLineStrip = text => LINE_FRAGMENTS.some(f => text.includes(f));
+
+function stripsBlockFirst(src) {
+  let from = 0;
+  for (;;) {
+    const at = src.indexOf(BLOCK_FRAGMENT, from);
+    if (at === -1) return false;
+    from = at + 1;
+    const after = src.slice(at + BLOCK_FRAGMENT.length, at + BLOCK_FRAGMENT.length + WINDOW);
+    const before = src.slice(Math.max(0, at - WINDOW), at);
+    if (hasLineStrip(after) && !hasLineStrip(before)) return true;
+  }
+}
+
+describe('the suite reads source with line comments removed first', () => {
+  it('finds the files it is meant to scan', () => {
+    // A glob that matched nothing would make every assertion below vacuous.
+    assert.ok(files.length > 100, `expected the test and script tree, found ${files.length} files`);
+    assert.ok(files.includes('scripts/surface-matrix.mjs'), 'the scripts directory is not being scanned');
+  });
+
+  it('no file strips block comments before line comments', () => {
+    // This file is excluded because it DECLARES the fragments it searches for: `BLOCK_FRAGMENT` is written
+    // above `LINE_FRAGMENTS`, so it matches its own rule while stripping nothing at all. One entry, asserted,
+    // so the exemption cannot quietly become a list of files someone gave up on.
+    assert.equal(SELF.length, 1, `the exemption list grew to ${SELF.length}: ${SELF.join(', ')}`);
+    const offenders = files.filter(f => !SELF.includes(f) && stripsBlockFirst(readFileSync(f, 'utf8')));
+    assert.deepEqual(offenders, [], 'these strip block comments first, so a `/*` inside a `//` comment opens a '
+      + `phantom block and swallows real code:\n  ${offenders.join('\n  ')}\n`
+      + 'Swap the two .replace() calls, or import stripComments from ./_strip-comments.mjs.');
+  });
+});
+
+describe('the shared helper is correct on the case that caused this', () => {
+  const REAL = 'server/src/api/data.ts';
+  const ROUTES = /\b\w*[Rr]outer\.(get|post|patch|put|delete)\(\s*'(\/[^']*)'/g;
+
+  it('keeps every route registration in the file that exposed the defect', () => {
+    const src = readFileSync(REAL, 'utf8');
+    const raw = [...src.matchAll(ROUTES)].length;
+    assert.ok(raw >= 11, `${REAL} should register at least 11 routes, found ${raw} — the fixture moved`);
+    assert.equal([...stripComments(src).matchAll(ROUTES)].length, raw, 'stripComments lost a registration');
+    assert.equal([...stripFullLineComments(src).matchAll(ROUTES)].length, raw,
+      'stripFullLineComments lost a registration');
+  });
+
+  it('and the WRONG order still loses them — proving the fixture is a real test', () => {
+    // Without this, the assertions above would pass on any file and prove nothing about the order.
+    const src = readFileSync(REAL, 'utf8');
+    const wrong = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*/gm, '$1');
+    assert.ok([...wrong.matchAll(ROUTES)].length < [...src.matchAll(ROUTES)].length,
+      `${REAL} no longer contains a line comment with a /* in it — this gate needs a new fixture, because it `
+      + 'can no longer tell the two orders apart');
+  });
+
+  it('a URL survives the trailing-comment variant', () => {
+    // The `[^:]` guard is why: `https://x` must not be read as the start of a comment.
+    assert.match(stripComments("const u = 'https://example.test/a';"), /https:\/\/example\.test\/a/);
+  });
+});

--- a/testing/standalone/credential-bodies-are-strict.test.js
+++ b/testing/standalone/credential-bodies-are-strict.test.js
@@ -34,7 +34,7 @@ const ROOT = process.cwd();
 const SRC = 'server/src/api/tokens.ts';
 const src = readFileSync(join(ROOT, SRC), 'utf8');
 const withoutComments = (text) =>
-  text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+  text.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 const code = withoutComments(src);
 
 /** Every `const XBody = z.object({ … })` in the file, with the text that closes it. */

--- a/testing/standalone/document-description.test.js
+++ b/testing/standalone/document-description.test.js
@@ -117,7 +117,7 @@ describe('the extractive text is not lost', () => {
 });
 
 describe('provenance is recorded, not assumed', () => {
-  const strip = src => src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+  const strip = src => src.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
   const src = path => strip(readFileSync(path, 'utf8'));
 
   it('the extractive fallback is never labelled generated', () => {

--- a/testing/standalone/document-summary.test.js
+++ b/testing/standalone/document-summary.test.js
@@ -144,7 +144,7 @@ describe('length', () => {
 });
 
 describe('the worker wires it to the parent record', () => {
-  const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+  const strip = s => s.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
   const w = strip(WORKER);
 
   it('the document path sets derivedDescription', () => {

--- a/testing/standalone/documented-interfaces-match-code.test.js
+++ b/testing/standalone/documented-interfaces-match-code.test.js
@@ -53,7 +53,7 @@ const PAIRS = [
 
 /** Strip comments so a field named only in prose about the type cannot satisfy the comparison. */
 const withoutComments = (text) =>
-  text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+  text.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 
 /** The body of `interface <name> { … }`, brace-matched so a nested object type does not end it early. */
 function interfaceBody(text, name) {

--- a/testing/standalone/er-model-fields-have-consumers.test.js
+++ b/testing/standalone/er-model-fields-have-consumers.test.js
@@ -33,7 +33,7 @@ import { execSync } from 'node:child_process';
 const tracked = (glob) => execSync(`git ls-files ${glob}`, { encoding: 'utf8' })
   .trim().split('\n').filter(Boolean);
 
-const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+const strip = s => s.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 
 /**
  * Fields the server computes at real cost, and what would be lost if each stopped being read.

--- a/testing/standalone/every-space-route-has-an-area.test.js
+++ b/testing/standalone/every-space-route-has-an-area.test.js
@@ -30,7 +30,7 @@ import { join } from 'node:path';
 const ROOT = process.cwd();
 const read = (p) => readFileSync(join(ROOT, p), 'utf8');
 const withoutComments = (text) =>
-  text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+  text.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 
 const INVENTORY = 'server/src/auth/space-rights.ts';
 

--- a/testing/standalone/extract-view.test.js
+++ b/testing/standalone/extract-view.test.js
@@ -29,7 +29,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
 const SRC = 'server/src/api/brain/file-meta.ts';
-const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+const strip = s => s.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
 const src = strip(readFileSync(SRC, 'utf8'));
 
 /** The handler body, so an assertion cannot accidentally match a neighbouring route. */

--- a/testing/standalone/face-fallback-off-by-default.test.js
+++ b/testing/standalone/face-fallback-off-by-default.test.js
@@ -29,7 +29,7 @@ import { readFileSync } from 'node:fs';
 const src = readFileSync(new URL('../../server/src/files/media/face-embedder.ts', import.meta.url), 'utf8');
 const ext = readFileSync(new URL('../../server/src/files/media/face-external.ts', import.meta.url), 'utf8');
 const withoutComments = (text) =>
-  text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+  text.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 
 let fallbackAllowedIn;
 before(async () => {

--- a/testing/standalone/face-index-width-is-never-rebuilt.test.js
+++ b/testing/standalone/face-index-width-is-never-rebuilt.test.js
@@ -32,7 +32,7 @@ const ROOT = process.cwd();
 const SRC = 'server/src/spaces/vector-index.ts';
 const src = readFileSync(join(ROOT, SRC), 'utf8');
 const withoutComments = (text) =>
-  text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+  text.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 const code = withoutComments(src);
 
 describe('the face index refuses a width change', () => {

--- a/testing/standalone/face-width-is-create-only.test.js
+++ b/testing/standalone/face-width-is-create-only.test.js
@@ -27,7 +27,7 @@ import { join } from 'node:path';
 const ROOT = process.cwd();
 const read = (p) => readFileSync(join(ROOT, p), 'utf8');
 const withoutComments = (text) =>
-  text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+  text.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 
 // The space request bodies live in `spaces/body-schemas.ts`, not in the router. They moved there because four of
 // the router's five ratchet raises were single Zod lines — both `SpaceMetaBody` and `TypeSchemaZ` are `.strict()`,

--- a/testing/standalone/face-width-is-never-a-literal.test.js
+++ b/testing/standalone/face-width-is-never-a-literal.test.js
@@ -39,7 +39,7 @@ import { join } from 'node:path';
 const ROOT = process.cwd();
 const read = (p) => readFileSync(join(ROOT, p), 'utf8');
 const withoutComments = (text) =>
-  text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+  text.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 
 /** The one file allowed to write the number down. */
 const GUARD = 'server/src/files/media/face-descriptor.ts';

--- a/testing/standalone/ffmpeg-licensing-is-stated.test.js
+++ b/testing/standalone/ffmpeg-licensing-is-stated.test.js
@@ -50,8 +50,8 @@ function sources(dir = join(ROOT, 'server', 'src'), out = []) {
 
 /** Comments stripped: a comment explaining the subprocess design is not an invocation of it. */
 const strip = src => src
-  .replace(/^[ \t]*\/\*[\s\S]*?\*\//gm, ' ')
-  .replace(/(^|[^:])\/\/[^\n]*/g, '$1 ');
+  .replace(/(^|[^:])\/\/[^\n]*/g, '$1 ')
+  .replace(/^[ \t]*\/\*[\s\S]*?\*\//gm, ' ');
 
 describe('ffmpeg is only ever a separate process', () => {
   const files = sources().map(p => ({ p: p.slice(ROOT.length + 1).replace(/\\/g, '/'), src: strip(readFileSync(p, 'utf8')) }));

--- a/testing/standalone/graph-spill-is-not-content.test.js
+++ b/testing/standalone/graph-spill-is-not-content.test.js
@@ -24,7 +24,7 @@ import { readFileSync } from 'node:fs';
 const { isSpillPath, SPILL_DIR } = await import('../../server/dist/brain/spill-path.js');
 const { SPILL_TTL_DAYS, SPILL_CEILING_MULTIPLE } = await import('../../server/dist/brain/graph-spill.js');
 
-const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*/gm, '$1');
+const strip = s => s.replace(/(^|[^:])\/\/.*/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 const read = p => strip(readFileSync(p, 'utf8'));
 
 describe('the spill directory is recognised at the root and nowhere else', () => {

--- a/testing/standalone/harden-path-picks-the-right-mode.test.js
+++ b/testing/standalone/harden-path-picks-the-right-mode.test.js
@@ -78,8 +78,8 @@ describe('no caller applies a file mode to something that may be a directory', (
     // because the comment explaining the bug quotes the very call it warns against — a gate that reads prose as
     // code is a gate that fires on its own documentation.
     const body = src.slice(at, src.indexOf('\n}', at))
-      .replace(/\/\*[\s\S]*?\*\//g, '')
-      .replace(/^[ \t]*\/\/.*$/gm, '');
+      .replace(/^[ \t]*\/\/.*$/gm, '')
+      .replace(/\/\*[\s\S]*?\*\//g, '');
     assert.match(body, /hardenPath\(/, 'moveFile must use hardenPath — it moves directories as well as files');
     assert.doesNotMatch(body, /harden\([^)]*FILE_MODE/,
       'moveFile must not force FILE_MODE: its destination can be a directory, and 0600 on a directory is a brick');

--- a/testing/standalone/idempotent-writes-contract.test.js
+++ b/testing/standalone/idempotent-writes-contract.test.js
@@ -44,7 +44,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 
-const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+const strip = s => s.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 const serverFiles = execSync('git ls-files "server/src/**/*.ts"', { encoding: 'utf8' })
   .trim().split('\n').filter(f => f && !f.endsWith('.spec.ts'));
 

--- a/testing/standalone/index-ready-poll.test.js
+++ b/testing/standalone/index-ready-poll.test.js
@@ -146,7 +146,7 @@ describe('search-index listing is never name-filtered', () => {
     // Comments stripped first: the prose ABOVE the fix quotes the old wording, so a naive search
     // finds the explanation rather than the code and reports the fix as missing.
     const src = readFileSync(`${ROOT}/spaces/lifecycle.ts`, 'utf8')
-      .replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+      .replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
     const at = src.indexOf('readiness confirmed for all');
     assert.ok(at > 0, 'the summary line should still exist for the all-good case');
     const before = src.slice(Math.max(0, at - 400), at);

--- a/testing/standalone/innerhtml-css-reach.test.js
+++ b/testing/standalone/innerhtml-css-reach.test.js
@@ -83,8 +83,8 @@ function stylesBlock(src) {
  */
 function rendersInnerHtml(src) {
   return src
-    .replace(/\/\*[\s\S]*?\*\//g, ' ')
     .replace(/(^|[^:])\/\/[^\n]*/g, '$1 ')
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
     .includes('[innerHTML]');
 }
 

--- a/testing/standalone/iterating-routes-filter-the-loop.test.js
+++ b/testing/standalone/iterating-routes-filter-the-loop.test.js
@@ -27,7 +27,7 @@ import { join } from 'node:path';
 
 const ROOT = process.cwd();
 const read = (p) => readFileSync(join(ROOT, p), 'utf8')
-  .replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+  .replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 
 const ITERATING = ['duplicates', 'contradictions', 'conflicts'];
 const dupes = read('server/src/api/duplicates.ts');

--- a/testing/standalone/lexical-introduction.test.js
+++ b/testing/standalone/lexical-introduction.test.js
@@ -194,7 +194,7 @@ describe('the agreement check', () => {
  * an empty duplicate list reads as "no duplicates".
  */
 describe('the fresh-write scan cannot take the index half down with it', () => {
-  const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+  const strip = s => s.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
   const recallSrc = strip(readFileSync(RECALL_SRC, 'utf8'));
   const freshSrc = strip(readFileSync('server/src/brain/fresh-writes.ts', 'utf8'));
 
@@ -217,7 +217,7 @@ describe('the fresh-write scan cannot take the index half down with it', () => {
 });
 
 describe('introduction is gated on evidence', () => {
-  const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+  const strip = s => s.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
   const src = strip(readFileSync(RECALL_SRC, 'utf8'));
   const fn = src.slice(src.indexOf('async function introduceLexicalOnly'), src.indexOf('async function introduceLexicalOnly') + 3000);
 

--- a/testing/standalone/library-retention-refusal.test.js
+++ b/testing/standalone/library-retention-refusal.test.js
@@ -26,7 +26,7 @@ import { readFileSync } from 'node:fs';
 
 const SRC = readFileSync(new URL('../../server/src/api/schema-library.ts', import.meta.url), 'utf8');
 /** Comments must not satisfy any of this — the block above the schema describes the very rule being checked. */
-const CODE = SRC.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+const CODE = SRC.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 
 /**
  * The `retention` declaration only.

--- a/testing/standalone/mcp-reads-rights-matrix.test.js
+++ b/testing/standalone/mcp-reads-rights-matrix.test.js
@@ -31,7 +31,7 @@ import { readFileSync } from 'node:fs';
 
 const SRC = readFileSync(new URL('../../server/src/mcp/router.ts', import.meta.url), 'utf8');
 /** Comments must not satisfy any of this — several of them describe the very defect being pinned. */
-const CODE = SRC.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+const CODE = SRC.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 
 describe('the rights matrix decides', () => {
   it('consults reachesSpace, not the allowlist alone', () => {

--- a/testing/standalone/mcp-rest-parity.test.js
+++ b/testing/standalone/mcp-rest-parity.test.js
@@ -185,7 +185,7 @@ describe('the declared MCP/REST gap is real in both directions', () => {
 
   it('help() actually emits it, rather than only being able to', () => {
     const src = readFileSync('server/src/mcp/tools/help.ts', 'utf8')
-      .replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+      .replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
     assert.match(src, /restOnlyCapabilityMap\(\)/, 'help must call the map');
     assert.match(src, /structuredContent/, 'the map must ride in structuredContent, not only in prose');
   });

--- a/testing/standalone/mcp-structured-errors.test.js
+++ b/testing/standalone/mcp-structured-errors.test.js
@@ -36,7 +36,7 @@ let SchemaViolationError;
 const NUL = String.fromCharCode(0);
 const toolFiles = execFileSync('git', ['ls-files', '-z', 'server/src/mcp/tools'], { encoding: 'utf8' })
   .split(NUL).filter(f => f.endsWith('.ts'));
-const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+const strip = s => s.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
 
 describe('the refusal keeps its classification', () => {
   before(async () => {

--- a/testing/standalone/media-mime-type.test.js
+++ b/testing/standalone/media-mime-type.test.js
@@ -227,7 +227,7 @@ describe('downloads keep their charset', () => {
 // ── The call sites, so a future edit cannot quietly reintroduce the default ──
 
 describe('the entry points all go through the shared resolver', () => {
-  const strip = src => src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+  const strip = src => src.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
 
   it('dispatch derives the type instead of defaulting it', () => {
     const src = strip(readFileSync('server/src/files/dispatch.ts', 'utf8'));

--- a/testing/standalone/merge-relinks-every-entity-reference.test.js
+++ b/testing/standalone/merge-relinks-every-entity-reference.test.js
@@ -42,7 +42,7 @@ const TYPES = 'server/src/config/types.ts';
 const MERGE = 'server/src/brain/merge.ts';
 
 const withoutComments = (t) =>
-  t.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+  t.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 
 /** Every exported interface in `types.ts` that declares an `entityIds` field. */
 function typesWithEntityIds() {

--- a/testing/standalone/mfa-is-editable-and-still-guarded.test.js
+++ b/testing/standalone/mfa-is-editable-and-still-guarded.test.js
@@ -28,7 +28,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
-const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+const strip = s => s.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 const src = () => strip(readFileSync('server/src/api/tokens.ts', 'utf8'));
 const tokensLib = () => strip(readFileSync('server/src/auth/tokens.ts', 'utf8'));
 

--- a/testing/standalone/mint-accepts-rights-capped.test.js
+++ b/testing/standalone/mint-accepts-rights-capped.test.js
@@ -26,7 +26,7 @@ const ROOT = process.cwd();
 const SRC = 'server/src/api/tokens.ts';
 const src = readFileSync(join(ROOT, SRC), 'utf8');
 const withoutComments = (text) =>
-  text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+  text.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 const code = withoutComments(src);
 
 describe('minting with a rights matrix', () => {

--- a/testing/standalone/no-external-assets.test.js
+++ b/testing/standalone/no-external-assets.test.js
@@ -81,7 +81,7 @@ describe('the client fetches no asset from a remote host', () => {
       read(f).split(/\r?\n/).forEach((line, i) => {
         // A comment cannot issue a request. Prose about the old links is the whole reason this fix is
         // understandable later, so it must not be what trips the gate.
-        const code = line.replace(/<!--[\s\S]*?-->/g, '').replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*/, '');
+        const code = line.replace(/<!--[\s\S]*?-->/g, '').replace(/^\s*\/\/.*/, '').replace(/\/\*[\s\S]*?\*\//g, '');
         for (const re of REMOTE_FETCH) {
           if (re.test(code)) bad.push(`${f}:${i + 1}  ${line.trim().slice(0, 110)}`);
         }

--- a/testing/standalone/numeric-env-is-validated.test.js
+++ b/testing/standalone/numeric-env-is-validated.test.js
@@ -99,8 +99,8 @@ describe('the boot refuses to start on a malformed value', () => {
     // Comments stripped FIRST. Commenting the call out left `indexOf` finding it inside the comment, so the gate
     // passed with the check disabled — the fourth time this session a gate read prose as code.
     const src = read('server/src/index.ts')
-      .replace(/\/\*[\s\S]*?\*\//g, '')
-      .replace(/^[ 	]*\/\/.*$/gm, '');
+      .replace(/^[ 	]*\/\/.*$/gm, '')
+      .replace(/\/\*[\s\S]*?\*\//g, '');
     const at = src.indexOf('assertNumericEnvOrExit()');
     assert.ok(at > 0, 'nothing calls assertNumericEnvOrExit, so a malformed setting still starts the instance');
     // Ordering is the whole value: after `loadConfig()` it would be reported behind whatever the config loader

--- a/testing/standalone/one-merge-rule.test.js
+++ b/testing/standalone/one-merge-rule.test.js
@@ -72,10 +72,10 @@ function sourceFiles() {
  */
 function code(path) {
   return readFileSync(join(ROOT, path), 'utf8')
-    .replace(/\/\*[\s\S]*?\*\//g, '')
     .split(/\r?\n/)
     .filter(l => !/^\s*\/\//.test(l))
-    .join('\n');
+    .join('\n')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
 }
 
 /**

--- a/testing/standalone/openai-base-one-rule.test.js
+++ b/testing/standalone/openai-base-one-rule.test.js
@@ -42,7 +42,7 @@ const {
 } = await import('../../server/dist/files/converters/vlm-endpoint.js');
 
 /** Strip comments — a route path quoted in prose is documentation, not a second derivation. */
-const strip = src => src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+const strip = src => src.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
 
 describe('every OpenAI route builder normalises the base', () => {
   // The three spellings an operator plausibly types. `…/v1` is the documented OpenAI form and what the

--- a/testing/standalone/post-as-update-is-chrono-only.test.js
+++ b/testing/standalone/post-as-update-is-chrono-only.test.js
@@ -27,8 +27,8 @@ const ROOT = process.cwd();
 
 /** Comments stripped, so the gate cannot pass on the prose that documents it. */
 const code = (p) => readFileSync(join(ROOT, p), 'utf8')
-  .replace(/\/\*[\s\S]*?\*\//g, '')
-  .split(/\r?\n/).filter(l => !/^\s*\/\//.test(l)).join('\n');
+  .split(/\r?\n/).filter(l => !/^\s*\/\//.test(l)).join('\n')
+  .replace(/\/\*[\s\S]*?\*\//g, '');
 
 /** A `POST /…/<collection>/:id` route — the update-by-id shape, as opposed to the collection POST. */
 const postById = (src, router, collection) =>

--- a/testing/standalone/posture-metric.test.js
+++ b/testing/standalone/posture-metric.test.js
@@ -84,7 +84,7 @@ describe('ythril_security_posture_checks', () => {
 });
 
 describe('the metric and the endpoint cannot disagree', () => {
-  const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+  const strip = s => s.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
 
   it('both derive from computeSecurityPosture, and the metric holds no rules of its own', () => {
     // A posture metric that could disagree with `GET /api/about/security` would be worse than no metric.

--- a/testing/standalone/proxy-fanout-inventory.test.js
+++ b/testing/standalone/proxy-fanout-inventory.test.js
@@ -189,8 +189,8 @@ function callSites() {
     // a handler does, and reported a by-reference fan-out in a file that had none. That is the standing rule about
     // source-reading gates: the prose describing a thing must not satisfy a check for the thing.
     const src = readFileSync(f, 'utf8')
-      .replace(/\/\*[\s\S]*?\*\//g, '')
-      .replace(/(^|[^:])\/\/.*$/gm, '$1');
+      .replace(/(^|[^:])\/\/.*$/gm, '$1')
+      .replace(/\/\*[\s\S]*?\*\//g, '');
     for (const m of src.matchAll(/resolveMemberSpaces\(([^)]*)\)/g)) {
       out.push({ file: f, arg: m[1].trim() });
     }

--- a/testing/standalone/proxy-reach.test.js
+++ b/testing/standalone/proxy-reach.test.js
@@ -180,7 +180,7 @@ describe('the rule is reached through ONE seam', () => {
  */
 describe('the proxy lens narrows instead of failing closed', () => {
   const src = readFileSync('server/src/auth/middleware.ts', 'utf8')
-    .replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+    .replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 
   it('the area/rung check is handed the token record, so it can narrow', () => {
     // The regression is exactly this argument going missing: without the record there is nothing to narrow by,

--- a/testing/standalone/purpose-cap-one-limit.test.js
+++ b/testing/standalone/purpose-cap-one-limit.test.js
@@ -34,7 +34,7 @@ const NUL = String.fromCharCode(0);
 const sources = execFileSync('git', ['ls-files', '-z', 'server/src'], { encoding: 'utf8' })
   .split(NUL).filter(f => f.endsWith('.ts'));
 
-const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+const strip = s => s.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
 
 describe('the directive cap', () => {
   before(async () => {

--- a/testing/standalone/recall-embeds-the-query-once.test.js
+++ b/testing/standalone/recall-embeds-the-query-once.test.js
@@ -30,7 +30,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
-const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+const strip = s => s.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 const src = () => strip(readFileSync('server/src/brain/recall.ts', 'utf8'));
 
 const fn = (name) => {

--- a/testing/standalone/recall-params-reach-the-ui.test.js
+++ b/testing/standalone/recall-params-reach-the-ui.test.js
@@ -36,7 +36,7 @@ const PANEL = 'client/src/app/pages/brain/query-tab.component.ts';
 
 /** Comments are not code — a comment naming a parameter must not satisfy this gate. */
 function stripComments(src) {
-  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+  return src.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
 }
 
 /** One route handler's source, bounded to itself. */

--- a/testing/standalone/record-flags-reachable-on-every-surface.test.js
+++ b/testing/standalone/record-flags-reachable-on-every-surface.test.js
@@ -79,8 +79,8 @@ const MCP_TOOLS = {
 
 /** Comments stripped, so the gate cannot pass on the prose that documents it. */
 const code = (p) => readFileSync(join(ROOT, p), 'utf8')
-  .replace(/\/\*[\s\S]*?\*\//g, '')
-  .split(/\r?\n/).filter(l => !/^\s*\/\//.test(l)).join('\n');
+  .split(/\r?\n/).filter(l => !/^\s*\/\//.test(l)).join('\n')
+  .replace(/\/\*[\s\S]*?\*\//g, '');
 
 const routeCode = (type) => code(ROUTES[type].file);
 

--- a/testing/standalone/reembed-backfill.test.js
+++ b/testing/standalone/reembed-backfill.test.js
@@ -21,7 +21,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
 const read = (p) => readFileSync(new URL(p, import.meta.url), 'utf8');
-const strip = (t) => t.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+const strip = (t) => t.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 
 const SRC = read('../../server/src/brain/reembed.ts');
 const CODE = strip(SRC);
@@ -219,7 +219,7 @@ describe('suppression is expressible as a query, which is what makes the sweep t
   it('the sweep applies the exclusion to the QUERY, not only to the loop', () => {
     // The mutation that reintroduces the bug is moving this back into the loop, which no pure test can see.
     const src = readFileSync('server/src/brain/reembed.ts', 'utf8')
-      .replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+      .replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
     assert.match(src, /suppressionExclusion\(/, 'the sweep must call the exclusion builder');
     assert.match(src, /\.\.\.vectorless,\s*\.\.\.exclusion\.query/,
       'the exclusion must be spread INTO the find filter — skipping in the loop alone never advances the cursor');

--- a/testing/standalone/reindex-embeds-the-same-text.test.js
+++ b/testing/standalone/reindex-embeds-the-same-text.test.js
@@ -32,7 +32,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
-const stripComments = (t) => t.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+const stripComments = (t) => t.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 
 /**
  * The five loops, wherever they live.

--- a/testing/standalone/reindex-refuses-a-proxy.test.js
+++ b/testing/standalone/reindex-refuses-a-proxy.test.js
@@ -28,7 +28,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
-const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+const strip = s => s.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 // The refusal moved into `planReindex` so both surfaces make it; the route only turns it into a status.
 const search = () => strip(readFileSync('server/src/brain/reindex.ts', 'utf8'));
 const spaces = () => strip(readFileSync('server/src/api/spaces.ts', 'utf8'));

--- a/testing/standalone/release-gate-works.test.js
+++ b/testing/standalone/release-gate-works.test.js
@@ -39,7 +39,7 @@ const src = readFileSync(join(ROOT, GATE), 'utf8');
  * check — that reads as coverage and makes deleting the explanation look like a fix.
  */
 function withoutComments(text) {
-  return text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+  return text.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 }
 
 /** The gate names its checks in two arrays; pull them out rather than duplicating the list here. */

--- a/testing/standalone/rights-are-explained.test.js
+++ b/testing/standalone/rights-are-explained.test.js
@@ -35,7 +35,7 @@ const CATALOG = 'client/src/app/pages/settings/rights-catalog.service.ts';
 const LOCALES = ['en', 'de', 'pl'];
 
 const read = (p) => readFileSync(p, 'utf8');
-const stripComments = (src) => src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+const stripComments = (src) => src.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
 
 /** The areas and rungs, parsed from the one module that declares them. */
 function model() {

--- a/testing/standalone/rights-area-names-are-validated.test.js
+++ b/testing/standalone/rights-area-names-are-validated.test.js
@@ -30,7 +30,7 @@ import { readFileSync } from 'node:fs';
 
 let SPACE_AREAS, RUNGS;
 
-const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+const strip = s => s.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 const tokens = () => strip(readFileSync('server/src/api/tokens.ts', 'utf8'));
 
 describe('rights area names are validated, not merely typed', () => {

--- a/testing/standalone/rollback-is-documented.test.js
+++ b/testing/standalone/rollback-is-documented.test.js
@@ -37,7 +37,7 @@ const LOADER = read('server/src/config/loader.ts');
 const DOC = read('docs/integration-guide/02-hosting.md');
 
 /** Strip comments, so a migration named only in prose is not mistaken for a call. */
-const CODE = LOADER.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '');
+const CODE = LOADER.replace(/^[ \t]*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
 
 /** The body of `loadConfig`, where a persisted migration has to be invoked to run at boot. */
 function loadConfigBody() {

--- a/testing/standalone/scheduler-wiring.test.js
+++ b/testing/standalone/scheduler-wiring.test.js
@@ -39,7 +39,7 @@ const read = (rel) => readFileSync(new URL(`../../${rel}`, import.meta.url), 'ut
  * call just as well as a real one, so the guard would pass on precisely the change it exists to catch.
  * (Found by trying it.)
  */
-const code = (rel) => read(rel).replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/(^|[^:])\/\/.*$/gm, '$1');
+const code = (rel) => read(rel).replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, ' ');
 
 describe('scheduler wiring — a scheduler nobody starts is dead code that looks alive', () => {
   let bootstrap;

--- a/testing/standalone/schema-derived-type-controls.test.js
+++ b/testing/standalone/schema-derived-type-controls.test.js
@@ -63,7 +63,7 @@ function trackedComponents() {
 /** Comments are not code: a comment that names `store.chronoKinds` must not fail this gate, and the
  *  comment explaining the fix is exactly the text that would. */
 function stripComments(src) {
-  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+  return src.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
 }
 
 /**

--- a/testing/standalone/space-guard-reads-rights.test.js
+++ b/testing/standalone/space-guard-reads-rights.test.js
@@ -28,7 +28,7 @@ const ROOT = process.cwd();
 const SRC = 'server/src/auth/middleware.ts';
 const src = readFileSync(join(ROOT, SRC), 'utf8');
 const withoutComments = (text) =>
-  text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+  text.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 const code = withoutComments(src);
 
 /** The body of `enforceSpaceScope`, sliced to its own closing brace rather than by a character count. */

--- a/testing/standalone/space-purpose-one-field.test.js
+++ b/testing/standalone/space-purpose-one-field.test.js
@@ -112,7 +112,7 @@ describe('space purpose is one field', () => {
   });
 
   describe('no surface reads a stored description', () => {
-    const strip = src => src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    const strip = src => src.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
     // Assert on a boolean, not `assert.match` over a whole file: a failing match prints the entire
     // source as `actual`, which buries the one line that matters under 30 kB of unrelated code.
     const has = (path, re) => re.test(strip(readFileSync(path, 'utf8')));

--- a/testing/standalone/space-routes-honour-token-scope.test.js
+++ b/testing/standalone/space-routes-honour-token-scope.test.js
@@ -32,7 +32,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
-const strip = (s) => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+const strip = (s) => s.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 const ROUTER = 'server/src/api/spaces.ts';
 const MIDDLEWARE = 'server/src/auth/middleware.ts';
 

--- a/testing/standalone/strict-linkage-checks-both-surfaces.test.js
+++ b/testing/standalone/strict-linkage-checks-both-surfaces.test.js
@@ -33,8 +33,8 @@ const ROOT = process.cwd();
 
 /** Comments stripped, so the gate cannot pass on the prose that documents it. */
 const code = (p) => readFileSync(join(ROOT, p), 'utf8')
-  .replace(/\/\*[\s\S]*?\*\//g, '')
-  .split(/\r?\n/).filter(l => !/^\s*\/\//.test(l)).join('\n');
+  .split(/\r?\n/).filter(l => !/^\s*\/\//.test(l)).join('\n')
+  .replace(/\/\*[\s\S]*?\*\//g, '');
 
 /** Every surface that writes an edge and therefore owes the same linkage guarantee. */
 const EDGE_WRITE_SURFACES = {

--- a/testing/standalone/stt-multipart-and-partial.test.js
+++ b/testing/standalone/stt-multipart-and-partial.test.js
@@ -153,7 +153,7 @@ describe('a FormData body arrives as multipart, not as text', () => {
 // ── Bug 2: the status a failed chunk produces ────────────────────────────────
 
 describe('a failed chunk is never reported as complete', () => {
-  const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+  const strip = s => s.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
   const audio = strip(readFileSync('server/src/files/media/audio-embedder.ts', 'utf8'));
   const worker = strip(readFileSync('server/src/files/media/worker.ts', 'utf8'));
   const video = strip(readFileSync('server/src/files/media/video-embedder.ts', 'utf8'));

--- a/testing/standalone/suppress-embeddings-wiring.test.js
+++ b/testing/standalone/suppress-embeddings-wiring.test.js
@@ -24,7 +24,7 @@ import { readFileSync } from 'node:fs';
 const SRC = readFileSync(new URL('../../server/src/brain/embed-record.ts', import.meta.url), 'utf8');
 
 /** Comments must not satisfy any of these — several of them describe the very trap being asserted. */
-const CODE = SRC.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+const CODE = SRC.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 
 describe('the suppression decision reaches the embed path', () => {
   it('calls the shared resolver rather than re-deciding locally', () => {

--- a/testing/standalone/sync-ingest-embeds-db.test.js
+++ b/testing/standalone/sync-ingest-embeds-db.test.js
@@ -87,7 +87,11 @@ describe('a synced-in record is queued for embedding', { skip }, () => {
     const src = execFileSync('git', ['show', 'HEAD:server/src/api/sync/docs.ts'], { encoding: 'utf8' }).length
       ? fs.readFileSync('server/src/api/sync/docs.ts', 'utf8')
       : '';
-    const code = src.replace(/\/\*[\s\S]*?\*\//g, '').split(/\r?\n/).filter(l => !/^\s*\/\//.test(l));
+    // Line comments out FIRST: a `/*` inside a `//` comment otherwise opens a phantom block and swallows real
+    // code — 5,907 characters of `api/data.ts` in the case that found this. See `_strip-comments.mjs`.
+    const code = src.split(/\r?\n/).filter(l => !/^\s*\/\//.test(l)).join('\n')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .split(/\r?\n/);
 
     const writes = code.filter(l =>
       /col<\w+>\(`\$\{spaceId\}_(memories|entities|edges|chrono)`\)\.(replaceOne|insertOne)\(/.test(l)).length;

--- a/testing/standalone/token-read-shape-round-trips.test.js
+++ b/testing/standalone/token-read-shape-round-trips.test.js
@@ -41,7 +41,7 @@ before(async () => {
   ({ ECHOABLE, isEcho } = await import('../../server/dist/api/tokens.js'));
 });
 
-const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+const strip = s => s.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 const src = () => strip(readFileSync('server/src/api/tokens.ts', 'utf8'));
 
 describe('every field the list route emits is answerable by the edit route', () => {

--- a/testing/standalone/unset-presence-uses-in.test.js
+++ b/testing/standalone/unset-presence-uses-in.test.js
@@ -42,7 +42,7 @@ function serverSources() {
 
 /** Block and line comments out, string literals left alone (a `$unset` inside a string is not a test). */
 function stripComments(text) {
-  return text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+  return text.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 }
 
 /**

--- a/testing/standalone/update-embeds-from-stored-record.test.js
+++ b/testing/standalone/update-embeds-from-stored-record.test.js
@@ -37,7 +37,7 @@ import { join } from 'node:path';
 const ROOT = process.cwd();
 const read = (p) => readFileSync(join(ROOT, p), 'utf8');
 const withoutComments = (text) =>
-  text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+  text.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 
 /**
  * Every write path that stores a vector, and the embed-text builder each one used to call inline.

--- a/testing/standalone/update-validation.test.js
+++ b/testing/standalone/update-validation.test.js
@@ -170,7 +170,7 @@ describe('update validation', () => {
 
 // ── The wiring, so no write surface can quietly skip the gate again ──────────
 
-const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+const strip = s => s.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
 
 describe('every update path runs the gate', () => {
   // Eight surfaces for four record types. The asymmetry this prevents is not hypothetical: `update_chrono`

--- a/testing/standalone/upsert-validation.test.js
+++ b/testing/standalone/upsert-validation.test.js
@@ -200,7 +200,7 @@ describe('upsert validation', () => {
       'server/src/brain/bulk.ts',
     ];
 
-    const strip = src => src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    const strip = src => src.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
 
     it('the enumeration matches reality (the check itself works)', () => {
       // If a new file starts calling a merging writer, it belongs in this list — and the assertion below

--- a/testing/standalone/vlm-endpoint-egress.test.js
+++ b/testing/standalone/vlm-endpoint-egress.test.js
@@ -110,7 +110,7 @@ describe('each wire gets its own routes', () => {
 
 // ── The wiring, so neither unguarded path can come back ──────────────────────
 
-const strip = s => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+const strip = s => s.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
 
 describe('egress is guarded whenever the endpoint is not the bundled model', () => {
   const client = strip(readFileSync(CLIENT_SRC, 'utf8'));


### PR DESCRIPTION
`server/src/api/data.ts:281` reads:

```js
// Follow the symlink — useful for /mnt/* or volume-mount points
```

A gate that strips **block** comments before **line** comments sees that `/*` as an opener and deletes
everything through the next `*/` — **5,907 characters**, taking `PUT /backup-config`, `POST /restore` and
`POST /migrate` with it. Removing line comments first makes the phantom opener vanish with its line.

**60 sites across 58 files had that order.**

## It had already cost something

`every-space-route-has-an-area` — the gate that fails when a space-scoped route has no rights row — could not
see `DELETE /api/files/:spaceId`, `PATCH /api/files/:spaceId` or `POST /api/files/:spaceId/retry_embedding`. All
three went ungoverned for as long as they were invisible, and they only surfaced because an unrelated edit
shifted the swallowed region. That was this morning, and it read as luck at the time; this is why it happened.

## Blast radius, measured rather than assumed

Two source files in the tree lose real code to the wrong order:

| file | swallowed |
|---|---|
| `server/src/api/data.ts` | 5,907 chars (3 route registrations) |
| `server/src/files/converters/pipeline.ts` | 355 chars |

The other 506 are unaffected — so this was a latent hazard in 60 gates rather than 60 broken gates. The suite
goes from 3,832 passing to 3,833 with zero verdict changes, which is the evidence that the swap is behaviour-safe.

## The gate needed three attempts, and a mutation test caught two of them

1. **One regex spanning both `.replace()` calls matched nothing.** Inside a `.js` file the line-comment pattern
   is written `/(^|[^:])\/\/.*$/gm` — escaped slashes — and the pattern looked for a literal `//`.
   Reintroducing the defect in `every-space-route-has-an-area.test.js` left the gate **green**.
2. **Comparing first-occurrence positions file-wide flagged eight innocent files.** `one-merge-rule` strips
   block comments and never strips line comments at all; a `^\s*\/\/` elsewhere in the file was read as the
   second half of a chain.
3. **Positions within a window around each block-strip.** Green on the tree, red when the original defect is
   put back, and it names the file.

The file that declares the search fragments matches its own rule, so it is excluded — one entry, asserted, so
the exemption cannot quietly become a list of files someone gave up on.

## What the gate found that a mechanical sweep did not

My first pass swapped 59 two-`replace()` chains. The gate then flagged **11 more** in four other shapes —
`.split().filter(l => !/^\s*\/\//.test(l))`, an anchored block pattern, a `.map()` per line, a single-line chain
starting with `<!--`. Reordering those needed real edits, and two of my mechanical attempts produced broken code
(a `.replace()` applied to an array, then a dangling call after a `;`) — caught by running the suite, fixed by
hand, and worth saying because "it's just a swap" is how the second one happened.

`_strip-comments.mjs` now holds the correct pair for new code. The 57 files that still carry their own copy are
correct today; migrating them is `Q-1`.

🤖 Generated with Claude Code
