### PR TITLE
perf(files): identical bytes do not get looked at twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Re-uploading identical bytes no longer re-runs vision or speech-to-text.** `enqueueMediaJob` resets a
+  terminal job on purpose, so the same file sent twice paid for a second full analysis to reproduce the caption
+  it already had — the most expensive work this instance does. File records now carry the SHA-256 the writer
+  already computed (for the response body and the webhook, then threw away), and the media dispatcher skips the
+  pipeline when the caller's hash, the stored hash and an `embeddingStatus` of `complete` all agree. That
+  conjunction is an identity, not a heuristic: same bytes, same pipeline, same answer. Every other case still
+  processes — different bytes, no hash from the writer, no hash on the record (everything written before this
+  release), and any status other than `complete`, so **re-uploading is still how a failed analysis is retried**.
+  The field is optional and self-healing rather than migrated, because file records sync.
 - **A record whose embedded text did not change is no longer re-embedded.** Every successful update enqueues an
   embed job unconditionally — correct, because the enqueue is also how `excludeFromVectorSearch` takes effect and
   it replaced four inline embeds built from stale reads. But most updates change something the vector does not

--- a/docs/integration-guide/05-files-api.md
+++ b/docs/integration-guide/05-files-api.md
@@ -41,6 +41,10 @@ with no extension.
 { "path": "reports/q1.pdf", "sha256": "a1b2c3...", "embeddingStatus": "pending" }
 ```
 
+A **media** re-upload whose bytes are unchanged answers `"complete"` instead: the analysis it already has
+is kept rather than re-run. See [Media Embedding](05b-media-embedding.md#upload-response) for when a
+re-upload does re-analyse — which is every case except that one.
+
 ### Upload a File (JSON / base64)
 
 ```http

--- a/docs/integration-guide/05b-media-embedding.md
+++ b/docs/integration-guide/05b-media-embedding.md
@@ -42,6 +42,19 @@ When a media file is uploaded, the response includes an `embeddingStatus` field:
 | `"pending"` | Job enqueued; background worker will process soon |
 | `"skipped"` | Not analysed — the file exceeds `MAX_FILE_SIZE_BYTES`, **or** this media class is `off` for the space (its `levels` entry). File stored, not embedded |
 | `"disabled"` | **Legacy** — set at upload while the removed media-embedding master switch was off. No longer produced (a class turned off now returns `"skipped"`); still appears on pre-migration records |
+| `"complete"` | The **identical bytes** were already analysed — nothing was re-run, and the existing description, transcript and vector still stand |
+
+##### Re-uploading the same file costs nothing
+
+Uploading a media file whose SHA-256 matches the one already stored, on a record that reached `"complete"`, skips
+the pipeline entirely and answers `"complete"` immediately. Vision and speech-to-text are the most expensive work
+this instance does, and the same bytes through the same pipeline cannot produce a different answer.
+
+Every uncertain case still processes, so this cannot leave a file unanalysed: a re-upload is re-run when the bytes
+differ, when the writer sends no hash, when the stored record has none (everything written before this release),
+and when the previous attempt was anything other than `"complete"` — `"failed"`, `"partial"`, `"pending"`,
+`"skipped"` and `"processing"` all re-run. **Re-uploading remains the way to retry a failed analysis.** To force a
+re-analysis of a file that succeeded, change the bytes, or delete it and upload it again.
 
 While processing, the filemeta record on the file (accessible via `GET /api/brain/spaces/:spaceId/files`) reflects the current status:
 

--- a/docs/userguide/03-files-and-schemas.md
+++ b/docs/userguide/03-files-and-schemas.md
@@ -20,6 +20,16 @@ what you need to weigh is that the derived records disappear — not that some b
 You are asked **once for a whole batch**, not once per file: a drop of twenty files where three collide is
 one question. **Cancel is the default**, and Replace is styled as destructive. There is no undo.
 
+**Uploading the very same image, audio or video again is free.** If the file you upload is byte-for-byte the
+one already there and Ythril finished analysing it, the analysis is kept instead of being redone. Looking at a
+picture or transcribing a recording is the slowest, most power-hungry thing the server does, and repeating it on
+unchanged content could only produce the same description it already has.
+
+Anything less than certain is analysed again, so nothing gets skipped by accident: a file whose contents changed
+at all, one whose analysis failed, was still running, or was never done, and every file uploaded before this
+release. **Re-uploading is still how you retry a failed analysis.** To have a file looked at again after it
+succeeded, delete it and upload it again.
+
 **Actions per row:**
 
 | Action | How |

--- a/server/src/api/files.ts
+++ b/server/src/api/files.ts
@@ -520,7 +520,7 @@ fileStoreRouter.post(
           const absTarget = resolveSafePath(targetSpace, filePath);
           await assertNoSymlinkEscape(targetSpace, absTarget);
           const sha256 = await assembleChunks(targetSpace, filePath, range.total, absTarget);
-          await upsertFileMeta(targetSpace, filePath, range.total, { ttlDays: parseTtlDaysQuery(req) }).catch(err => {
+          await upsertFileMeta(targetSpace, filePath, range.total, { ttlDays: parseTtlDaysQuery(req), sha256 }).catch(err => {
             log.warn(`upsertFileMeta error for space ${targetSpace}, path ${filePath}: ${err}`);
           });
 
@@ -528,7 +528,7 @@ fileStoreRouter.post(
           // the single-request upload). Previously the media branch here only recorded `pending` —
           // `disabled`/`skipped` states were dropped; the shared helper records all three.
           const { resolvedFormat: resolvedFmt, embeddingStatus: chunkedEmbeddingStatus } =
-            await dispatchFileProcessing(targetSpace, filePath, { bytes: range.total, contentType: req.headers['content-type'] });
+            await dispatchFileProcessing(targetSpace, filePath, { bytes: range.total, contentType: req.headers['content-type'], sha256 });
 
           emitWebhookEvent({ event: 'file.created', spaceId: targetSpace, entry: { path: filePath, sha256 }, ...webhookToken(req) });
           const isDocFormat = resolvedFmt !== 'text' && !isMediaFormat(resolvedFmt);
@@ -595,7 +595,7 @@ fileStoreRouter.post(
       }
 
       // Persist file metadata to MongoDB
-      const metaOpts: { description?: string; tags?: string[]; properties?: Record<string, string | number | boolean>; ttlDays?: number } = {};
+      const metaOpts: { description?: string; tags?: string[]; properties?: Record<string, string | number | boolean>; ttlDays?: number; sha256?: string } = {};
       if (typeof req.body?.description === 'string') metaOpts.description = req.body.description;
       if (Array.isArray(req.body?.tags)) metaOpts.tags = req.body.tags as string[];
       if (req.body?.properties != null && typeof req.body.properties === 'object' && !Array.isArray(req.body.properties)) {
@@ -603,6 +603,7 @@ fileStoreRouter.post(
       }
       const ttlDaysQ = parseTtlDaysQuery(req);
       if (ttlDaysQ !== undefined) metaOpts.ttlDays = ttlDaysQ;
+      metaOpts.sha256 = sha256;
       await upsertFileMeta(targetSpace, filePath, incomingBytes, metaOpts).catch(err => {
         log.warn(`upsertFileMeta error for space ${targetSpace}, path ${filePath}: ${err}`);
       });
@@ -610,7 +611,7 @@ fileStoreRouter.post(
       // Resolve format, record media state, and enqueue the async embedding job (media or document).
       const inputFormat = typeof req.body?.inputFormat === 'string' ? req.body.inputFormat as InputFormat : 'auto';
       const { resolvedFormat, embeddingStatus: embeddingStatusForResponse } = await dispatchFileProcessing(
-        targetSpace, filePath, { bytes: incomingBytes, contentType: req.headers['content-type'], inputFormat },
+        targetSpace, filePath, { bytes: incomingBytes, contentType: req.headers['content-type'], inputFormat, sha256 },
       );
 
       const response: { path: string; sha256: string; storageWarning?: boolean; embeddingStatus?: string } = { path: filePath, sha256 };

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -1493,6 +1493,17 @@ export interface FileMetaDoc {
   createdAt: string;    // ISO8601 — first write timestamp
   updatedAt: string;    // ISO8601 — last write timestamp
   sizeBytes: number;    // file size in bytes at last write
+  /**
+   * SHA-256 of the bytes as last written, when the writer supplied it.
+   *
+   * Optional and self-healing: absent means "unknown", which the media dispatcher treats as "process it". It is
+   * filled by the next write, so nothing has to migrate — which matters because file records SYNC, and a synced
+   * data migration has to be lazy rather than a boot step.
+   *
+   * It exists so re-uploading identical bytes does not re-run vision or speech-to-text over them. See
+   * `files/dispatch.ts`.
+   */
+  sha256?: string;
   author: AuthorRef;    // writer: instanceId + instanceLabel
   /** Set when the file was deleted while `softDeleteFileMeta` is enabled: ISO8601
    *  timestamp of the deletion. The record is retained (still listed/searchable, shown

--- a/server/src/files/dispatch.ts
+++ b/server/src/files/dispatch.ts
@@ -28,11 +28,23 @@ import { toDocId } from '../util/paths.js';
 import { log } from '../util/log.js';
 
 /** Embedding-pipeline state surfaced to the HTTP/MCP response after a write. */
-export type FileEmbeddingStatus = 'disabled' | 'skipped' | 'pending';
+/**
+ * The statuses this dispatcher can put a media file into — plus `complete`, which it REPORTS without
+ * setting: identical bytes that already embedded are left exactly as they are, and the caller is told the
+ * truth about the file rather than a status describing work that did not happen.
+ */
+export type FileEmbeddingStatus = 'disabled' | 'skipped' | 'pending' | 'complete';
 
 export interface DispatchInput {
   /** File size in bytes (used for the media size cap). */
   bytes: number;
+  /**
+   * SHA-256 of the bytes just written, when the caller has it.
+   *
+   * Absent means "unknown" and the file is processed, which is the safe direction: the alternative — assuming
+   * unchanged — would leave a file silently unembedded, and that is invisible until someone searches for it.
+   */
+  sha256?: string;
   /**
    * Raw `Content-Type` header, if any — used to resolve the format and as the enqueue MIME type.
    * Generic values (`application/octet-stream` and friends) are treated as "not stated" and the
@@ -74,11 +86,33 @@ export async function dispatchFileProcessing(
     // Media (image/audio/video): enqueue an async embedding job, or record why we didn't.
     // `mediaType` is the guard-narrowed format so it satisfies FileMetaDoc's media subset.
     const mediaType = resolvedFormat;
-    const setMediaStatus = (status: FileEmbeddingStatus): Promise<unknown> =>
+    const setMediaStatus = (status: Exclude<FileEmbeddingStatus, 'complete'>): Promise<unknown> =>
       col<FileMetaDoc>(`${spaceId}_files`).updateOne(
         asFilter<FileMetaDoc>({ _id: normId }),
         { $set: { mediaType, embeddingStatus: status } },
       );
+    // Identical bytes that already completed: nothing to do, and this is the most expensive thing on the
+    // instance to redo. `enqueueMediaJob` deliberately resets a terminal job "so re-upload triggers
+    // re-processing" — right when the bytes are new, waste when they are not, and it could not tell the
+    // difference because no hash was stored.
+    //
+    // The three conditions are a conjunction on purpose, and each is the safe direction on its own:
+    //   - a hash from the CALLER, so an unknown hash processes rather than assumes;
+    //   - the SAME hash on the record, which is the identity — same bytes through the same pipeline;
+    //   - `embeddingStatus: 'complete'`, so a file that failed, was skipped, or is still pending is retried.
+    //
+    // Getting this wrong in the other direction is invisible: a file silently never embedded, discovered only
+    // when someone searches for it and it is not there. So the guard refuses to guess.
+    if (input.sha256) {
+      const prior = await col<FileMetaDoc>(`${spaceId}_files`).findOne(
+        asFilter<FileMetaDoc>({ _id: normId }),
+      ) as FileMetaDoc | null;
+      if (prior?.sha256 === input.sha256 && prior?.embeddingStatus === 'complete') {
+        log.debug(`Media file ${spaceId}/${filePath}: identical bytes already embedded — pipeline skipped`);
+        return { resolvedFormat, embeddingStatus: 'complete' };
+      }
+    }
+
     const mediaCfg = getMediaEmbeddingConfig();
     const maxBytes = mediaCfg.maxFileSizeBytes ?? DEFAULT_MEDIA_MAX_FILE_SIZE_BYTES;
     // No master switch any more: whether this class runs is decided entirely by its per-class level

--- a/server/src/files/file-meta.ts
+++ b/server/src/files/file-meta.ts
@@ -39,7 +39,7 @@ export async function upsertFileMeta(
   spaceId: string,
   filePath: string,
   sizeBytes: number,
-  opts: { description?: string; tags?: string[]; properties?: Record<string, string | number | boolean>; ttlDays?: number | null } = {},
+  opts: { description?: string; tags?: string[]; properties?: Record<string, string | number | boolean>; ttlDays?: number | null; sha256?: string } = {},
 ): Promise<void> {
   const normalised = toDocId(filePath);
   const now = new Date().toISOString();
@@ -60,6 +60,9 @@ export async function upsertFileMeta(
     if (opts.description !== undefined) $set['description'] = opts.description;
     if (opts.tags !== undefined) $set['tags'] = opts.tags;
     if (opts.properties !== undefined) $set['properties'] = opts.properties;
+    // Only when stated. A writer that does not compute a hash must not erase the one already there — that would
+    // turn "unknown" into a permanent state and the skip below into dead code.
+    if (opts.sha256 !== undefined) $set['sha256'] = opts.sha256;
     // A write to a soft-deleted path means the file is live again — clear the flag.
     const $unset: Record<string, unknown> = { deletedAt: '' };
     // Only an EXPLICIT ttlDays on a re-upload touches expiry: >0 (re)stamps, 0/null clears it. A plain
@@ -87,6 +90,7 @@ export async function upsertFileMeta(
       createdAt: now,
       updatedAt: now,
       sizeBytes,
+      ...(opts.sha256 !== undefined ? { sha256: opts.sha256 } : {}),
       author: authorRef(),
       ...(expireAt ? { _expireAt: expireAt } : {}),
     };

--- a/server/src/mcp/tools/file.ts
+++ b/server/src/mcp/tools/file.ts
@@ -82,13 +82,14 @@ export const write_fileTool: ToolHandler = {
     const sizeBytes = Buffer.byteLength(content, 'utf8');
     const wfQuota = await checkQuota('files', sizeBytes);
     const { sha256 } = await writeFile(wt.target, filePath, content);
-    const metaOpts: { description?: string; tags?: string[]; properties?: Record<string, string | number | boolean>; ttlDays?: number | null } = {};
+    const metaOpts: { description?: string; tags?: string[]; properties?: Record<string, string | number | boolean>; ttlDays?: number | null; sha256?: string } = {};
     if (typeof a['description'] === 'string') metaOpts.description = a['description'];
     if (Array.isArray(a['tags'])) metaOpts.tags = a['tags'] as string[];
     if (a['properties'] != null && typeof a['properties'] === 'object' && !Array.isArray(a['properties'])) {
       metaOpts.properties = a['properties'] as Record<string, string | number | boolean>;
     }
     metaOpts.ttlDays = ttlDaysFromArgs(a);
+    metaOpts.sha256 = sha256;
     await upsertFileMeta(wt.target, filePath, sizeBytes, metaOpts);
     // Resolve format, record media state, and enqueue the async embedding job — one shared policy
     // with the REST upload path. Documents are converted by the background worker (not inline), so
@@ -97,7 +98,7 @@ export const write_fileTool: ToolHandler = {
     // derives the type from the file extension, so an image written here reaches the vision provider
     // as `image/png` rather than the byte-blob type this comment used to describe as intended.
     const ifFmt = typeof a['inputFormat'] === 'string' ? a['inputFormat'] as InputFormat : 'auto';
-    await dispatchFileProcessing(wt.target, filePath, { bytes: sizeBytes, inputFormat: ifFmt });
+    await dispatchFileProcessing(wt.target, filePath, { bytes: sizeBytes, inputFormat: ifFmt, sha256 });
     emitWebhookEvent({ event: 'file.created', spaceId: wt.target, entry: { path: filePath, sha256 }, ...(ctx.actor ?? {}) });
     const wfText = `Written (sha256: ${sha256}).`
       + (wfQuota.softBreached ? `\n⚠️ Storage warning: ${wfQuota.warning}` : '');

--- a/testing/standalone/identical-bytes-skip-media-pipeline-db.test.js
+++ b/testing/standalone/identical-bytes-skip-media-pipeline-db.test.js
@@ -1,0 +1,173 @@
+/**
+ * Re-uploading identical bytes does not re-run vision or speech-to-text over them.
+ *
+ * ## The waste
+ *
+ * `enqueueMediaJob` resets a terminal job on purpose — its own comment says "reset so re-upload triggers
+ * re-processing" — because until now the pipeline had no way to tell a corrected file from the same file sent
+ * twice. Every re-upload therefore paid for a full vision or speech-to-text pass, which is the single most
+ * expensive thing this instance does, to reproduce a caption it already had.
+ *
+ * ## Why this is lossless rather than a heuristic
+ *
+ * The guard is an identity, not a guess: the same bytes (SHA-256, computed by the writer that just wrote them)
+ * through the same pipeline produce the same analysis. It fires only on the conjunction of three conditions, and
+ * every one of them is asserted separately below, because each alone would make it a guess:
+ *
+ *   - the CALLER supplied a hash — an unknown hash processes rather than assumes;
+ *   - the STORED hash matches it;
+ *   - the stored `embeddingStatus` is `complete` — anything else (failed, partial, pending, skipped) is retried.
+ *
+ * The wrong direction here is invisible in a way the right one is not: a file silently never embedded is
+ * discovered only when someone searches for it and it is not there. So every uncertain case processes.
+ *
+ * Run: node --test testing/standalone/identical-bytes-skip-media-pipeline-db.test.js
+ */
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+const SPACE = `mediaskip${Date.now()}`;
+const FILE = 'clip.png';
+const HASH = 'a'.repeat(64);
+
+let mongo;
+let dispatchFileProcessing;
+
+before(async () => {
+  if (skip) return;
+  mongo = await openTestMongo('mediaskip');
+  ({ dispatchFileProcessing } = await import('../../server/dist/files/dispatch.js'));
+});
+
+after(async () => {
+  if (skip) return;
+  await mongo.col(`${SPACE}_files`).drop().catch(() => {});
+  await closeTestMongo(mongo);
+});
+
+/**
+ * "It did not skip" is proven by "it went on to the pipeline".
+ *
+ * The guard sits immediately above `getMediaEmbeddingConfig()`, and this is a database harness with no config
+ * loaded — so falling through raises a recognisable error. That failure IS the evidence. Matching the message
+ * rather than merely catching means an unrelated fault cannot pass as proof.
+ */
+async function ranThePipeline(input) {
+  try {
+    const result = await dispatchFileProcessing(SPACE, FILE, input);
+    return { processed: false, result };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    assert.match(msg, /Config not loaded/,
+      `expected the media pipeline to be reached and fail on the absent config, got: ${msg}`);
+    return { processed: true, result: null };
+  }
+}
+
+/** A file metadata record as an upload leaves one. */
+async function seed(over = {}) {
+  const c = mongo.col(`${SPACE}_files`);
+  await c.deleteOne({ _id: FILE }).catch(() => {});
+  await c.insertOne({
+    _id: FILE, spaceId: SPACE, path: FILE, sizeBytes: 1024, mediaType: 'image',
+    sha256: HASH, embeddingStatus: 'complete', createdAt: new Date().toISOString(),
+    ...over,
+  });
+  return c;
+}
+
+describe('the media pipeline is skipped only when re-running it could not change anything', { skip }, () => {
+  it('same hash, already complete -> skipped, and the record is left alone', async () => {
+    const c = await seed();
+    const before = await c.findOne({ _id: FILE });
+
+    const { processed, result } = await ranThePipeline({ bytes: 1024, sha256: HASH });
+    assert.equal(processed, false, 'identical bytes that already embedded must not be analysed again');
+    assert.equal(result.embeddingStatus, 'complete',
+      'the caller is told the truth about the file, not a status describing work that did not happen');
+
+    // Nothing was reset — the point of the change is that the completed job SURVIVES the re-upload.
+    assert.deepEqual(await c.findOne({ _id: FILE }), before);
+  });
+
+  it('a DIFFERENT hash re-processes', async () => {
+    await seed();
+    const { processed } = await ranThePipeline({ bytes: 1024, sha256: 'b'.repeat(64) });
+    assert.equal(processed, true, 'new bytes are a new file — skipping would leave the old caption in place');
+  });
+
+  it('NO caller hash re-processes, even against a stored hash', async () => {
+    // A writer that does not compute one is the pre-upgrade case, and every record written before this
+    // shipped. Unknown must mean "process it".
+    await seed();
+    const { processed } = await ranThePipeline({ bytes: 1024 });
+    assert.equal(processed, true, 'an unknown hash must process rather than assume');
+  });
+
+  for (const status of ['failed', 'partial', 'pending', 'skipped', 'processing']) {
+    it(`same hash but status "${status}" re-processes`, async () => {
+      // These are exactly the states a retry exists for. Skipping here would make a failed analysis
+      // permanent and a re-upload — the obvious human fix — do nothing at all.
+      await seed({ embeddingStatus: status });
+      const { processed } = await ranThePipeline({ bytes: 1024, sha256: HASH });
+      assert.equal(processed, true, `"${status}" is not a finished analysis`);
+    });
+  }
+
+  it('NO stored hash re-processes', async () => {
+    // Every media record that exists today. The field is optional and self-healing precisely so this case
+    // behaves like it always did.
+    await seed({ sha256: undefined });
+    const { processed } = await ranThePipeline({ bytes: 1024, sha256: HASH });
+    assert.equal(processed, true, 'a record that never stored a hash cannot claim identity');
+  });
+});
+
+describe('the writers supply the hash, or the guard is dead code', () => {
+  it('every upload path passes sha256 to both the meta write and the dispatch', async () => {
+    const { readFileSync } = await import('node:fs');
+    const strip = s => s.replace(/(^|[^:])\/\/.*/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
+
+    // The guard can only ever fire if the three writers that compute a hash also hand it over. Each of these
+    // computed one already — for the response body and the webhook — and threw it away.
+    const rest = strip(readFileSync('server/src/api/files.ts', 'utf8'));
+    assert.match(rest, /upsertFileMeta\(targetSpace, filePath, range\.total, \{ ttlDays: parseTtlDaysQuery\(req\), sha256 \}/,
+      'chunked assembly must store the hash it computed');
+    assert.match(rest, /dispatchFileProcessing\(targetSpace, filePath, \{ bytes: range\.total,[^)]*sha256 \}/,
+      'chunked assembly must pass the hash to the dispatcher');
+    assert.match(rest, /metaOpts\.sha256 = sha256;/, 'the single-request upload must store the hash');
+    assert.match(rest, /\{ bytes: incomingBytes,[^)]*sha256 \}/,
+      'the single-request upload must pass the hash to the dispatcher');
+
+    const mcp = strip(readFileSync('server/src/mcp/tools/file.ts', 'utf8'));
+    assert.match(mcp, /metaOpts\.sha256 = sha256;/, 'MCP write_file must store the hash');
+    assert.match(mcp, /dispatchFileProcessing\(wt\.target, filePath, \{ bytes: sizeBytes,[^)]*sha256 \}/,
+      'MCP write_file must pass the hash to the dispatcher — both doors, or one of them keeps burning GPU');
+  });
+
+  it('the stored hash is never erased by a writer that does not have one', async () => {
+    const { readFileSync } = await import('node:fs');
+    const strip = s => s.replace(/(^|[^:])\/\/.*/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
+    const meta = strip(readFileSync('server/src/files/file-meta.ts', 'utf8'));
+    // An unconditional `$set` would turn "unknown" into a permanent state — a `PATCH` of a description would
+    // silently disarm the skip for that file for ever.
+    assert.match(meta, /if \(opts\.sha256 !== undefined\) \$set\['sha256'\] = opts\.sha256;/,
+      'the hash is written only when the caller states one');
+  });
+
+  it('the guard is a conjunction, in source', async () => {
+    const { readFileSync } = await import('node:fs');
+    const strip = s => s.replace(/(^|[^:])\/\/.*/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
+    const src = strip(readFileSync('server/src/files/dispatch.ts', 'utf8'));
+    assert.match(src, /prior\?\.sha256 === input\.sha256 && prior\?\.embeddingStatus === 'complete'/,
+      'either condition alone would skip work that still needs doing');
+    // And it must sit above the enqueue it is meant to prevent, not after it. Anchored on the CALL: the
+    // import of the same name is at the top of the file and would make this pass no matter where the guard is.
+    const guardAt = src.indexOf('prior?.sha256 === input.sha256');
+    const enqueueAt = src.indexOf('await enqueueMediaJob(');
+    assert.ok(enqueueAt > 0, 'the enqueue call moved or was renamed — this ordering check now proves nothing');
+    assert.ok(guardAt > 0 && guardAt < enqueueAt, 'a guard after the enqueue prevents nothing');
+  });
+});

--- a/testing/standalone/no-new-god-files.test.js
+++ b/testing/standalone/no-new-god-files.test.js
@@ -188,7 +188,12 @@ const FROZEN = {
   // `SpaceMeta` from the slice-1 leaf rather than back from `types.ts`. 677 -> 645 -> 578 across the two slices,
   // and the first attempt at this move — before the leaf existed — reached 609 while silently degrading
   // `NetworkConfig` to `any` in a caller. The number was never the point; where the growth goes is.
-  'server/src/config/types.ts': 578,
+  // RAISED 578 -> 579 for `FileMetaDoc.sha256`: one optional field, and there is nowhere else a field on a
+  // document type can live. It is what lets the media dispatcher tell identical bytes from new ones, so a
+  // re-upload stops re-running vision and speech-to-text over content already embedded. Optional on purpose:
+  // absent means "unknown", which processes rather than assumes, and it fills itself on the next write —
+  // file records SYNC, so a boot migration would have been the wrong shape.
+  'server/src/config/types.ts': 579,
   'client/src/app/pages/settings/data.component.ts': 644,
   // RAISED 646 -> 647 by ONE line: the Q-6 narrowing swapped `resolveMemberSpaces` for `memberSpacesForRequest`,
   // and this file no longer needed the old import, so it gained an import line and lost none. Not growth in any


### PR DESCRIPTION
## The waste

`enqueueMediaJob` resets a terminal job on purpose. Its own comment says so — *"Terminal state (complete/failed) —
reset so re-upload triggers re-processing"* — and it was right to, because until now the pipeline had no way to tell
a corrected file from the same file sent again.

The cost of that is asymmetric. Re-uploading an unchanged image or recording paid for a **full vision or
speech-to-text pass** to reproduce the description it already had. Under the owner's instruction to find hardware
savings with no loss of accuracy or quality, this is the largest one left: it is the most expensive work the
instance does.

## What makes this lossless

The three writers that upload a file **already computed the SHA-256** of the bytes they had just written — for the
response body and for the webhook — and then threw it away. `FileMetaDoc` now keeps it, and the media dispatcher
skips the pipeline when three things agree:

| condition | why it is in the conjunction |
|---|---|
| the **caller** supplied a hash | an unknown hash processes rather than assumes |
| the **stored** hash matches it | this is the identity: same bytes, same pipeline, same answer |
| stored `embeddingStatus` is `complete` | anything else is an analysis that has not finished |

Each one alone would make this a guess, so each is asserted separately in the tests.

**The wrong direction here is invisible in a way the right one is not.** A file silently never embedded is
discovered only when somebody searches for it and it is not there. So every uncertain case processes:

- different bytes → re-runs
- no hash from the writer → re-runs
- no hash on the record (every record written before this) → re-runs
- `failed`, `partial`, `pending`, `skipped`, `processing` → all re-run

**Re-uploading is still how a failed analysis is retried.** To force a re-analysis of one that succeeded, change the
bytes, or delete and upload again.

## Why the field is optional rather than migrated

File records **sync**. A synced data migration has to be lazy and self-healing, not a boot step — so `sha256` is
optional, absent means "unknown" (which processes), and the next write fills it.

`upsertFileMeta` writes it **only when the caller states one**. An unconditional `$set` would let a `PATCH` of a
description erase the hash and quietly disarm the skip for that file for ever; there is a gate on that line.

## Verification

`testing/standalone/identical-bytes-skip-media-pipeline-db.test.js` — 12 tests against a real Mongo. "It did not
skip" is proven by "it reached the pipeline": the guard sits immediately above `getMediaEmbeddingConfig()` and the
harness has no config, so falling through raises a recognisable error, matched by message rather than merely caught.
The skip case additionally asserts the **record is byte-identical afterwards** — the completed job surviving the
re-upload is the whole point.

Two mutants, both killed:

| mutant | caught by |
|---|---|
| drop the `embeddingStatus === 'complete'` condition | 6 tests — all five status cases and the source conjunction |
| MCP `write_file` stops passing the hash | the writers gate |

The ordering assertion anchors on `await enqueueMediaJob(`, not the bare name: the **import** of the same name is at
the top of the file and would have made it pass wherever the guard sat.

## Five places

- **REST route** — both upload paths (single-request and chunked assembly) pass the hash.
- **MCP tool** — `write_file` passes it in the same commit. One door forgetting it leaves that door burning GPU,
  which is why a gate asserts all three call sites.
- **integration guide** — `05b-media-embedding.md` gains the `complete` row and the re-upload rule;
  `05-files-api.md` points at it from the upload response.
- **userguide** — `03-files-and-schemas.md`, beside the existing overwrite dialog, says the same thing without a
  hash in sight.
- **token rights** — unchanged: no new route, no new capability.

## Other

`FileEmbeddingStatus` gains `complete`, which the dispatcher **reports** from the record without ever setting;
`setMediaStatus` is narrowed to `Exclude<…, 'complete'>` so the writer half cannot drift into it.

The god-file freeze on `config/types.ts` is raised 578 → 579 **deliberately**, per the gate's own rule: one optional
field on a document type, and there is nowhere else a field on a document type can live.
