### PR TITLE
fix(mcp): crossSpace is not deprecated, and the schema said it was

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,6 +282,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     it cannot read) is a failure naming the file, and the routes are asserted BY NAME rather than by count.
 
 ### Fixed
+- **`crossSpace` on `find_similar` is NOT deprecated after all, and its schema description said otherwise.**
+  It was slated for removal — omitting `space` on MCP says the same thing — until removing it turned the
+  MCP/REST parity gate red: the REST route takes the space in its **path**, so "omit the space" cannot be
+  expressed there and `crossSpace: true` is its only route to the same capability. The flag stays on both
+  doors, and the MCP tool schema now says why it exists instead of telling callers to avoid it. If you
+  designed around `crossSpace` disappearing, it is not going to.
 - **60 gates stripped block comments before line comments, so a `/*` inside a `//` comment blinded them.**
   `server/src/api/data.ts:281` reads `// Follow the symlink — useful for /mnt/* or volume-mount points`, and
   removing block comments first treats that `/*` as an opener: it deletes **5,907 characters** through the next

--- a/server/src/mcp/tools/search.ts
+++ b/server/src/mcp/tools/search.ts
@@ -306,7 +306,7 @@ export const find_similarTool: ToolHandler = {
               type: 'number', minimum: 0, maximum: MAX_RECALL_TRAVERSE, default: 0,
               description: `Optional graph-expansion depth (integer 0–${MAX_RECALL_TRAVERSE}, default 0). When > 0, each similar match is expanded along knowledge-graph edges up to this many hops and what the walk reached is NESTED under the match that reached it in a \`_graph\` array — {edge, node, paths} per node, identical to \`recall\`'s shape: \`edge\` is the whole edge document, \`node\` the reached entity, \`paths\` every route to it as record ids with the match first. \`count\` is the number of matches and \`graphNodes\` how many nodes were reached. A neighbourhood past the inline cap is written out in full and reported as \`graphTruncated\` + \`graphComplete\` (an authenticated download, valid one day), exactly as on \`recall\`. With traverse > 0 the response is JSON instead of the plain text summary.`,
             },
-            crossSpace: { type: 'boolean', default: false, description: 'DEPRECATED — omit `space` instead to search all accessible spaces. When true, forces a cross-space search even if `space` is given.' },
+            crossSpace: { type: 'boolean', default: false, description: 'Forces a cross-space search even when `space` is given. On MCP the idiomatic form is to OMIT `space`, which does the same thing; this flag exists because the REST route takes the space in its PATH and has no way to omit it, and both doors must accept the same parameters. Not slated for removal.' },
           },
           required: ['entryId', 'entryType'],
           additionalProperties: false,

--- a/testing/standalone/mcp-tool-schemas.test.js
+++ b/testing/standalone/mcp-tool-schemas.test.js
@@ -101,14 +101,31 @@ describe('MCP tool schemas — high-value enrichments', () => {
     }
   });
 
-  it('find_similar is harmonised to omit-space (space optional) + traverse, crossSpace deprecated', () => {
+  it('find_similar is harmonised to omit-space, and crossSpace is kept rather than deprecated', () => {
     const fs = schemaOf('find_similar');
     assert.ok(!fs.required.includes('space'), 'space must be optional (omit → all accessible spaces)');
     assert.deepEqual(fs.required, ['entryId', 'entryType']);
     assert.ok(fs.properties.traverse, 'find_similar must expose traverse (parity with recall)');
     assert.equal(fs.properties.traverse.maximum, 5);
-    assert.ok(/DEPRECATED/i.test(fs.properties.crossSpace.description), 'crossSpace must be marked deprecated');
     assert.equal(ALL_TOOLS.find(t => t.name === 'find_similar').spaceRequired, false);
+
+    // THIS ASSERTION WAS REVERSED IN 3.0, and the reason is worth more than the line it replaces.
+    //
+    // `crossSpace` was slated for removal as row 1.2 of the deprecation checklist — omitting `space` says
+    // the same thing, so the tool took two spellings for one idea. Removing it from the tool turned
+    // `mcp-rest-parity`'s "find-similar ↔ find_similar" case RED: the REST route takes the space in its
+    // PATH, so "omit the space" is not expressible there and `crossSpace: true` is its only route to the
+    // same capability. Dropping it on one door alone is the parameter-level divergence that gate exists
+    // to catch.
+    //
+    // So the flag is KEPT on both doors, and the schema description must stop promising a removal that
+    // cannot happen — a caller reading "DEPRECATED" builds around an absence that will never arrive, and
+    // an `inputSchema` description is what they read while constructing arguments.
+    const desc = fs.properties.crossSpace.description;
+    assert.ok(!/DEPRECATED/i.test(desc),
+      'crossSpace is kept for REST parity — calling it deprecated tells a caller to avoid a supported flag');
+    assert.match(desc, /OMIT `space`/i, 'the description must still name the idiomatic MCP form');
+    assert.match(desc, /PATH/, 'and say WHY the flag exists, or the next reader files it as a duplicate again');
   });
 
   it('id fields carry a UUID-v4 pattern', () => {


### PR DESCRIPTION
**Row 1.2 of the 3.0 deprecation checklist turns out to be a KEEP.** No capability is removed here — the row
moves to section 4, and this PR records why, because the reasoning is worth more than the deletion would
have been.

## Why it looked like a removal

On MCP, omitting `space` searches every accessible space. So `crossSpace: true` read as a second spelling of
one idea — and `space` present *with* `crossSpace: true` had to pick a winner, which is the shape of a
redundant parameter.

## Why it is not

Removing it from the tool turned `mcp-rest-parity`'s `find-similar ↔ find_similar` case **red**.

The REST route is `POST /api/brain/spaces/:spaceId/find-similar` — the space is in the **path**. "Omit the
space" is not expressible there, so `crossSpace: true` is REST's only route to the same capability. Dropping
it on one door alone is precisely the parameter-level divergence that gate exists to catch, and CLAUDE.md
names it as the half that hides:

> A capability present on both surfaces still violates the rule if one door accepts less.

I reverted the removal rather than adjusting the gate.

## What was actually wrong

The **schema description**, which called it `DEPRECATED — omit \`space\` instead`.

An `inputSchema` description is what a caller reads while constructing arguments, and `help()` says so. A
caller who believed that sentence would design around an absence that is never going to arrive — the same
failure as the `recall` filter sentence aigents read and built a skill around, where the wrong surface was
the one being read.

It now states what the flag is for, that omitting `space` is the idiomatic MCP form, and that it is not
slated for removal.

## The gate assertion is reversed, not deleted

`mcp-tool-schemas.test.js` asserted `crossSpace must be marked deprecated`. It now requires the opposite:

- the description must **not** say DEPRECATED — that tells a caller to avoid a supported flag;
- it must still name the idiomatic **omit-`space`** form;
- it must say **why** the flag exists (the path), so the next reader does not file it as a duplicate again.

The reversal carries its reasoning inline. A gate that flips without one reads like somebody made it green.
