### PR TITLE
feat(mcp): er_model — the space's real shape, not just its declared schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`er_model` — the entity-relationship model reaches MCP.** `GET /api/brain/spaces/:spaceId/er-model` was
+  REST-only, and it answers the question an agent asks first: which entity types actually exist here, which edge
+  labels connect which of them, and how many of each. `get_space_meta` answers a different question — the
+  DECLARED schema, what may exist — so an MCP-only client could learn what a space permits and not what it
+  contains.
+  - **Found by the capability matrix**, which listed `GET /er-model` in the REST-only column. Second finding
+    from that generator, after the `reindex` description pointing at a route MCP cannot reach.
+  - A proxy space reports its members **separately**, exactly as the REST route does: merging counts for two
+    types that share a name across spaces would invent relationships that cannot exist, because an edge cannot
+    cross a space. The narrowing is `memberSpacesWithin`, the MCP half of the rule REST states with
+    `memberSpacesForRequest`.
+  - **The REST route is audited now too.** `brain.stats` was recorded and `er-model` was not, which was an
+    asymmetry rather than a decision — both report what a space contains. New operation: `brain.er_model`,
+    classified as a `read` for the per-space usage counters.
+  - Five gates had something to say and each was answered rather than adjusted: the audit map, the tool-count
+    tripwire, the read-only classification, the proxy fan-out conserved total (38 → 39), and the
+    activity classifier.
+  - Verified through both doors on one fixture — two entity types and an edge between them — asserting the two
+    responses are `deepEqual`, not merely both plausible.
+
 ### Fixed
 - **60 gates stripped block comments before line comments, so a `/*` inside a `//` comment blinded them.**
   `server/src/api/data.ts:281` reads `// Follow the symlink — useful for /mnt/* or volume-mount points`, and

--- a/docs/integration-guide/04b-graph-api.md
+++ b/docs/integration-guide/04b-graph-api.md
@@ -405,6 +405,11 @@ GET /api/brain/spaces/:spaceId/er-model
 The space's entity-relationship model, derived from the schema **and** from what is stored. Read-only,
 nothing cached, every number a real count of records.
 
+> **Also available as MCP tool:** `er_model` — same output, same proxy rule (members reported separately),
+> and available to every token including read-only ones. It answers what a space *contains*, where
+> `get_space_meta` answers what its schema *permits*; an agent deciding how to write into an unfamiliar
+> space usually wants both.
+
 ```json
 {
   "spaceId": "ops",

--- a/docs/integration-guide/13-audit-log-api.md
+++ b/docs/integration-guide/13-audit-log-api.md
@@ -157,7 +157,7 @@ Audit entries are recorded for all write operations and (when `logReads` is enab
 | Space | `space.create`, `space.update`, `space.delete`, `space.wipe`, `space.list` |
 | Token | `token.create`, `token.delete` |
 | Webhook | `webhook.create`, `webhook.update`, `webhook.delete`, `webhook.test` |
-| Brain | `brain.recall`, `brain.recall_global`, `brain.query`, `brain.find_similar`, `brain.stats`, `brain.bulk_write`, `brain.traverse` |
+| Brain | `brain.recall`, `brain.recall_global`, `brain.query`, `brain.find_similar`, `brain.stats`, `brain.er_model`, `brain.bulk_write`, `brain.traverse` |
 | Config | `config.reload` |
 | Audit | `audit.export` — taking a copy of the whole record. Logged even when `logReads` is off |
 | Auth | `auth.failed` (invalid or expired tokens on any endpoint) |

--- a/docs/integration-guide/16-mcp.md
+++ b/docs/integration-guide/16-mcp.md
@@ -183,6 +183,7 @@ row survives its own tool being built, so the list cannot keep advertising a gap
 | `find_similar` | Find entries with high vector similarity to an existing entry by ID — no re-embedding step. Provide `space` to scope to one space, or omit it to search across all accessible spaces (like `recall`). Supports `traverse` (graph expansion). The legacy `crossSpace` flag is deprecated — omit `space` instead |
 | `get_stats` | Return counts of memories, entities, edges, chrono entries, and files |
 | `get_space_meta` | Return the full space schema definition, purpose, usage notes, stats, and `needsReindex` — the field to poll after `reindex`, which returns as soon as the job starts |
+| `er_model` | The space's entity-relationship model: which entity types actually exist, which edge labels connect which types, and the counts — inferred from the stored records as well as the declared schema. `get_space_meta` says what MAY exist; this says what DOES. Same output as [`GET /er-model`](04b-graph-api.md) |
 | `upsert_entity` | Create or update a named entity (with optional properties) |
 | `update_entity` | Update an existing entity by ID (name, type, description, tags, properties, `excludeFromVectorSearch`); supports `deleteFields` for field removal |
 | `delete_entity` | Delete an entity by ID. Refused when the space has `strictLinkage` and another record still references it — the same rule the REST route enforces. Face labels are unlabelled rather than blocking |

--- a/scripts/surface-matrix.mjs
+++ b/scripts/surface-matrix.mjs
@@ -142,6 +142,7 @@ const MAP = [
   ['Brain — search', 'traverse', 'POST /api/brain/spaces/:spaceId/traverse'],
   ['Brain — bulk', 'bulk_write', 'POST /api/brain/spaces/:spaceId/bulk'],
   ['Brain — ops', 'get_stats', 'GET /api/brain/spaces/:spaceId/stats'],
+  ['Brain — ops', 'er_model', 'GET /api/brain/spaces/:spaceId/er-model'],
   ['Brain — ops', 'reindex', 'POST /api/brain/spaces/:spaceId/reindex'],
   ['Brain — ops', 'list_embed_jobs', 'GET /api/brain/spaces/:spaceId/embedding-queue/records'],
   ['Brain — ops', 'retry_record_embedding', 'POST /api/brain/spaces/:spaceId/embedding-queue/records/retry'],

--- a/server/src/audit/middleware.ts
+++ b/server/src/audit/middleware.ts
@@ -244,6 +244,7 @@ const ROUTE_RULES: RouteRule[] = [
   { method: 'POST',   pattern: /^\/api\/brain\/(?:spaces\/)?([^/]+)\/query$/,      operation: 'brain.query',          spaceGroup: 1, read: true },
   { method: 'POST',   pattern: /^\/api\/brain\/(?:spaces\/)?([^/]+)\/find-similar$/, operation: 'brain.find_similar', spaceGroup: 1, read: true },
   { method: 'GET',    pattern: /^\/api\/brain\/(?:spaces\/)?([^/]+)\/stats$/,      operation: 'brain.stats',          spaceGroup: 1, read: true },
+  { method: 'GET',    pattern: /^\/api\/brain\/(?:spaces\/)?([^/]+)\/er-model$/,   operation: 'brain.er_model',       spaceGroup: 1, read: true },
 
   // ── Bulk write ───────────────────────────────────────────────────────────
   { method: 'POST',   pattern: /^\/api\/brain\/(?:spaces\/)?([^/]+)\/bulk$/,       operation: 'bulk.write',     spaceGroup: 1 },

--- a/server/src/mcp/audit-map.ts
+++ b/server/src/mcp/audit-map.ts
@@ -75,6 +75,10 @@ export const MCP_TOOL_OPERATIONS: Record<string, string | null> = {
   recall: 'brain.recall',
   traverse: 'brain.traverse',
   get_stats: 'brain.stats',
+  // Audited for the same reason `get_stats` is: it reports what a space CONTAINS — type names, edge labels
+  // and counts. The REST route was not audited while `stats` was, which was an asymmetry rather than a
+  // decision; both are now.
+  er_model: 'brain.er_model',
   list_chrono: 'chrono.list',
   list_spaces: 'space.list',
   list_dir: 'file.list',

--- a/server/src/mcp/tools/index.ts
+++ b/server/src/mcp/tools/index.ts
@@ -1,5 +1,5 @@
 import type { ToolHandler } from './types.js';
-import { list_spacesTool, get_statsTool, get_space_metaTool, update_spaceTool, update_space_schemaTool, create_spaceTool, reindexTool, wipe_spaceTool , list_tokensTool } from './spaces.js';
+import { list_spacesTool, get_statsTool, get_space_metaTool, er_modelTool, update_spaceTool, update_space_schemaTool, create_spaceTool, reindexTool, wipe_spaceTool , list_tokensTool } from './spaces.js';
 import { rememberTool, update_memoryTool, delete_memoryTool } from './memory.js';
 import { recallTool, find_similarTool, queryTool } from './search.js';
 import { bulk_writeTool } from './bulk.js';
@@ -31,6 +31,7 @@ export const ALL_TOOLS: ToolHandler[] = [
   delete_memoryTool,
   get_statsTool,
   get_space_metaTool,
+  er_modelTool,
   queryTool,
   upsert_entityTool,
   find_entities_by_nameTool,

--- a/server/src/mcp/tools/spaces.ts
+++ b/server/src/mcp/tools/spaces.ts
@@ -88,6 +88,52 @@ export const get_statsTool: ToolHandler = {
   },
 };
 
+/**
+ * The space's entity-relationship model — REST-only until now, and it is the question an agent asks first.
+ *
+ * `get_space_meta` returns the DECLARED schema: what may exist. This returns what DOES exist — which types are
+ * actually present, which relationships actually occur between them, and how many of each. An agent deciding how
+ * to write into an unfamiliar space wants both, and only one of them was reachable.
+ *
+ * Found by the capability matrix (`scripts/surface-matrix.mjs`), which put `GET /er-model` in the REST-only
+ * column. Filed as B-21.
+ *
+ * **On a proxy space the members are reported SEPARATELY rather than merged**, exactly as the REST route does.
+ * Merging would add up counts for two types that share a name and mean different things in different spaces, and
+ * would invent relationships between types that can never be joined, because an edge cannot cross a space. A
+ * union would look richer and be false — so the shape differs by design, not by omission.
+ */
+export const er_modelTool: ToolHandler = {
+  name: 'er_model',
+  description:
+        'Return the space\'s entity-relationship model: which entity types actually exist, which edge labels '
+        + 'connect which types, and the counts of each — inferred from the stored records AND the declared '
+        + 'schema. Use it to learn how a space is actually shaped before writing into it; `get_space_meta` gives '
+        + 'the declared schema (what MAY exist), this gives what DOES. A type with zero records is reported '
+        + 'rather than omitted. On a proxy space each member is reported separately, because merging would '
+        + 'invent relationships that cannot exist across spaces.',
+  spaceRequired: true,
+  inputSchema: (s: ToolSchemas) => ({
+          type: 'object',
+          properties: {
+            space: s.requiredSpace,
+          },
+          required: ['space'],
+          additionalProperties: false,
+        }),
+  async handle(ctx: ToolContext): Promise<ToolResult> {
+    const { callSpace, accessibleSpaceIds } = ctx;
+    const { buildErModel } = await import('../../brain/er-model.js');
+    // The same narrowing every MCP read uses: the connection's accessible spaces, not the request's.
+    const memberIds = memberSpacesWithin(callSpace, accessibleSpaceIds);
+    const models = await Promise.all(memberIds.map(mid => buildErModel(mid)));
+    const output = memberIds.length === 1 && memberIds[0] === callSpace
+      ? models[0]
+      : { spaceId: callSpace, members: models };
+    return { content: [{ type: 'text' as const, text: JSON.stringify(output) }] };
+  },
+};
+
 export const get_space_metaTool: ToolHandler = {
   name: 'get_space_meta',
   description:

--- a/server/src/metrics/space-activity.ts
+++ b/server/src/metrics/space-activity.ts
@@ -179,7 +179,9 @@ export function classifyOperation(operation: string): CallClass | null {
   // Demand on the file store, reads only (the mutations went to `write` above).
   if (/^file\./.test(operation)) return 'file';
 
-  if (/\.(list|get|stats|traverse|export|search|validate)$/.test(operation)) return 'read';
+  // `er_model` joins this list rather than the suffix pattern gaining a `model$` alternative: it is a READ of
+  // what a space contains — type names, edge labels, counts — which is the same demand signal as `stats`.
+  if (/\.(list|get|stats|er_model|traverse|export|search|validate)$/.test(operation)) return 'read';
 
   // Anything unrecognised counts as nothing rather than guessing. `space-activity-classes.test.js` enumerates
   // every operation the audit middleware defines and fails on one that lands here undeclared, so a new route

--- a/testing/integration/er-model-both-doors.test.js
+++ b/testing/integration/er-model-both-doors.test.js
@@ -1,0 +1,116 @@
+/**
+ * The entity-relationship model comes back the same through both doors.
+ *
+ * ## Why the tool exists
+ *
+ * `GET /api/brain/spaces/:spaceId/er-model` was REST-only, and it answers the question an agent asks FIRST:
+ * which entity types are actually here, which edge labels connect which of them, and how many of each.
+ * `get_space_meta` answers a different question — the DECLARED schema, what may exist — so an MCP-only client
+ * could learn what a space permits and not what it contains.
+ *
+ * Found by `scripts/surface-matrix.mjs`, which listed `GET /er-model` in the REST-only column.
+ *
+ * ## What these assertions are for
+ *
+ * Not "the tool returns 200". The two doors must return the SAME model from the same fixture, because a second
+ * implementation that merely looks right is the defect this repo produces most. The fixture is built so the
+ * answer is not trivially empty: two entity types and an edge between them, so a wrong narrowing or a dropped
+ * relationship shows up as a difference rather than as two identical empty objects.
+ *
+ * Run: node --test testing/integration/er-model-both-doors.test.js
+ */
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, get } from '../sync/helpers.js';
+import { openMcpSession } from '../sync/mcp-session.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+const RUN = Date.now();
+const SPACE = `er-model-${RUN}`;
+
+let tokenA;
+const token = () => tokenA;
+
+before(async () => {
+  tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+  const created = await post(INSTANCES.a, token(), '/api/spaces', { id: SPACE, label: `ER model ${RUN}` });
+  assert.equal(created.status, 201, JSON.stringify(created.body));
+
+  // Two types and a relationship, so the model has something to report either way.
+  const svc = await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/entities`, {
+    name: `api-gateway-${RUN}`, type: 'service', tags: [], properties: {},
+  });
+  const team = await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/entities`, {
+    name: `platform-team-${RUN}`, type: 'team', tags: [], properties: {},
+  });
+  assert.equal(svc.status, 201, JSON.stringify(svc.body));
+  assert.equal(team.status, 201, JSON.stringify(team.body));
+  const edge = await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/edges`, {
+    from: svc.body._id, to: team.body._id, label: 'owned_by',
+  });
+  assert.equal(edge.status, 201, JSON.stringify(edge.body));
+});
+
+after(async () => {
+  await fetch(`${INSTANCES.a}/api/spaces/${SPACE}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token()}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ confirm: true }),
+  }).catch(() => {});
+});
+
+describe('er_model reaches both doors with the same answer', () => {
+  it('REST reports the two types and the relationship', async () => {
+    const r = await get(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/er-model`);
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    const json = JSON.stringify(r.body);
+    assert.match(json, /service/, `the stored types must appear: ${json.slice(0, 300)}`);
+    assert.match(json, /team/);
+    assert.match(json, /owned_by/, 'the edge label is the relationship half of the model');
+  });
+
+  it('the MCP tool returns the same model, byte for byte', async (t) => {
+    let session;
+    try {
+      session = await openMcpSession(token());
+    } catch (e) {
+      return t.skip(`MCP session unavailable: ${e.message}`);
+    }
+    try {
+      const rest = await get(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/er-model`);
+      const res = await session.callTool('er_model', { space: SPACE });
+      const text = res?.content?.[0]?.text ?? '';
+      const mcp = JSON.parse(text);
+      // Same object, not merely both plausible. One builder serves both, and this is what says so.
+      assert.deepEqual(mcp, rest.body, `the two doors disagree:\nMCP:  ${text.slice(0, 300)}\nREST: ${JSON.stringify(rest.body).slice(0, 300)}`);
+    } finally {
+      session.close();
+    }
+  });
+
+  it('a space the token cannot reach is refused, not answered', async (t) => {
+    // The tool narrows with `memberSpacesWithin`; a tool that ignored it would answer for any space id.
+    let session;
+    try {
+      session = await openMcpSession(token());
+    } catch (e) {
+      return t.skip(`MCP session unavailable: ${e.message}`);
+    }
+    try {
+      const res = await session.callTool('er_model', { space: `no-such-space-${RUN}` });
+      const text = JSON.stringify(res ?? {});
+      // NOT just /error/: against a stale image this assertion passed on "Unknown tool: er_model", which is
+      // a refusal of the TOOL rather than of the space — a false pass that hid the tool being absent.
+      assert.doesNotMatch(text, /Unknown tool/i, 'the tool itself must exist — rebuild the test image');
+      assert.match(text, /space|not found|not accessible/i,
+        `an unknown space must be refused rather than answered: ${text.slice(0, 200)}`);
+    } finally {
+      session.close();
+    }
+  });
+});
+

--- a/testing/standalone/mcp-tool-schemas.test.js
+++ b/testing/standalone/mcp-tool-schemas.test.js
@@ -36,7 +36,10 @@ describe('MCP tool schemas — universal invariants', () => {
     // was five rows long because five routes shipped alone. Prerequisites done for both: `retry_record_embedding` maps
     // to `brain.retry_embedding` and is listed among the tools a readOnly token cannot see, `list_embed_jobs` is
     // read-only and deliberately visible to a readOnly token, and `16-mcp.md` carries a row for each.
-    assert.equal(ALL_TOOLS.length, 41);
+    // 41 -> 42: `er_model`. Prerequisites done — `audit-map.ts` maps it to `brain.er_model` (and the REST
+    // route is now audited too, which it was not while `stats` was), it is read-only and deliberately
+    // visible to a readOnly token, and `16-mcp.md` carries its row.
+    assert.equal(ALL_TOOLS.length, 42);
   });
 
   it('every tool advertises a closed object schema (type:object, additionalProperties:false)', () => {

--- a/testing/standalone/proxy-fanout-inventory.test.js
+++ b/testing/standalone/proxy-fanout-inventory.test.js
@@ -123,7 +123,15 @@ const RECLASSIFIED = 1;
  * The number moving UP as narrowing becomes explicit is the healthy direction for this invariant. It moved down once in
  * my hands, on a plausible story about consolidation, and the arithmetic said otherwise.
  */
-const TOTAL = 38;
+/**
+ * 38 -> 39: the `er_model` MCP tool.
+ *
+ * The REST route has always narrowed with `memberSpacesForRequest`; the tool is new and narrows with
+ * `memberSpacesWithin`, which is the MCP half of the same rule. One more visible site, and it reports a proxy's
+ * members SEPARATELY rather than merged — merging type counts across spaces would invent relationships that
+ * cannot exist, since an edge cannot cross a space.
+ */
+const TOTAL = 39;
 
 const GUARDS = {
   'server/src/auth/middleware.ts': 2,


### PR DESCRIPTION
`GET /api/brain/spaces/:spaceId/er-model` was REST-only, and it answers the question an agent asks **first**:
which entity types actually exist here, which edge labels connect which of them, and how many of each.

`get_space_meta` answers a different question — the **declared** schema, what *may* exist. So an MCP-only client
could learn what a space permits and not what it contains.

**Found by `scripts/surface-matrix.mjs`**, which listed the route in its REST-only column. Second finding from
that generator within the hour, after the `reindex` description pointing at a route MCP cannot reach.

## One builder, two doors, proven equal

The tool calls `buildErModel` and narrows with `memberSpacesWithin` — the MCP half of the rule REST states with
`memberSpacesForRequest`. A proxy space reports its members **separately**, exactly as the route does: merging
counts for two types that share a name across spaces would invent relationships that cannot exist, because an
edge cannot cross a space. A union would look richer and be false.

The E2E asserts the two responses are `deepEqual` on one fixture — two entity types and an edge between them, so
a dropped relationship or a wrong narrowing shows up as a difference rather than as two identical empty objects.

## The REST route is audited now too

`brain.stats` was recorded in the audit log and `er-model` was not, which was an asymmetry rather than a
decision — both report what a space *contains*. New operation `brain.er_model`, classified as a `read` for the
per-space usage counters, documented in the audit-log operations table.

## Five gates objected, and each was answered rather than adjusted

| gate | what it wanted |
|---|---|
| `mcp-audit-coverage` | an operation, or `null` with a reason |
| `mcp-tool-schemas` | the tool-count tripwire bumped **with** its three prerequisites named |
| `mcp-help` | a read-only classification, so a read-only token sees it |
| `proxy-fanout-inventory` | the conserved total 38 → 39, with the arithmetic written down |
| `space-activity-classes` | a call class, or a named exclusion |

`surface-matrix.mjs` refused to publish at all until the tool had a map row — which is what caught the row
being missing.

## A false pass, caught before it shipped

"An unknown space is refused, not answered" **passed** while the tool did not exist: the local stack runs a
stale image, so the MCP call returned `Unknown tool: er_model`, and a `/error/` assertion happily matched it.
The assertion now rejects that message explicitly — a refusal of the *tool* is not a refusal of the *space* —
and the stack was rebuilt before the suite was believed.

## Userguide

Already covered, under a different name: the Overview tab's **Data model** panel is this model, described in
detail including the proxy behaviour and the dashed boxes for memories/chrono/files. Nothing to add — worth
recording because the matrix's userguide column reports a `—` here, and that column matches names, not concepts.

🤖 Generated with Claude Code
