### PR TITLE
feat(spaces)!: `description` is gone, and saying it is now an error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ ideas/
 **/.claude/agent-memory-local
 **/.claude/first-run
 **/.claude/assistant-daemon-state.json
+
+# Owner-facing open decisions — working document, never committed.
+XREVIEWX.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+*The 3.0 deprecation checklist. Each entry names its replacement; `todo/_DEPRECATIONS.md` carries the row.*
+
+- **BREAKING — `description` on a space is gone from every surface. Say `meta.purpose`.** It was announced
+  as *"Removal in 3.0"* in `docs/integration-guide/06-spaces-api.md` since 2.3, and it is the one
+  deprecation whose removal version was published rather than merely tracked. Removed from: the create and
+  update REST bodies, every REST response that carried the derived alias, `update_space`'s MCP input schema,
+  and `list_spaces`' output. The `spaceDescriptionAlias` / `spaceResponse` shapers are deleted with it.
+  **A request still sending `description` now gets a `400` naming `meta.purpose` — it is not silently
+  dropped.** That refusal is the point: these top-level bodies are not `.strict()`, so without it a caller
+  would have received a `200` with no directive written, while the same request over MCP already 400'd on
+  `additionalProperties: false` — one rule with two behaviours, and the quiet one is the one that loses
+  data. The refusal lives in the shared planners, so both doors answer identically.
+  The boot migration **stays**: a `config.json` written by an older build still carries a stored
+  `description`, and dropping the migration alongside the alias would discard the operator's directive on
+  upgrade. It goes once the version floor 3.0 supports upgrading from is fixed.
+
+
 ### Changed
 - **Re-uploading identical bytes no longer re-runs vision or speech-to-text.** `enqueueMediaJob` resets a
   terminal job on purpose, so the same file sent twice paid for a second full analysis to reproduce the caption

--- a/client/src/app/core/api.types.ts
+++ b/client/src/app/core/api.types.ts
@@ -47,8 +47,6 @@ export interface Space {
   folders?: string[];
   maxGiB?: number;
   usageGiB?: number;
-  /** @deprecated Derived alias of `meta.purpose` — the server no longer stores it. Removal in 3.0. */
-  description?: string;
   proxyFor?: string[];
   meta?: SpaceMeta;
   dupeRules?: DupeActionRule[];

--- a/client/src/app/core/spaces-api.service.ts
+++ b/client/src/app/core/spaces-api.service.ts
@@ -30,11 +30,11 @@ export class SpacesApi {
     return this.http.get<SpacesResponse>('/api/spaces');
   }
 
-  createSpace(body: { label: string; id?: string; maxGiB?: number; description?: string; proxyFor?: string[]; meta?: Partial<SpaceMeta> }): Observable<{ space: Space }> {
+  createSpace(body: { label: string; id?: string; maxGiB?: number; proxyFor?: string[]; meta?: Partial<SpaceMeta> }): Observable<{ space: Space }> {
     return this.http.post<{ space: Space }>('/api/spaces', body);
   }
 
-  updateSpace(id: string, body: { label?: string; description?: string; maxGiB?: number | null; meta?: Partial<SpaceMeta>; typeSchemasMode?: 'merge' | 'replace'; dupeRules?: DupeActionRule[]; dupeMergeSurvivor?: 'older' | 'newer'; dupeRulesOnInsert?: boolean; recordTtlDays?: number | RecordTtlWindows | null; documentExtraction?: 'off' | 'ocr' | 'vlm' | 'repair' | 'auto' | null; imageAnalysis?: 'off' | 'caption' | 'recognition' | 'auto' | null; audioAnalysis?: 'off' | 'on' | 'auto' | null; videoAnalysis?: 'off' | 'audio' | 'full' | 'auto' | null; textAnalysis?: 'off' | 'embed' | 'chunk' | 'auto' | null }): Observable<UpdateSpaceResult> {
+  updateSpace(id: string, body: { label?: string; maxGiB?: number | null; meta?: Partial<SpaceMeta>; typeSchemasMode?: 'merge' | 'replace'; dupeRules?: DupeActionRule[]; dupeMergeSurvivor?: 'older' | 'newer'; dupeRulesOnInsert?: boolean; recordTtlDays?: number | RecordTtlWindows | null; documentExtraction?: 'off' | 'ocr' | 'vlm' | 'repair' | 'auto' | null; imageAnalysis?: 'off' | 'caption' | 'recognition' | 'auto' | null; audioAnalysis?: 'off' | 'on' | 'auto' | null; videoAnalysis?: 'off' | 'audio' | 'full' | 'auto' | null; textAnalysis?: 'off' | 'embed' | 'chunk' | 'auto' | null }): Observable<UpdateSpaceResult> {
     return this.http.patch<UpdateSpaceResult>(`/api/spaces/${id}`, body);
   }
 

--- a/docs/integration-guide/06-spaces-api.md
+++ b/docs/integration-guide/06-spaces-api.md
@@ -70,7 +70,6 @@ Authorization: Bearer <admin-token>
 |-------|----------|-------------|
 | `id` | no | Lowercase `^[a-z0-9-]+$`, max 40 chars. Auto-generated if omitted. |
 | `label` | yes | Human-readable display name, max 200 chars. |
-| `description` | no | **Deprecated** — writes `meta.purpose`. Max 4000 chars. Removal in 3.0. |
 | `folders` | no | Pre-create these directories on disk at space creation time. |
 | `maxGiB` | no | Maximum storage quota for the space (positive number in GiB). |
 | `faceDescriptorDims` | no | Width of this space's face descriptors (integer, 64–4096, default 128). **Create-only** — see below. |
@@ -354,7 +353,6 @@ PATCH /api/spaces/flows
 | Field | Required | Description |
 |-------|----------|-------------|
 | `label` | no | New display name, max 200 chars. |
-| `description` | no | **Deprecated alias of `meta.purpose`**, max 4000 chars — it writes that one field, and both names read back the same text. Because purpose is meta, a description change to a **networked** space follows the meta-vote path (`202 vote_pending`) rather than applying at once. Removal in 3.0. |
 | `meta` | no | Space schema definition (see [Schema Validation](06a-schema-api.md#schema-validation) below). |
 
 **Response** `200`: the updated space object.
@@ -381,8 +379,7 @@ A round proposed by a peer running an older build carries neither field and is a
 as before — its proposer computed the snapshot as the complete intended result, so field-merging an
 unknown changed-set would apply nothing at all.
 
-> **MCP tool:** `update_space` — accepts `label` and `purpose` (and `description` as the deprecated
-> spelling of `purpose`). Requires `admin: true`.
+> **MCP tool:** `update_space` — accepts `label` and `purpose`. Requires `admin: true`.
 
 ---
 

--- a/docs/integration-guide/12-admin-api.md
+++ b/docs/integration-guide/12-admin-api.md
@@ -131,7 +131,7 @@ Each document must have a string `_id`. Documents with an existing `_id` in the 
 ### Wipe Space
 
 Clear all data — or a specific subset of collection types — from a space, while
-preserving the space itself (label, description, config, OIDC mappings, and quota
+preserving the space itself (label, purpose, config, OIDC mappings, and quota
 settings).
 
 ```http
@@ -193,7 +193,7 @@ collection.  On a partial wipe the unaffected fields will be `0`.
 - **Idempotent** — wiping an already-empty space (or a type with no documents) returns `0` for that field; no error is raised.
 - **Tombstones** — internal sync-tombstone records are cleared for the wiped types so peers do not re-sync deleted data. For full wipes all tombstones are cleared.  For partial wipes only the matching type tombstones are removed.
 - **Files** — when `"files"` is included, both the MongoDB metadata collection and the physical files directory on disk are cleared. The directory is recreated empty so new uploads work immediately.
-- **Space preserved** — the space itself is not deleted. Its label, description, configuration, OIDC mappings, and quota settings remain unchanged.
+- **Space preserved** — the space itself is not deleted. Its label, purpose, configuration, OIDC mappings, and quota settings remain unchanged.
 
 #### Error responses
 

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -9,7 +9,7 @@ import { capDocExtractionMode } from '../files/converters/extraction-level.js';
 import { slugify, SPACE_PURPOSE_MAX, needsReindex } from '../spaces/_shared.js';
 import { createSpace, removeSpace } from '../spaces/lifecycle.js';
 import { renameSpace } from '../spaces/rename.js';
-import { updateSpace, reorderSpaces, spaceDescriptionAlias, spaceResponse } from '../spaces/spaces.js';
+import { updateSpace, reorderSpaces } from '../spaces/spaces.js';
 import { checkMetaPrecondition, preconditionErrorBody } from '../spaces/meta-precondition.js';
 import { gatherCompletenessFacts, scoreCompleteness } from '../spaces/completeness.js';
 import { ensureTtlIndex } from '../brain/ttl.js';
@@ -117,7 +117,7 @@ spacesRouter.post('/reorder', globalRateLimit, requireAdminMfa, (req, res) => {
   }
   res.json({ spaces: reordered.map(space => ({
     id: space.id, label: space.label, builtIn: space.builtIn, folders: space.folders,
-    maxGiB: space.maxGiB, flex: space.flex, ...spaceDescriptionAlias(space),
+    maxGiB: space.maxGiB, flex: space.flex,
     ...(space.proxyFor ? { proxyFor: space.proxyFor } : {}),
   })) });
 });
@@ -175,8 +175,6 @@ spacesRouter.get('/', globalRateLimit, requireAuth, async (req, res) => {
     const { id, label, builtIn, folders, maxGiB, flex, proxyFor, meta, dupeRules, dupeMergeSurvivor, dupeRulesOnInsert, recordTtlDays, documentExtraction, imageAnalysis, audioAnalysis, videoAnalysis, textAnalysis, indexStatus } = space;
     return {
     id, label, builtIn, folders, maxGiB, flex,
-    // Deprecated alias of `meta.purpose`, derived rather than stored — see `spaceDescriptionAlias`.
-    ...spaceDescriptionAlias(space),
     usageGiB: usageGiBByIdx[idx],
     ...(indexStatus ? { indexStatus } : {}),
     ...(proxyFor ? { proxyFor } : {}),
@@ -254,7 +252,7 @@ spacesRouter.post('/', globalRateLimit, requireAdminMfa, async (req, res) => {
     res.status(500).json({ error: result.error });
     return;
   }
-  res.status(201).json({ space: spaceResponse(result.space) });
+  res.status(201).json({ space: result.space });
 });
 
 // PATCH /api/spaces/:id
@@ -289,7 +287,7 @@ spacesRouter.patch('/:id', globalRateLimit, requireAdminMfaScoped('id'), async (
     res.status(202).json({ status: 'vote_pending', rounds: result.rounds, message: 'Meta change requires network vote' });
     return;
   }
-  res.json({ space: spaceResponse(result.space) });
+  res.json({ space: result.space });
 });
 
 // PUT /api/spaces/:id/schema — full replacement of the space's typeSchemas.
@@ -367,7 +365,7 @@ spacesRouter.put('/:id/schema', globalRateLimit, requireAdminMfaScoped('id'), as
     before: { typeSchemas: previousTypeSchemas ?? {} },
     after: { typeSchemas: newMeta.typeSchemas ?? {} },
   };
-  res.json({ space: spaceResponse(updated) });
+  res.json({ space: updated });
 });
 
 // GET /api/spaces/:id/meta — read the meta block with derived stats

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -179,10 +179,12 @@ export interface SpaceConfig {
   faceDescriptorDims?: number;
   flex?: number;
   /**
-   * @deprecated Say `meta.purpose`. This is the legacy spelling of the same thing: it was the field
-   * MCP clients read while the UI only ever gained an editor for `purpose`, so the two disagreed and
-   * the readable one was uneditable. Migrated into `meta.purpose` at boot and no longer stored;
-   * `spacePurpose()` derives it for the published API surfaces. Removal in 3.0.
+   * Legacy ON-DISK field only — removed from every API surface in 3.0, and no longer accepted, stored or
+   * emitted. It survives on this type because `migrateSpaceDescriptionToPurpose` still has to RECOGNISE it
+   * in a config written by an older build, and a boot migration cannot read a field the type denies.
+   *
+   * Delete this with the migration (`_DEPRECATIONS.md` row 3.1) once the version floor 3.0 upgrades from is
+   * fixed — not before, or upgrading from 2.x silently drops the operator's directive.
    */
   description?: string;
   proxyFor?: string[];  // virtual proxy space — aggregates reads, routes writes to member spaces

--- a/server/src/mcp/tools/spaces.ts
+++ b/server/src/mcp/tools/spaces.ts
@@ -37,13 +37,12 @@ export const list_spacesTool: ToolHandler = {
     for (const r of spaceCountResults) {
       if (r.status === 'fulfilled') countsBySpaceId[r.value.id] = r.value.counts;
     }
-    // `purpose` is the field an admin can edit and the one `get_space_meta` returns; `description` is
-    // its deprecated alias, kept because it is published API. They cannot disagree — one store.
+    // `purpose` is the field an admin can edit, the one `get_space_meta` returns, and since 3.0 the only
+    // spelling — its `description` alias was removed from every surface in the same release.
     const result = accessibleSpaces.map(s => ({
       id: s.id,
       label: s.label ?? null,
       purpose: spacePurpose(s) ?? null,
-      description: spacePurpose(s) ?? null,
       counts: countsBySpaceId[s.id] ?? { memories: 0, entities: 0, edges: 0, chrono: 0 },
     }));
     return {
@@ -199,7 +198,7 @@ export const get_space_metaTool: ToolHandler = {
 
 export const update_spaceTool: ToolHandler = {
   name: 'update_space',
-  description: 'Update the label or purpose of the specified space. Requires an admin token. `purpose` is the space-level directive MCP clients receive at handshake; `description` is its deprecated alias and writes the same field.',
+  description: 'Update the label or purpose of the specified space. Requires an admin token. `purpose` is the space-level directive MCP clients receive at handshake. Its `description` alias was removed in 3.0 — sending `description` is now rejected, not silently folded into `purpose`.',
   mutating: true,
   admin: true,
   spaceRequired: true,
@@ -209,7 +208,6 @@ export const update_spaceTool: ToolHandler = {
             space: s.requiredSpace,
             label: { type: 'string', minLength: 1, maxLength: 200, description: 'New display label for the space (1–200 chars).' },
             purpose: { type: 'string', maxLength: SPACE_PURPOSE_MAX, description: `New purpose for the space (max ${SPACE_PURPOSE_MAX} chars) — the space-level directive injected into MCP instructions at handshake.` },
-            description: { type: 'string', maxLength: SPACE_PURPOSE_MAX, description: 'DEPRECATED alias of `purpose`; writes the same field. Removal in 3.0.' },
           },
           required: ['space'],
           additionalProperties: false,
@@ -223,18 +221,19 @@ export const update_spaceTool: ToolHandler = {
       };
     }
     const newLabel = typeof a['label'] === 'string' ? a['label'].trim() : undefined;
-    // One field with two spellings. `purpose` wins if both are sent, since it is the current name.
-    const newDesc = typeof a['purpose'] === 'string' ? a['purpose']
-      : typeof a['description'] === 'string' ? a['description'] : undefined;
+    const newDesc = typeof a['purpose'] === 'string' ? a['purpose'] : undefined;
     if (newLabel === undefined && newDesc === undefined) {
       throw new Error('At least one of label or purpose must be provided');
     }
     if (newLabel !== undefined && newLabel.length === 0) throw new Error('label must not be empty');
     if (newDesc !== undefined && newDesc.length > SPACE_PURPOSE_MAX) throw new Error(`purpose must not exceed ${SPACE_PURPOSE_MAX} characters`);
     if (newLabel !== undefined && newLabel.length > 200) throw new Error('label must not exceed 200 characters');
-    const updates: { label?: string; description?: string } = {};
+    // `meta.purpose` directly. Until 3.0 this sent `description` and let the planner fold it in — that fold is
+    // gone with the alias, so a tool still sending the old spelling would now be dropped by a `.strict()` body
+    // rather than rewritten. The planner is the same one the REST route uses, so both doors keep one rule.
+    const updates: { label?: string; meta?: { purpose: string } } = {};
     if (newLabel !== undefined) updates.label = newLabel;
-    if (newDesc !== undefined) updates.description = newDesc;
+    if (newDesc !== undefined) updates.meta = { purpose: newDesc };
 
     // Through the planner, NOT `updateSpace` directly — and this was a live governance bypass, not a tidy-up.
     //

--- a/server/src/spaces/body-schemas.ts
+++ b/server/src/spaces/body-schemas.ts
@@ -183,7 +183,6 @@ export const ProxyForZ = z.union([
 export const CreateSpaceBody = z.object({
   id: z.string().min(1).max(40).regex(/^[a-z0-9-]+$/).optional(),
   label: z.string().min(1).max(200),
-  description: z.string().max(SPACE_PURPOSE_MAX).optional(),
   folders: z.array(z.string()).optional(),
   maxGiB: z.number().positive().optional(),
   // Create-only, and deliberately absent from the update body: a populated gallery cannot be re-dimensioned,
@@ -215,7 +214,6 @@ const TtlWindowZ = z.number().int().nonnegative().max(36500).nullable().optional
 
 export const UpdateSpaceBody = z.object({
   label: z.string().min(1).max(200).optional(),
-  description: z.string().max(SPACE_PURPOSE_MAX).optional(),
   maxGiB: z.number().positive().nullable().optional(),
   meta: SpaceMetaBody.optional(),
   /**
@@ -261,8 +259,8 @@ export const UpdateSpaceBody = z.object({
   audioAnalysis: z.enum(AUDIO_LEVELS).nullable().optional(),
   videoAnalysis: z.enum(VIDEO_LEVELS).nullable().optional(),
   textAnalysis: z.enum(TEXT_LEVELS).nullable().optional(),
-}).refine(d => d.label !== undefined || d.description !== undefined || d.meta !== undefined || d.maxGiB !== undefined || d.dupeRules !== undefined || d.dupeMergeSurvivor !== undefined || d.dupeRulesOnInsert !== undefined || d.recordTtlDays !== undefined || d.documentExtraction !== undefined || d.imageAnalysis !== undefined || d.audioAnalysis !== undefined || d.videoAnalysis !== undefined || d.textAnalysis !== undefined, {
-  message: 'At least one of label, description, maxGiB, meta, dupeRules, dupeMergeSurvivor, dupeRulesOnInsert, recordTtlDays, documentExtraction, imageAnalysis, audioAnalysis, videoAnalysis, or textAnalysis must be provided',
+}).refine(d => d.label !== undefined || d.meta !== undefined || d.maxGiB !== undefined || d.dupeRules !== undefined || d.dupeMergeSurvivor !== undefined || d.dupeRulesOnInsert !== undefined || d.recordTtlDays !== undefined || d.documentExtraction !== undefined || d.imageAnalysis !== undefined || d.audioAnalysis !== undefined || d.videoAnalysis !== undefined || d.textAnalysis !== undefined, {
+  message: 'At least one of label, maxGiB, meta, dupeRules, dupeMergeSurvivor, dupeRulesOnInsert, recordTtlDays, documentExtraction, imageAnalysis, audioAnalysis, videoAnalysis, or textAnalysis must be provided',
 });
 
 export const ReorderSpacesBody = z.object({

--- a/server/src/spaces/lifecycle.ts
+++ b/server/src/spaces/lifecycle.ts
@@ -317,7 +317,6 @@ export async function ensureGeneralSpace(): Promise<void> {
 export async function createSpace(opts: {
   id: string;
   label: string;
-  description?: string;
   folders?: string[];
   maxGiB?: number;
   proxyFor?: string[];
@@ -329,11 +328,6 @@ export async function createSpace(opts: {
   if (cfg.spaces.some(s => s.id === opts.id)) {
     throw new Error(`Space '${opts.id}' already exists`);
   }
-  const legacyPurpose = opts.description?.trim();
-  const mergedCreateMeta: SpaceMeta | undefined =
-    legacyPurpose && !opts.meta?.purpose?.trim()
-      ? { ...(opts.meta ?? {}), purpose: legacyPurpose.slice(0, 4_000) }
-      : opts.meta;
   const space: SpaceConfig = {
     id: opts.id,
     label: opts.label,
@@ -344,9 +338,7 @@ export async function createSpace(opts: {
     // are the same shape on disk — a stored `128` would read as a deliberate choice nobody made.
     ...(opts.faceDescriptorDims ? { faceDescriptorDims: opts.faceDescriptorDims } : {}),
     ...(opts.proxyFor ? { proxyFor: opts.proxyFor } : {}),
-    // `description` on the create body is the deprecated spelling of `meta.purpose`; it seeds the
-    // one store rather than a second one, so a space cannot be born with the two disagreeing.
-    ...(mergedCreateMeta ? { meta: mergedCreateMeta } : {}),
+    ...(opts.meta ? { meta: opts.meta } : {}),
   };
   // Initialize MongoDB collections/indexes before committing to config so the space
   // always has a backing DB (prevents the old "in config but no collections" race).

--- a/server/src/spaces/meta-update.ts
+++ b/server/src/spaces/meta-update.ts
@@ -32,7 +32,7 @@
 import type { SpaceConfig, SpaceMeta, KnowledgeType, TypeSchema, DocExtractionMode } from '../config/types.js';
 import { normalizeDocExtractionMode } from '../config/types.js';
 import { getConfig, saveConfig, getSecrets, getDocumentProcessingConfig } from '../config/loader.js';
-import { updateSpace } from './spaces.js';
+import { updateSpace, refuseRemovedDescription } from './spaces.js';
 import { ensureTtlIndex } from '../brain/ttl.js';
 import { peerSafeFetch } from '../sync/peer-fetch.js';
 import { proposedMetaFields } from '../sync/meta-round-merge.js';
@@ -161,6 +161,9 @@ export function planSpaceMetaUpdate(input: {
     return { ok: false, refusal: { status: 404, body: { error: `Space '${spaceId}' not found` } } };
   }
 
+  const removed = refuseRemovedDescription(body);
+  if (removed) return { ok: false, refusal: removed };
+
   // Optimistic concurrency: honour If-Match against the current meta version, if the client sent one.
   // Runs before validation, the audit snapshot and every side effect — a rejected write must change
   // nothing and record nothing.
@@ -182,17 +185,6 @@ export function planSpaceMetaUpdate(input: {
     return { ok: false, refusal: { status: 400, body: { error: parsed.error.message } } };
   }
 
-  // `description` is the deprecated spelling of `meta.purpose`. Rewrite it HERE, before any branching, so it
-  // travels the meta path in full: the $ref check, the merge, the version bump, and — the one that matters — the
-  // network vote. Applying it further down as a "non-meta update" would let a directive change skip governance in
-  // exactly the spaces that voted to govern it. That is also why the rewrite is in the PLAN and not at the write:
-  // a caller that applied it after the vote branch would reintroduce the bypass without touching this file.
-  // `meta.purpose` wins when both are sent; it is the current name.
-  if (parsed.data.description !== undefined) {
-    const legacy = parsed.data.description.trim();
-    parsed.data.meta = { ...(parsed.data.meta ?? {}), ...(parsed.data.meta?.purpose === undefined ? { purpose: legacy } : {}) };
-    delete parsed.data.description;
-  }
 
   // Validate any $ref values in the incoming meta against the instance schema library
   if (parsed.data.meta?.typeSchemas) {

--- a/server/src/spaces/space-create.ts
+++ b/server/src/spaces/space-create.ts
@@ -26,6 +26,7 @@ import { getConfig } from '../config/loader.js';
 import { slugify } from './_shared.js';
 import { createSpace } from './lifecycle.js';
 import { CreateSpaceBody, TypeSchemasZ, findBrokenLibraryRefs, brokenRefsError } from './body-schemas.js';
+import { refuseRemovedDescription } from './spaces.js';
 
 /** A refusal, carrying the status the contract suite pins. */
 export type SpaceCreateRefusal = {
@@ -49,11 +50,14 @@ export type SpaceCreateDecision =
  * request and testable without standing up Docker.
  */
 export function planSpaceCreate(body: unknown): SpaceCreateDecision {
+  const removed = refuseRemovedDescription(body);
+  if (removed) return { ok: false, refusal: removed };
+
   const parsed = CreateSpaceBody.safeParse(body);
   if (!parsed.success) {
     return { ok: false, refusal: { status: 400, body: { error: parsed.error.message } } };
   }
-  const { id: rawId, label, description, folders, maxGiB, proxyFor, meta, faceDescriptorDims } = parsed.data;
+  const { id: rawId, label, folders, maxGiB, proxyFor, meta, faceDescriptorDims } = parsed.data;
   const id = rawId ?? slugify(label);
 
   // Validate proxy members exist and are not themselves proxies.
@@ -104,7 +108,7 @@ export function planSpaceCreate(body: unknown): SpaceCreateDecision {
 
   return {
     ok: true,
-    plan: { args: { id, label, description, folders, maxGiB, proxyFor, meta: seededMeta, faceDescriptorDims } },
+    plan: { args: { id, label, folders, maxGiB, proxyFor, meta: seededMeta, faceDescriptorDims } },
   };
 }
 

--- a/server/src/spaces/spaces.ts
+++ b/server/src/spaces/spaces.ts
@@ -1,5 +1,5 @@
 /**
- * Space settings — update (label/description/meta/dupe rules) and display ordering.
+ * Space settings — update (label/meta/dupe rules) and display ordering.
  *
  * The heavy machinery now lives beside this file (A17.7): `vector-index.ts` (Atlas $vectorSearch),
  * `lifecycle.ts` (init/create/remove/wipe/recovery), `rename.ts`, and `_shared.ts`.
@@ -32,28 +32,6 @@ export function spacePurpose(space: { meta?: SpaceMeta }): string | undefined {
   return purpose ? purpose : undefined;
 }
 
-/**
- * The deprecated `description` alias, ready to spread into a response object — `{}` when the space has no
- * purpose, so the key is absent rather than explicitly empty.
- *
- * Exists so the derivation has ONE spelling in the API layer. The list endpoints wrote it out inline while
- * the single-space responses returned the stored record as-is, which was correct only while `description`
- * WAS stored: the moment it became derived, create / PATCH / PUT-schema silently stopped carrying it, so a
- * PATCH echoed back a space with no `description` even though the write had landed. Spread this, or call
- * `spaceResponse`; never re-derive it at a call site.
- */
-export function spaceDescriptionAlias(space: { meta?: SpaceMeta }): { description?: string } {
-  const purpose = spacePurpose(space);
-  return purpose === undefined ? {} : { description: purpose };
-}
-
-/**
- * A space as the API publishes it: the whole stored record plus the derived `description` alias. For
- * responses that project a subset of fields, spread `spaceDescriptionAlias` instead.
- */
-export function spaceResponse<T extends { meta?: SpaceMeta }>(space: T): T & { description?: string } {
-  return { ...space, ...spaceDescriptionAlias(space) };
-}
 
 /** Update mutable fields (label, description, meta) of an existing space in config.
  *  When `meta` is provided the version counter is auto-incremented and the
@@ -168,4 +146,26 @@ export function reorderSpaces(orderedIds: string[]): SpaceConfig[] | null {
   cfg.spaces = reordered;
   saveConfig(cfg);
   return reordered;
+}
+
+/**
+ * The `description` alias was removed in 3.0, and this is what stops that removal being SILENT.
+ *
+ * The top-level space bodies are not `.strict()` — they drop an unknown key — so without this a caller who
+ * kept sending `description` would get a `200` and no directive written. MCP's `additionalProperties: false`
+ * refuses it outright, so the same request would 400 on one door and quietly do nothing on the other: one
+ * rule, two implementations, and the weaker one winning silently.
+ *
+ * It lives in the shared planners because both surfaces reach the store through them, and it names the
+ * replacement rather than the removal — a caller reading `description is not a field` has to go and look up
+ * what is.
+ */
+export function refuseRemovedDescription(body: unknown): { status: 400; body: { error: string } } | undefined {
+  if (body && typeof body === 'object' && !Array.isArray(body) && 'description' in body) {
+    return {
+      status: 400,
+      body: { error: '`description` was removed in 3.0 — send `meta.purpose` instead. It is the same directive, under the one name that was ever editable.' },
+    };
+  }
+  return undefined;
 }

--- a/testing/integration/proxy-spaces.test.js
+++ b/testing/integration/proxy-spaces.test.js
@@ -151,7 +151,7 @@ describe('Proxy spaces', () => {
     const rP = await post(BASE, tokenA, '/api/spaces', {
       id: PROXY,
       label: 'Proxy',
-      description: 'Aggregates alpha and beta.',
+      meta: { purpose: 'Aggregates alpha and beta.' },
       proxyFor: [SPACE_A, SPACE_B],
     });
     assert.equal(rP.status, 201, `Create proxy: ${JSON.stringify(rP.body)}`);
@@ -172,7 +172,9 @@ describe('Proxy spaces', () => {
       const proxy = r.body.spaces.find(s => s.id === PROXY);
       assert.ok(proxy, 'Proxy space should be in listing');
       assert.deepEqual(proxy.proxyFor, [SPACE_A, SPACE_B]);
-      assert.equal(proxy.description, 'Aggregates alpha and beta.');
+      assert.equal(proxy.meta?.purpose, 'Aggregates alpha and beta.');
+      assert.equal('description' in proxy, false,
+        'the alias was removed in 3.0 — the list endpoint derived it for longest, so it is the one to check');
     });
 
     it('Proxy nesting rejected', async () => {

--- a/testing/integration/spaces.test.js
+++ b/testing/integration/spaces.test.js
@@ -201,27 +201,30 @@ describe('Space management', () => {
       'Space must not appear in list after confirmed deletion',
     );
   });
-  it('Update space description via PATCH /api/spaces/:id', async () => {
+  it('Update space purpose via PATCH /api/spaces/:id', async () => {
     const created = await post(INSTANCES.a, tokenA, '/api/spaces', {
       id: `patch-desc-test-${RUN_ID}`,
       label: 'Patch Desc Test',
-      description: 'original description',
+      meta: { purpose: 'original purpose' },
     });
     assert.equal(created.status, 201);
     const spaceId = created.body.space?.id;
     createdSpaceIds.push(spaceId);
 
     const r = await patch(INSTANCES.a, tokenA, `/api/spaces/${spaceId}`, {
-      description: 'updated description',
+      meta: { purpose: 'updated purpose' },
     });
     assert.equal(r.status, 200, `Expected 200, got ${r.status}: ${JSON.stringify(r.body)}`);
-    assert.equal(r.body.space?.description, 'updated description');
+    assert.equal(r.body.space?.meta?.purpose, 'updated purpose');
+    assert.equal('description' in (r.body.space ?? {}), false,
+      'the alias was removed in 3.0 — a response carrying it means a shaper put it back');
 
     // Verify the list endpoint reflects the change
     const listR = await get(INSTANCES.a, tokenA, '/api/spaces');
     const found = listR.body?.spaces?.find(s => s.id === spaceId);
     assert.ok(found, 'Space should still appear in list');
-    assert.equal(found.description, 'updated description');
+    assert.equal(found.meta?.purpose, 'updated purpose');
+    assert.equal('description' in found, false, 'the list endpoint derived the alias for longest');
   });
 
   it('Update space label via PATCH /api/spaces/:id', async () => {
@@ -255,12 +258,12 @@ describe('Space management', () => {
 
   it('PATCH /api/spaces/:id on non-existent space returns 404', async () => {
     const r = await patch(INSTANCES.a, tokenA, '/api/spaces/does-not-exist-space', {
-      description: 'something',
+      meta: { purpose: 'something' },
     });
     assert.equal(r.status, 404, `Expected 404, got ${r.status}`);
   });
 
-  it('PATCH /api/spaces/:id with description exceeding 4000 chars returns 400', async () => {
+  it('PATCH /api/spaces/:id with purpose exceeding 4000 chars returns 400', async () => {
     const created = await post(INSTANCES.a, tokenA, '/api/spaces', {
       id: `patch-toolong-test-${RUN_ID}`,
       label: 'Patch Too Long',
@@ -270,9 +273,37 @@ describe('Space management', () => {
     createdSpaceIds.push(spaceId);
 
     const r = await patch(INSTANCES.a, tokenA, `/api/spaces/${spaceId}`, {
-      description: 'x'.repeat(4001),
+      meta: { purpose: 'x'.repeat(4001) },
     });
     assert.equal(r.status, 400, `Expected 400, got ${r.status}`);
+  });
+
+  it('PATCH /api/spaces/:id still sending `description` is REFUSED, not ignored', async () => {
+    // The removal's loud half. These top-level bodies are not `.strict()` — an unknown key is DROPPED — so
+    // without an explicit refusal this request would answer 200 having written nothing, while the same
+    // request over MCP hit `additionalProperties: false` and 400'd. The refusal names the replacement,
+    // because a caller told only that the field is gone still has to go and find out what replaced it.
+    const created = await post(INSTANCES.a, tokenA, '/api/spaces', {
+      id: `patch-removed-alias-${RUN_ID}`,
+      label: 'Removed Alias',
+    });
+    assert.equal(created.status, 201);
+    createdSpaceIds.push(created.body.space?.id);
+
+    const r = await patch(INSTANCES.a, tokenA, `/api/spaces/${created.body.space?.id}`, {
+      description: 'the removed spelling',
+    });
+    assert.equal(r.status, 400, `Expected 400, got ${r.status}: ${JSON.stringify(r.body)}`);
+    assert.match(r.body?.error ?? '', /meta\.purpose/,
+      'the refusal must name the field that replaced it');
+
+    // And the same refusal on CREATE, so the two doors of the same removal agree.
+    const c = await post(INSTANCES.a, tokenA, '/api/spaces', {
+      id: `create-removed-alias-${RUN_ID}`,
+      label: 'Removed Alias On Create',
+      description: 'the removed spelling',
+    });
+    assert.equal(c.status, 400, `Expected 400 on create, got ${c.status}: ${JSON.stringify(c.body)}`);
   });
 
   it('PATCH /api/spaces/:id merges typeSchemas — existing types are preserved', async () => {
@@ -420,10 +451,10 @@ describe('Space management', () => {
 
     // Patching the token's own space should succeed
     const r = await patch(INSTANCES.a, scopedToken, `/api/spaces/${targetId}`, {
-      description: 'updated by scoped token',
+      meta: { purpose: 'updated by scoped token' },
     });
     assert.equal(r.status, 200, `Expected 200 on own space, got ${r.status}: ${JSON.stringify(r.body)}`);
-    assert.equal(r.body.space?.description, 'updated by scoped token');
+    assert.equal(r.body.space?.meta?.purpose, 'updated by scoped token');
 
     // Revoke the token
     const revokeR = await del(INSTANCES.a, tokenA, `/api/tokens/${tokenRes.body.token?.id}`);
@@ -454,7 +485,7 @@ describe('Space management', () => {
 
     // Attempting to PATCH the forbidden space should return 403
     const r = await patch(INSTANCES.a, scopedToken, `/api/spaces/${forbiddenId}`, {
-      description: 'should be blocked',
+      meta: { purpose: 'should be blocked' },
     });
     assert.equal(r.status, 403, `Expected 403 on forbidden space, got ${r.status}: ${JSON.stringify(r.body)}`);
 
@@ -511,7 +542,7 @@ describe('Space management', () => {
 
     // tokenA has no spaces restriction — must succeed on any space
     const r = await patch(INSTANCES.a, tokenA, `/api/spaces/${spaceId}`, {
-      description: 'written by unrestricted admin',
+      meta: { purpose: 'written by unrestricted admin' },
     });
     assert.equal(r.status, 200, `Expected 200 for unrestricted admin, got ${r.status}: ${JSON.stringify(r.body)}`);
   });

--- a/testing/standalone/space-purpose-one-field.test.js
+++ b/testing/standalone/space-purpose-one-field.test.js
@@ -1,7 +1,7 @@
 /**
- * A space's directive has ONE store, and the field an operator can edit is the one clients read.
+ * A space's directive has ONE store — and as of 3.0, one NAME.
  *
- * ## The defect
+ * ## The defect this started as
  *
  * `SpaceConfig.description` was commented "shown to MCP clients as space-level instructions".
  * `SpaceMeta.purpose` is "short directive injected into MCP instructions at handshake". Two fields, one
@@ -13,12 +13,16 @@
  * spaces returning `null`, three returning mojibake from an old import, and the purposes their admins had
  * written sitting invisible beside them.
  *
- * ## The fix this pins
+ * ## What 2.x did, and what 3.0 does
  *
- * `purpose` is the store. `description` survives as a derived alias because it is published API, and
- * derived means the two cannot disagree. Legacy stored text is migrated into `meta.purpose` at boot —
- * allowed to be a boot migration rather than a lazy one because `config.json` is local state and does not
- * replicate.
+ * 2.x made `purpose` the store and kept `description` as a DERIVED alias, because it was published API.
+ * 3.0 removes the alias — announced at `docs/integration-guide/06-spaces-api.md` since 2.3, and the only
+ * deprecation in `_DEPRECATIONS.md` that named a version in the published docs.
+ *
+ * **The boot migration stays.** It is what makes the removal safe: a `config.json` written by an older
+ * build still carries a stored `description`, and dropping the migration with the alias would silently
+ * discard the operator's directive on upgrade. It goes at row 3.1, once the version floor 3.0 supports
+ * upgrading from is fixed.
  *
  * Run: node --test testing/standalone/space-purpose-one-field.test.js
  */
@@ -28,18 +32,19 @@ import { readFileSync } from 'node:fs';
 
 let migrateSpaceDescriptionToPurpose;
 let spacePurpose;
-let spaceDescriptionAlias;
-let spaceResponse;
+let refuseRemovedDescription;
+let spacesModule;
 
 const space = (over = {}) => ({ id: 's', label: 'S', builtIn: false, folders: [], ...over });
 
 describe('space purpose is one field', () => {
   before(async () => {
     ({ migrateSpaceDescriptionToPurpose } = await import('../../server/dist/config/loader.js'));
-    ({ spacePurpose, spaceDescriptionAlias, spaceResponse } = await import('../../server/dist/spaces/spaces.js'));
+    spacesModule = await import('../../server/dist/spaces/spaces.js');
+    ({ spacePurpose, refuseRemovedDescription } = spacesModule);
   });
 
-  describe('the boot migration', () => {
+  describe('the boot migration — kept, because it is what makes the removal safe', () => {
     it('moves a legacy description into an empty purpose', () => {
       const cfg = { spaces: [space({ description: 'Papers and findings.' })] };
       assert.equal(migrateSpaceDescriptionToPurpose(cfg), true);
@@ -81,7 +86,7 @@ describe('space purpose is one field', () => {
     });
   });
 
-  describe('the derived alias', () => {
+  describe('purpose is read from one place', () => {
     it('reads purpose', () => {
       assert.equal(spacePurpose({ meta: { purpose: 'the directive' } }), 'the directive');
     });
@@ -92,80 +97,87 @@ describe('space purpose is one field', () => {
       assert.equal(spacePurpose({ meta: { purpose: '  ' } }), undefined,
         'whitespace is not a directive; returning it would show an empty box as if it were content');
     });
+  });
 
-    it('a shaped response carries the alias beside the record', () => {
-      // The regression this pins: `res.json({ space: updated })` was right while `description` was
-      // STORED, and dropped the field the moment it became derived — so PATCH echoed back a space with
-      // no description even though the write had landed.
-      const shaped = spaceResponse(space({ meta: { purpose: 'the directive', version: 3 } }));
-      assert.equal(shaped.description, 'the directive');
-      assert.equal(shaped.meta.version, 3, 'the rest of the record must survive the shaping');
+  describe('the alias is gone, and its removal is LOUD', () => {
+    it('the derivation helpers no longer exist', () => {
+      // Exported helpers are the shape a caller inside this repo would reach for. Leaving them in place
+      // "harmlessly" is how a removed field comes back on the next response someone shapes.
+      assert.equal(spacesModule.spaceDescriptionAlias, undefined);
+      assert.equal(spacesModule.spaceResponse, undefined);
     });
 
-    it('omits the key entirely when there is no purpose', () => {
-      // Not `null`: the list endpoints have always omitted it, and a client that treats present-but-null
-      // as "an admin cleared it" would read the two shapes differently.
-      assert.equal('description' in spaceResponse(space()), false);
-      assert.deepEqual(spaceDescriptionAlias(space()), {});
-      assert.deepEqual(spaceDescriptionAlias(space({ meta: { purpose: 'x' } })), { description: 'x' });
+    it('a create or update still sending `description` is REFUSED, not ignored', () => {
+      // The half that would otherwise be silent. The top-level space bodies are NOT `.strict()` — they
+      // DROP an unknown key — so without this refusal a caller who kept sending `description` would get a
+      // 200 with no directive written, while MCP's `additionalProperties: false` refused the same request.
+      // One rule, two implementations, the weaker one winning silently: the defect class this repo
+      // produces most.
+      const refusal = refuseRemovedDescription({ description: 'still sending it' });
+      assert.equal(refusal?.status, 400);
+      assert.match(refusal.body.error, /meta\.purpose/,
+        'a refusal that does not name the replacement makes the caller go and look it up');
+    });
+
+    it('refuses nothing else', () => {
+      assert.equal(refuseRemovedDescription({ label: 'fine' }), undefined);
+      assert.equal(refuseRemovedDescription({ meta: { purpose: 'fine' } }), undefined);
+      assert.equal(refuseRemovedDescription(undefined), undefined);
+      assert.equal(refuseRemovedDescription(null), undefined);
+      // An array has no keys a caller meant as fields; `'description' in []` is false anyway, but a
+      // future rewrite using `Object.keys` would change that silently.
+      assert.equal(refuseRemovedDescription([]), undefined);
+    });
+
+    it('BOTH planners refuse it, so neither door is the weaker one', () => {
+      const strip = src => src.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
+      for (const path of ['server/src/spaces/space-create.ts', 'server/src/spaces/meta-update.ts']) {
+        assert.match(strip(readFileSync(path, 'utf8')), /refuseRemovedDescription\(body\)/,
+          `${path} must refuse the removed field — MCP and REST both reach the store through these`);
+      }
     });
   });
 
-  describe('no surface reads a stored description', () => {
+  describe('no surface accepts, stores or emits it', () => {
     const strip = src => src.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
     // Assert on a boolean, not `assert.match` over a whole file: a failing match prints the entire
     // source as `actual`, which buries the one line that matters under 30 kB of unrelated code.
     const has = (path, re) => re.test(strip(readFileSync(path, 'utf8')));
 
-    it('list_spaces serves purpose, not the legacy field', () => {
+    it('list_spaces serves purpose and nothing else', () => {
       assert.ok(has('server/src/mcp/tools/spaces.ts', /purpose: spacePurpose\(s\)/),
         'list_spaces is the tool that disagreed with get_space_meta');
-      assert.ok(!has('server/src/mcp/tools/spaces.ts', /description: s\.description/),
-        'that is the stored legacy field, which no longer exists after the migration');
+      assert.ok(!has('server/src/mcp/tools/spaces.ts', /description: spacePurpose\(s\)/),
+        'the alias was removed from the tool output in 3.0');
     });
 
-    // The first cut of this gate hand-picked the list endpoint and passed while three other responses
-    // dropped the field. Enumerate the sites out of the source instead: whatever answers with a space has
-    // to be in this list, including one added tomorrow.
-    it('every response that carries a space routes through the shared shaper', () => {
-      const src = strip(readFileSync('server/src/api/spaces.ts', 'utf8'));
-      const sites = [...src.matchAll(/\.json\(\s*\{\s*space:\s*([A-Za-z_$][\w$]*\(?)/g)].map(m => m[1]);
-      assert.ok(sites.length >= 3,
-        `expected at least the create / PATCH / PUT-schema responses, enumerated ${sites.length}`);
-      const raw = sites.filter(expr => expr !== 'spaceResponse(');
-      assert.deepEqual(raw, [],
-        `these answer with the stored record, so the derived alias is missing from them: ${raw.join(', ')}`);
+    it('update_space no longer takes the alias on its input schema', () => {
+      const src = strip(readFileSync('server/src/mcp/tools/spaces.ts', 'utf8'));
+      assert.ok(!/description: \{ type: 'string', maxLength: SPACE_PURPOSE_MAX/.test(src),
+        'the tool schema is what a caller reads while constructing arguments');
+      assert.ok(/updates\.meta = \{ purpose: newDesc \}/.test(src),
+        'the handler must speak meta.purpose — the planner no longer folds the old spelling in');
     });
 
-    it('the alias is derived in exactly one place', () => {
-      // Two spellings is how it drifted the first time. `spaceDescriptionAlias` spreads, so a response
-      // that projects a subset of fields uses the same derivation as one that returns the whole record.
+    it('the request bodies do not declare it', () => {
+      const src = strip(readFileSync('server/src/spaces/body-schemas.ts', 'utf8'));
+      assert.ok(!/^\s*description: z\.string\(\)\.max\(SPACE_PURPOSE_MAX\)/m.test(src),
+        'CreateSpaceBody and UpdateSpaceBody both carried it');
+    });
+
+    it('no space response shapes it back in', () => {
       const src = strip(readFileSync('server/src/api/spaces.ts', 'utf8'));
+      assert.ok(!/spaceDescriptionAlias|spaceResponse/.test(src),
+        'the shaper existed only to add the alias');
       const assigned = [...src.matchAll(/description:\s*([^,\n]{1,24})/g)].map(m => m[1].trim());
-      const inline = assigned.filter(v => !v.startsWith('z.'));
-      assert.deepEqual(inline, [],
-        `derive the alias via spaceDescriptionAlias/spaceResponse, not inline: ${inline.join(', ')}`);
-    });
-
-    it('a description write is folded into meta before the vote decision', () => {
-      // The one that would be silent: a governed space votes on meta changes. If `description` were
-      // still applied as a non-meta update, a directive change would skip the vote in exactly the
-      // spaces that voted to govern it.
-      // The fold happens in the planner now, which is still BEFORE the router's vote branch — and further from
-      // it than before, since a caller cannot reach the branch without going through the plan.
-      assert.ok(has('server/src/spaces/meta-update.ts', /parsed\.data\.meta = \{[\s\S]{0,300}?purpose: legacy/),
-        'description must become meta.purpose before the networked branch is reached');
-      assert.ok(!has('server/src/api/spaces.ts', /nonMetaUpdates\.description/),
-        'applying it as a non-meta update is the bypass this test exists to prevent');
+      assert.deepEqual(assigned.filter(v => !v.startsWith('z.')), [],
+        'a space response must not carry a description under any derivation');
     });
 
     it('the settings dialog handles the 202 a governed space answers with', () => {
       // Typed as `{ space: Space }` unconditionally, the 202 body destructured to undefined and threw
       // inside `next` — which RxJS does not route to `error`. Save did nothing, said nothing, and left
       // the editor dirty, so closing it offered to discard a change that had just been submitted.
-      // The save handler moved with the dialog: the pop-up is its own component now, hosted by the Spaces
-      // page and (next) by the Brain page. The path follows the code — and the first assertion is positive,
-      // so a path resolving to a file without the branch fails loudly instead of passing vacuously.
       const POPUP = 'client/src/app/pages/settings/space-settings-popup.component.ts';
       assert.ok(has(POPUP, /result\.status === 'vote_pending'/),
         'the save handler must branch on the vote-pending response');


### PR DESCRIPTION
**BREAKING.** `description` is removed from every space surface. Send `meta.purpose`.

First row of the 3.0 deprecation checklist (owner ruled **C**: 3.0.0 performs the full list before the tag),
and the only row whose removal version was ever **published** rather than merely tracked —
`docs/integration-guide/06-spaces-api.md` has said *"Removal in 3.0"* since 2.3.

## What is gone

| surface | before | now |
|---|---|---|
| `POST /api/spaces` body | accepted `description` | `400` naming `meta.purpose` |
| `PATCH /api/spaces/:id` body | accepted `description` | `400` naming `meta.purpose` |
| every REST response carrying a space | derived `description` alias | `meta.purpose` only |
| `update_space` (MCP) input schema | accepted `description` | rejected (`additionalProperties: false`) |
| `list_spaces` (MCP) output | `purpose` **and** `description` | `purpose` |

`spaceDescriptionAlias` and `spaceResponse` existed only to add the alias and are deleted.

## The refusal is the half that matters

A straight deletion would have been **silent on REST**. These top-level space bodies are not `.strict()` —
they DROP an unknown key — so a caller who kept sending `description` would have received a `200` with no
directive written, while the identical request over MCP already `400`'d on `additionalProperties: false`.

One rule, two implementations, the quiet one winning — the defect class this repo produces most, arriving
inside a removal meant to simplify things.

`refuseRemovedDescription` therefore lives in the **shared planners** (`space-create.ts`,
`meta-update.ts`), which both surfaces reach the store through, so the two doors answer the same `400`. It
names `meta.purpose` rather than just reporting the removal, and it sits **after** the 404 check — a write
to a space that does not exist is still a 404, not a lecture about a field.

## The boot migration stays — deliberately against the tracker row

`_DEPRECATIONS.md` row 1.1 said migration 3.1 goes with the alias. It does not, and the file's own
procedure is why: section-3 migrations wait for the version floor.

**That floor is now answered — 2.0.0**, measured from the tag each migration first shipped in.
`migrateSpaceDescriptionToPurpose` shipped in **v2.2.2**, which is *above* the floor, so a 2.0.0 or 2.1.x
`config.json` still carries a stored `description`. Dropping the migration here would silently discard the
operator's directive on upgrade.

`SpaceConfig.description` therefore survives as an **on-disk type only**, with a comment saying exactly
that — a boot migration cannot read a field the type denies.

## Five places

- **REST route** — both bodies, all responses.
- **MCP tool** — same commit, same refusal. The tool *description* is updated too: it is what a caller
  reads while constructing arguments, and it previously advertised the alias.
- **integration guide** — both parameter rows and the MCP pointer deleted; `12-admin-api.md` prose corrected
  (it listed "label, description, config" among what a wipe preserves).
- **userguide** — already speaks only of **Purpose**; no change needed.
- **token rights** — unchanged. No new route, no new capability.

## Verification

`space-purpose-one-field.test.js` pinned the alias; its alias assertions are now **removal** assertions —
the helpers must not exist, both planners must refuse, and no response may shape it back in. The boot-migration
block is untouched, because that behaviour is unchanged.

Seven integration tests moved to `meta.purpose`, and a **new** one asserts the `400` on create *and* update
rather than merely that the old field stopped working — the difference between proving a removal and proving
a silence.

3881 standalone tests green; preflight passed.
