### PR TITLE
feat(files)!: `max` is not an extraction mode, `repair` is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reach for a chrono type finds two names for one thing. Removed from the server types and the client
   mirror. Type-only — no request or response is affected.
 
+- **BREAKING — `max` is no longer accepted as a document-extraction mode. Say `repair`.** It was the legacy
+  spelling of the same level, and it left the API accepting six values where the type meant five — a
+  one-element difference between two lists that nobody could explain a year later. A request sending `max`
+  is now refused by the enum rather than quietly folded. **A `max` already STORED in `config.json` or on a
+  space still reads as `repair`**, and that normaliser is deliberately kept: it is a self-healing read, not
+  a one-time upgrade path, and dropping it would move an instance to a different extraction level on load —
+  the quietest possible way to change what a document search can find.
+
 ### Changed
 - **Re-uploading identical bytes no longer re-runs vision or speech-to-text.** `enqueueMediaJob` resets a
   terminal job on purpose, so the same file sent twice paid for a second full analysis to reproduce the caption

--- a/docs/integration-guide/05a-conversion-pipeline.md
+++ b/docs/integration-guide/05a-conversion-pipeline.md
@@ -374,7 +374,7 @@ They are never queued, so they do not sit at `pending` waiting for work that wil
 > **Why two numbers.** They bound different things. `maxPages` is one round trip; `maxTotalPages` is the
 > job's cost ceiling — every page is a VLM call, so an unbounded walk over a 600-page scan means 600 model
 > calls and, with an external endpoint, 600 pages of content leaving the instance, on an upload nobody is
-> watching. Raise `maxTotalPages` deliberately. In `max` mode the consensus pass is skipped for a document
+> watching. Raise `maxTotalPages` deliberately. In `repair` mode the consensus pass is skipped for a document
 > that had to be walked, since it re-transcribes every page with a second model.
 
 The VLM modes require both a running `doc-render` sidecar and a configured `vlmModel`. If either is missing,

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -614,10 +614,27 @@ export interface DocAssistModelConfig {
  */
 export type DocExtractionMode = 'off' | 'ocr' | 'vlm' | 'repair' | 'auto';
 
-/** Every value accepted on input, including the legacy `max` spelling of `repair`. */
-export const DOC_EXTRACTION_MODES_IN = ['off', 'ocr', 'vlm', 'repair', 'auto', 'max'] as const;
+/**
+ * Every value accepted on input. Identical to `DocExtractionMode` since 3.0 removed the legacy `max`
+ * spelling of `repair` — there is deliberately no longer a difference between what the API takes and what
+ * the type means, because a one-element gap between two lists is exactly what nobody can explain later.
+ *
+ * It stays a separate `as const` only because zod needs a runtime array; the `satisfies` clause is what
+ * keeps the two from drifting apart again — re-adding `max` here stops the build.
+ */
+export const DOC_EXTRACTION_MODES_IN = ['off', 'ocr', 'vlm', 'repair', 'auto'] as const satisfies readonly DocExtractionMode[];
 
-/** Fold the legacy `max` spelling into `repair`; pass everything else through. */
+/**
+ * Fold a STORED legacy `max` into `repair`.
+ *
+ * 3.0 stopped ACCEPTING `max` — a request sending it is now refused by the enum. This normaliser is not
+ * that surface and does not go with it: `config.json` and space records written by an older build still
+ * carry `max`, and both readers below go through here. Dropping it would silently move an instance or a
+ * space to a different extraction level on load, which is the quietest possible way to change what a
+ * document search can find.
+ *
+ * Same shape as `normalizeVisionModel`: an ongoing self-healing read, not a one-time upgrade path.
+ */
 export function normalizeDocExtractionMode(mode: string | undefined | null): DocExtractionMode | undefined {
   if (mode === null || mode === undefined) return undefined;
   return (mode === 'max' ? 'repair' : mode) as DocExtractionMode;

--- a/testing/integration/vlm-extraction.test.js
+++ b/testing/integration/vlm-extraction.test.js
@@ -56,11 +56,18 @@ describe('VLM extraction mode wiring (F11)', () => {
   it('a PDF uploaded under the repair tier also degrades gracefully (202)', async () => {
     // `repair` adds the repair pass on top of `vlm`. With no VLM/render/OCR sidecar in CI the route still
     // collapses to OCR — the repair tier must never make an upload fail where `vlm`/`ocr` would succeed.
-    // Sent as the LEGACY `max` spelling on purpose: existing config carries it, and it must land as
-    // `repair` rather than falling through as an unknown level and silently dropping the repair pass.
-    const set = await patch(INSTANCES.a, tokenA, '/api/admin/media-config', { documentProcessing: { mode: 'max' } });
+    const set = await patch(INSTANCES.a, tokenA, '/api/admin/media-config', { documentProcessing: { mode: 'repair' } });
     assert.equal(set.status, 200, JSON.stringify(set.body));
-    assert.equal(set.body?.config?.documentProcessing?.mode, 'repair', 'legacy max must normalise to repair');
+    assert.equal(set.body?.config?.documentProcessing?.mode, 'repair');
+
+    // 3.0 removed the legacy `max` spelling from the input surface, so this is a 400 rather than a silent
+    // fold. Asserted over HTTP and not only against the accept-list, because the list is what the zod enum
+    // is BUILT from — checking the list alone would pass even if a route bypassed it.
+    // A `max` already in config.json still reads as `repair`; that half is unit-tested in
+    // `extraction-policy.test.js`, where it can be exercised without writing a legacy value through an API
+    // that no longer accepts one.
+    const legacy = await patch(INSTANCES.a, tokenA, '/api/admin/media-config', { documentProcessing: { mode: 'max' } });
+    assert.equal(legacy.status, 400, `expected 400 for the removed spelling, got ${legacy.status}`);
 
     const r = await upload(tokenA, `max-mode-${Date.now()}.pdf`, Buffer.from('%PDF-1.4 test').toString('base64'));
     assert.equal(r.status, 202, `expected 202 (graceful async), got ${r.status}: ${JSON.stringify(r.body)}`);
@@ -85,11 +92,13 @@ describe('VLM extraction mode wiring (F11)', () => {
 
   // ── F11-c: per-space extraction-mode override ─────────────────────────────────
   it('a per-space documentExtraction override round-trips and clears (F11-c)', async () => {
-    // Sent as the legacy `max`, stored as `repair` — a space configured before the rename keeps the
-    // level it asked for instead of quietly dropping to a lower rung.
-    const set = await patch(INSTANCES.a, tokenA, '/api/spaces/general', { documentExtraction: 'max' });
+    const set = await patch(INSTANCES.a, tokenA, '/api/spaces/general', { documentExtraction: 'repair' });
     assert.equal(set.status, 200, JSON.stringify(set.body));
     assert.equal(set.body?.space?.documentExtraction, 'repair');
+
+    // The removed spelling is refused on this door too — both surfaces, one rule.
+    const legacy = await patch(INSTANCES.a, tokenA, '/api/spaces/general', { documentExtraction: 'max' });
+    assert.equal(legacy.status, 400, `expected 400 for the removed spelling, got ${legacy.status}`);
 
     // The override is surfaced on the spaces list too (so the UI can render it).
     const list = await get(INSTANCES.a, tokenA, '/api/spaces');

--- a/testing/standalone/extraction-policy.test.js
+++ b/testing/standalone/extraction-policy.test.js
@@ -13,7 +13,7 @@ import {
   decideRoute, validateExtraction, evidenceCoverage, coverageTokens, bestByEvidence,
 } from '../../server/dist/files/converters/extraction-policy.js';
 import { capDocExtractionMode } from '../../server/dist/files/converters/extraction-level.js';
-import { normalizeDocExtractionMode } from '../../server/dist/config/types.js';
+import { normalizeDocExtractionMode, DOC_EXTRACTION_MODES_IN } from '../../server/dist/config/types.js';
 
 const ALL = { ocr: true, render: true, vlm: true, repair: true, verify: true };
 const none = (o) => ({ ocr: false, render: false, vlm: false, repair: false, verify: false, ...o });
@@ -238,5 +238,28 @@ describe('normalizeDocExtractionMode — the legacy max spelling', () => {
   it("a space stored as 'max' still gets the repair pass after the rename", () => {
     assert.equal(capDocExtractionMode('auto', normalizeDocExtractionMode('max')), 'repair');
     assert.ok(decideRoute(normalizeDocExtractionMode('max'), ALL).stages.includes('repair'));
+  });
+});
+
+/**
+ * 3.0 stopped ACCEPTING `max` (`_DEPRECATIONS.md` row 1.3) while keeping it READABLE from storage.
+ *
+ * Those two halves pull in opposite directions and both matter, so both are asserted here. The block
+ * above proves a stored `max` still reaches the repair pass — that is the half whose failure would be
+ * silent, moving an instance to a different extraction level on load. This block proves the input door
+ * is shut, which is the half whose absence would leave a removal that removed nothing.
+ */
+describe('the max spelling is removed from the input surface, not from storage', () => {
+  it('the accept-list no longer carries it', async () => {
+    const { DOC_EXTRACTION_MODES_IN } = await import('../../server/dist/config/types.js');
+    assert.equal(DOC_EXTRACTION_MODES_IN.includes('max'), false,
+      'both request bodies build their zod enum from this list — a value here is a value accepted');
+  });
+
+  it('the accept-list and the mode type are now the SAME set', () => {
+    // The row said to collapse them rather than leave a one-element difference nobody can explain. The
+    // build enforces this too (`_modesMatch` in types.ts is `never`-typed on mismatch); this asserts the
+    // resulting VALUES, since a type-level guard leaves nothing behind at runtime to check.
+    assert.deepEqual([...DOC_EXTRACTION_MODES_IN].sort(), ['auto', 'ocr', 'off', 'repair', 'vlm']);
   });
 });


### PR DESCRIPTION
**BREAKING.** `max` is no longer accepted as a document-extraction mode. Send `repair`.

Row 1.3 of the 3.0 deprecation checklist.

## What was wrong with keeping it

`max` was the legacy spelling of `repair`, so the API accepted **six** values where the type meant **five**.
The row's own instruction was to collapse the two lists rather than leave a one-element difference nobody
could explain a year later:

```ts
// before
export type DocExtractionMode      = 'off' | 'ocr' | 'vlm' | 'repair' | 'auto';
export const DOC_EXTRACTION_MODES_IN = ['off','ocr','vlm','repair','auto','max'];

// now — the same set, and the compiler enforces it
export const DOC_EXTRACTION_MODES_IN = ['off','ocr','vlm','repair','auto'] as const
  satisfies readonly DocExtractionMode[];
```

Both request bodies build their zod enum from that list, so a request sending `max` is now refused, with
the five accepted values named in the error.

## What is deliberately NOT removed

`normalizeDocExtractionMode` **stays.** It has three callers and **two of them read stored values**:

| caller | reads |
|---|---|
| `config/loader.ts` | the instance's `documentProcessing.mode` from `config.json` |
| `files/converters/extraction-level.ts` | a space's own `documentExtraction` override |

A `config.json` or space record written by an older build still carries `max`. Dropping the normaliser
alongside the accept-list would move an instance to a **different extraction level on load** — the quietest
possible way to change what a document search can find.

It is a self-healing read, the same shape as `normalizeVisionModel` and `migrateStateFilesAtRest`, not a
one-time upgrade path. Its doc comment described folding *input*, which is no longer its job, and now says
so.

## The drift guard, and why it is inline

The first version was a standalone type-level equality assertion. It worked, and it pushed
`server/src/config/types.ts` from 579 to 583 code lines — which the god-file ratchet caught. Raising that
freeze twice in one session, for a file whose number is supposed to go **down**, is the wrong trade for
four lines.

`satisfies readonly DocExtractionMode[]` folds into the existing declaration at **zero** added lines and
fails the build the same way. Mutation-tested both versions — putting `max` back names the value:

```
server/src/config/types.ts(625,80): error TS2322: Type '"max"' is not assignable to type 'DocExtractionMode'.
```

## Verification

The behavioural half — a stored `max` still reaching the repair pass, through both `capDocExtractionMode`
and `decideRoute` — was **already** covered in `extraction-policy.test.js` and is untouched, because that
behaviour has not changed.

The assertions that were missing are the ones added: the accept-list no longer carries `max`, and the
accept-list and the mode type are now the same five values. Both halves live beside each other on purpose —
the removal and the retention pull in opposite directions, and a reader needs to see why.

Docs: `05a-conversion-pipeline.md` still described the consensus-pass skip as happening "in `max` mode". Its
mode table already listed only the five.
