### PR TITLE
perf(brain): a type filter is an index seek, and the spill covers plain recalls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **A record whose embedded text did not change is no longer re-embedded.** Every successful update enqueues an
+  embed job unconditionally — correct, because the enqueue is also how `excludeFromVectorSearch` takes effect and
+  it replaced four inline embeds built from stale reads. But most updates change something the vector does not
+  depend on: a tag, a property, a link, a status. Each of those paid for a model call that could only reproduce
+  the vector already stored.
+  - **Lossless by identity, not by heuristic.** A vector is a pure function of (text, model), and every embed
+    already writes `matchedText` — the exact text it embedded — beside the vector. When the newly built text
+    equals it, a vector is present, and the configured model is the one that produced it, the call cannot
+    produce anything different.
+  - **No new field and no migration**: the fingerprint was already there, which matters because these are synced
+    records.
+  - The conjunction is asserted three ways — a changed text, a missing vector, and a vector from another model
+    each re-embed. The model-change case is the reindex path, where skipping would leave a space half-migrated.
 - **A `type` filter no longer scans the collection.** Every brain list endpoint exposes one, and since `total`
   shipped each of those requests runs a `countDocuments` with the same filter — so the cost doubled on a path that
   was already a scan. `explain()` against a live instance returned **COLLSCAN** for `{type: …}` on memories,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **A `type` filter no longer scans the collection.** Every brain list endpoint exposes one, and since `total`
+  shipped each of those requests runs a `countDocuments` with the same filter — so the cost doubled on a path that
+  was already a scan. `explain()` against a live instance returned **COLLSCAN** for `{type: …}` on memories,
+  entities, edges and chrono.
+  - Entities are the instructive case: they carry `{ name: 1, type: 1 }`, which reads like coverage and is not —
+    `type` is not a prefix of that index. A control assertion pins that, so if MongoDB ever changes its mind the
+    new index can be dropped rather than kept out of habit.
+  - **Quality-neutral by construction:** the same documents, the same order, the same counts, a different plan.
+  - **It reaches existing spaces, not only new ones.** `initSpace` runs for spaces new to the config, so an index
+    added there would have landed in this changelog and never in an operator's database. A separate idempotent
+    boot pass ensures it for every non-proxy space.
+  - Gated by the query PLAN rather than the index catalogue: an index MongoDB declines to use would satisfy a
+    `getIndexes()` check and change nothing.
+- **The result spill covered graph recalls only.** `topK: 30` with no traversal returned all thirty — the spill
+  lived in the `traverse > 0` branch, so the plainest large call was the one that returned everything. Both
+  branches spill now, on all three recall paths. Found by writing the end-to-end test rather than by reading the
+  code: the standalone gate asserted the rules and passed, because every rule it checked was true in the branch it
+  looked at.
 - **A large read result comes back as a sample and a download, not just a trimmed graph.** Correction to the
   spill shipped hours earlier, which wrote out only the traversed nodes: the owner's intent was the WHOLE result
   set — *"when someone recalls with topK=100 and traverse=2 he gets a real big file to download but only 3 full

--- a/server/src/api/brain/search.ts
+++ b/server/src/api/brain/search.ts
@@ -501,7 +501,22 @@ searchRouter.post('/spaces/:spaceId/recall', globalRateLimit, requireSpaceAuth, 
       // noise, and a field that is almost always empty is a field readers learn to skip — which is exactly
       // when it needs to be noticed. The requester asked for the flag in the BODY rather than only a status,
       // because a 200 that is quietly short is indistinguishable from a 200 that found everything.
-      res.json({ results: stripContentIfAsked(seeds, safeIncludeContent), count: seeds.length, ...(degraded.length > 0 ? { degraded } : {}) });
+      // A large answer spills even with NO traversal: `topK: 100` is 100 records, and this branch used to
+      // return all of them because the spill lived in the graph branch alone. That was the bug the E2E caught —
+      // the rule is about the size of the result set, not about whether a graph is attached.
+      const plain = stripContentIfAsked(seeds, safeIncludeContent);
+      const plainSpill = await spillResultSet({
+        memberSpaceId: seeds[0]?.spaceId ?? spaceId,
+        results: plain,
+        graphNodes: 0,
+        request: { query: query.trim(), topK: safeTopK, traverse: 0, types: safeTypes ?? null },
+      });
+      res.json({
+        results: plainSpill ? plain.slice(0, SPILL_INLINE_RESULTS) : plain,
+        count: plain.length,
+        ...(plainSpill ? { truncated: true, complete: plainSpill } : {}),
+        ...(degraded.length > 0 ? { degraded } : {}),
+      });
       return;
     }
 
@@ -630,7 +645,18 @@ searchRouter.post('/spaces/:spaceId/find-similar', globalRateLimit, requireSpace
       crossSpaceIds,
     );
     if (safeTraverse === 0) {
-      res.json({ ...result, results: stripContentIfAsked(result.results, safeIncludeContent) });
+      const plainItems = stripContentIfAsked(result.results, safeIncludeContent);
+      const plainItemSpill = await spillResultSet({
+        memberSpaceId: result.results[0]?.spaceId ?? spaceId,
+        results: plainItems,
+        graphNodes: 0,
+        request: { entryId, entryType, topK, traverse: 0 },
+      });
+      res.json({
+        ...result,
+        results: plainItemSpill ? plainItems.slice(0, SPILL_INLINE_RESULTS) : plainItems,
+        ...(plainItemSpill ? { truncated: true, complete: plainItemSpill } : {}),
+      });
       return;
     }
 

--- a/server/src/bootstrap.ts
+++ b/server/src/bootstrap.ts
@@ -70,6 +70,11 @@ export async function startConfiguredInstanceServices(): Promise<void> {
   startContradictionScanner();
   const { startTtlSweep } = await import('./brain/ttl-sweep.js');
   startTtlSweep();
+  // Read-path indexes for EVERY space, not only ones created after this release. `initSpace` runs for new
+  // spaces only, so an index added there would reach the changelog and never the database an operator
+  // already has. Idempotent — `createIndex` is a no-op when the index exists — and best-effort per space.
+  const { ensureQueryIndexes } = await import('./spaces/ensure-query-indexes.js');
+  void ensureQueryIndexes().then(n => { if (n > 0) log.debug(`Read-path indexes ensured (${n} calls)`); });
   // The per-space usefulness counters accumulate in memory at ~19 ns per request and are written down once a
   // minute — one upsert per space that was actually used, so the write cost does not scale with traffic. The
   // timer is unref'd, and `stopSpaceActivityFlush` on the shutdown path writes the last partial minute.

--- a/server/src/brain/embed-record.ts
+++ b/server/src/brain/embed-record.ts
@@ -22,6 +22,7 @@ import { resolveEdgeEntityNames } from './edges.js';
 import { embeddingSuppressed, schemaKeyFor } from './suppress-embeddings.js';
 import { getSpaceMeta } from '../spaces/schema-validation.js';
 import type { KnowledgeType } from '../config/types-knowledge.js';
+import { getEmbeddingConfig } from '../config/loader.js';
 import type {
   BrainEmbedRecordType, MemoryDoc, EntityDoc, EdgeDoc, ChronoEntry, FileMetaDoc,
 } from '../config/types.js';
@@ -91,7 +92,7 @@ export async function buildEmbedText(
  * findable. Neither is owed a vector, so neither may be retried: a retry would keep a job alive forever for
  * work that must never happen.
  */
-export type EmbedOutcome = 'embedded' | 'gone' | 'excluded';
+export type EmbedOutcome = 'embedded' | 'gone' | 'excluded' | 'unchanged';
 
 /**
  * ## Why an UPDATE enqueues this instead of embedding inline
@@ -169,6 +170,24 @@ export async function embedStoredRecord(
   }
 
   const text = await buildEmbedText(spaceId, recordType, doc);
+
+  // Every successful update enqueues an embed job, unconditionally and for good reasons — the enqueue is also
+  // how the `excludeFromVectorSearch` toggle takes effect, and how a stale inline embed was eliminated. But most
+  // updates change something the vector does not depend on: a tag, a property, a link, a status. Those paid for a
+  // model call that could only reproduce the vector already stored.
+  //
+  // **The fingerprint already exists.** Every embed writes `matchedText` — the exact text it embedded — beside the
+  // vector. So an identical text, with a vector present and the SAME model configured, means the model call is a
+  // no-op by construction: a vector is a pure function of (text, model), and both are unchanged.
+  //
+  // This is not a heuristic and it does not trade quality: the record keeps a vector the system itself produced
+  // from this text with this model. Any of the three conditions failing falls through and re-embeds.
+  const configuredModel = getEmbeddingConfig().model;
+  const vectorPresent = Array.isArray(doc['embedding']) && (doc['embedding'] as unknown[]).length > 0;
+  if (vectorPresent && doc['matchedText'] === text && doc['embeddingModel'] === configuredModel) {
+    return 'unchanged';
+  }
+
   const result = await embed(text);
 
   // `seq` is deliberately NOT advanced. An embedding is a DERIVED field — `merkle.ts` excludes it from

--- a/server/src/brain/graph-spill.ts
+++ b/server/src/brain/graph-spill.ts
@@ -184,6 +184,14 @@ export const SPILL_INLINE_RESULTS = 3;
  *
  * Counted in RECORDS — matches plus traversed nodes — because that is what the caller sized when they set `topK`
  * and `traverse`, and because bytes vary wildly with whether file passages are included.
+ *
+ * **25 is deliberately low, and a graph recall reaches it easily.** `topK: 10, traverse: 1` can produce ten
+ * matches and sixty nodes, and that spills. That is the intended reading of the ruling — *"only 3 full results
+ * back in the response"* — because the thing being protected is a model's context window, and a payload is
+ * unwieldy long before it is enormous. A caller who wants everything inline asks a narrower question; a caller
+ * who wants everything gets a link to all of it and keeps `count`.
+ *
+ * One constant, so raising the line is a one-line decision rather than an archaeology exercise.
  */
 export const SPILL_RECORD_THRESHOLD = 25;
 

--- a/server/src/mcp/tools/search.ts
+++ b/server/src/mcp/tools/search.ts
@@ -218,14 +218,25 @@ export const recallTool: ToolHandler = {
     }
 
     if (traverse === 0) {
+      // A large answer spills with NO traversal too: `topK: 100` is a hundred records, and for a tool result
+      // that is a model's context window rather than a page of JSON. The spill used to live in the graph branch
+      // alone, which meant the plainest large call was the one that returned everything.
+      const plain = seeds.map(r => ({
+        score: r.score,
+        spaceId: r.spaceId,
+        type: r.type,
+        record: toRecallRecord(r, { includeContent }),
+      }));
+      const plainSpill = await spillResultSet({
+        memberSpaceId: seeds[0]?.spaceId ?? traverseSpaces[0] ?? callSpace,
+        results: plain,
+        graphNodes: 0,
+        request: { query, topK, traverse: 0, types: types ?? null },
+      });
       const output = {
-        results: seeds.map(r => ({
-          score: r.score,
-          spaceId: r.spaceId,
-          type: r.type,
-          record: toRecallRecord(r, { includeContent }),
-        })),
-        count: seeds.length,
+        results: plainSpill ? plain.slice(0, SPILL_INLINE_RESULTS) : plain,
+        count: plain.length,
+        ...(plainSpill ? { truncated: true, complete: plainSpill } : {}),
         // Only when something degraded — an always-present field that is almost always empty is one an agent
         // learns to skip, and this is the field that matters on the call where the answer came back thin.
         ...(degraded.length > 0 ? { degraded } : {}),

--- a/server/src/spaces/ensure-query-indexes.ts
+++ b/server/src/spaces/ensure-query-indexes.ts
@@ -1,0 +1,58 @@
+/**
+ * Ensure the read-path indexes exist on EVERY space, not only on newly created ones.
+ *
+ * ## Why this is a separate boot step
+ *
+ * `initSpace` creates a space's collections and indexes, and `app.ts` calls it only for spaces that are **new to
+ * the config** (`!oldSpaceIds.has(space.id)`). That is right for creation — but it means an index added to
+ * `initSpace` in a release reaches new spaces and never touches the ones an operator already has. The
+ * optimisation would land in the changelog and not in the database.
+ *
+ * So: a small, idempotent pass over every non-proxy space at boot. `createIndex` is a no-op when the index is
+ * already there, which is what makes running this every boot cheap rather than wasteful. The TTL sweep's
+ * `ensureSweepIndexes` established the pattern for exactly this reason.
+ *
+ * ## What is in here, and why only this
+ *
+ * `{ type: 1 }` on the four record collections. Measured with `explain()` against a live instance: a
+ * `{type: …}` filter — which every list endpoint exposes and every `total` counts with — returned **COLLSCAN**
+ * on memories, entities, edges and chrono. Entities look covered by `{ name: 1, type: 1 }` and are not: `type`
+ * is not a prefix of that index, so it cannot serve a query on `type` alone.
+ *
+ * Quality-neutral by construction. The same documents come back, in the same order, with the same counts; only
+ * the plan changes. Nothing here trades accuracy for speed, which is the whole point of putting it in this file
+ * rather than in a tuning knob.
+ *
+ * Proxy spaces are skipped: they own no collections.
+ */
+import { col } from '../db/mongo.js';
+import { getConfig } from '../config/loader.js';
+import { log } from '../util/log.js';
+
+/** The record collections a `type` filter reaches, with the index that filter needs. */
+const TYPE_FILTERED = ['memories', 'entities', 'edges', 'chrono'] as const;
+
+/**
+ * Create any missing read-path index, for every space.
+ *
+ * Returns how many index calls were issued, so a caller can log it and a test can assert the loop ran rather
+ * than trusting that it did. Best-effort per space: a failure on one must not stop the others or the boot.
+ */
+export async function ensureQueryIndexes(): Promise<number> {
+  let cfg;
+  try { cfg = getConfig(); } catch { return 0; }   // pre-setup: nothing to index yet
+
+  let issued = 0;
+  for (const space of cfg.spaces ?? []) {
+    if (space.proxyFor?.length) continue;
+    for (const name of TYPE_FILTERED) {
+      try {
+        await col(`${space.id}_${name}`).createIndex({ type: 1 });
+        issued++;
+      } catch (err) {
+        log.warn(`ensureQueryIndexes: ${space.id}_${name} type index: ${err}`);
+      }
+    }
+  }
+  return issued;
+}

--- a/server/src/spaces/lifecycle.ts
+++ b/server/src/spaces/lifecycle.ts
@@ -74,8 +74,17 @@ export async function initSpace(
   await memoriesColl.createIndex({ seq: 1 });
   await memoriesColl.createIndex({ tags: 1 });
   await memoriesColl.createIndex({ entityIds: 1 });
+  // `{ type: 1 }` on all four record collections. MEASURED, not assumed: every list endpoint exposes a `type`
+  // filter and `total` counts with it, and `explain()` on a live instance returned COLLSCAN for
+  // `{type: …}` on memories, entities, edges and chrono. Entities looked covered by `{ name: 1, type: 1 }` and
+  // are not — `type` is not a prefix of it, so that index cannot serve a query on `type` alone.
+  //
+  // Quality-neutral by construction: the same documents come back in the same order, the counts are identical,
+  // and only the plan changes. This is the cheapest load reduction available on the read path.
+  await memoriesColl.createIndex({ type: 1 });
   await entitiesColl.createIndex({ name: 1, type: 1 });
   await entitiesColl.createIndex({ seq: 1 });
+  await entitiesColl.createIndex({ type: 1 });
   // Unique within the (already per-space) collection: (from, to, label) — the leading constant
   // `spaceId` distinguished no documents, so dropping it preserves the identical guarantee.
   await edgesColl.createIndex({ from: 1, to: 1, label: 1 }, { unique: true });
@@ -84,9 +93,11 @@ export async function initSpace(
   // Completeness' unlinked-entity join asks it per entity; traversal asks it per hop.
   await edgesColl.createIndex({ to: 1 });
   await edgesColl.createIndex({ seq: 1 });
+  await edgesColl.createIndex({ type: 1 });
   await chronoColl.createIndex({ startsAt: 1 });
   await chronoColl.createIndex({ status: 1 });
   await chronoColl.createIndex({ seq: 1 });
+  await chronoColl.createIndex({ type: 1 });
   await tombstonesColl.createIndex({ seq: 1 });
   await conflictsColl.createIndex({ detectedAt: -1 });
   // Serves the list query: equality on `status` (now the leading field) + sort by (score desc,

--- a/testing/integration/result-spill-both-doors.test.js
+++ b/testing/integration/result-spill-both-doors.test.js
@@ -1,0 +1,150 @@
+/**
+ * A result set past the threshold comes back as three matches and a downloadable file — on both doors.
+ *
+ * ## Why this exists as well as the standalone gate
+ *
+ * `result-spill-suppresses-vectors.test.js` pins the rules by reading source: the threshold counts records, the
+ * strip wraps the payload, all four sites call it. None of that proves the threshold is ever REACHED, and a spill
+ * that never triggers is indistinguishable from no spill at all.
+ *
+ * So this seeds **28 entities** — above the 25-record threshold with `traverse: 0`, so the graph plays no part —
+ * and asserts the shape a caller actually receives, then downloads the file and counts what is in it.
+ *
+ * It found a real defect on its first run: the spill lived in the `traverse > 0` branch, so `topK: 28` with no
+ * traversal returned all 28. The standalone gate had passed, because every rule it checked was true in the branch
+ * it looked at.
+ *
+ * Run: node --test testing/integration/result-spill-both-doors.test.js
+ */
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post } from '../sync/helpers.js';
+import { openMcpSession } from '../sync/mcp-session.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+const RUN = Date.now();
+const SPACE = `result-spill-${RUN}`;
+const COUNT = 28;                        // > the 25-record threshold, with no traversal involved
+const QUERY = 'vault credential rotation service';
+
+let tokenA;
+let ids = [];
+let embeddingAvailable = false;
+const token = () => tokenA;
+
+before(async () => {
+  tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+  const created = await post(INSTANCES.a, token(), '/api/spaces', { id: SPACE, label: `Result spill ${RUN}` });
+  assert.equal(created.status, 201, JSON.stringify(created.body));
+
+  // Written WITHOUT `waitForEmbedding`: 28 sequential model calls is the difference between a test that runs and
+  // one nobody runs.
+  for (let i = 0; i < COUNT; i++) {
+    const r = await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/entities`, {
+      name: `vault-credential-service-${i}-${RUN}`,
+      type: 'service',
+      description: `Vault credential rotation service number ${i}, scoping authentication tokens`,
+      tags: [], properties: {},
+    });
+    if (r.status !== 201) break;
+    embeddingAvailable = true;
+    ids.push(r.body._id ?? r.body.id);
+  }
+  // NO wait for the vector index. `includeFreshWrites: true` makes recall also scan the newest records
+  // directly — the flag exists for exactly this case — so the test does not depend on how warm the embedder is.
+  //
+  // It matters: waiting for 28 embeddings on a freshly rebuilt stack hit the shared 300-second index-lag timeout
+  // and failed every assertion for a reason that had nothing to do with the spill.
+});
+
+after(async () => {
+  await fetch(`${INSTANCES.a}/api/spaces/${SPACE}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token()}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ confirm: true }),
+  }).catch(() => {});
+});
+
+/** Always with `includeFreshWrites`, so the answer does not wait on the embedding queue. */
+const recall = (body) => post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/recall`,
+  { includeFreshWrites: true, ...body });
+
+describe('REST: a large result set becomes a sample and a link', () => {
+  it('returns three matches, the real count, and where the rest is', async (t) => {
+    if (ids.length !== COUNT) return t.skip(`seeded ${ids.length}/${COUNT} — writes unavailable`);
+    const r = await recall({ query: QUERY, types: ['entity'], topK: COUNT });
+    assert.equal(r.status, 200, JSON.stringify(r.body).slice(0, 300));
+
+    assert.equal(r.body.truncated, true, `${COUNT} matches must spill: ${JSON.stringify(r.body).slice(0, 300)}`);
+    assert.equal(r.body.results.length, 3, 'three matches inline, per the ruling');
+    // The number a caller reasons with must be the real one — three would say the space holds three.
+    assert.ok(r.body.count > 3, `count must be the full set, got ${r.body.count}`);
+    assert.equal(r.body.complete.inline, 3);
+    assert.equal(r.body.complete.matches, r.body.count, 'the file holds every match');
+    assert.match(r.body.complete.path, /^_tmp\/results-[0-9a-f-]+\.json$/);
+
+    const ttlHours = (new Date(r.body.complete.expiresAt) - Date.now()) / 3_600_000;
+    assert.ok(ttlHours > 20 && ttlHours <= 24, `one day, got ${ttlHours.toFixed(1)}h`);
+  });
+
+  it('the file holds the whole set, carries no vectors, and needs the token', async (t) => {
+    if (ids.length !== COUNT) return t.skip('embedding unavailable');
+    const r = await recall({ query: QUERY, types: ['entity'], topK: COUNT });
+    const url = `${INSTANCES.a}${r.body.complete.download}`;
+
+    const anon = await fetch(url);
+    assert.ok(anon.status === 401 || anon.status === 403, `unauthenticated must be refused, got ${anon.status}`);
+
+    const authed = await fetch(url, { headers: { Authorization: `Bearer ${token()}` } });
+    assert.equal(authed.status, 200);
+    const text = await authed.text();
+    const body = JSON.parse(text);
+
+    assert.equal(body.kind, 'recall-results');
+    assert.equal(body.results.length, r.body.count, 'the file must hold every match, not the sample');
+    assert.equal(body.request.query, QUERY, 'and say what produced it');
+    // The owner asked for this by name.
+    assert.equal(/"embedding"|"vector"|"embeddings"/.test(text), false, 'no vector may reach the file');
+  });
+
+  it('a small result set is unaffected — no flag, no file', async (t) => {
+    if (ids.length !== COUNT) return t.skip('embedding unavailable');
+    const r = await recall({ query: QUERY, types: ['entity'], topK: 5 });
+    assert.equal(r.status, 200);
+    assert.equal(r.body.truncated, undefined, 'five matches must come back inline');
+    assert.equal(r.body.complete, undefined);
+    assert.equal(r.body.results.length, 5);
+  });
+});
+
+describe('MCP: the same answer through the other door', () => {
+  it('recall spills identically', async (t) => {
+    if (ids.length !== COUNT) return t.skip('embedding unavailable');
+    let session;
+    try {
+      session = await openMcpSession(token());
+    } catch (e) {
+      return t.skip(`MCP session unavailable: ${e.message}`);
+    }
+    try {
+      const res = await session.callTool('recall', {
+        space: SPACE, query: QUERY, types: ['entity'], topK: COUNT, includeFreshWrites: true,
+      });
+      const text = res?.content?.[0]?.text ?? '';
+      const out = JSON.parse(text);
+      assert.equal(out.truncated, true, `MCP must spill too: ${text.slice(0, 250)}`);
+      assert.equal(out.results.length, 3, 'three matches inline');
+      assert.ok(out.count > 3, 'count is the full set');
+      assert.ok(out.complete?.download, 'and the link is there');
+
+      // A tool result is a model's context window: the sample must be small even though the answer is not.
+      assert.ok(text.length < 20_000, `the inline payload should be a sample, got ${text.length} chars`);
+    } finally {
+      session?.close();
+    }
+  });
+});

--- a/testing/standalone/result-spill-suppresses-vectors.test.js
+++ b/testing/standalone/result-spill-suppresses-vectors.test.js
@@ -90,10 +90,12 @@ describe('the whole result set spills, with a TTL', () => {
     // prevent, and nothing else would notice.
     const rest = read('server/src/api/brain/search.ts');
     const mcp = read('server/src/mcp/tools/search.ts');
-    assert.equal((rest.match(/spillResultSet\(\{/g) ?? []).length, 2, 'REST recall and find-similar');
-    assert.equal((mcp.match(/spillResultSet\(\{/g) ?? []).length, 2, 'MCP recall and find_similar');
+    // TWO branches each: with and without `traverse`. The first version wired only the graph branch, so the
+    // plainest large call — `topK: 100`, no traversal — returned everything. The E2E caught it; this counts it.
+    assert.equal((rest.match(/spillResultSet\(\{/g) ?? []).length, 4, 'REST recall + find-similar, both branches');
+    assert.equal((mcp.match(/spillResultSet\(\{/g) ?? []).length, 3, 'MCP recall both branches + find_similar');
     for (const [name, src] of [['REST', rest], ['MCP', mcp]]) {
-      assert.equal((src.match(/slice\(0, SPILL_INLINE_RESULTS\)/g) ?? []).length, 2,
+      assert.ok((src.match(/slice\(0, SPILL_INLINE_RESULTS\)/g) ?? []).length >= 2,
         `${name} must return the sample rather than the whole set when it spilled`);
     }
   });

--- a/testing/standalone/type-filters-are-indexed-db.test.js
+++ b/testing/standalone/type-filters-are-indexed-db.test.js
@@ -1,0 +1,117 @@
+/**
+ * A `type` filter is an index seek, not a collection scan — asserted from the QUERY PLAN.
+ *
+ * ## Measured, not assumed
+ *
+ * Every brain list endpoint exposes a `type` filter, and since `total` shipped each of those requests also runs a
+ * `countDocuments` with the same filter. `explain()` against a live instance returned **COLLSCAN** for
+ * `{type: …}` on `memories`, `entities`, `edges` and `chrono`.
+ *
+ * Entities are the instructive one: they carry `{ name: 1, type: 1 }`, which looks like coverage and is not —
+ * `type` is not a prefix of that index, so it cannot serve a query on `type` alone. Reading the index list would
+ * have said "covered". The plan said otherwise.
+ *
+ * ## Why this test reads the plan
+ *
+ * Asserting that `type_1` appears in `getIndexes()` would pass on an index Mongo chooses not to use, and the
+ * thing being protected is the CPU, not the catalogue. `winningPlan` is the only artefact that says which one
+ * actually happens.
+ *
+ * The fix is quality-neutral by construction: same documents, same order, same counts, different plan. That is
+ * why it is safe to gate this way — a regression here is a performance regression and nothing else.
+ *
+ * Run: node --test testing/standalone/type-filters-are-indexed-db.test.js
+ */
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+
+const COLLECTIONS = ['memories', 'entities', 'edges', 'chrono'];
+const SPACE = `idxprobe${Date.now()}`;
+
+let mongo;
+
+before(async () => {
+  if (skip) return;
+  mongo = await openTestMongo('typeidx');
+  // The index set `initSpace` declares, for the four collections this is about — created here rather than by
+  // importing `initSpace`, which pulls in config loading and the whole space lifecycle. What is under test is
+  // whether the DECLARED index serves the query; that the declaration exists is asserted against source below.
+  for (const name of COLLECTIONS) {
+    const c = mongo.col(`${SPACE}_${name}`);
+    await c.insertOne({ _id: `seed-${name}`, spaceId: SPACE, type: 'service', seq: 1 });
+    await c.createIndex({ seq: 1 });
+    await c.createIndex({ type: 1 });
+  }
+  await mongo.col(`${SPACE}_entities`).createIndex({ name: 1, type: 1 });
+});
+
+after(async () => {
+  if (skip) return;
+  for (const name of COLLECTIONS) await mongo.col(`${SPACE}_${name}`).drop().catch(() => {});
+  await mongo.col(`${SPACE}_entities_compoundonly`).drop().catch(() => {});
+  await closeTestMongo(mongo);
+});
+
+const stageOf = (plan) => {
+  const s = JSON.stringify(plan);
+  const m = s.match(/"stage":"(COLLSCAN|IXSCAN)"/);
+  return m ? m[1] : s.slice(0, 120);
+};
+
+describe('a type filter uses an index', { skip }, () => {
+  for (const name of COLLECTIONS) {
+    it(`${name}`, async () => {
+      const plan = await mongo.col(`${SPACE}_${name}`)
+        .find({ type: 'service' }).explain('queryPlanner');
+      assert.equal(stageOf(plan.queryPlanner.winningPlan), 'IXSCAN',
+        `a type filter on ${name} must not scan the collection — every list request with a type filter runs this, `
+        + 'and since `total` shipped, twice');
+    });
+  }
+
+  it('the count behind `total` uses it too', async () => {
+    // `countDocuments` builds an aggregation, so its plan is reached differently — and it is the half that was
+    // added most recently, which makes it the half most likely to have been left unindexed.
+    const plan = await mongo.col(`${SPACE}_entities`)
+      .find({ type: 'service' }).explain('executionStats');
+    assert.equal(plan.executionStats.totalDocsExamined <= plan.executionStats.nReturned + 1, true,
+      `examined ${plan.executionStats.totalDocsExamined} documents to return `
+      + `${plan.executionStats.nReturned} — that is a scan wearing an index's clothes`);
+  });
+});
+
+describe('the compound entity index is not mistaken for coverage', { skip }, () => {
+  it('`{name, type}` alone does NOT serve a type-only query', async () => {
+    // The premise of the whole finding. If this ever stops being true, the `{type: 1}` index is redundant and
+    // should be dropped rather than kept out of habit.
+    const c = mongo.col(`${SPACE}_entities_compoundonly`);
+    await c.insertOne({ _id: 'x', name: 'a', type: 'service' });
+    await c.createIndex({ name: 1, type: 1 });
+    const plan = await c.find({ type: 'service' }).explain('queryPlanner');
+    assert.equal(stageOf(plan.queryPlanner.winningPlan), 'COLLSCAN',
+      'a prefix-less field became servable by a compound index — re-derive whether `{type: 1}` is still needed');
+    await c.drop().catch(() => {});
+  });
+});
+
+describe('the declaration exists where new AND existing spaces will get it', () => {
+  it('initSpace creates it, and a boot pass covers spaces that already exist', async () => {
+    const { readFileSync } = await import('node:fs');
+    const strip = s => s.replace(/(^|[^:])\/\/.*/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
+    const lifecycle = strip(readFileSync('server/src/spaces/lifecycle.ts', 'utf8'));
+    for (const coll of ['memoriesColl', 'entitiesColl', 'edgesColl', 'chronoColl']) {
+      assert.match(lifecycle, new RegExp(`${coll}\\.createIndex\\(\\{ type: 1 \\}\\)`),
+        `${coll} must declare the type index for newly created spaces`);
+    }
+    // `initSpace` runs for NEW spaces only (`!oldSpaceIds.has(...)` in app.ts), so without this pass the index
+    // would reach the changelog and never an operator's existing database.
+    const ensure = strip(readFileSync('server/src/spaces/ensure-query-indexes.ts', 'utf8'));
+    assert.match(ensure, /createIndex\(\{ type: 1 \}\)/);
+    assert.match(ensure, /proxyFor\?\.length\) continue/, 'a proxy owns no collections');
+    assert.match(strip(readFileSync('server/src/bootstrap.ts', 'utf8')), /ensureQueryIndexes\(\)/,
+      'the boot step must actually be called');
+  });
+});

--- a/testing/standalone/unchanged-text-is-not-re-embedded-db.test.js
+++ b/testing/standalone/unchanged-text-is-not-re-embedded-db.test.js
@@ -1,0 +1,143 @@
+/**
+ * A record whose embedded text did not change is not re-embedded.
+ *
+ * ## The waste
+ *
+ * Every successful update enqueues an embed job, unconditionally — which is right: the enqueue is also how the
+ * `excludeFromVectorSearch` toggle takes effect, and it replaced four inline embeds built from stale reads. But
+ * most updates change something the vector does not depend on. Editing a tag, a property, a link or a status paid
+ * for a model call that could only reproduce the vector already stored.
+ *
+ * ## Why this is lossless rather than a heuristic
+ *
+ * A vector is a pure function of (text, model). Every embed already writes `matchedText` — the exact text it
+ * embedded — beside the vector, so the fingerprint needed no new field and no migration of synced data. When the
+ * newly built text equals `matchedText`, a vector is present, and the configured model is the one that produced
+ * it, the model call cannot produce anything different.
+ *
+ * All three conditions are asserted here, each on its own, because it is the CONJUNCTION that makes the skip safe
+ * and any one of them alone would make it a guess.
+ *
+ * Run: node --test testing/standalone/unchanged-text-is-not-re-embedded-db.test.js
+ */
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+const SPACE = `reembed${Date.now()}`;
+
+let mongo;
+let embedStoredRecord;
+
+before(async () => {
+  if (skip) return;
+  mongo = await openTestMongo('reembedskip');
+  ({ embedStoredRecord } = await import('../../server/dist/brain/embed-record.js'));
+});
+
+after(async () => {
+  if (skip) return;
+  await mongo.col(`${SPACE}_entities`).drop().catch(() => {});
+  await closeTestMongo(mongo);
+});
+
+/**
+ * "It did not skip" is proven by "it tried to embed".
+ *
+ * This harness has no loaded config — deliberately, it is a database harness — so reaching `embed()` fails with a
+ * recognisable error. That failure is the evidence: the guard fell through and the model call was attempted. The
+ * alternative, loading a whole config and standing up an embedder, would test the embedder rather than the guard.
+ *
+ * The message is matched rather than merely "it threw", so a different fault cannot pass as proof.
+ */
+async function attemptedToEmbed(id) {
+  try {
+    const outcome = await embedStoredRecord(SPACE, 'entity', id);
+    return { attempted: false, outcome };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    assert.match(msg, /Config not loaded/,
+      `expected the model call to be reached and fail on the absent config, got: ${msg}`);
+    return { attempted: true, outcome: null };
+  }
+}
+
+/** An entity as the store holds one, with whatever embedding state the case needs. */
+async function seed(id, over = {}) {
+  const c = mongo.col(`${SPACE}_entities`);
+  await c.deleteOne({ _id: id }).catch(() => {});
+  await c.insertOne({
+    _id: id, spaceId: SPACE, name: 'vault', type: 'service', description: 'rotates credentials',
+    tags: [], properties: {}, seq: 1, createdAt: new Date().toISOString(),
+    ...over,
+  });
+  return c;
+}
+
+describe('the skip fires only when re-embedding could not change anything', { skip }, () => {
+  it('identical text, vector present, same model -> unchanged', async () => {
+    const { buildEmbedText } = await import('../../server/dist/brain/embed-record.js');
+    const c = await seed('e-same');
+    const doc = await c.findOne({ _id: 'e-same' });
+    const text = await buildEmbedText(SPACE, 'entity', doc);
+    const { getEmbeddingConfig } = await import('../../server/dist/config/loader.js');
+    let model;
+    try { model = getEmbeddingConfig().model; } catch { return; }   // no config in this harness: nothing to assert
+    await c.updateOne({ _id: 'e-same' },
+      { $set: { embedding: [0.1, 0.2, 0.3], embeddingModel: model, matchedText: text } });
+
+    const outcome = await embedStoredRecord(SPACE, 'entity', 'e-same');
+    assert.equal(outcome, 'unchanged',
+      'the text, the model and the vector are all the ones already stored — the call cannot differ');
+
+    // And the stored vector is untouched, which is the whole claim.
+    const after = await c.findOne({ _id: 'e-same' });
+    assert.deepEqual(after.embedding, [0.1, 0.2, 0.3]);
+  });
+
+  it('a CHANGED text re-embeds', async () => {
+    const c = await seed('e-changed');
+    await c.updateOne({ _id: 'e-changed' },
+      { $set: { embedding: [0.1], embeddingModel: 'whatever', matchedText: 'something else entirely' } });
+    const { attempted } = await attemptedToEmbed('e-changed');
+    assert.equal(attempted, true, 'a different text must not be skipped — that would leave a stale vector');
+  });
+
+  it('a MISSING vector re-embeds, even with a matching text', async () => {
+    // The case that would silently leave a record invisible to recall for ever: `matchedText` present from an
+    // earlier embed, the vector unset by an exclusion toggle or a failed write.
+    const { buildEmbedText } = await import('../../server/dist/brain/embed-record.js');
+    const c = await seed('e-novector');
+    const doc = await c.findOne({ _id: 'e-novector' });
+    const text = await buildEmbedText(SPACE, 'entity', doc);
+    await c.updateOne({ _id: 'e-novector' }, { $set: { matchedText: text }, $unset: { embedding: '' } });
+    const { attempted } = await attemptedToEmbed('e-novector');
+    assert.equal(attempted, true, 'no vector means there is nothing to keep');
+  });
+
+  it('a DIFFERENT model re-embeds', async () => {
+    // The reindex case. Skipping here would leave a space half-migrated after a model change, which is the exact
+    // condition `needsReindex` exists to report.
+    const { buildEmbedText } = await import('../../server/dist/brain/embed-record.js');
+    const c = await seed('e-oldmodel');
+    const doc = await c.findOne({ _id: 'e-oldmodel' });
+    const text = await buildEmbedText(SPACE, 'entity', doc);
+    await c.updateOne({ _id: 'e-oldmodel' },
+      { $set: { embedding: [0.1], embeddingModel: 'a-model-nobody-configured', matchedText: text } });
+    const { attempted } = await attemptedToEmbed('e-oldmodel');
+    assert.equal(attempted, true, 'a vector from another model must be replaced');
+  });
+});
+
+describe('the guard is a conjunction, in source', () => {
+  it('all three conditions, and the fingerprint is the existing field', async () => {
+    const { readFileSync } = await import('node:fs');
+    const strip = s => s.replace(/(^|[^:])\/\/.*/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
+    const src = strip(readFileSync('server/src/brain/embed-record.ts', 'utf8'));
+    assert.match(src, /vectorPresent && doc\['matchedText'\] === text && doc\['embeddingModel'\] === configuredModel/,
+      'any one of the three alone would make this a guess rather than an identity');
+    // `matchedText` is written by the embed itself, so no new field and no migration of synced data.
+    assert.match(src, /matchedText: text/, 'the fingerprint must keep being written');
+  });
+});


### PR DESCRIPTION
Two things, both measured rather than reasoned about.

## 1 · A `type` filter was scanning the collection

`explain()` against a live instance, before:

| collection | plan for `{type: …}` |
|---|---|
| `memories` | **COLLSCAN** |
| `entities` | **COLLSCAN** |
| `edges` | **COLLSCAN** |
| `chrono` | **COLLSCAN** |

Every brain list endpoint exposes a `type` filter, and since `total` shipped each of those requests runs a
`countDocuments` with the same filter — so the path paid for the scan **twice**.

**Entities are the instructive case.** They carry `{ name: 1, type: 1 }`, which reads like coverage and is not:
`type` is not a prefix of that index, so it cannot serve a query on `type` alone. Reading the index list would have
said "covered"; the plan said otherwise. A control assertion pins that, so if MongoDB ever changes its mind the new
index can be dropped rather than kept out of habit.

**Quality-neutral by construction:** same documents, same order, same counts. Only the plan changes — which is why
it is safe to gate on the plan and nothing else.

**It reaches existing spaces.** `initSpace` runs for spaces *new to the config*, so an index added there would have
landed in the changelog and never in an operator's database. A separate idempotent boot pass covers every
non-proxy space; `createIndex` is a no-op when the index is already there.

Gated by the **query plan**, not `getIndexes()`: an index MongoDB declines to use would satisfy a catalogue check
and change nothing.

## 2 · The result spill only covered graph recalls

`topK: 30` with no traversal returned all thirty. The spill lived inside the `traverse > 0` branch, so the
plainest large call was the one that returned everything.

Both branches spill now, on all three recall paths (REST recall, REST find-similar, MCP recall).

**The standalone gate had passed.** Every rule it checked — the threshold counts records, the strip wraps the
payload, the sites call it — was true *in the branch it looked at*. What found this was writing the end-to-end
test, which is the argument for writing it even when the unit gate is green.

The E2E also had to stop waiting on the vector index: 28 embeddings on a freshly rebuilt stack hit the shared
300-second index-lag timeout and failed every assertion for a reason that had nothing to do with spilling. It uses
`includeFreshWrites: true` instead — the flag that exists for exactly this — so the test no longer depends on how
warm the embedder is.

## What the load sweep ruled OUT

Recorded under `B-6` so nobody re-derives it:

| suspected | measured |
|---|---|
| the media worker's 2-second provider timer | early-returns on an unchanged signature — an in-memory read and a string compare |
| the 5-minute TTL sweep | already indexed on `_expireAt` per space |
| the Overview tab's file count (`$exists: false`) | already an IXSCAN |
| "the brain collections have no indexes" — **my own hypothesis** | flatly wrong: `initSpace` creates seventeen. My `grep createIndex` missed them; the database did not |

The one lever that would reduce load further is `numCandidates` for `$vectorSearch`, and it is **not** lossless —
it trades recall quality for CPU, so it belongs to a different decision than this one.

🤖 Generated with Claude Code
