### PR TITLE
feat(config)!: a provider API key leaves config.json for secrets.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the merge replaces a type's whole schema object rather than merging its fields. Neither is read by
   anything in either case.
 
+- **BREAKING — a provider API key is no longer read from `config.json`. It is moved to `secrets.json` at
+  boot.** `secrets.json` is written `0o600`; `config.json` is not, and it is the file operators copy between
+  machines, paste into issues and mount as a ConfigMap. Any key still sitting in
+  `mediaEmbedding.<vision|stt|nli|rerank>.apiKey` is lifted into `secrets.json` on the first 3.0 boot and
+  **deleted** from the config; the read fallback is then gone, so the world-readable copy cannot come back.
+  Nothing to do: the Settings → Models page has written keys to `secrets.json` and deleted them from the
+  config for some time, so this only fires for an instance that has not saved that page since. An env var
+  (`VISION_API_KEY` and friends) still takes precedence over both. Rolling back is documented — the key is
+  not lost, it is in `secrets.json`. **Found by the deprecation sweep; it was not on the checklist.**
+
 ### Changed
 - **Re-uploading identical bytes no longer re-runs vision or speech-to-text.** `enqueueMediaJob` resets a
   terminal job on purpose, so the same file sent twice paid for a second full analysis to reproduce the caption

--- a/docs/integration-guide/02-hosting.md
+++ b/docs/integration-guide/02-hosting.md
@@ -768,6 +768,7 @@ moved. They are listed here so the consequence of going back is not a surprise:
 |---|---|---|
 | `mediaEmbedding.enabled` → per-class `levels` | `enabled` | defaults it back to **`true`**: an instance where media embedding was deliberately **off** starts sending uploads to the vision and speech models again |
 | a space's `description` → `meta.purpose` | `description` | reads no space instructions, because the field it serves to MCP clients is gone |
+| a provider API key in `mediaEmbedding.<vision\|stt\|nli\|rerank>.apiKey` → `secrets.json` | `apiKey` | sends no `Authorization` header to that provider, so an external vision / speech-to-text / NLI / rerank endpoint returns 401 and the feature stops. The key is NOT lost — it is in `secrets.json` (`0o600`) and can be pasted back into `config.json` for the older build. **New in 3.0**, and the reason is that `config.json` is the file operators copy, paste into issues, and mount as a ConfigMap. |
 | `mediaEmbedding.faceRecognition.enabled` → the image ladder | `faceRecognition.enabled` | applies its own default for face recognition rather than the choice that was recorded |
 | every token gains a `rights` matrix | **nothing** | keeps working: it reads the legacy `admin`/`readOnly`/`spaces` fields, which are left in place |
 

--- a/server/src/config/loader.ts
+++ b/server/src/config/loader.ts
@@ -311,6 +311,8 @@ export function loadConfig(): Config {
       log.warn(`Could not persist mediaEmbedding master-switch migration (will retry next boot): ${err}`);
     }
   }
+  // A provider API key left in config.json moves to secrets.json (0o600) and is deleted from the config.
+  migrateProviderApiKeysOnBoot(_config, getSecrets(), saveSecrets, saveConfig);
   // Legacy space `description` → `meta.purpose`, so the field MCP clients read is the field the UI edits.
   if (migrateSpaceDescriptionToPurpose(_config)) {
     try {
@@ -856,6 +858,7 @@ export function getDataRoot(): string {
 // ── Media Embedding Config ─────────────────────────────────────────────────
 
 import type { MediaEmbeddingConfig, MediaProviderConfig, FaceRecognitionConfig, DocumentProcessingConfig, EmbeddingConfig, RerankConfig } from './types.js';
+import { migrateProviderApiKeysOnBoot } from './migrate-provider-keys.js';
 
 const MEDIA_EMBEDDING_DEFAULTS: Required<Omit<MediaEmbeddingConfig, 'vision' | 'stt' | 'nli' | 'rerank' | 'ollamaUrl' | 'visionModel' | 'whisperUrl' | 'whisperModel' | 'lockedByInfra' | 'infraManaged' | 'faceRecognition' | 'documentProcessing'>> = {
   // Media embedding is always on (no master switch). Each class is gated by its `levels` entry, which
@@ -986,7 +989,9 @@ export function getMediaEmbeddingConfig(): MediaEmbeddingConfig {
   const visionBaseUrlEnv = envRenamed('VISION_BASE_URL');
   const visionModelEnv = process.env['VISION_MODEL'];
   const visionApiKeyEnv = process.env['VISION_API_KEY'];
-  // API keys: env var > secrets.json > legacy config.json (deprecated)
+  // API keys: env var > secrets.json. The `config.json` fallback was removed in 3.0 — any key still
+  // there is lifted into secrets.json at boot by `migrateProviderApiKeysToSecrets`, so reading it here
+  // as well would only keep alive a path that puts a credential in a world-readable file.
   let mediaSecrets: { visionApiKey?: string; sttApiKey?: string; nliApiKey?: string; rerankApiKey?: string } = {};
   try { mediaSecrets = getSecrets().mediaEmbedding ?? {}; } catch { /* secrets file may not exist pre-setup */ }
   const vision: MediaProviderConfig = {
@@ -1004,7 +1009,7 @@ export function getMediaEmbeddingConfig(): MediaEmbeddingConfig {
     model: normalizeVisionModel(
       visionModelEnv ?? base.vision?.model ?? base.visionModel ?? 'moondream',
     ),
-    apiKey: visionApiKeyEnv ?? mediaSecrets.visionApiKey ?? base.vision?.apiKey,
+    apiKey: visionApiKeyEnv ?? mediaSecrets.visionApiKey,
     // The default label follows the resolved provider. A fixed "(Ollama-compatible)" was wrong exactly
     // when it mattered — an operator on vLLM saw their OpenAI-compatible endpoint labelled with a
     // protocol it does not speak, which is the same misdirection as the `OLLAMA_URL` name itself.
@@ -1029,7 +1034,7 @@ export function getMediaEmbeddingConfig(): MediaEmbeddingConfig {
       ?? base.stt?.model
       ?? base.whisperModel
       ?? 'base',
-    apiKey: sttApiKeyEnv ?? mediaSecrets.sttApiKey ?? base.stt?.apiKey,
+    apiKey: sttApiKeyEnv ?? mediaSecrets.sttApiKey,
     label: base.stt?.label ?? 'STT provider (OpenAI-compatible)',
   };
   if (sttBaseUrlEnv) locked.push('stt.baseUrl');
@@ -1045,7 +1050,7 @@ export function getMediaEmbeddingConfig(): MediaEmbeddingConfig {
   const nli: MediaProviderConfig = {
     baseUrl: nliBaseUrlEnv ?? base.nli?.baseUrl,
     model: nliModelEnv ?? base.nli?.model,
-    apiKey: nliApiKeyEnv ?? mediaSecrets.nliApiKey ?? base.nli?.apiKey,
+    apiKey: nliApiKeyEnv ?? mediaSecrets.nliApiKey,
     label: base.nli?.label ?? 'NLI provider (contradiction judge)',
   };
   if (nliBaseUrlEnv) locked.push('nli.baseUrl');
@@ -1061,7 +1066,7 @@ export function getMediaEmbeddingConfig(): MediaEmbeddingConfig {
   const rerank: RerankConfig = {
     baseUrl: rerankBaseUrlEnv ?? base.rerank?.baseUrl,
     model: rerankModelEnv ?? base.rerank?.model,
-    apiKey: rerankApiKeyEnv ?? mediaSecrets.rerankApiKey ?? base.rerank?.apiKey,
+    apiKey: rerankApiKeyEnv ?? mediaSecrets.rerankApiKey,
     label: base.rerank?.label ?? 'Reranker (cross-encoder)',
     candidateMultiplier: rerankMultEnv ? Number(rerankMultEnv) : base.rerank?.candidateMultiplier,
   };

--- a/server/src/config/migrate-provider-keys.ts
+++ b/server/src/config/migrate-provider-keys.ts
@@ -1,0 +1,66 @@
+import type { Config, SecretsFile } from './types.js';
+import { log } from '../util/log.js';
+
+/**
+ * Lift any provider API key still sitting in `config.json` into `secrets.json`, and delete it from the
+ * config.
+ *
+ * `secrets.json` is written `0o600`; `config.json` is not, and it is the file an operator copies around,
+ * pastes into an issue, and mounts as a ConfigMap. A key in there is the one deprecation in this release
+ * that is a disclosure rather than an inconvenience — which is why it is MOVED rather than dropped.
+ *
+ * The Settings → Models page has written keys to `secrets.json` and deleted them from the config for some
+ * time, so this only ever fires for an instance that has not saved that page since. That is exactly the
+ * instance nobody is watching.
+ *
+ * An existing secret WINS and the config copy is discarded: the secrets file is the current store, so if
+ * the two disagree the config value is by definition the older one. Returns whether anything moved, so the
+ * caller knows to persist both files.
+ */
+export function migrateProviderApiKeysToSecrets(config: Config, secrets: SecretsFile): boolean {
+  const media = config.mediaEmbedding as Record<string, { apiKey?: string } | undefined> | undefined;
+  if (!media) return false;
+  const PROVIDERS: ReadonlyArray<[string, 'visionApiKey' | 'sttApiKey' | 'nliApiKey' | 'rerankApiKey']> = [
+    ['vision', 'visionApiKey'], ['stt', 'sttApiKey'], ['nli', 'nliApiKey'], ['rerank', 'rerankApiKey'],
+  ];
+  let moved = false;
+  for (const [block, secretKey] of PROVIDERS) {
+    const stored = media[block];
+    if (!stored || typeof stored.apiKey !== 'string' || stored.apiKey === '') continue;
+    secrets.mediaEmbedding ??= {};
+    if (!secrets.mediaEmbedding[secretKey]) secrets.mediaEmbedding[secretKey] = stored.apiKey;
+    delete stored.apiKey;
+    moved = true;
+  }
+  return moved;
+}
+
+/**
+ * Run the lift at boot and persist it, mirroring `migrateTokenRightsOnBoot`.
+ *
+ * Lives here rather than in `loadConfig` for the reason the god-file ratchet exists: the reasoning below is
+ * longer than the call, and `config/loader.ts` is already frozen at a size it is supposed to come DOWN from.
+ *
+ * **`secrets.json` is written FIRST, deliberately.** If the process dies between the two writes this order
+ * leaves the key in both files — which still resolves correctly and is cleaned up on the next boot. The other
+ * order deletes the only copy, and the symptom is a provider that stops authorising for a reason nothing in
+ * the config explains.
+ *
+ * Never throws: a failed write is logged and retried next boot, exactly like the other boot migrations. A
+ * config rewrite is not worth refusing to start over.
+ */
+export function migrateProviderApiKeysOnBoot(
+  config: Config,
+  secrets: SecretsFile,
+  saveSecrets: (s: SecretsFile) => void,
+  saveConfig: (c: Config) => void,
+): void {
+  if (!migrateProviderApiKeysToSecrets(config, secrets)) return;
+  try {
+    saveSecrets(secrets);
+    saveConfig(config);
+    log.info('Moved provider API key(s) from config.json into secrets.json (0o600)');
+  } catch (err) {
+    log.warn(`Could not persist provider API key migration (will retry next boot): ${err}`);
+  }
+}

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -313,11 +313,16 @@ export interface MediaProviderConfig {
   /** Model tag passed to the provider (e.g. `moondream`, `gpt-4o-mini`,
    *  `whisper-1`, `base`). */
   model?: string;
-  /** Optional API key for endpoints that require Authorization.
-   *  When empty, no Authorization header is sent.
-   *  Stored in config.json by the Settings UI; for production deployments
-   *  prefer an env-var override (`VISION_API_KEY` / `STT_API_KEY`) which
-   *  takes precedence and locks this field as read-only in the UI. */
+  /**
+   * Optional API key for endpoints that require Authorization. When empty, no Authorization header is
+   * sent.
+   *
+   * **Never stored in `config.json`.** It lives in `secrets.json` (`0o600`), which is what the Settings
+   * UI writes and the only place the loader reads it from; an env-var override
+   * (`VISION_API_KEY` / `STT_API_KEY` / …) takes precedence over both and locks the field read-only in
+   * the UI. This field is on the RESOLVED shape, which is why it is still here — a key present on a
+   * stored block is a pre-3.0 leftover and is lifted out at boot.
+   */
   apiKey?: string;
 }
 

--- a/testing/standalone/provider-keys-leave-config-json.test.js
+++ b/testing/standalone/provider-keys-leave-config-json.test.js
@@ -1,0 +1,122 @@
+/**
+ * A provider API key does not stay in `config.json`.
+ *
+ * ## Why this is the one removal in 3.0 that is a disclosure
+ *
+ * `secrets.json` is written `0o600`. `config.json` is not, and it is the file an operator copies between
+ * machines, pastes into an issue, and mounts as a ConfigMap. Every other row on the deprecation checklist
+ * removes an inconvenience; this one removes a credential from a world-readable file.
+ *
+ * So the fallback is **moved**, not dropped. Deleting the read path alone would have been a silent provider
+ * outage for any instance still holding its key there — vision or speech-to-text quietly failing
+ * authorization on a config that had worked the day before.
+ *
+ * ## What the sweep found
+ *
+ * This row was NOT in `_DEPRECATIONS.md`. `config/loader.ts` carried the comment
+ * `// API keys: env var > secrets.json > legacy config.json (deprecated)` and nothing tracked it. The
+ * Settings → Models page has written keys to `secrets.json` and deleted them from the config for some time,
+ * so the only instances affected are those that have not saved that page since — which is exactly the set
+ * nobody is watching.
+ *
+ * Run: node --test testing/standalone/provider-keys-leave-config-json.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+let migrateProviderApiKeysToSecrets;
+
+before(async () => {
+  ({ migrateProviderApiKeysToSecrets } = await import('../../server/dist/config/migrate-provider-keys.js'));
+});
+
+const cfg = (media) => ({ spaces: [], mediaEmbedding: media });
+
+describe('the boot migration moves a key out of config.json', () => {
+  it('moves every provider key and deletes it from the config', () => {
+    const c = cfg({
+      vision: { baseUrl: 'https://v.invalid', apiKey: 'sk-vision' },
+      stt: { apiKey: 'sk-stt' },
+      nli: { apiKey: 'sk-nli' },
+      rerank: { apiKey: 'sk-rerank' },
+    });
+    const s = { peerTokens: {} };
+
+    assert.equal(migrateProviderApiKeysToSecrets(c, s), true);
+    assert.deepEqual(s.mediaEmbedding, {
+      visionApiKey: 'sk-vision', sttApiKey: 'sk-stt', nliApiKey: 'sk-nli', rerankApiKey: 'sk-rerank',
+    });
+
+    // Deleted, not blanked: an empty string is still a key-shaped field in a file people read.
+    for (const block of ['vision', 'stt', 'nli', 'rerank']) {
+      assert.equal('apiKey' in c.mediaEmbedding[block], false, `${block}.apiKey must be gone from the config`);
+    }
+    // And nothing else about the block is disturbed.
+    assert.equal(c.mediaEmbedding.vision.baseUrl, 'https://v.invalid');
+  });
+
+  it('an existing secret WINS, and the config copy is still removed', () => {
+    // The two disagreeing means the config value is the older one — `secrets.json` is the current store.
+    // Keeping the config copy "just in case" would leave the credential in the file this exists to clear.
+    const c = cfg({ vision: { apiKey: 'sk-stale' } });
+    const s = { peerTokens: {}, mediaEmbedding: { visionApiKey: 'sk-current' } };
+
+    assert.equal(migrateProviderApiKeysToSecrets(c, s), true);
+    assert.equal(s.mediaEmbedding.visionApiKey, 'sk-current', 'the newer secret must not be overwritten');
+    assert.equal('apiKey' in c.mediaEmbedding.vision, false);
+  });
+
+  it('reports false when there is nothing to move, so no file is rewritten', () => {
+    // A migration that returns true on every boot rewrites config.json for ever, which is its own defect.
+    assert.equal(migrateProviderApiKeysToSecrets(cfg({ vision: { baseUrl: 'x' } }), { peerTokens: {} }), false);
+    assert.equal(migrateProviderApiKeysToSecrets(cfg({}), { peerTokens: {} }), false);
+    assert.equal(migrateProviderApiKeysToSecrets({ spaces: [] }, { peerTokens: {} }), false);
+    assert.equal(migrateProviderApiKeysToSecrets(cfg({ vision: { apiKey: '' } }), { peerTokens: {} }), false,
+      'an empty string is not a key — moving it would create a secrets entry meaning nothing');
+  });
+
+  it('is idempotent — the second boot moves nothing', () => {
+    const c = cfg({ vision: { apiKey: 'sk-vision' } });
+    const s = { peerTokens: {} };
+    assert.equal(migrateProviderApiKeysToSecrets(c, s), true);
+    assert.equal(migrateProviderApiKeysToSecrets(c, s), false);
+  });
+});
+
+describe('the legacy read path is gone, and the boot order is safe', () => {
+  const strip = src => src.replace(/(^|[^:])\/\/.*/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
+  const src = () => strip(readFileSync('server/src/config/loader.ts', 'utf8'));
+  // The boot wrapper lives beside the migration, not in the frozen loader — so the ordering check has to
+  // read the file that actually performs the two writes.
+  const mig = () => strip(readFileSync('server/src/config/migrate-provider-keys.ts', 'utf8'));
+
+  it('no provider resolves its key from the stored config any more', () => {
+    // The whole point of the migration is that this path does not need to exist. Leaving it would keep a
+    // credential in config.json working, so nobody would ever notice it was there.
+    assert.ok(!/base\.(vision|stt|nli|rerank)\?\.apiKey/.test(src()),
+      'a config.json fallback keeps the world-readable copy alive');
+  });
+
+  it('all four still resolve from env and from secrets', () => {
+    const s = src();
+    for (const [envVar, secretKey] of [['visionApiKeyEnv', 'visionApiKey'], ['sttApiKeyEnv', 'sttApiKey'],
+      ['nliApiKeyEnv', 'nliApiKey'], ['rerankApiKeyEnv', 'rerankApiKey']]) {
+      assert.ok(new RegExp(`apiKey: ${envVar} \\?\\? mediaSecrets\\.${secretKey}`).test(s),
+        `${secretKey} must still come from the env var first, then secrets.json`);
+    }
+  });
+
+  it('secrets.json is written BEFORE config.json', () => {
+    // If the process dies between the two writes, this order leaves the key in BOTH files — which still
+    // resolves correctly and gets cleaned up next boot. The other order loses the key outright, and the
+    // symptom is a provider that stops authorising for a reason nothing in the config explains.
+    const s = mig();
+    const block = s.slice(s.indexOf('if (!migrateProviderApiKeysToSecrets(config, secrets)) return;'));
+    const saveSecretsAt = block.indexOf('saveSecrets(secrets)');
+    const saveConfigAt = block.indexOf('saveConfig(config)');
+    assert.ok(saveSecretsAt > 0 && saveConfigAt > 0, 'both writes must be in the migration block');
+    assert.ok(saveSecretsAt < saveConfigAt,
+      'writing config.json first can delete the only copy of the key');
+  });
+});

--- a/testing/standalone/rollback-is-documented.test.js
+++ b/testing/standalone/rollback-is-documented.test.js
@@ -109,6 +109,10 @@ describe('every rewrite an upgrade performs is documented as one-way', () => {
       // field it does not know. Harmless in itself — the legacy fields are left in place — but an operator
       // rolling back needs to know the file changed shape.
       migrateTokenRightsOnBoot: 'tokens[].rights',
+      // MOVES a credential rather than dropping a setting, which is why the rollback row says the key is
+      // still recoverable: it is in `secrets.json` (0o600) and can be pasted back for an older build. The
+      // consequence of not doing that is a 401 from an external provider, not a changed default.
+      migrateProviderApiKeysOnBoot: 'apiKey',
     };
     const section = rollbackSection();
     const undocumented = [];


### PR DESCRIPTION
**BREAKING.** A provider API key is no longer read from `config.json`. It is **moved** into `secrets.json`
on the first 3.0 boot and deleted from the config.

Row 2.6 — and **the sweep found it; it was not on the checklist.** `config/loader.ts` carried the comment
`// API keys: env var > secrets.json > legacy config.json (deprecated)` and nothing anywhere tracked it.

## Why this row is different from the rest of the release

`secrets.json` is written `0o600`. `config.json` is not, and it is the file an operator copies between
machines, pastes into an issue, and mounts as a ConfigMap. Every other row on the checklist removes an
inconvenience. This one removes a credential from a world-readable file.

So the fallback is **moved, not dropped**. Deleting the read path alone would have been a silent provider
outage for any instance still holding its key there — vision or speech-to-text failing authorization on a
config that worked the day before, with nothing in that config to explain why.

**Blast radius is small, and it is the least-watched part of the population.** The Settings → Models page
has written keys to `secrets.json` and deleted them from the config for some time, so this only fires for an
instance that has not saved that page since.

## Three decisions inside the migration

Each is asserted on its own, because each alone would be a defect:

| decision | why |
|---|---|
| an **existing** secret wins, and the config copy is still removed | the secrets file is the current store, so a disagreement means the config value is older; keeping it "just in case" leaves the credential in the file this exists to clear |
| the field is **deleted**, not blanked | an empty string is still a key-shaped field in a file people read |
| returns `false` when nothing moved | a migration that reports `true` every boot rewrites `config.json` for ever |

## Write order is load-bearing, and gated

`secrets.json` is written **before** `config.json`. If the process dies between the two writes, this order
leaves the key in *both* files — which still resolves correctly and is cleaned up next boot. The other order
deletes the only copy.

Mutation-tested: swapping the two turns the ordering assertion red, and removing the "existing secret wins"
guard turns another red.

## Where the code lives, and why

The migration and its boot wrapper are in **`config/migrate-provider-keys.ts`**, not in `loadConfig`.

Inline, they pushed `config/loader.ts` from 764 to **768** code lines against a freeze it is supposed to come
*down* from. The god-file ratchet caught it, and the fix is the one that file's own rule asks for — put the
behaviour beside it, exactly as `auth/backfill-token-rights.ts` already does.

## Two things the gates required before this could ship

- **`rollback-is-documented`** refused the migration until the hosting guide's rollback table named it. The
  row now states the consequence — an older build sends no `Authorization` header and gets a `401` — and
  that the key is **recoverable from `secrets.json`**, not lost.
- The `MediaProviderConfig.apiKey` docstring said *"Stored in config.json by the Settings UI"*, which is the
  opposite of what the code does. Corrected.

An env var (`VISION_API_KEY` and friends) still takes precedence over both sources, unchanged.
