### PR TITLE
feat(auth)!: one rung for both doors, and every token carries a matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Seven destructive REST routes now ask for the `write` rung instead of `admin`, and every token carries a
+  rights matrix.** Owner rulings, 2026-08-13, after the difference was **measured** rather than argued: a token
+  holding `rights.perSpace.general.knowledge = 'write'` was refused `DELETE /memories/:id` with
+  `403 Token needs 'admin' on knowledge in space 'general'` — and deleted the same record through MCP
+  `delete_memory` seconds later, because `mcp/router.ts` gates on the token's `readOnly`/`admin` flags and never
+  consults the rung. One rule, two implementations, the weaker one silently in charge.
+  - **Levelled DOWN, not up:** `write` is the right rung for deleting a single record you could have created. The
+    rows are `/memories/:id`, `/entities/:id`, `/edges/:id`, `/chrono/:id`, the entity merge, `/bulk` and
+    `DELETE /api/files/:spaceId`.
+  - **The collection wipes stay `admin`**, matching `wipe_space` — emptying a collection is not the same act as
+    deleting a row. `DELETE /api/brain/spaces/:spaceId/files` stays `admin` too: no tool mirrors it, so lowering
+    it would weaken a door for parity with nothing.
+  - **`update_space_schema` remains the one known difference**, in the safe direction: REST asks `schema: write`,
+    the tool is admin-gated. `scripts/surface-matrix.mjs` reports it every run.
+- **Every token now carries a rights matrix, written to disk.** *"Translate old tokens into matrix rights and
+  overwrite on update. Only matrix from now on."*
+  - `createToken` **always** stores one, deriving it from the legacy fields when the caller did not supply it. It
+    used to omit the field and rely on a load-time backfill — which runs once, over the tokens already in the
+    config, so a token minted afterwards had **no matrix until the next boot**, and `enforceAreaRung` passes when
+    rights are absent. That is why a plain token deleted over REST with a `204` in the same probe.
+  - The boot backfill is **persisted** rather than in-memory, so the matrix becomes the record of record and "no
+    matrix" means something is wrong rather than something is old. A failed write retries next boot.
+  - `updateTokenSpaces` is **deleted**. It had no callers and its only job was editing the legacy allowlist —
+    exactly what a future caller would reach for to put the two descriptions of access out of step.
+  - The legacy `admin`/`readOnly`/`spaces` fields are **left in place**, so an older build rolls back unaffected.
+    Recorded in the hosting guide's rollback table for the shape change alone.
+- **The capability map is published.** `docs/integration-guide/16-mcp.md` now carries every capability with its
+  MCP tool, its REST route and the token level it needs — generated from the code and checked against the running
+  routers. The doc-coverage columns stay internal: an integrator cannot act on which of our files mentions a
+  thing, and a `—` there means our name-matcher missed it rather than that a gap exists.
 - **The capability matrix is generated and audited from running code.** `scripts/surface-matrix-audit.mjs`
   imports every mounted `Router`, walks its stack including sub-routers, and compares both ways against the
   static extraction: **208 = 208**, plus 41 of 41 tools mapped and each pair sharing an implementation module.

--- a/docs/integration-guide/02-hosting.md
+++ b/docs/integration-guide/02-hosting.md
@@ -769,9 +769,16 @@ moved. They are listed here so the consequence of going back is not a surprise:
 | `mediaEmbedding.enabled` → per-class `levels` | `enabled` | defaults it back to **`true`**: an instance where media embedding was deliberately **off** starts sending uploads to the vision and speech models again |
 | a space's `description` → `meta.purpose` | `description` | reads no space instructions, because the field it serves to MCP clients is gone |
 | `mediaEmbedding.faceRecognition.enabled` → the image ladder | `faceRecognition.enabled` | applies its own default for face recognition rather than the choice that was recorded |
+| every token gains a `rights` matrix | **nothing** | keeps working: it reads the legacy `admin`/`readOnly`/`spaces` fields, which are left in place |
 
-Each of those is silent in the old build — the field is simply absent, which reads as "never configured" rather
-than "removed".
+The first three are silent in the old build — the field is simply absent, which reads as "never configured"
+rather than "removed".
+
+**`tokens[].rights` is the exception, and the safe kind.** The upgrade derives a per-space rights matrix for every
+token from its legacy `admin`/`readOnly`/`spaces` fields and writes it down; it does **not** remove those fields.
+So an older build ignores the new one and enforces exactly what it did before, and a rollback needs no token work.
+It is listed here because the file changes shape and an operator reading `config.json` should know why, not
+because anything is lost.
 
 #### The procedure
 

--- a/docs/integration-guide/16-mcp.md
+++ b/docs/integration-guide/16-mcp.md
@@ -422,7 +422,81 @@ For cross-space recall (omit `space`), `spaceId` on each result identifies which
 
 When `space` is omitted, `recall` searches across all accessible spaces — the same as the former `recall_global` behaviour.
 
-### Example: update_memory
+### Capability map — both doors, and what a token needs
+
+Every capability, the MCP tool and the REST route that perform it, and the per-space rung a token needs. This is
+generated from the code and checked against the running routers, so it is the same list the server enforces
+rather than a summary someone maintained by hand.
+
+**How to read the token column.** REST enforces a per-space **rung** (`read` / `write` / `admin`) for an area —
+`knowledge`, `files`, `schema`, `dataQuality`. MCP gates on the token's flags: a read-only token cannot see
+mutating tools, and a non-admin token cannot see admin tools. Where the two differ the cell names both doors;
+one row does today (`update_space_schema`, where the tool is stricter than the route). `instance-level` means the
+route sits outside the per-space matrix by design — `/api/spaces`, `/api/tokens`, `/api/networks`.
+
+**MCP only** means the capability has no single REST route: `help` is the tool-caller's guide, and `wipe_space`
+composes what REST exposes as one DELETE per collection.
+
+| capability | MCP tool | REST route | token needs |
+|---|---|---|---|
+| **Brain — memories** | | | |
+| | `remember` | `POST /api/brain/spaces/:spaceId/memories` | write `knowledge` |
+| | `update_memory` | `PATCH /api/brain/spaces/:spaceId/memories/:id` | write `knowledge` |
+| | `delete_memory` | `DELETE /api/brain/spaces/:spaceId/memories/:id` | write `knowledge` |
+| **Brain — entities** | | | |
+| | `upsert_entity` | `POST /api/brain/spaces/:spaceId/entities` | write `knowledge` |
+| | `update_entity` | `PATCH /api/brain/spaces/:spaceId/entities/:id` | write `knowledge` |
+| | `delete_entity` | `DELETE /api/brain/spaces/:spaceId/entities/:id` | write `knowledge` |
+| | `merge_entities` | `POST /api/brain/spaces/:spaceId/entities/:survivorId/merge/:absorbedId` | write `knowledge` |
+| | `find_entities_by_name` | `GET /api/brain/spaces/:spaceId/entities/by-name` | read `knowledge` |
+| **Brain — edges** | | | |
+| | `upsert_edge` | `POST /api/brain/spaces/:spaceId/edges` | write `knowledge` |
+| | `update_edge` | `PATCH /api/brain/spaces/:spaceId/edges/:id` | write `knowledge` |
+| | `delete_edge` | `DELETE /api/brain/spaces/:spaceId/edges/:id` | write `knowledge` |
+| **Brain — chrono** | | | |
+| | `create_chrono` | `POST /api/brain/spaces/:spaceId/chrono` | write `knowledge` |
+| | `update_chrono` | `PATCH /api/brain/spaces/:spaceId/chrono/:id` | write `knowledge` |
+| | `delete_chrono` | `DELETE /api/brain/spaces/:spaceId/chrono/:id` | write `knowledge` |
+| | `list_chrono` | `GET /api/brain/spaces/:spaceId/chrono` | read `knowledge` |
+| **Brain — search** | | | |
+| | `recall` | `POST /api/brain/spaces/:spaceId/recall` | read `knowledge` |
+| | `query` | `POST /api/brain/spaces/:spaceId/query` | read `knowledge` |
+| | `find_similar` | `POST /api/brain/spaces/:spaceId/find-similar` | read `knowledge` |
+| | `traverse` | `POST /api/brain/spaces/:spaceId/traverse` | read `knowledge` |
+| **Brain — bulk** | | | |
+| | `bulk_write` | `POST /api/brain/spaces/:spaceId/bulk` | write `knowledge` |
+| **Brain — ops** | | | |
+| | `get_stats` | `GET /api/brain/spaces/:spaceId/stats` | read `knowledge` |
+| | `er_model` | `GET /api/brain/spaces/:spaceId/er-model` | read `knowledge` |
+| | `reindex` | `POST /api/brain/spaces/:spaceId/reindex` | admin `schema` |
+| | `list_embed_jobs` | `GET /api/brain/spaces/:spaceId/embedding-queue/records` | read `knowledge` |
+| | `retry_record_embedding` | `POST /api/brain/spaces/:spaceId/embedding-queue/records/retry` | write `knowledge` |
+| | `retry_failed_embeddings` | `POST /api/brain/spaces/:spaceId/embedding-queue/retry-failed` | write `files` |
+| **Files** | | | |
+| | `read_file` | `GET /api/files/:spaceId` | read `files` |
+| | `write_file` | `POST /api/files/:spaceId` | write `files` |
+| | `delete_file` | `DELETE /api/files/:spaceId` | write `files` |
+| | `move_file` | `PATCH /api/files/:spaceId` | write `files` |
+| | `list_dir` | `GET /api/files/:spaceId` | read `files` |
+| | `create_dir` | `POST /api/files/:spaceId/mkdir` | write `files` |
+| | `retry_embedding` | `POST /api/files/:spaceId/retry_embedding` | write `files` |
+| | `update_file_meta` | `PATCH /api/brain/spaces/:spaceId/files` | write `files` |
+| **Spaces** | | | |
+| | `list_spaces` | `GET /api/spaces` | read (MCP) · instance-level |
+| | `create_space` | `POST /api/spaces` | admin (MCP) · instance-level |
+| | `update_space` | `PATCH /api/spaces/:id` | admin (MCP) · instance-level |
+| | `get_space_meta` | `GET /api/spaces/:id/meta` | read `schema` |
+| | `update_space_schema` | `PUT /api/spaces/:id/schema` | **REST write `schema` · MCP admin** |
+| | `wipe_space` | **MCP only** | admin (MCP) |
+| **Tokens** | | | |
+| | `list_tokens` | `GET /api/tokens` | admin (MCP) · instance-level |
+| **Networks / sync** | | | |
+| | `list_peers` | `GET /api/networks` | admin (MCP) · instance-level |
+| | `sync_now` | `POST /api/networks/:id/sync` | admin (MCP) · instance-level |
+| **Meta** | | | |
+| | `help` | **MCP only** | read (MCP) |
+
+## Example: update_memory
 
 ```json
 {

--- a/scripts/surface-matrix.mjs
+++ b/scripts/surface-matrix.mjs
@@ -254,6 +254,23 @@ for (const [a, list] of [...byArea].sort((x, y) => y[1].length - x[1].length)) {
 }
 
 writeFileSync(join(ROOT, 'todo/_matrix-capabilities.md'), out.join('\n'), 'utf8');
+
+/**
+ * The PUBLISHED table: capability, both doors, and the token level. No doc columns.
+ *
+ * An integrator cannot act on "which of our files mentions this" — that is our bookkeeping, and publishing it
+ * would also publish a `—` that means "our name-matcher missed it", which reads as a gap that is not there.
+ * What they can act on is: does this exist on my door, and what does my token need.
+ */
+const pub = [];
+pub.push('| capability | MCP tool | REST route | token needs |');
+pub.push('|---|---|---|---|');
+let pubArea = null;
+for (const r of rows) {
+  if (r.area !== pubArea) { pubArea = r.area; pub.push(`| **${pubArea}** | | | |`); }
+  pub.push(`| | \`${r.tool}\` | ${r.route ? `\`${r.route}\`` : '**MCP only**'} | ${rungCell(r)} |`);
+}
+writeFileSync(join(ROOT, 'todo/_matrix-published.md'), pub.join('\n'), 'utf8');
 writeFileSync(join(ROOT, 'todo/_matrix-rest-only.md'), rest.join('\n'), 'utf8');
 const rungMismatch = rows.filter(r => r.route && r.restRung && r.restRung !== 'exempt' && r.restRung !== r.mcpRung);
 const noRightsRow = rows.filter(r => r.route && r.restRung === null);

--- a/server/src/auth/backfill-token-rights.ts
+++ b/server/src/auth/backfill-token-rights.ts
@@ -1,0 +1,76 @@
+/**
+ * Derive a rights matrix for every token that lacks one, once, and write it down.
+ *
+ * ## Why it is here and not in `config/loader.ts`
+ *
+ * It was there, and persisting the result pushed that file past its god-file freeze (764 → 772). The ratchet's
+ * instruction is to put new behaviour beside a large file rather than inside it, and this is not
+ * configuration-loading behaviour: it is a token migration that happens to run at boot. The loader keeps one call.
+ *
+ * ## Why it writes to disk
+ *
+ * Owner ruling, 2026-08-13: *"translate old tokens into matrix rights and overwrite on update. only matrix from
+ * now on."*
+ *
+ * In-memory derivation meant the matrix was never the record of record — recomputed on every boot from fields
+ * that were still authoritative, so nobody could tell a token that had been migrated from one nobody had looked
+ * at. Written down, "this token has no matrix" means something is wrong rather than something is old.
+ *
+ * A boot migration is the right shape here at all only because tokens are LOCAL state: `config.json` does not
+ * sync. Synced data must be migrated lazily and self-healingly instead.
+ */
+import type { Config } from '../config/types.js';
+import { migrateToken } from './rights-migration.js';
+import { log } from '../util/log.js';
+
+/**
+ * Give every token a `rights` object derived from its legacy fields, if it lacks one.
+ *
+ * Returns how many were filled, so a caller can log it and a test can assert the count rather than trusting
+ * that the loop ran.
+ *
+ * **The result is now PERSISTED** — owner ruling 2026-08-13: *"translate old tokens into matrix rights and
+ * overwrite on update. only matrix from now on."* It used to be in-memory only, which meant the matrix was
+ * re-derived on every boot and never became the record of record. Writing it makes the migration a one-time
+ * event with an auditable result, and makes "this token has no matrix" mean something is wrong rather than
+ * something is old.
+ */
+export function backfillTokenRights(config: Config): number {
+  let filled = 0;
+  for (const t of config.tokens ?? []) {
+    if (t.rights) continue;
+    t.rights = migrateToken(t) as unknown as typeof t.rights;
+    filled++;
+  }
+  return filled;
+}
+
+
+/**
+ * The boot step: derive, then persist if anything changed.
+ *
+ * `saveConfig` is injected rather than imported so this module does not depend on the loader that calls it — the
+ * cycle would be real, and a token migration has no business reaching back into configuration loading.
+ *
+ * A failed write is logged and retried next boot, exactly like the media-embedding migration beside it. Throwing
+ * would take the instance down over housekeeping; pretending it succeeded would lose the migration silently.
+ */
+export function migrateTokenRightsOnBoot(config: Config, save?: (c: Config) => void): number {
+  const filled = backfillTokenRights(config);
+  if (filled === 0) return 0;
+  const persist = save ?? defaultSave;
+  try {
+    persist(config);
+    log.info(`Derived a rights matrix for ${filled} token(s) from their legacy fields (written to disk)`);
+  } catch (err) {
+    log.warn(`Could not persist derived token rights (will retry next boot): ${err}`);
+  }
+  return filled;
+}
+
+/** Late-bound so the import graph stays one-way: loader -> here, never back. */
+function defaultSave(config: Config): void {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { saveConfig } = require('../config/loader.js') as { saveConfig: (c: Config) => void };
+  saveConfig(config);
+}

--- a/server/src/auth/space-rights.ts
+++ b/server/src/auth/space-rights.ts
@@ -59,6 +59,32 @@ export interface RouteRight {
  * most callers holding it also write, because the question at the gate is "may this call happen", not "who
  * usually makes it".
  */
+/**
+ * ## Why seven destructive rows ask for `write` rather than `admin`
+ *
+ * Owner ruling, 2026-08-13, after the difference was MEASURED rather than argued. A token carrying
+ * `rights.perSpace.general.knowledge = 'write'` was refused `DELETE /memories/:id` with
+ * `403 Token needs 'admin' on knowledge in space 'general'` — and deleted the same record through MCP
+ * `delete_memory` seconds later, because `mcp/router.ts` gates on the token's `readOnly`/`admin` FLAGS and never
+ * consults the rung. One rule, two implementations, and the weaker one silently in charge.
+ *
+ * The ruling was to level DOWN, not up: **`write` is the right rung for deleting a single record you could have
+ * created.** The rows are `/memories/:id`, `/entities/:id`, `/edges/:id`, `/chrono/:id`, the entity merge, `/bulk`,
+ * and `DELETE /api/files/:spaceId`.
+ *
+ * **What deliberately did NOT move:**
+ * - The **collection wipes** (`DELETE /memories`, `/entities`, `/edges`, `/chrono`) stay `admin`. Their MCP
+ *   counterpart `wipe_space` is `admin: true`, so those two doors already agree — and emptying a collection is not
+ *   the same act as deleting a row.
+ * - `DELETE /api/brain/spaces/:spaceId/files` (the file-META record) stays `admin`. No tool mirrors it, so
+ *   lowering it would weaken a door for parity with nothing.
+ * - `update_space_schema` remains the one known difference in the OTHER direction: REST asks `schema: write`,
+ *   the tool is `admin: true`. MCP being stricter is safe, and levelling it down is a separate decision about
+ *   schema authoring rather than about deletes. `surface-matrix.mjs` still reports it.
+ *
+ * A directory delete goes through the same `DELETE /api/files/:spaceId` row and therefore also becomes `write` —
+ * it keeps its own `{confirm: true}` body requirement, which is the guard that made this acceptable.
+ */
 export const ROUTE_RIGHTS: readonly RouteRight[] = [
   // ── Knowledge ────────────────────────────────────────────────────────────────────────────────────────
   { route: '/api/brain/spaces/:spaceId/recall', method: 'POST', area: 'knowledge', needs: 'read', scope: 'path' },
@@ -73,29 +99,29 @@ export const ROUTE_RIGHTS: readonly RouteRight[] = [
   { route: '/api/brain/spaces/:spaceId/memories', method: 'POST', area: 'knowledge', needs: 'write', scope: 'path' },
   { route: '/api/brain/spaces/:spaceId/memories/:id', method: 'GET', area: 'knowledge', needs: 'read', scope: 'path' },
   { route: '/api/brain/spaces/:spaceId/memories/:id', method: 'PATCH', area: 'knowledge', needs: 'write', scope: 'path' },
-  { route: '/api/brain/spaces/:spaceId/memories/:id', method: 'DELETE', area: 'knowledge', needs: 'admin', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/memories/:id', method: 'DELETE', area: 'knowledge', needs: 'write', scope: 'path' },
   { route: '/api/brain/spaces/:spaceId/entities', method: 'GET', area: 'knowledge', needs: 'read', scope: 'path' },
   { route: '/api/brain/spaces/:spaceId/entities', method: 'POST', area: 'knowledge', needs: 'write', scope: 'path' },
   { route: '/api/brain/spaces/:spaceId/entities/by-ids', method: 'GET', area: 'knowledge', needs: 'read', scope: 'path' },
   { route: '/api/brain/spaces/:spaceId/entities/by-name', method: 'GET', area: 'knowledge', needs: 'read', scope: 'path' },
   { route: '/api/brain/spaces/:spaceId/entities/:id', method: 'GET', area: 'knowledge', needs: 'read', scope: 'path' },
   { route: '/api/brain/spaces/:spaceId/entities/:id', method: 'PATCH', area: 'knowledge', needs: 'write', scope: 'path' },
-  { route: '/api/brain/spaces/:spaceId/entities/:id', method: 'DELETE', area: 'knowledge', needs: 'admin', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/entities/:id', method: 'DELETE', area: 'knowledge', needs: 'write', scope: 'path' },
   // A merge DESTROYS one of the two records, so it is admin even though each half looks like an edit.
-  { route: '/api/brain/spaces/:spaceId/entities/:survivorId/merge/:absorbedId', method: 'POST', area: 'knowledge', needs: 'admin', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/entities/:survivorId/merge/:absorbedId', method: 'POST', area: 'knowledge', needs: 'write', scope: 'path' },
   { route: '/api/brain/spaces/:spaceId/edges', method: 'GET', area: 'knowledge', needs: 'read', scope: 'path' },
   { route: '/api/brain/spaces/:spaceId/edges', method: 'POST', area: 'knowledge', needs: 'write', scope: 'path' },
   { route: '/api/brain/spaces/:spaceId/edges/:id', method: 'GET', area: 'knowledge', needs: 'read', scope: 'path' },
   { route: '/api/brain/spaces/:spaceId/edges/:id', method: 'PATCH', area: 'knowledge', needs: 'write', scope: 'path' },
-  { route: '/api/brain/spaces/:spaceId/edges/:id', method: 'DELETE', area: 'knowledge', needs: 'admin', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/edges/:id', method: 'DELETE', area: 'knowledge', needs: 'write', scope: 'path' },
   { route: '/api/brain/spaces/:spaceId/chrono', method: 'GET', area: 'knowledge', needs: 'read', scope: 'path' },
   { route: '/api/brain/spaces/:spaceId/chrono', method: 'POST', area: 'knowledge', needs: 'write', scope: 'path' },
   { route: '/api/brain/spaces/:spaceId/chrono/:id', method: 'GET', area: 'knowledge', needs: 'read', scope: 'path' },
   { route: '/api/brain/spaces/:spaceId/chrono/:id', method: 'PATCH', area: 'knowledge', needs: 'write', scope: 'path' },
-  { route: '/api/brain/spaces/:spaceId/chrono/:id', method: 'DELETE', area: 'knowledge', needs: 'admin', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/chrono/:id', method: 'DELETE', area: 'knowledge', needs: 'write', scope: 'path' },
   // `bulk` can create OR delete, so it takes the higher rung of what it can do rather than of what it is
   // usually used for. A bulk endpoint gated at `write` is a delete endpoint with a friendly name.
-  { route: '/api/brain/spaces/:spaceId/bulk', method: 'POST', area: 'knowledge', needs: 'admin', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/bulk', method: 'POST', area: 'knowledge', needs: 'write', scope: 'path' },
   // COLLECTION-level deletes. Every one of these empties a whole record type in the space, and not one was
   // in the first draft of this list — the gate found them. They are the single most destructive thing in the
   // area and would have been the least governed.
@@ -130,7 +156,7 @@ export const ROUTE_RIGHTS: readonly RouteRight[] = [
   // `DELETE` is `admin` to match `DELETE /api/brain/spaces/:spaceId/files`: deleting a directory takes the tree
   // with it, and the metadata half of the same operation has always been the highest rung. `PATCH` (move/rename)
   // and `retry_embedding` (re-queues a file's embedding) are `write`.
-  { route: '/api/files/:spaceId', method: 'DELETE', area: 'files', needs: 'admin', scope: 'path' },
+  { route: '/api/files/:spaceId', method: 'DELETE', area: 'files', needs: 'write', scope: 'path' },
   { route: '/api/files/:spaceId', method: 'PATCH', area: 'files', needs: 'write', scope: 'path' },
   { route: '/api/files/:spaceId/retry_embedding', method: 'POST', area: 'files', needs: 'write', scope: 'path' },
 

--- a/server/src/auth/tokens.ts
+++ b/server/src/auth/tokens.ts
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { getConfig, saveConfig, mutateConfig, getSecrets, saveSecrets } from '../config/loader.js';
 import { log } from '../util/log.js';
 import type { TokenRecord } from '../config/types.js';
+import { migrateToken } from './rights-migration.js';
 
 const BCRYPT_ROUNDS = 12;
 const BASE62 = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
@@ -202,9 +203,20 @@ export async function createToken(opts: {
     // Stored only when it says something. `inherit` IS the absent state, so writing it would put a field on
     // every future token that means exactly what its absence already means.
     ...(opts.mfa && opts.mfa !== 'inherit' ? { mfa: opts.mfa } : {}),
-    // Stored when given. Omitted otherwise so the backfill derives it — writing an empty matrix here would
-    // mint a token that reaches nothing while its legacy fields say otherwise.
-    ...(opts.rights ? { rights: opts.rights } : {}),
+    // ALWAYS stored. Owner ruling 2026-08-13: *"translate old tokens into matrix rights and overwrite on
+    // update. only matrix from now on."*
+    //
+    // It used to be omitted so the load-time backfill would derive it — but that backfill runs once, at load,
+    // over the tokens already in the config. A token minted afterwards had no matrix until the next restart,
+    // and `enforceAreaRung` PASSES when `rights` is absent. Measured: a plain non-admin token deleted a memory
+    // over REST with a 204 where a rights-bearing `write` token got a 403 for the same call. The hole was the
+    // missing matrix, not the rung.
+    rights: opts.rights ?? (migrateToken({
+      admin: opts.admin ?? false,
+      readOnly: opts.readOnly ?? false,
+      spaces: opts.spaces,
+      ...(opts.schemaLibrary ? { schemaLibrary: true } : {}),
+    }) as unknown as TokenRecord['rights']),
   };
   const config = getConfig();
   config.tokens.push(record);
@@ -279,15 +291,6 @@ export function listTokens(): Omit<TokenRecord, 'hash'>[] {
   return getConfig().tokens.map(({ hash: _h, ...rest }) => rest);
 }
 
-/** Update space allowlist for a token (undefined = all spaces) */
-export function updateTokenSpaces(id: string, spaces: string[] | undefined): boolean {
-  const config = getConfig();
-  const idx = config.tokens.findIndex(t => t.id === id);
-  if (idx < 0) return false;
-  config.tokens[idx]!.spaces = spaces;
-  saveConfig(config);
-  return true;
-}
 
 /** Rename a token — updates only its human-readable label (`name`); the secret and scope are untouched. */
 /**

--- a/server/src/config/loader.ts
+++ b/server/src/config/loader.ts
@@ -5,7 +5,7 @@ import type { Config, SecretsFile, SchemaLibraryEntry, SchemaCatalog } from './t
 import { normalizeDocExtractionMode } from './types.js';
 import { resolveMasterSecret, isEnvelope, encryptEnvelope, decryptEnvelope } from './secretbox.js';
 import { envIntOpt } from './env-num.js';
-import { migrateToken } from '../auth/rights-migration.js';
+import { migrateTokenRightsOnBoot } from '../auth/backfill-token-rights.js';
 
 const CONFIG_PATH = process.env['CONFIG_PATH'] ?? '/config/config.json';
 const SECRETS_PATH = path.join(path.dirname(CONFIG_PATH), 'secrets.json');
@@ -195,21 +195,6 @@ export function configExists(): boolean {
  *
  * @returns true if it changed the config (caller persists).
  */
-/**
- * Give every token a `rights` object derived from its legacy fields, if it lacks one.
- *
- * Returns how many were filled, so a caller can log it and a test can assert the count rather than trusting
- * that the loop ran. In-memory only — see the call site for why this is not written to disk yet.
- */
-export function backfillTokenRights(config: Config): number {
-  let filled = 0;
-  for (const t of config.tokens ?? []) {
-    if (t.rights) continue;
-    t.rights = migrateToken(t) as unknown as typeof t.rights;
-    filled++;
-  }
-  return filled;
-}
 
 export function migrateMediaEmbeddingMasterSwitch(config: Config): boolean {
   const media = config.mediaEmbedding as (MediaEmbeddingConfig & { enabled?: boolean }) | undefined;
@@ -315,7 +300,7 @@ export function loadConfig(): Config {
   //
   // A boot migration is the right shape here at all only because tokens are LOCAL state — config.json does
   // not sync. Synced data must be migrated lazily and self-healingly instead.
-  backfillTokenRights(_config);
+  migrateTokenRightsOnBoot(_config);
 
   // Durable one-time migration of the removed media-embedding master switch (writes config.json once).
   if (migrateMediaEmbeddingMasterSwitch(_config)) {

--- a/testing/integration/rung-matches-on-both-doors.test.js
+++ b/testing/integration/rung-matches-on-both-doors.test.js
@@ -1,0 +1,134 @@
+/**
+ * A `write` token can delete a single record through either door, and a token with no matrix is not exempt.
+ *
+ * ## The two defects this covers, both measured before the fix
+ *
+ * A token minted with `rights.perSpace.general.knowledge = 'write'`:
+ *
+ * | call | before | after |
+ * |---|---|---|
+ * | `DELETE /api/brain/spaces/general/memories/:id` | **403** `Token needs 'admin' on knowledge…` | 204 |
+ * | MCP `delete_memory`, same record | deleted it | deletes it |
+ *
+ * One rule, two implementations, and the weaker one silently in charge — `mcp/router.ts` gates on the token's
+ * `readOnly`/`admin` FLAGS and never consults the rung. Owner ruling B, 2026-08-13: level DOWN. `write` is the
+ * right rung for deleting a single record you could have created, so the seven REST rows that asked for `admin`
+ * now ask for `write`. The collection WIPES still ask for `admin`, matching `wipe_space`.
+ *
+ * The second defect: a token minted with no `rights` at all skipped the rung check entirely, because
+ * `enforceAreaRung` returns early without a matrix. Minting now always derives one — *"only matrix from now on"*.
+ *
+ * Run: node --test testing/integration/rung-matches-on-both-doors.test.js
+ */
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, get } from '../sync/helpers.js';
+import { openMcpSession } from '../sync/mcp-session.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+const RUN = Date.now();
+
+let admin;
+const WRITE_RIGHTS = {
+  instanceAdmin: false,
+  createSpaces: false,
+  floor: null,
+  perSpace: { general: { knowledge: 'write', files: 'write', schema: 'none', dataQuality: 'none' } },
+};
+
+const minted = [];
+
+async function mint(name, body) {
+  const r = await post(INSTANCES.a, admin, '/api/tokens', { name, ...body });
+  assert.equal(r.status, 201, `minting ${name}: ${JSON.stringify(r.body)}`);
+  minted.push(r.body.id);
+  return r.body;
+}
+
+const writeMemory = async (tk) => {
+  const r = await post(INSTANCES.a, tk, '/api/brain/spaces/general/memories', { fact: `rung probe ${RUN} ${Math.random()}` });
+  assert.equal(r.status, 201, `writing a memory: ${JSON.stringify(r.body)}`);
+  return r.body._id ?? r.body.id;
+};
+
+const restDelete = (tk, id) => fetch(`${INSTANCES.a}/api/brain/spaces/general/memories/${id}`, {
+  method: 'DELETE', headers: { Authorization: `Bearer ${tk}` },
+});
+
+before(() => { admin = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim(); });
+
+after(async () => {
+  for (const id of minted) {
+    await fetch(`${INSTANCES.a}/api/tokens/${id}`, {
+      method: 'DELETE', headers: { Authorization: `Bearer ${admin}` },
+    }).catch(() => {});
+  }
+});
+
+describe('a write token deletes one record on both doors', () => {
+  it('REST accepts the delete it used to refuse', async () => {
+    const tok = await mint(`rung-rest-${RUN}`, { rights: WRITE_RIGHTS });
+    const id = await writeMemory(tok.plaintext);
+    const r = await restDelete(tok.plaintext, id);
+    const text = await r.text();
+    assert.equal(r.status, 204, `a write token must be able to delete one record: ${r.status} ${text}`);
+  });
+
+  it('MCP accepts it too, which it always did — the point is that they now agree', async (t) => {
+    const tok = await mint(`rung-mcp-${RUN}`, { rights: WRITE_RIGHTS });
+    const id = await writeMemory(tok.plaintext);
+    let session;
+    try {
+      session = await openMcpSession(tok.plaintext);
+    } catch (e) {
+      return t.skip(`MCP session unavailable: ${e.message}`);
+    }
+    try {
+      const res = await session.callTool('delete_memory', { space: 'general', id });
+      assert.doesNotMatch(JSON.stringify(res ?? {}), /isError/, `MCP delete failed: ${JSON.stringify(res).slice(0, 200)}`);
+      const after = await get(INSTANCES.a, admin, `/api/brain/spaces/general/memories/${id}`);
+      assert.equal(after.status, 404, 'the record must be gone');
+    } finally {
+      session?.close();
+    }
+  });
+
+  it('the collection WIPE still needs admin — levelling down was about single records', async () => {
+    const tok = await mint(`rung-wipe-${RUN}`, { rights: WRITE_RIGHTS });
+    const r = await fetch(`${INSTANCES.a}/api/brain/spaces/general/memories`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${tok.plaintext}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ confirm: true }),
+    });
+    assert.equal(r.status, 403, `emptying a collection is not deleting a row: ${r.status} ${await r.text()}`);
+  });
+});
+
+describe('a token minted without rights is not exempt from the rung', () => {
+  it('it gets a derived matrix, so the schema area is still refused', async () => {
+    // Before: no matrix meant `enforceAreaRung` returned early and the rung was never consulted. The token is
+    // minted with legacy `spaces` only, so its matrix has to come from the derivation.
+    const tok = await mint(`rung-derived-${RUN}`, { spaces: ['general'] });
+    const r = await fetch(`${INSTANCES.a}/api/spaces/general/schema`, {
+      method: 'PUT',
+      headers: { Authorization: `Bearer ${tok.plaintext}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ typeSchemas: {} }),
+    });
+    // A legacy full-access token derives `write` everywhere, and the schema PUT asks for `schema: write` — so
+    // this is allowed. What matters is that the answer is a DECISION, not a skipped check: an admin-rung route
+    // must still refuse it.
+    assert.ok(r.status !== 500, `the derived matrix must not break the request: ${r.status}`);
+
+    const wipe = await fetch(`${INSTANCES.a}/api/brain/spaces/general/memories`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${tok.plaintext}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ confirm: true }),
+    });
+    assert.equal(wipe.status, 403,
+      `a derived write matrix must still be refused an admin-rung route: ${wipe.status} ${await wipe.text()}`);
+  });
+});

--- a/testing/standalone/every-token-carries-a-rights-matrix.test.js
+++ b/testing/standalone/every-token-carries-a-rights-matrix.test.js
@@ -1,0 +1,102 @@
+/**
+ * Every token carries a rights matrix — at mint, not only after a restart.
+ *
+ * ## The hole this closes, measured
+ *
+ * `enforceAreaRung` returns `true` when a record has no `rights`, so the per-space rung is not checked at all for
+ * such a token. The load-time backfill derived a matrix for every token in the config — but only for the tokens
+ * that were already there. A token minted afterwards had none until the next boot.
+ *
+ * Probed against a running instance on 2026-08-13:
+ *
+ * | token | `DELETE /api/brain/spaces/general/memories/:id` |
+ * |---|---|
+ * | minted with an explicit `rights` matrix (`knowledge: write`) | **403** `Token needs 'admin' on knowledge…` |
+ * | minted with no rights at all | **204** — the rung was never consulted |
+ *
+ * Owner ruling, 2026-08-13: *"translate old tokens into matrix rights and overwrite on update. only matrix from
+ * now on."*
+ *
+ * ## What this gate holds, and why by source
+ *
+ * The behaviour needs a running server and a config write, which the integration suite covers. What this gate
+ * pins is cheaper and catches the regression that actually happened: the code paths that can produce a token
+ * must all produce a matrix, and nothing may edit the legacy fields afterwards.
+ *
+ * Run: node --test testing/standalone/every-token-carries-a-rights-matrix.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { stripComments } from './_strip-comments.mjs';
+
+const read = p => stripComments(readFileSync(p, 'utf8'));
+const TOKENS = 'server/src/auth/tokens.ts';
+// The boot step moved out of the loader when persisting it pushed that file past its god-file freeze.
+const BOOT = 'server/src/auth/backfill-token-rights.ts';
+
+describe('a minted token has a matrix', () => {
+  const src = read(TOKENS);
+
+  it('createToken derives one when the caller did not supply it', () => {
+    // NOT `...(opts.rights ? {rights} : {})` — that spread is what left a new token matrix-less until the next
+    // boot, and the rung silently unenforced in the meantime.
+    assert.match(src, /rights: opts\.rights \?\? \(migrateToken\(\{/,
+      'createToken must fall back to a derived matrix rather than omitting the field');
+    assert.ok(!/\.\.\.\(opts\.rights \? \{ rights: opts\.rights \} : \{\}\)/.test(src),
+      'the conditional spread is back — a token minted without explicit rights would carry no matrix');
+  });
+
+  it('the derivation is the shared one, not a second opinion', () => {
+    // `migrateToken` is the single translation from legacy fields. A local re-implementation would be the
+    // two-implementations-of-one-rule defect this repo produces most.
+    assert.match(src, /import \{ migrateToken \} from '\.\/rights-migration\.js'/);
+  });
+});
+
+describe('the boot migration is durable', () => {
+  const src = read(BOOT);
+
+  it('the backfill result is written to disk, not just held in memory', () => {
+    const at = src.indexOf('export function migrateTokenRightsOnBoot');
+    assert.ok(at > -1, 'the boot step is gone — re-anchor this gate');
+    const after = src.slice(at, at + 700);
+    assert.match(after, /if \(filled === 0\) return 0;/, 'a write only when something changed');
+    assert.match(after, /persist\(config\)/, 'and it must actually persist');
+    // And the loader must still CALL it, or the migration is code nobody runs.
+    assert.match(read('server/src/config/loader.ts'), /migrateTokenRightsOnBoot\(_config\)/);
+  });
+
+  it('a failed write retries next boot rather than being reported as done', () => {
+    const at = src.indexOf('export function migrateTokenRightsOnBoot');
+    const after = src.slice(at, at + 900);
+    assert.match(after, /catch/, 'a failed persist must not throw at boot');
+    assert.match(after, /will retry next boot/i, 'and must say so, like the media-embedding migration beside it');
+  });
+});
+
+describe('nothing edits the legacy fields after mint', () => {
+  it('the legacy-allowlist writer is gone, not merely unused', () => {
+    // `updateTokenSpaces` had zero callers and its whole job was editing `spaces` — the field the matrix
+    // replaces. Kept around, it is the obvious thing for a future caller to reach for, and it would put the two
+    // descriptions of access back out of step.
+    // `git grep` exits 1 with no output when nothing matches, and does not see this file until it is tracked —
+    // so both "no hits" and "only this file" are the healthy answers, and anything else is a real reference.
+    let hits = '';
+    try {
+      hits = execFileSync('git', ['grep', '-l', 'updateTokenSpaces', '--', 'server/src', 'client/src', 'testing'],
+        { encoding: 'utf8', cwd: process.cwd() }).trim();
+    } catch { /* exit 1 = no matches */ }
+    const others = hits.split('\n').map(l => l.trim().replace(/\\/g, '/')).filter(Boolean)
+      .filter(f => !f.endsWith('every-token-carries-a-rights-matrix.test.js'));
+    assert.deepEqual(others, [], `updateTokenSpaces is referenced again by: ${others.join(', ')}`);
+  });
+
+  it('rights are replaced wholesale, never merged', () => {
+    // A merge would let a caller widen one area while believing they had described the whole token.
+    const src = read(TOKENS);
+    assert.match(src, /config\.tokens\[idx\]!\.rights = rights;/,
+      'setTokenRights must assign, not merge');
+  });
+});

--- a/testing/standalone/mint-accepts-rights-capped.test.js
+++ b/testing/standalone/mint-accepts-rights-capped.test.js
@@ -67,9 +67,15 @@ describe('minting with a rights matrix', () => {
     // replace, so it would work, and work WRONGLY.
     assert.match(code, /createToken\(\{[^}]*rights/,
       'createToken is called without `rights`, so an accepted matrix is silently discarded');
-    const store = readFileSync(join(ROOT, 'server/src/auth/tokens.ts'), 'utf8');
-    assert.match(withoutComments(store), /opts\.rights \? \{ rights: opts\.rights \}/,
-      'createToken does not persist the matrix it was handed');
+    const store = withoutComments(readFileSync(join(ROOT, 'server/src/auth/tokens.ts'), 'utf8'));
+    // The PROPERTY: an explicitly supplied matrix is what gets stored. The old anchor was the conditional
+    // spread `opts.rights ? {rights} : {}`, which was removed on purpose — omitting the field left a newly
+    // minted token with NO matrix until the next boot, and `enforceAreaRung` passes when rights are absent.
+    // Demanding that spread back would demand the hole back.
+    assert.match(store, /rights: opts\.rights \?\?/,
+      'createToken must store the matrix it was handed, and derive one when it was not');
+    assert.match(store, /migrateToken\(\{/,
+      'and the fallback must be the shared derivation, not a local re-implementation');
   });
 
   it('the cap runs BEFORE anything is created', () => {

--- a/testing/standalone/rollback-is-documented.test.js
+++ b/testing/standalone/rollback-is-documented.test.js
@@ -74,8 +74,20 @@ describe('the sweep works before it is trusted', () => {
   it('each one actually persists, which is what makes it one-way', () => {
     // A migration that only adjusts the in-memory config is harmless to a rollback. It is `saveConfig` that
     // rewrites the file on disk, and that is what an older build then has to read.
+    //
+    // Counted in the loader AND in the modules it delegates to. `migrateTokenRightsOnBoot` lives in
+    // `auth/backfill-token-rights.ts` — it was moved out when persisting it pushed the loader past its
+    // god-file freeze — and it saves there. Counting only the loader body made this gate report three saves
+    // for four migrations and call the fourth non-persisting, which was the opposite of true.
     const body = loadConfigBody();
-    const saves = [...body.matchAll(/saveConfig\(_config\)/g)].length;
+    const delegated = [...LOADER.matchAll(/import \{ (migrate[A-Za-z0-9_]+) \} from '([^']+)'/g)]
+      .map(m => m[2].replace(/^\.\.?\//, '').replace(/\.js$/, '.ts'))
+      .map(rel => {
+        try { return read(`server/src/${rel}`); } catch { return ''; }
+      })
+      .join('\n');
+    const saves = [...body.matchAll(/saveConfig\(_config\)/g)].length
+      + [...delegated.matchAll(/persist\(config\)|saveConfig\(config\)/g)].length;
     const migrations = bootMigrations().length;
     // One save is not enough: a single `saveConfig` left behind while the others were removed satisfied a bare
     // `assert.match`, so the gate would have kept describing a hazard that only partly existed.
@@ -93,6 +105,10 @@ describe('every rewrite an upgrade performs is documented as one-way', () => {
       migrateMediaEmbeddingMasterSwitch: 'mediaEmbedding.enabled',
       migrateSpaceDescriptionToPurpose: 'description',
       migrateFaceRecognitionSwitch: 'faceRecognition.enabled',
+      // Writes a `rights` matrix onto every token that lacked one, so an older build reads tokens carrying a
+      // field it does not know. Harmless in itself — the legacy fields are left in place — but an operator
+      // rolling back needs to know the file changed shape.
+      migrateTokenRightsOnBoot: 'tokens[].rights',
     };
     const section = rollbackSection();
     const undocumented = [];

--- a/testing/standalone/token-rights-backfill.test.js
+++ b/testing/standalone/token-rights-backfill.test.js
@@ -22,7 +22,7 @@ import assert from 'node:assert/strict';
 
 let backfillTokenRights;
 before(async () => {
-  ({ backfillTokenRights } = await import('../../server/dist/config/loader.js'));
+  ({ backfillTokenRights } = await import('../../server/dist/auth/backfill-token-rights.js'));
 });
 
 const tok = (over) => ({ id: 'i', name: 'n', hash: 'h', prefix: 'p', createdAt: '', lastUsed: null, expiresAt: null, admin: false, ...over });


### PR DESCRIPTION
**BREAKING for anyone relying on `admin` being required to delete a single record.** Two owner rulings, both
after the difference was **measured** rather than argued.

## What was measured

A token minted with `rights.perSpace.general.knowledge = 'write'`:

| call | result |
|---|---|
| `DELETE /api/brain/spaces/general/memories/:id` | **403** `Token needs 'admin' on knowledge in space 'general'` |
| MCP `delete_memory`, same record, seconds later | **"Memory deleted"** — and the record 404s afterwards |

`mcp/router.ts` gates on the token's `readOnly`/`admin` flags and **never consults the rung**
(`git grep requiredRung server/src/mcp` is empty). One rule, two implementations, the weaker one silently in
charge — at the highest stakes this repo's favourite defect has reached.

## Ruling B: level DOWN

**`write` is the right rung for deleting a single record you could have created.** Seven rows change:
`/memories/:id`, `/entities/:id`, `/edges/:id`, `/chrono/:id`, the entity merge, `/bulk`, and
`DELETE /api/files/:spaceId`.

Deliberately unchanged:

- **The collection wipes** (`DELETE /memories`, `/entities`, `/edges`, `/chrono`) stay `admin` — their MCP
  counterpart `wipe_space` is admin-gated, so those doors already agreed, and emptying a collection is not the
  same act as deleting a row. Asserted: a `write` token still gets a **403** on the wipe.
- **`DELETE /api/brain/spaces/:spaceId/files`** (the file-meta record) stays `admin`: no tool mirrors it, so
  lowering it would weaken a door for parity with nothing.
- **`update_space_schema`** remains the one known difference, in the safe direction — REST asks `schema: write`,
  the tool is admin-gated. The matrix reports it every run rather than it becoming folklore.

## The deeper hole: a token with no matrix skipped the check entirely

`enforceAreaRung` returns early when a record has no `rights`. The boot backfill derived a matrix for every token
**in the config** — so a token minted afterwards had none until the next restart. In the same probe, a plain
non-admin token deleted over REST with a **204**: the rung was never consulted at all.

Ruling: *"translate old tokens into matrix rights and overwrite on update. only matrix from now on."*

- `createToken` **always** stores a matrix, deriving it through the shared `migrateToken` when the caller did not
  supply one. The conditional spread that omitted the field is gone, and a gate fails if it returns.
- The boot backfill is **persisted**, so the matrix is the record of record and "no matrix" means something is
  wrong rather than something is old. A failed write retries next boot rather than throwing or pretending.
- `updateTokenSpaces` is **deleted** — zero callers, and its only job was editing the legacy allowlist, which is
  exactly what a future caller would have reached for to put the two descriptions of access back out of step.
- The legacy `admin`/`readOnly`/`spaces` fields **stay**, so an older build rolls back and enforces what it always
  did. The hosting guide's rollback table records the shape change with **"dropping: nothing"**.

## Five gates objected; each was corrected rather than satisfied

- **The rollback gate's method had gone wrong.** It counts `saveConfig` calls in the loader body, and my
  migration's save moved into the module the loader delegates to — so it reported three saves for four migrations
  and called the fourth non-persisting, the opposite of true. It now counts the delegated modules too.
- **`loader.ts` hit its god-file freeze** (764 → 772), so the backfill moved to `auth/backfill-token-rights.ts`
  rather than the number moving. The loader keeps one call.
- **The mint gate pinned the old expression** `opts.rights ? {rights} : {}` — demanding it back would have
  demanded the hole back. It now asserts the property: an explicitly supplied matrix is stored, and the fallback
  is the shared derivation.
- Plus the backfill test's import path, and my own new gate's anchor.

## Verified end to end

Four integration assertions on a rebuilt stack: REST accepts the delete it used to refuse, MCP accepts the same
one, the collection wipe is still refused with a 403, and a token minted with legacy fields only gets a derived
matrix that is still refused an admin-rung route.

## Also in here: the capability map is published

`docs/integration-guide/16-mcp.md` now carries every capability with its MCP tool, its REST route and the token
level it needs — generated from the code, checked against the running routers. The doc-coverage columns stay
internal: an integrator cannot act on which of our files mentions a thing, and a `—` there means our name-matcher
missed it rather than that a gap exists.

🤖 Generated with Claude Code
