### PR TITLE
refactor(types)!: ChronoKind is gone, say ChronoType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `description`, and dropping the migration alongside the alias would discard the operator's directive on
   upgrade. It goes once the version floor 3.0 supports upgrading from is fixed.
 
+- **`ChronoKind` is removed. Say `ChronoType`.** A type alias with zero consumers on either side, which is
+  exactly how a dead alias survives a major: nothing breaks, so nothing notices, and the next person to
+  reach for a chrono type finds two names for one thing. Removed from the server types and the client
+  mirror. Type-only — no request or response is affected.
 
 ### Changed
 - **Re-uploading identical bytes no longer re-runs vision or speech-to-text.** `enqueueMediaJob` resets a

--- a/client/src/app/core/api.types.ts
+++ b/client/src/app/core/api.types.ts
@@ -278,8 +278,6 @@ export interface Edge {
 }
 
 export type ChronoType = 'event' | 'deadline' | 'plan' | 'prediction' | 'milestone';
-/** @deprecated Use ChronoType */
-export type ChronoKind = ChronoType;
 export type ChronoStatus = 'upcoming' | 'active' | 'completed' | 'overdue' | 'cancelled';
 
 export interface ChronoEntry {

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -1376,8 +1376,6 @@ export interface EdgeDoc extends StampSkewable {
 }
 
 export type ChronoType = 'event' | 'deadline' | 'plan' | 'prediction' | 'milestone';
-/** @deprecated Use ChronoType */
-export type ChronoKind = ChronoType;
 export type ChronoStatus = 'upcoming' | 'active' | 'completed' | 'overdue' | 'cancelled';
 
 export interface ChronoEntry extends StampSkewable {

--- a/testing/standalone/chrono-type-allowlist.test.js
+++ b/testing/standalone/chrono-type-allowlist.test.js
@@ -93,3 +93,25 @@ describe('create_chrono still enforces the same rule', () => {
     assert.equal(a.message, b.message);
   });
 });
+
+/**
+ * `ChronoKind` was removed in 3.0 (`_DEPRECATIONS.md` row 2.5). It aliased `ChronoType` and had zero
+ * consumers on either side — which is exactly how a dead alias survives a major: nothing breaks, so
+ * nothing notices, and the next person to reach for a chrono type has two names to choose between.
+ *
+ * A type alias leaves nothing at runtime to assert against, so this one has to be a source check. It is
+ * scoped to the two files that declared it rather than the whole tree, so an unrelated identifier that
+ * merely contains the word — `onEditChronoKindChange`, `drawerChronoKind` — cannot fail it.
+ */
+describe('the ChronoKind alias does not come back', () => {
+  it('neither type module declares it', () => {
+    for (const path of ['server/src/config/types.ts', 'client/src/app/core/api.types.ts']) {
+      const src = fs.readFileSync(path, 'utf8');
+      assert.ok(!/export type ChronoKind\b/.test(src),
+        `${path} re-declares the alias removed in 3.0 — say ChronoType`);
+      // And the type it aliased must still be there, or this gate would pass on a file that lost both.
+      assert.ok(/export type ChronoType\b/.test(src),
+        `${path} no longer declares ChronoType, so the check above proves nothing`);
+    }
+  });
+});


### PR DESCRIPTION
**BREAKING.** The `ChronoKind` type alias is removed. Use `ChronoType`.

Row 2.5 of the 3.0 deprecation checklist.

## Why a dead alias is worth a row

It aliased `ChronoType` and had **zero consumers** on either side — which is exactly how a dead alias
survives a major release. Nothing breaks, so nothing notices, and the next person reaching for a chrono type
finds two names for one thing and has to work out whether the difference means something. It never did.

Removed from `server/src/config/types.ts` and its mirror in `client/src/app/core/api.types.ts`.

Type-only: nothing is emitted at runtime, so no request, response or stored document changes shape.

## The gate, and why it is a source check

A type alias leaves nothing at runtime to assert against, so this one has to read the source. Two things
about how it is written:

- **Scoped to the two declaring modules**, not the tree. A tree-wide grep for the word fails on
  `onEditChronoKindChange` and `drawerChronoKind`, which are unrelated component methods.
- **It also asserts `ChronoType` is still declared** in both files. Without that, the check passes
  vacuously on a file that lost *both* names — the standard failure of every "X is absent" test. Renaming
  `ChronoType` away turns it red, which is how I confirmed it bites rather than assuming it.

It lives in `chrono-type-allowlist.test.js` rather than a new file, beside the other chrono-type rules.
