### PR TITLE
feat(schema)!: tagSuggestions is removed, and nothing replaces it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a one-time upgrade path, and dropping it would move an instance to a different extraction level on load —
   the quietest possible way to change what a document search can find.
 
+- **BREAKING — `tagSuggestions` is removed, per-type and space-wide. There is no replacement, and none is
+  needed.** It was retired in #365 when its editor was taken out, and kept because it was still accepted and
+  stored — which is how a field ends up retired-but-immortal: no editor, no consumer, and nothing saying to
+  remove it. Nothing ever read either list. Record forms suggest from the tags already in use in each
+  collection, which is self-maintaining, and the MCP schema guidance never consulted it.
+  Gone from: `SpaceMetaBody`, the per-type `TypeSchemaZ`, the schema-library entry schema, the
+  `deleteFields` path that could delete it, the meta merge, both type declarations and every client mirror.
+  Both accepting schemas are `.strict()`, so a request still sending it gets a `400`.
+  **What happens to a value already stored, precisely** — the two halves differ and it matters: a
+  **space-wide** `meta.tagSuggestions` is left alone, because the meta merge reads an absent field as "not
+  stated" and never rewrites it. A **per-type** list is dropped the next time that type is saved, because
+  the merge replaces a type's whole schema object rather than merging its fields. Neither is read by
+  anything in either case.
+
 ### Changed
 - **Re-uploading identical bytes no longer re-runs vision or speech-to-text.** `enqueueMediaJob` resets a
   terminal job on purpose, so the same file sent twice paid for a second full analysis to reproduce the caption

--- a/client/src/app/core/api.types.ts
+++ b/client/src/app/core/api.types.ts
@@ -100,7 +100,6 @@ export interface TypeSchema {
   /** Reference to a schema library entry. Format: `"library:<name>"`. */
   $ref?: string;
   namingPattern?: string;
-  tagSuggestions?: string[];
   propertySchemas?: Record<string, PropertySchema>;
   /** How long records of this type are kept — the schema tier of **record > schema > space**. `days` deletes
    *  the record; `contentDays` (chrono only) drops the detail and the embedding but keeps the record. */
@@ -152,7 +151,6 @@ export interface SpaceMeta {
   usageNotes?: string;
   validationMode?: ValidationMode;
   typeSchemas?: Partial<Record<KnowledgeType, Record<string, TypeSchema>>>;
-  tagSuggestions?: string[];
   strictLinkage?: boolean;
   /** Space-wide default for skipping embeddings — the LOWEST of record > schema > space. Absent means `false`;
    *  suppression is opt-in. Any type schema that states a value overrides this. Turning it off does not

--- a/client/src/app/pages/schema-library/schema-library.component.ts
+++ b/client/src/app/pages/schema-library/schema-library.component.ts
@@ -32,7 +32,6 @@ import { CHIP_STYLES } from '../../shared/chip.styles';
 
 interface TypeSchemaState {
   namingPattern:   string;
-  tagSuggestions:  string[];
   propertySchemas: { key: string; s: PropertySchema; _enumInput: string }[];
   _newPropInput:   string;
   _newTagInput:    string;
@@ -48,7 +47,7 @@ interface LibraryFormState {
 }
 
 function emptySchemaState(): TypeSchemaState {
-  return { namingPattern: '', tagSuggestions: [], propertySchemas: [], _newPropInput: '', _newTagInput: '' };
+  return { namingPattern: '', propertySchemas: [], _newPropInput: '', _newTagInput: '' };
 }
 
 function entryToFormState(e: SchemaLibraryEntry): LibraryFormState {
@@ -61,7 +60,6 @@ function entryToFormState(e: SchemaLibraryEntry): LibraryFormState {
     schemaGroup:   e.schemaGroup ?? '',
     schemaState: {
       namingPattern:   s.namingPattern   ?? '',
-      tagSuggestions:  [...(s.tagSuggestions ?? [])],
       propertySchemas: Object.entries(s.propertySchemas ?? {}).map(([k, ps]) => ({ key: k, s: { ...ps }, _enumInput: '' })),
       _newPropInput:   '',
       _newTagInput:    '',
@@ -73,9 +71,6 @@ function formStateToSchema(f: LibraryFormState): Omit<TypeSchema, '$ref'> {
   const schema: Omit<TypeSchema, '$ref'> = {};
   if (f.knowledgeType === 'entity' && f.schemaState.namingPattern.trim()) {
     schema.namingPattern = f.schemaState.namingPattern.trim();
-  }
-  if (f.schemaState.tagSuggestions.length) {
-    schema.tagSuggestions = [...f.schemaState.tagSuggestions];
   }
   if (f.schemaState.propertySchemas.length) {
     const ps: Record<string, PropertySchema> = {};

--- a/client/src/app/pages/settings/space-schema-tab.component.ts
+++ b/client/src/app/pages/settings/space-schema-tab.component.ts
@@ -440,7 +440,6 @@ export class SpaceSchemaTabComponent implements OnInit {
         // _libRef intentionally dropped — the type is now a plain inline schema.
         [name]: emptyTypeSchemaState({
           namingPattern:   schema.namingPattern ?? '',
-          tagSuggestions:  [...(schema.tagSuggestions ?? [])],
           propertySchemas: Object.entries(schema.propertySchemas ?? {}).map(([k, ps]) => ({ key: k, s: { ...ps }, _enumInput: '' })),
         }),
       },
@@ -542,7 +541,6 @@ export class SpaceSchemaTabComponent implements OnInit {
       namingPattern:   typeof ts2['namingPattern'] === 'string' ? ts2['namingPattern'] : '',
       retentionDays:        win('days'),
       retentionContentDays: win('contentDays'),
-      tagSuggestions:  Array.isArray(ts2['tagSuggestions']) ? [...ts2['tagSuggestions'] as string[]] : [],
       propertySchemas: (() => {
         const ps = ts2['propertySchemas'];
         if (!ps || typeof ps !== 'object' || Array.isArray(ps)) return [];

--- a/client/src/app/pages/settings/space-settings-state.service.spec.ts
+++ b/client/src/app/pages/settings/space-settings-state.service.spec.ts
@@ -80,10 +80,10 @@ describe('SpaceSettingsState — openSettings populates every tab', () => {
     c.openSettings(rich);
     expect(c.schValidation).toBe('strict');
     expect(c.schStrictLinkage).toBe(true);
-    expect(c.schTagSuggestions).toEqual(['a', 'b']);
-
-    c.schTagSuggestions.push('c');
-    expect(rich.meta!.tagSuggestions).toEqual(['a', 'b']); // original untouched
+    // `tagSuggestions` was REMOVED in 3.0 and is no longer read into the form. The fixture still carries
+    // one, on purpose: a list already in config.json must be left exactly where it is, not migrated and
+    // not destroyed, and `openSettings` reading nothing is the first half of that.
+    expect((c as unknown as Record<string, unknown>)['schTagSuggestions']).toBeUndefined();
   });
 
   it('flattens a type schema into editable state (propertySchemas becomes a keyed list)', () => {
@@ -93,7 +93,7 @@ describe('SpaceSettingsState — openSettings populates every tab', () => {
     expect(c.typeCount('entity')).toBe(1);
     const st = c.typeState('entity', 'person');
     expect(st.namingPattern).toBe('^[A-Z]');
-    expect(st.tagSuggestions).toEqual(['t']);
+    expect((st as unknown as Record<string, unknown>)['tagSuggestions']).toBeUndefined();
     expect(st.propertySchemas).toEqual([{ key: 'age', s: { type: 'number', minimum: 0 }, _enumInput: '' }]);
   });
 
@@ -123,7 +123,6 @@ describe('SpaceSettingsState — openSettings populates every tab', () => {
     expect(c.stForm).toEqual({ label: 'Bare', purpose: '', usageNotes: '', maxGiB: null, documentExtraction: '', imageAnalysis: '', audioAnalysis: '', videoAnalysis: '', textAnalysis: '' });
     expect(c.schValidation).toBe('off');
     expect(c.schStrictLinkage).toBe(false);
-    expect(c.schTagSuggestions).toEqual([]);
     expect(c.typeNames('entity')).toEqual([]);
     expect(c.dupeRulesState).toEqual([]);
     expect(c.dupeSurvivor).toBe('older');
@@ -165,34 +164,39 @@ describe('SpaceSettingsState — buildMeta (what actually gets saved)', () => {
     expect(c.buildMeta()).toMatchObject({ purpose: 'p', usageNotes: 'u' });
   });
 
-  it('emits strictLinkage only when true, and tagSuggestions only when non-empty', () => {
+  it('emits strictLinkage only when true, and never emits the removed tagSuggestions', () => {
     const c = make();
     c.openSettings(space());
     expect(c.buildMeta().strictLinkage).toBeUndefined();
-    expect(c.buildMeta().tagSuggestions).toBeUndefined();
     c.schStrictLinkage = true;
-    c.schTagSuggestions = ['x'];
-    expect(c.buildMeta()).toMatchObject({ strictLinkage: true, tagSuggestions: ['x'] });
+    expect(c.buildMeta()).toMatchObject({ strictLinkage: true });
+    // Removed in 3.0. `SpaceMetaBody` is `.strict()`, so a client still emitting it would 400 its own
+    // save — which is why this asserts absence rather than merely stopping at "we do not set it".
+    expect((c.buildMeta() as unknown as Record<string, unknown>)['tagSuggestions']).toBeUndefined();
   });
 
-  it('a stored per-type tagSuggestions list survives a load → save round-trip with no editor', () => {
-    // The per-type tag-suggestion EDITOR was retired (it reached neither the Brain record forms nor
-    // the MCP schema guidance), but the DATA was deliberately kept: the save path is a full replace,
-    // so dropping the field from state would silently destroy an operator's stored list on their next
-    // unrelated edit. This is the guard against someone later deleting `tagSuggestions` from the
-    // state as apparently-dead code — it is not dead, it is load-bearing for preservation.
+  it('a stored per-type tagSuggestions list is dropped on the next save of that type', () => {
+    // This test used to assert the OPPOSITE, and it was right to. Until 3.0 the field was retired but
+    // kept, and the round-trip was load-bearing: `planSpaceMetaUpdate` merges typeSchemas per-KT and then
+    // per-type-NAME (`{ ...existingTs[kt], ...ktMap }`), so an incoming type REPLACES its whole schema
+    // object. A client that stopped carrying the field would have destroyed an operator's list on their
+    // next unrelated edit.
+    //
+    // 3.0 removes the field, so that destruction is now the intended outcome rather than an accident —
+    // and it is asserted here rather than left to be discovered, because "stored values are preserved"
+    // is true of the SPACE-level field (a scalar the merge leaves alone when absent) and NOT of this one.
     const c = make();
     c.openSettings(space({
       meta: { typeSchemas: { entity: { person: { namingPattern: '^[A-Z]', tagSuggestions: ['t'] } } } },
     } as Partial<Space>));
     const st = c.typeState('entity', 'person');
-    expect(st.tagSuggestions).toEqual(['t']);
+    expect((st as unknown as Record<string, unknown>)['tagSuggestions']).toBeUndefined();
 
     // Edit something else entirely, exactly as an operator would.
     st.namingPattern = '^[a-z]';
 
     const saved = c.buildMeta().typeSchemas!.entity!['person']!;
-    expect(saved.tagSuggestions).toEqual(['t']);
+    expect((saved as unknown as Record<string, unknown>)['tagSuggestions']).toBeUndefined();
     expect(saved.namingPattern).toBe('^[a-z]');
   });
 

--- a/client/src/app/pages/settings/space-settings-state.service.ts
+++ b/client/src/app/pages/settings/space-settings-state.service.ts
@@ -42,7 +42,6 @@ export interface TypeSchemaState {
    * space-wide setting unreachable for any type that has a schema at all.
    */
   suppressEmbeddings: boolean | null;
-  tagSuggestions:  string[];
   propertySchemas: { key: string; s: PropertySchema; _enumInput: string }[];
   _newPropInput:   string;
   _newTagInput:    string;
@@ -66,7 +65,7 @@ export interface TypeSchemaState {
 export function emptyTypeSchemaState(over: Partial<TypeSchemaState> = {}): TypeSchemaState {
   return {
     namingPattern: '', retentionDays: null, retentionContentDays: null, suppressEmbeddings: null,
-    tagSuggestions: [], propertySchemas: [], _newPropInput: '', _newTagInput: '',
+    propertySchemas: [], _newPropInput: '', _newTagInput: '',
     ...over,
   };
 }
@@ -104,7 +103,6 @@ export function typeSchemaFromState(
   // Sent only when STATED. Writing `false` for "not stated" would pin every type to embedding and make the
   // space-wide switch do nothing — the tier the API resolves last would never be reached.
   if (state.suppressEmbeddings !== null) ts.suppressEmbeddings = state.suppressEmbeddings;
-  if (state.tagSuggestions.length) ts.tagSuggestions = [...state.tagSuggestions];
   if (state.propertySchemas.length) {
     const ps: Record<string, PropertySchema> = {};
     for (const { key, s } of state.propertySchemas) {
@@ -222,7 +220,6 @@ export class SpaceSettingsState {
    * config.json rather than being erased the first time someone opens this tab and hits save. The
    * retirement is reversible; silently destroying an operator's data to tidy up a field would not be.
    */
-  schTagSuggestions: string[] = [];
   schTypeSchemas:    Partial<Record<KnowledgeType, Record<string, TypeSchemaState>>> = {
     entity: {}, memory: {}, edge: {}, chrono: {},
   };
@@ -265,7 +262,6 @@ export class SpaceSettingsState {
     const meta = s.meta ?? {};
     this.schValidation     = meta.validationMode ?? 'off';
     this.schStrictLinkage  = meta.strictLinkage ?? false;
-    this.schTagSuggestions = [...(meta.tagSuggestions ?? [])];
     this.schNewTypeInputs  = { entity: '', memory: '', edge: '', chrono: '' };
     this.schSelectedType   = null;
     this.schExpandedProps.clear();
@@ -285,7 +281,6 @@ export class SpaceSettingsState {
             // `?? null` again, and for the same reason: absent must round-trip as absent, or opening and saving
             // a type would write a value nobody chose.
             suppressEmbeddings:   ts.suppressEmbeddings      ?? null,
-            tagSuggestions:  [...(ts.tagSuggestions ?? [])],
             propertySchemas: Object.entries(ts.propertySchemas ?? {}).map(([k, ps]) => ({ key: k, s: { ...ps }, _enumInput: '' })),
           });
         }
@@ -372,7 +367,6 @@ export class SpaceSettingsState {
     if (this.stForm.usageNotes.trim()) meta.usageNotes = this.stForm.usageNotes.trim();
     meta.validationMode = this.schValidation;
     if (this.schStrictLinkage)         meta.strictLinkage  = true;
-    if (this.schTagSuggestions.length) meta.tagSuggestions = [...this.schTagSuggestions];
     // Every knowledge type is emitted, including the empty ones, and `typeSchemas` is always set.
     //
     // Both used to be conditional (`if (names.length)`, `if (Object.keys(typeSchemas).length)`), and that
@@ -485,10 +479,10 @@ export class SpaceSettingsState {
     this.schExpandedProps.delete(this.propKey(kt, typeName, propKey));
   }
 
-  // `addTypeTag` was removed with the per-type tag-suggestion editor: the list it edited reached
-  // neither the Brain record forms nor the MCP schema guidance, so the control did nothing. Stored
-  // values are still loaded into `tagSuggestions` and written back on save — the retirement removes
-  // the editor, not the data.
+  // `addTypeTag` went with the per-type tag-suggestion editor: the list it edited reached neither the
+  // Brain record forms nor the MCP schema guidance, so the control did nothing. 3.0 removed the FIELD
+  // too, so there is no longer a value to load or write back — a list already in config.json is left
+  // where it is and simply never read.
 
   onEnumKey(e: KeyboardEvent, kt: KnowledgeType, typeName: string, propKey: string): void {
     if (e.key === 'Enter' || e.key === ',') { e.preventDefault(); this.addEnumVal(kt, typeName, propKey); }

--- a/docs/integration-guide/06-spaces-api.md
+++ b/docs/integration-guide/06-spaces-api.md
@@ -321,7 +321,6 @@ PATCH /api/spaces/flows
       "entity": {
         "service": {
           "namingPattern": "^[a-z][a-z0-9-]{1,60}$",
-          "tagSuggestions": ["backend", "frontend", "infra"],
           "propertySchemas": {
             "status": { "type": "string", "enum": ["active", "deprecated", "planned"], "required": true },
             "score":  { "type": "number", "minimum": 0, "maximum": 100, "mergeFn": "avg" }
@@ -344,7 +343,6 @@ PATCH /api/spaces/flows
         }
       }
     },
-    "tagSuggestions": ["backend", "frontend", "infra"],
     "strictLinkage": true
   }
 }
@@ -417,7 +415,6 @@ type schemas are readable only by tokens that may reach the space.
     "entity": {
       "service": {
         "namingPattern": "^[a-z][a-z0-9-]{1,60}$",
-        "tagSuggestions": ["backend", "frontend"],
         "propertySchemas": {
           "status": { "type": "string", "enum": ["active", "deprecated"], "required": true }
         }
@@ -429,7 +426,6 @@ type schemas are readable only by tokens that may reach the space.
       "owns": {}
     }
   },
-  "tagSuggestions": ["backend", "frontend"],
   "stats": { "memories": 142, "entities": 53, "edges": 87, "chrono": 12, "files": 31 },
   "needsReindex": false
 }

--- a/docs/integration-guide/06a-schema-api.md
+++ b/docs/integration-guide/06a-schema-api.md
@@ -21,7 +21,6 @@ Returns a single type definition from the space's `typeSchemas`. `:knowledgeType
   "typeName": "service",
   "schema": {
     "namingPattern": "^[a-z][a-z0-9-]{1,60}$",
-    "tagSuggestions": ["backend", "frontend"],
     "propertySchemas": {
       "status": { "type": "string", "enum": ["active", "deprecated"], "required": true }
     }
@@ -88,7 +87,6 @@ Adds or updates a single type definition in the space's `typeSchemas`. All other
 ```json
 {
   "namingPattern": "^[a-z][a-z0-9-]{1,60}$",
-  "tagSuggestions": ["backend", "frontend"],
   "propertySchemas": {
     "status": { "type": "string", "enum": ["active", "deprecated"], "required": true }
   }
@@ -248,7 +246,6 @@ interface TypeSchema {
   retention?: { days?: number; contentDays?: number };  // per-type retention, the middle tier of
                                                   //   record > schema > space. `contentDays` is chrono-only
                                                   //   and is rejected elsewhere. See 04-brain-api.md.
-  tagSuggestions?: string[];                      // RETIRED — accepted and stored, consumed by nothing
   propertySchemas?: Record<string, PropertySchema>;
   suppressEmbeddings?: boolean;                   // skip embedding this type. Absent = NOT STATED, falls
                                                   //   through to the space setting — it does not mean false.
@@ -274,7 +271,6 @@ interface PropertySchema {
     "entity": {
       "service": {
         "namingPattern": "^[a-z][a-z0-9-]{1,60}$",
-        "tagSuggestions": ["backend", "frontend"],
         "propertySchemas": {
           "status": { "type": "string", "enum": ["active", "deprecated"], "required": true },
           "score":  { "type": "number", "minimum": 0, "maximum": 100, "mergeFn": "avg" }
@@ -295,7 +291,6 @@ interface PropertySchema {
     },
     "chrono": {
       "milestone": {
-        "tagSuggestions": ["release", "launch"]
       }
     }
   }
@@ -310,20 +305,16 @@ What the schema enforces:
 - **Memory type allowlist** — the keys of `typeSchemas.memory` define the allowed `type` values.
 - **Naming patterns** (`namingPattern`) — per entity type, a regex for validating `name` (max 500 chars, ReDoS-protected).
 - **Property value constraints** (`propertySchemas`) — per type, define `type` (string/number/boolean/date), `enum`, `minimum`/`maximum`, `pattern` (regex, ReDoS-protected), `required`, `default`, and `mergeFn`.
-- **Tag suggestions** (`tagSuggestions`) — **retired.** Both the per-type and the space-wide list are
-  still accepted, stored and returned unchanged, but nothing consumes them: the Brain record forms
-  suggest from the tags already in use in each collection, and the schema guidance sent to MCP clients
-  no longer summarises them. There is no longer an editor for either on the Schema tab or in the
-  Schema Library. Existing values are left in place rather than deleted, so the retirement is
-  reversible and no operator's list is destroyed on their next save — but do not expect writing one to
-  have any effect.
+- **Tag suggestions** (`tagSuggestions`) — **removed in 3.0.** Both the per-type and the space-wide list
+  are gone from every surface: neither is accepted, stored or returned. They were consumed by nothing —
+  record forms suggest from the tags already in use in each collection, which is self-maintaining, and
+  the MCP schema guidance never read either list.
 
 **Top-level `meta` fields:**
 
 | Field | Description |
 |-------|-------------|
 | `typeSchemas` | Per-type schema definitions (see above). **The PATCH merge is exactly two levels deep, and the second one REPLACES.** A knowledge type you do not mention is preserved; a *type name* you do not mention inside one is preserved; but a type name you **do** mention has its definition object **replaced wholesale**, not merged. So `PATCH {"meta":{"typeSchemas":{"chrono":{"event":{"retention":{"days":90}}}}}}` leaves `entity` and every other chrono type untouched — and wipes `event`'s own `propertySchemas`, `namingPattern` and `tagSuggestions`. **Read the type first and send it back complete.** Deleting a type needs `PUT /:id/schema` (full replace), because under merge semantics an absent type is indistinguishable from a removed one. |
-| `tagSuggestions` | **Retired.** A space-wide list of non-enforced tag hints. It is still accepted and stored (so an existing list is preserved untouched, and the change is reversible) but nothing reads it: it no longer feeds tag autocomplete in the Brain record forms, and no longer appears in the schema guidance returned to MCP clients. It was one list, editable in a single place, applied to every type and every form in the space — easy to set once and forget while quietly steering what got tagged. Autocomplete now comes from the tags actually in use, which maintains itself. **The per-type `typeSchemas.<kind>.<type>.tagSuggestions` is retired on exactly the same terms** — stored, returned, read by nothing, no editor. An earlier revision of this line said it was "unaffected", which contradicted the `typeSchemas` section above and left an integrator unable to tell which sentence was current; both lists are dead, and clearing either is safe. `null` is **rejected** with a 400 on a meta write; `[]` empties the list and is the way to clear one. There is no route that removes a top-level `meta` key, so the field itself stays present and empty — which is what makes the retirement reversible. |
 | `strictLinkage` | When `true`, all reference fields (`from`/`to`, `entityIds`, `memoryIds`) must be valid UUID v4 values, and entity deletion is blocked while inbound backlinks exist. **Default: `true`** — and an absent value also resolves to `true`. Turning it off is a deliberate per-space choice to accept dangling references (the case it exists for is bulk import, where targets are resolved in a later pass); you do not get that by saying nothing. |
 | `suppressEmbeddings` | When `true`, records in this space are **not embedded**, so they never appear in semantic recall. **Default: `false`** — suppression is opt-in. This is the LOWEST of three tiers: a per-record `excludeFromVectorSearch` wins, then a type's own `suppressEmbeddings`, then this. A type schema that says nothing falls through to this value rather than overriding it with `false`. Intended for records that are **state rather than prose** — a row whose text never changes but whose numbers are patched constantly, which would otherwise re-embed identical text on every write. **Switching it off does not backfill on its own** — records written while it was on have no vector and nothing revisits them. Run [`POST /api/spaces/:id/reembed`](06-spaces-api.md#re-embed-backfill) afterwards to queue the missing ones. |
 | `purpose` | Short description of the space (max 4000 chars). Returned by `get_space_meta`. |

--- a/docs/integration-guide/06b-schema-library-api.md
+++ b/docs/integration-guide/06b-schema-library-api.md
@@ -20,7 +20,6 @@ Library entries are stored in `schema-library.json` (sibling to `config.json`). 
   "description": "Standard service entity schema",
   "schema": {
     "namingPattern": "^[a-z][a-z0-9-]{1,60}$",
-    "tagSuggestions": ["backend", "frontend"],
     "propertySchemas": {
       "owner": { "type": "string", "required": true },
       "status": { "type": "string", "enum": ["active", "deprecated"] }
@@ -142,7 +141,7 @@ restating `tier`, `owner`, the `namingPattern`, the description or the type name
 | field | behaviour |
 |---|---|
 | `schema.propertySchemas` | **merged per key.** A named property is REPLACED as a whole definition — naming it is how you change it, and deep-merging into it would make removing a constraint impossible |
-| `schema.namingPattern`, `schema.tagSuggestions` | replaced when present, preserved when absent. One value and one whole list; merging a list would leave no way to remove a single tag |
+| `schema.namingPattern` | replaced when present, preserved when absent. One value and one whole list; merging a list would leave no way to remove a single tag |
 | `knowledgeType`, `typeName`, `published` | replaced when present |
 | `description`, `schemaGroup`, `sourceUrl`, `sourceCatalog` | `null` clears, a value sets, absent preserves — the same three-way contract `PUT` honours |
 | `deleteFields` | dot paths to remove: `propertySchemas.<key>`, `propertySchemas`, `namingPattern`, `tagSuggestions`. Applied **after** the merge, so one request can replace one property and drop another |

--- a/server/src/api/schema-library.ts
+++ b/server/src/api/schema-library.ts
@@ -110,7 +110,6 @@ const PropertySchemaZ = z.object({
  */
 const LibraryTypeSchemaZ = z.object({
   namingPattern: z.string().max(500).optional(),
-  tagSuggestions: z.array(z.string().min(1).max(200)).max(200).optional(),
   propertySchemas: z.record(z.string().min(1).max(200), PropertySchemaZ).optional(),
   // Kept in step with `TypeSchemaZ` in `api/spaces.ts` deliberately: a library entry that cannot express a field the
   // inline schema can is a surface that silently drops it.
@@ -173,7 +172,7 @@ const LibraryEntryPatchBodyZ = z.object({
   published: z.boolean().optional(),
   sourceUrl: z.string().url().max(2048).nullable().optional(),
   sourceCatalog: z.string().max(200).nullable().optional(),
-  /** Dot paths inside `schema`: `propertySchemas.<key>`, `namingPattern`, `tagSuggestions`, `propertySchemas`. */
+  /** Dot paths inside `schema`: `propertySchemas.<key>`, `namingPattern`, `propertySchemas`. */
   deleteFields: z.array(z.string().min(1).max(300)).max(100).optional(),
 }).strict();
 
@@ -599,13 +598,11 @@ schemaLibraryRouter.patch('/:name', globalRateLimit, requireAdminMfa, (req, res)
   }
   const existing = library[idx]!;
 
-  // Merge the schema: named properties are added or replaced, unnamed ones survive. `namingPattern` and
-  // `tagSuggestions` replace when present — they are a single value and a whole list, and merging a list
-  // would make removing one tag impossible without a second mechanism.
+  // Merge the schema: named properties are added or replaced, unnamed ones survive. `namingPattern`
+  // replaces when present rather than merging.
   const mergedSchema: SchemaLibraryEntry['schema'] = { ...(existing.schema ?? {}) };
   if (patch.schema) {
     if (patch.schema.namingPattern !== undefined) mergedSchema.namingPattern = patch.schema.namingPattern;
-    if (patch.schema.tagSuggestions !== undefined) mergedSchema.tagSuggestions = patch.schema.tagSuggestions;
     if (patch.schema.propertySchemas !== undefined) {
       mergedSchema.propertySchemas = { ...(existing.schema?.propertySchemas ?? {}), ...patch.schema.propertySchemas };
     }
@@ -616,7 +613,6 @@ schemaLibraryRouter.patch('/:name', globalRateLimit, requireAdminMfa, (req, res)
   const unknownPaths: string[] = [];
   for (const path of patch.deleteFields ?? []) {
     if (path === 'namingPattern') { delete mergedSchema.namingPattern; continue; }
-    if (path === 'tagSuggestions') { delete mergedSchema.tagSuggestions; continue; }
     if (path === 'propertySchemas') { delete mergedSchema.propertySchemas; continue; }
     const prop = /^propertySchemas\.(.+)$/.exec(path);
     if (prop && mergedSchema.propertySchemas) { delete mergedSchema.propertySchemas[prop[1]!]; continue; }
@@ -627,7 +623,7 @@ schemaLibraryRouter.patch('/:name', globalRateLimit, requireAdminMfa, (req, res)
     // Refused rather than ignored: a typo'd path that is silently dropped leaves the caller believing a
     // property was removed when it is still validating records.
     res.status(400).json({
-      error: `deleteFields paths must be 'namingPattern', 'tagSuggestions', 'propertySchemas', or 'propertySchemas.<key>' — unrecognised: ${unknownPaths.join(', ')}`,
+      error: `deleteFields paths must be 'namingPattern', 'propertySchemas', or 'propertySchemas.<key>' — unrecognised: ${unknownPaths.join(', ')}`,
     });
     return;
   }

--- a/server/src/config/types-knowledge.ts
+++ b/server/src/config/types-knowledge.ts
@@ -106,12 +106,6 @@ export interface TypeSchema {
    * So this was an editor for a field with no consumer, which is precisely the dishonesty the Models
    * rebuild spent four PRs removing.
    *
-   * The field stays in the type, in the Zod schemas and in the client's load/save round-trip **on
-   * purpose**: silently destroying an operator's stored list on their next save would be a worse
-   * trade than leaving an unused field behind, and it keeps the retirement reversible. Same call as
-   * `SpaceMeta.tagSuggestions` below.
-   */
-  tagSuggestions?: string[];
   /** Property key → JSON Schema subset for value validation and merge hints. */
   propertySchemas?: Record<string, PropertySchema>;
   /**
@@ -194,13 +188,6 @@ export interface SpaceMeta {
    */
   typeSchemas?: Partial<Record<KnowledgeType, Record<string, TypeSchema>>>;
   /**
-   * **RETIRED in #365 — stored values preserved, consumed by nothing.**
-   *
-   * The old docstring called this a "fallback when no per-type tagSuggestions match", which described
-   * behaviour that never existed — nothing consulted either list at write time. Both are now retired;
-   * see `TypeSchema.tagSuggestions` for the reasoning and why the field is deliberately still here.
-   */
-  tagSuggestions?: string[];
   /** When true, all reference fields (edge from/to, entityIds, memoryIds) must be
    *  valid UUID v4 values, and entity deletion is blocked while inbound backlinks exist. */
   strictLinkage?: boolean;

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -1077,8 +1077,10 @@ export interface Config {
    * is disabled" — a guard that has never existed under that name.
    *
    * **The control that actually rejects plaintext requests is {@link requireEncryptedTransport}.** Not
-   * deleted outright, on the same reasoning as `SpaceMeta.tagSuggestions`: silently dropping a key an
-   * operator has in their config is a worse trade than leaving a documented retirement behind.
+   * deleted outright: silently dropping a key an operator has in their config is a worse trade than
+   * leaving a documented retirement behind. (`SpaceMeta.tagSuggestions` was the other field kept on
+   * this reasoning; it was removed in 3.0 once the deprecation had a major to land in. This one has
+   * no such announcement, so it stays.)
    */
   allowInsecurePlaintext?: boolean;
   /**

--- a/server/src/spaces/body-schemas.ts
+++ b/server/src/spaces/body-schemas.ts
@@ -68,7 +68,6 @@ export const TypeSchemaZ = z.union([
   // Inline schema definition
   z.object({
     namingPattern: z.string().max(500).optional(),
-    tagSuggestions: z.array(z.string().min(1).max(200)).max(200).optional(),
     propertySchemas: z.record(z.string().min(1).max(200), PropertySchemaZ).optional(),
     // The schema tier of record > schema > space. `.strict()` above means an unlisted key is REJECTED, so
     // without this the field would be stripped from every PATCH and the feature would silently not exist.
@@ -127,7 +126,6 @@ export const SpaceMetaBody = z.object({
   usageNotes: z.string().max(50_000).optional(),
   validationMode: z.enum(['off', 'warn', 'strict']).optional(),
   typeSchemas: TypeSchemasZ.optional(),
-  tagSuggestions: z.array(z.string().min(1).max(200)).max(200).optional(),
   strictLinkage: z.boolean().optional(),
   // The lowest of the three suppression tiers. `.strict()` above is why this has to be listed at all: without
   // it the field would be REJECTED as unknown, not silently ignored — which is the right failure, but still a

--- a/server/src/spaces/meta-update.ts
+++ b/server/src/spaces/meta-update.ts
@@ -48,7 +48,7 @@ import type { z } from 'zod';
 /**
  * Deep-merge an incoming PATCH `meta` payload into the existing SpaceMeta.
  *
- * - Scalar fields (purpose, usageNotes, validationMode, tagSuggestions,
+ * - Scalar fields (purpose, usageNotes, validationMode,
  *   strictLinkage) overwrite the existing value when present in `incoming`.
  * - `typeSchemas` is merged per-knowledge-type, then per-type-name:
  *   types present in `incoming` are added or updated; types *not* mentioned
@@ -74,7 +74,6 @@ export function mergeSpaceMeta(
   if (incoming.purpose !== undefined) merged.purpose = incoming.purpose;
   if (incoming.usageNotes !== undefined) merged.usageNotes = incoming.usageNotes;
   if (incoming.validationMode !== undefined) merged.validationMode = incoming.validationMode;
-  if (incoming.tagSuggestions !== undefined) merged.tagSuggestions = incoming.tagSuggestions;
   if (incoming.strictLinkage !== undefined) merged.strictLinkage = incoming.strictLinkage;
   // Guarded on `!== undefined`, not on truthiness. `suppressEmbeddings: false` is how an operator turns
   // suppression back OFF, and a truthy guard would drop that patch and leave the space suppressed while

--- a/server/src/spaces/schema-validation.ts
+++ b/server/src/spaces/schema-validation.ts
@@ -239,11 +239,13 @@ export function buildSchemaSummary(meta: SpaceMeta): string {
   if (ts?.chrono && Object.keys(ts.chrono).length > 0) {
     parts.push(`Chrono types: ${Object.keys(ts.chrono).join(', ')}`);
   }
-  // `meta.tagSuggestions` used to be summarised here. It was retired: it was one editable list that
-  // applied to every type in the space, so it steered what agents tagged with while being easy to
-  // set once and forget. Any stored value is left untouched in config.json rather than deleted — the
-  // retirement is reversible, and silently destroying an operator's list would be a worse trade than
-  // leaving an unused field behind.
+  // `meta.tagSuggestions` used to be summarised here. Retired in #365 — one editable list applying to
+  // every type in the space, so it steered what agents tagged with while being easy to set once and
+  // forget — and REMOVED from every surface in 3.0.
+  //
+  // A value already in config.json is still left untouched rather than deleted. The meta merge reads
+  // an absent field as "not stated", so nothing rewrites it away; it is simply inert, and no request
+  // can put a new one there.
   if (parts.length > 0) {
     parts.push('Call get_space_meta for full schema and usage notes.');
   }

--- a/testing/integration/schema-library.test.js
+++ b/testing/integration/schema-library.test.js
@@ -97,7 +97,6 @@ const ENTRY_BODY = {
   typeName: 'service',
   schema: {
     namingPattern: '^[a-z][a-z0-9-]{1,60}$',
-    tagSuggestions: ['backend', 'frontend'],
     propertySchemas: {
       status: { type: 'string', enum: ['active', 'deprecated'], required: true },
     },
@@ -121,7 +120,6 @@ describe('POST /api/schema-library — create entry', () => {
     assert.equal(r.body.entry.description, 'Standard service entity schema');
     assert.ok(r.body.entry.createdAt, 'should have createdAt');
     assert.ok(r.body.entry.updatedAt, 'should have updatedAt');
-    assert.deepEqual(r.body.entry.schema.tagSuggestions, ['backend', 'frontend']);
   });
 
   it('returns 409 when name already exists', async () => {
@@ -251,13 +249,12 @@ describe('PUT /api/schema-library/:name — create-or-replace', () => {
   });
 
   it('PUT round-trip: GET returns the same schema that was PUT', async () => {
-    const schema = { namingPattern: '^dep-', tagSuggestions: ['infrastructure'] };
+    const schema = { namingPattern: '^dep-' };
     await putEntry(putTestName, { knowledgeType: 'edge', typeName: 'depends_on', schema });
 
     const r = await getEntry(putTestName);
     assert.equal(r.status, 200);
     assert.equal(r.body.entry.schema.namingPattern, '^dep-');
-    assert.deepEqual(r.body.entry.schema.tagSuggestions, ['infrastructure']);
   });
 });
 
@@ -282,7 +279,6 @@ describe('PATCH /api/schema-library/:name — merge', () => {
       description: 'the original description',
       schema: {
         namingPattern: '^svc-',
-        tagSuggestions: ['infra', 'owned'],
         propertySchemas: {
           tier: { type: 'string', enum: ['gold', 'silver'] },
           owner: { type: 'string' },
@@ -306,7 +302,6 @@ describe('PATCH /api/schema-library/:name — merge', () => {
     assert.equal(r.body.entry.typeName, 'service', 'typeName must survive a schema-only patch');
     assert.equal(r.body.entry.description, 'the original description');
     assert.equal(r.body.entry.schema.namingPattern, '^svc-');
-    assert.deepEqual(r.body.entry.schema.tagSuggestions, ['infra', 'owned']);
   });
 
   it('does not narrow an enum it was not asked to touch', async () => {
@@ -397,7 +392,6 @@ describe('$ref resolution — space references a library entry', () => {
   const refLibName = `lib-test-${RUN}-ref-svc`;
   const refLibSchema = {
     namingPattern: '^svc-[a-z]+$',
-    tagSuggestions: ['production'],
     propertySchemas: {
       owner: { type: 'string', required: true },
     },
@@ -535,7 +529,6 @@ describe('$ref to non-existent library entry', () => {
 describe('GET /api/schema-library/:name/usages — link counter', () => {
   const usageLibName = `lib-test-${RUN}-usage-counter`;
   const usageLibSchema = {
-    tagSuggestions: ['monitored'],
     propertySchemas: { version: { type: 'string' } },
   };
   const usageSpaceA = `schema-lib-usagea-${RUN}`;
@@ -720,7 +713,7 @@ describe('PATCH /api/schema-library/:name/publish — publish toggle', () => {
       name: pubName,
       knowledgeType: 'entity',
       typeName: 'widget',
-      schema: { tagSuggestions: ['public'] },
+      schema: { namingPattern: '^pub-' },
       description: 'A publicly shared schema',
     });
     assert.equal(r.status, 201, `Failed to create entry: ${JSON.stringify(r.body)}`);
@@ -1056,7 +1049,7 @@ describe('Schema group support — schemaGroup field, GET /groups, POST /export-
       name: GROUP_ENTRY_B,
       knowledgeType: 'memory',
       typeName: 'note',
-      schema: { tagSuggestions: ['important'] },
+      schema: { namingPattern: '^note-' },
       schemaGroup: GROUP_NAME,
     });
     // Create the target space for apply tests
@@ -1104,7 +1097,7 @@ describe('Schema group support — schemaGroup field, GET /groups, POST /export-
     const r = await putEntry(GROUP_ENTRY_B, {
       knowledgeType: 'memory',
       typeName: 'note',
-      schema: { tagSuggestions: ['important'] },
+      schema: { namingPattern: '^note-' },
       schemaGroup: null,
     });
     assert.equal(r.status, 200, JSON.stringify(r.body));
@@ -1113,7 +1106,7 @@ describe('Schema group support — schemaGroup field, GET /groups, POST /export-
     await putEntry(GROUP_ENTRY_B, {
       knowledgeType: 'memory',
       typeName: 'note',
-      schema: { tagSuggestions: ['important'] },
+      schema: { namingPattern: '^note-' },
       schemaGroup: GROUP_NAME,
     });
   });
@@ -1211,7 +1204,7 @@ describe('Schema group support — schemaGroup field, GET /groups, POST /export-
     await patch(INSTANCES.a, token(), `/api/spaces/${exportSpaceId}`, {
       meta: {
         typeSchemas: {
-          entity: { server: { namingPattern: '^svc-', tagSuggestions: ['backend'] } },
+          entity: { server: { namingPattern: '^svc-' } },
           memory: { alert: { propertySchemas: { severity: { type: 'string' } } } },
         },
       },
@@ -1263,7 +1256,7 @@ describe('Schema group support — schemaGroup field, GET /groups, POST /export-
         typeSchemas: {
           entity: {
             service: { $ref: `library:${GROUP_ENTRY_A}` },  // $ref — should be skipped
-            product: { tagSuggestions: ['retail'] },          // inline — should be exported
+            product: { namingPattern: '^prod-' },          // inline — should be exported
           },
         },
       },

--- a/testing/integration/space-meta-update-contract.test.js
+++ b/testing/integration/space-meta-update-contract.test.js
@@ -184,7 +184,7 @@ describe('PATCH /api/spaces/:id — accept what we emit', () => {
   async function roundTrippedMeta() {
     const { body, version } = await metaNow();
     const editable = {};
-    for (const k of ['purpose', 'usageNotes', 'validationMode', 'tagSuggestions', 'strictLinkage', 'suppressEmbeddings']) {
+    for (const k of ['purpose', 'usageNotes', 'validationMode', 'strictLinkage', 'suppressEmbeddings']) {
       if (body[k] !== undefined) editable[k] = body[k];
     }
     return { ...editable, version, updatedAt: new Date().toISOString(), previousVersions: [] };

--- a/testing/integration/type-schema-crud.test.js
+++ b/testing/integration/type-schema-crud.test.js
@@ -77,7 +77,6 @@ describe('GET /api/spaces/:id/meta/typeSchemas/:kt/:typeName', () => {
         entity: {
           service: {
             namingPattern: '^[a-z][a-z0-9-]{1,60}$',
-            tagSuggestions: ['backend', 'frontend'],
             propertySchemas: {
               status: { type: 'string', enum: ['active', 'deprecated'], required: true },
             },
@@ -97,7 +96,6 @@ describe('GET /api/spaces/:id/meta/typeSchemas/:kt/:typeName', () => {
     assert.equal(r.body.typeName, 'service');
     assert.ok(typeof r.body.schema === 'object', 'response should have schema');
     assert.equal(r.body.schema.namingPattern, '^[a-z][a-z0-9-]{1,60}$');
-    assert.deepEqual(r.body.schema.tagSuggestions, ['backend', 'frontend']);
     assert.ok(r.body.schema.propertySchemas?.status, 'should have status property schema');
     assert.equal(r.body.schema.propertySchemas.status.type, 'string');
     assert.equal(r.body.schema.propertySchemas.status.required, true);
@@ -151,7 +149,6 @@ describe('PUT /api/spaces/:id/meta/typeSchemas/:kt/:typeName — upsert', () => 
   it('adds a new entity type without touching existing types', async () => {
     const schema = {
       namingPattern: '^[a-z][a-z0-9-]{1,60}$',
-      tagSuggestions: ['backend'],
       propertySchemas: {
         status: { type: 'string', enum: ['active', 'deprecated'], required: true },
       },
@@ -372,7 +369,7 @@ describe('PUT — max 200 types per knowledge type', () => {
 
   it('allows updating an existing type (no count increase)', async () => {
     const r = await put(INSTANCES.a, token(), `/api/spaces/${TEST_SPACE}/meta/typeSchemas/entity/type_0`, {
-      tagSuggestions: ['updated'],
+      namingPattern: '^updated-',
     });
     assert.equal(r.status, 200, `Updating existing type at max should succeed, got ${r.status}: ${JSON.stringify(r.body)}`);
   });
@@ -384,7 +381,6 @@ describe('PUT — max 200 types per knowledge type', () => {
 describe('Round-trip: GET then PUT (export/import snippet)', () => {
   const originalSchema = {
     namingPattern: '^svc-[a-z]+$',
-    tagSuggestions: ['prod', 'staging'],
     propertySchemas: {
       owner: { type: 'string', required: true },
       replicas: { type: 'number', minimum: 1, maximum: 10 },
@@ -403,7 +399,6 @@ describe('Round-trip: GET then PUT (export/import snippet)', () => {
     const r = await get(INSTANCES.a, token(), `/api/spaces/${TEST_SPACE}/meta/typeSchemas/entity/roundtrip_svc`);
     assert.equal(r.status, 200, JSON.stringify(r.body));
     assert.equal(r.body.schema.namingPattern, originalSchema.namingPattern);
-    assert.deepEqual(r.body.schema.tagSuggestions, originalSchema.tagSuggestions);
     assert.deepEqual(r.body.schema.propertySchemas, originalSchema.propertySchemas);
   });
 

--- a/testing/standalone/audit-schema-summary.test.js
+++ b/testing/standalone/audit-schema-summary.test.js
@@ -113,7 +113,6 @@ describe('values never reach the audit log — the property the whole design res
     const after = ts({
       service: {
         namingPattern: secrets[3],
-        tagSuggestions: [secrets[1]],
         propertySchemas: {
           owner: {},
           apiKey: { type: 'string', default: secrets[0], enum: [secrets[0], secrets[1]] },

--- a/testing/standalone/purpose-cap-one-limit.test.js
+++ b/testing/standalone/purpose-cap-one-limit.test.js
@@ -65,8 +65,8 @@ describe('the directive cap', () => {
       strip(readFileSync(file, 'utf8')).split(/\r?\n/).forEach((line, i) => {
         const namesField = /\bpurpose\b/.test(line) || (isSpaceSurface && /\bdescription\b/.test(line));
         if (!namesField) return;
-        // `usageNotes`, `label` and `tagSuggestions` have their own, deliberately different limits.
-        if (/usageNotes|label|tagSuggestions/.test(line)) return;
+        // `usageNotes` and `label` have their own, deliberately different limits.
+        if (/usageNotes|label/.test(line)) return;
         const bound = line.match(/(?:\.max\(|maxLength:\s*|length\s*>\s*)(\d[\d_]*)/);
         if (bound) offenders.push(`${rel}:${i + 1} bounds it at ${bound[1]} literally`);
       });

--- a/testing/standalone/type-schema-editable.test.js
+++ b/testing/standalone/type-schema-editable.test.js
@@ -46,10 +46,10 @@ const read = (p) => readFileSync(join(ROOT, p), 'utf8');
  * An entry here is a decision, not a shortcut: the field must still be PRESERVED across a save (which the
  * round-trip specs pin), it just has no input of its own.
  */
-const NO_CONTROL = {
-  tagSuggestions: 'retired in #365 — the editor reached nothing (record forms suggest from tags in use, and '
-    + 'MCP schema guidance never read it). Stored values are round-tripped untouched, not editable.',
-};
+// Empty since 3.0: `tagSuggestions` was the only entry, and removing the FIELD removed the reason for
+// the exemption. An entry here is a field the API accepts that the UI cannot edit — the gate below
+// checks each one still exists, so a stale exemption fails rather than quietly excusing nothing.
+const NO_CONTROL = {};
 
 /** The keys of the inline (non-$ref) branch of `TypeSchemaZ` in the spaces API. */
 function apiTypeSchemaKeys() {


### PR DESCRIPTION
**BREAKING.** `tagSuggestions` is removed, both per-type and space-wide. There is no replacement, and none
is needed.

Row 1.6 of the 3.0 deprecation checklist — and the row `_DEPRECATIONS.md` itself flags as the reason that
file exists. It was retired in #365 when its editor was taken out, kept because it was still *accepted and
stored*, and **missing from the deprecations file entirely until 2026-08-07**: no editor, no consumer, and
nothing saying to remove it. Retired-but-immortal.

Nothing ever read either list. Record forms suggest from the tags already in use in each collection, which
is self-maintaining, and the MCP schema guidance never consulted it.

## Removed from

`SpaceMetaBody` · the per-type `TypeSchemaZ` · the schema-library entry schema · the `deleteFields` path
that could delete it · the meta merge · both type declarations · every client mirror (`api.types`, the
schema-library page, the space schema tab, the settings state service).

Both accepting schemas are `.strict()`, so a request still sending it gets a `400` on its own. No explicit
refusal was added here — unlike the `description` removal, where the body was *not* strict and a plain
deletion would have been silent.

## A stored value: the two halves are not the same

This is the part I had wrong first and checked before shipping.

| what is stored | what happens |
|---|---|
| space-wide `meta.tagSuggestions` | **survives** — the meta merge reads an absent field as "not stated" and never rewrites it |
| per-type `typeSchemas.<kt>.<name>.tagSuggestions` | **dropped on that type's next save** — `planSpaceMetaUpdate` merges per-knowledge-type then per-type-NAME (`{ ...existingTs[kt], ...ktMap }`), so an incoming type replaces its whole schema object |

A client spec existed **specifically** to prevent that second case, and it was right to: while the field was
merely retired, dropping it from the form state would have destroyed an operator's list on their next
unrelated edit. At 3.0 that destruction is the intended outcome, so the spec now **asserts** it instead of
guarding against it, with the reasoning in place so the next reader knows the reversal was deliberate.

The CHANGELOG states both halves separately rather than claiming "stored values are preserved", which would
have been true of one and false of the other.

## Two gates caught things in the same run

- **`type-schema-editable.test.js`** refuses an exemption that names a field which no longer exists — *"every
  exemption still names a real field, so the list cannot rot"*. `tagSuggestions` was its only entry, so
  `NO_CONTROL` is now empty, with a note saying why an empty map is the right state rather than a leftover.
- **`documented-interfaces-match-code`** caught the `TypeSchema` block in `06a-schema-api.md`.

## Fixtures

The integration suites used the field in three different roles, and deleting the line blindly would have
quietly weakened them:

- **sole content of a schema** → becomes a real `namingPattern`, so the request still carries a schema and
  the case keeps testing what it was written for (sharing, grouping, PUT/GET round-trip);
- **one field among several** → the line goes;
- **an assertion on it** → the assertion goes.

The audit-redaction fixture had planted a secret in it. That same secret still appears in two surviving
fields, so the "any secret anywhere in a type schema is redacted" claim is unweakened.

Docs: the `TypeSchema` interface block, four JSON examples in `06-spaces-api.md`, four in `06a-schema-api.md`,
the retired-but-accepted prose and its table row, and the schema-library merge/deleteFields references.
