### PR TITLE
feat(mcp)!: the rights matrix is enforced on MCP, not just readOnly and admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   spelling would turn an upgrade into an outage.
 
 ### Changed
+- **BREAKING — MCP now enforces the per-space rights matrix, not just `readOnly` and `admin`.** This is the
+  S-1 fix. MCP gated on two booleans while REST enforced a per-space, per-area rung, so one policy had two
+  implementations and the weaker one was reachable — measured, not inferred: a token whose matrix said
+  `perSpace.general.knowledge = 'write'` was refused `DELETE /api/brain/spaces/general/memories/:id` with a
+  **403** and the identical delete through `delete_memory` answered *"Memory deleted"*. A tool call now
+  resolves the token's rung for the space it named and refuses with a message naming what was needed and
+  what the token holds. **A token that has been reaching a tool its matrix does not cover will start being
+  refused** — that is the point, and it is worth checking your token rungs before upgrading. The tool→rung
+  table is DERIVED from the route table, and a gate re-derives it and fails if the two disagree, so a
+  capability can no longer be priced differently depending on which door you use. Unchanged: tokens with no
+  matrix (the OIDC path builds a record per request) and instance-level tools, which are still governed by
+  `instanceAdmin` and the tool's `admin` flag.
 - **Re-uploading identical bytes no longer re-runs vision or speech-to-text.** `enqueueMediaJob` resets a
   terminal job on purpose, so the same file sent twice paid for a second full analysis to reproduce the caption
   it already had — the most expensive work this instance does. File records now carry the SHA-256 the writer

--- a/server/src/auth/space-rights.ts
+++ b/server/src/auth/space-rights.ts
@@ -206,6 +206,74 @@ export const ROUTE_RIGHTS: readonly RouteRight[] = [
  *
  * An empty exemption list would be the honest default; this one is not empty, so each entry says why.
  */
+
+/**
+ * What an MCP tool needs, in the same vocabulary the routes use.
+ *
+ * ## Why this table exists at all
+ *
+ * MCP gated on two BOOLEANS — `readOnly` and `admin` — while REST enforced a per-space, per-area rung. Same
+ * store, same policy, two enforcement models, and the weaker one was reachable: a token whose matrix said
+ * `knowledge: write` was refused `DELETE /memories/:id` over REST with a 403 and allowed the identical
+ * delete through `delete_memory`. That was measured against a running instance, not reasoned about.
+ *
+ * ## Why it is generated from ROUTE_RIGHTS rather than written
+ *
+ * A second hand-written copy of one rule is the defect this repo produces most. Every row below was DERIVED
+ * from the `ROUTE_RIGHTS` entry of the route that tool mirrors, using the capability map in
+ * `scripts/surface-matrix.mjs`, and `mcp-tool-rights.test.js` re-derives it and fails if the two disagree.
+ * So a rung changed on a route moves its tool in the same commit, or the gate goes red.
+ *
+ * A tool ABSENT from this table is instance-level: it is governed by the `admin` flag on the tool and by
+ * `instanceAdmin` on the token, not by a per-space rung, because the capability it maps to is not scoped to
+ * a space at all (`list_spaces`, `create_space`, `update_space`, `list_tokens`, `list_peers`, `sync_now`,
+ * `wipe_space`, `help`).
+ */
+export interface ToolRight {
+  tool: string;
+  area: SpaceArea;
+  needs: Rung;
+}
+
+export const TOOL_RIGHTS: readonly ToolRight[] = [
+  { tool: 'remember', area: 'knowledge', needs: 'write' },
+  { tool: 'update_memory', area: 'knowledge', needs: 'write' },
+  { tool: 'delete_memory', area: 'knowledge', needs: 'write' },
+  { tool: 'upsert_entity', area: 'knowledge', needs: 'write' },
+  { tool: 'update_entity', area: 'knowledge', needs: 'write' },
+  { tool: 'delete_entity', area: 'knowledge', needs: 'write' },
+  { tool: 'merge_entities', area: 'knowledge', needs: 'write' },
+  { tool: 'find_entities_by_name', area: 'knowledge', needs: 'read' },
+  { tool: 'upsert_edge', area: 'knowledge', needs: 'write' },
+  { tool: 'update_edge', area: 'knowledge', needs: 'write' },
+  { tool: 'delete_edge', area: 'knowledge', needs: 'write' },
+  { tool: 'create_chrono', area: 'knowledge', needs: 'write' },
+  { tool: 'update_chrono', area: 'knowledge', needs: 'write' },
+  { tool: 'delete_chrono', area: 'knowledge', needs: 'write' },
+  { tool: 'list_chrono', area: 'knowledge', needs: 'read' },
+  { tool: 'recall', area: 'knowledge', needs: 'read' },
+  { tool: 'query', area: 'knowledge', needs: 'read' },
+  { tool: 'find_similar', area: 'knowledge', needs: 'read' },
+  { tool: 'traverse', area: 'knowledge', needs: 'read' },
+  { tool: 'bulk_write', area: 'knowledge', needs: 'write' },
+  { tool: 'get_stats', area: 'knowledge', needs: 'read' },
+  { tool: 'er_model', area: 'knowledge', needs: 'read' },
+  { tool: 'reindex', area: 'schema', needs: 'admin' },
+  { tool: 'list_embed_jobs', area: 'knowledge', needs: 'read' },
+  { tool: 'retry_record_embedding', area: 'knowledge', needs: 'write' },
+  { tool: 'retry_failed_embeddings', area: 'files', needs: 'write' },
+  { tool: 'read_file', area: 'files', needs: 'read' },
+  { tool: 'write_file', area: 'files', needs: 'write' },
+  { tool: 'delete_file', area: 'files', needs: 'write' },
+  { tool: 'move_file', area: 'files', needs: 'write' },
+  { tool: 'list_dir', area: 'files', needs: 'read' },
+  { tool: 'create_dir', area: 'files', needs: 'write' },
+  { tool: 'retry_embedding', area: 'files', needs: 'write' },
+  { tool: 'update_file_meta', area: 'files', needs: 'write' },
+  { tool: 'get_space_meta', area: 'schema', needs: 'read' },
+  { tool: 'update_space_schema', area: 'schema', needs: 'write' },
+];
+
 export const NOT_AREA_SCOPED: readonly { route: string; why: string }[] = [
   {
     route: '/api/spaces/:id/rename',

--- a/server/src/mcp/router.ts
+++ b/server/src/mcp/router.ts
@@ -11,6 +11,7 @@ import { globalRateLimit } from '../rate-limit/middleware.js';
 import { getConfig } from '../config/loader.js';
 import { log } from '../util/log.js';
 import { reachesSpace } from '../auth/space-reach.js';
+import { toolRightsRefusal } from './tool-rights-guard.js';
 import type { TokenRights } from '../config/rights-shape.js';
 import { memberSpacesWithin } from '../spaces/proxy-scoped.js';
 import { ALL_TOOLS, TOOLS_BY_NAME, type ToolSchemas } from './tools/index.js';
@@ -215,6 +216,15 @@ function createGlobalMcpServer(tokenSpaces?: string[], readOnly?: boolean, isAdm
       const members = memberSpacesWithin(rawSpace, accessibleSpaceIds);
       if (members.length === 0) {
         return { content: [{ type: 'text' as const, text: `Error: token does not have access to '${rawSpace}' or any of its member spaces` }], isError: true };
+      }
+      // The rights matrix, enforced on MCP. Until 3.0 this dispatcher gated on two BOOLEANS — `readOnly`
+      // above, and the tool's `admin` flag — while REST enforced a per-space, per-area RUNG. One policy,
+      // two implementations, and the weaker one was reachable. The decision lives in a pure function so it
+      // can be exercised without a transport: a guard testable only by reading it is one whose test cannot
+      // tell live code from dead, and the first version of this check passed against `if (false && ...)`.
+      const rightsRefusal = toolRightsRefusal(name, rights, rawSpace);
+      if (rightsRefusal) {
+        return { content: [{ type: 'text' as const, text: rightsRefusal }], isError: true };
       }
     }
     const callSpace = rawSpace;

--- a/server/src/mcp/tool-rights-guard.ts
+++ b/server/src/mcp/tool-rights-guard.ts
@@ -1,0 +1,50 @@
+import { TOOL_RIGHTS } from '../auth/space-rights.js';
+import { effectiveRung } from '../auth/mint-cap.js';
+import { satisfies } from '../auth/required-rung.js';
+import type { TokenRights } from '../config/rights-shape.js';
+
+/**
+ * Does this token hold the rung this tool needs, in this space?
+ *
+ * Returns the refusal TEXT, or `null` to allow — so the dispatcher's job is one line and this decision can
+ * be exercised without standing up an MCP server. Pure on purpose, for the same reason
+ * `resolveFindSimilarScope` is: a guard that can only be tested through a transport gets tested by reading
+ * it, and a source-reading test cannot tell live code from dead. The first version of this check WAS a
+ * source grep, and it passed against `if (false && !satisfies(...))`.
+ *
+ * ## What it is fixing
+ *
+ * Until 3.0 the MCP dispatcher gated on two booleans — `readOnly`, and the tool's `admin` flag — while REST
+ * enforced a per-space, per-area rung. One policy, two implementations, and the weaker one was reachable.
+ * Measured, not inferred: a token whose matrix said `perSpace.general.knowledge = 'write'` was refused
+ * `DELETE /api/brain/spaces/general/memories/:id` with a 403, and the identical delete through
+ * `delete_memory` answered "Memory deleted".
+ *
+ * ## The two ways it deliberately does nothing
+ *
+ * - **No rights matrix.** Every token created since 2.9 carries one and a boot migration backfills the
+ *   rest, so in practice this is the OIDC path, where the record is built per request from the identity
+ *   and legitimately has none. Those are still governed by `readOnly` and the `admin` flag.
+ * - **No row for the tool.** It is instance-level — `list_spaces`, `create_space`, `list_tokens`,
+ *   `list_peers`, `sync_now`, `wipe_space`, `help` — and governed by the tool's `admin` flag against
+ *   `instanceAdmin`, because the capability is not scoped to a space at all.
+ *
+ * The space is the one the CALLER named. For a proxy that is the proxy's own id, which is where an operator
+ * grants access to a proxy; narrowing to members happens inside the tools. Checking a member here would let
+ * a proxy grant be bypassed by naming the member instead.
+ */
+export function toolRightsRefusal(
+  toolName: string,
+  rights: TokenRights | undefined,
+  space: string,
+): string | null {
+  if (!rights || !space) return null;
+  const need = TOOL_RIGHTS.find(r => r.tool === toolName);
+  if (!need) return null;
+
+  const held = effectiveRung(rights, space, need.area);
+  if (satisfies(held, need.needs)) return null;
+
+  return `Error: tool '${toolName}' needs ${need.area}: ${need.needs} on space '${space}'; `
+    + `this token holds ${need.area}: ${held}`;
+}

--- a/testing/standalone/mcp-tool-rights.test.js
+++ b/testing/standalone/mcp-tool-rights.test.js
@@ -1,0 +1,158 @@
+/**
+ * MCP enforces the rights matrix, using the ROUTE's own requirement rather than a second opinion about it.
+ *
+ * ## The defect
+ *
+ * Until 3.0 the MCP dispatcher gated on two BOOLEANS — `readOnly`, and the tool's `admin` flag — while REST
+ * enforced a per-space, per-area RUNG through `effectiveRung`/`satisfies`. One policy, two implementations,
+ * and the weaker one was reachable.
+ *
+ * That is not a reading of the code. It was measured against a running instance: a token whose matrix said
+ * `perSpace.general.knowledge = 'write'` was refused `DELETE /api/brain/spaces/general/memories/:id` with a
+ * **403**, and the identical delete through the `delete_memory` tool answered **"Memory deleted"**.
+ *
+ * ## Why the table is derived and not written
+ *
+ * A second hand-written copy of one rule is the defect this repo produces most — a proxy lens computed and
+ * discarded on three routes, an empty allowlist read as unrestricted on three more. So `TOOL_RIGHTS` is
+ * DERIVED from `ROUTE_RIGHTS` via the capability map, and this file re-derives it independently and fails if
+ * the two disagree. A rung changed on a route moves its tool in the same commit, or this goes red.
+ *
+ * Run: node --test testing/standalone/mcp-tool-rights.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+let TOOL_RIGHTS, ROUTE_RIGHTS, ALL_TOOLS, effectiveRung, satisfies, toolRightsRefusal;
+
+/** The capability map: one MCP tool and the REST route that does the same thing. */
+function capabilityMap() {
+  const src = readFileSync('scripts/surface-matrix.mjs', 'utf8');
+  const at = src.indexOf('const MAP = [');
+  assert.ok(at > 0, 'the capability map moved — this gate derives its expectations from it');
+  const body = src.slice(at, src.indexOf('];', at) + 2).replace('const MAP =', '');
+  // eslint-disable-next-line no-eval
+  return eval(body);
+}
+
+before(async () => {
+  ({ TOOL_RIGHTS, ROUTE_RIGHTS } = await import('../../server/dist/auth/space-rights.js'));
+  ({ ALL_TOOLS } = await import('../../server/dist/mcp/tools/index.js'));
+  ({ effectiveRung } = await import('../../server/dist/auth/mint-cap.js'));
+  ({ satisfies } = await import('../../server/dist/auth/required-rung.js'));
+  ({ toolRightsRefusal } = await import('../../server/dist/mcp/tool-rights-guard.js'));
+});
+
+describe('TOOL_RIGHTS agrees with ROUTE_RIGHTS, row for row', () => {
+  it('every area-scoped tool needs exactly what its route needs', () => {
+    const byRoute = new Map(ROUTE_RIGHTS.map(r => [`${r.method} ${r.route}`, r]));
+    const byTool = new Map(TOOL_RIGHTS.map(r => [r.tool, r]));
+    const disagreements = [];
+
+    for (const [, tool, route] of capabilityMap()) {
+      if (!route) continue;                       // instance-level: no space, no area
+      const expected = byRoute.get(route);
+      if (!expected) continue;                    // not area-scoped (spaces/tokens/networks CRUD)
+      const actual = byTool.get(tool);
+      if (!actual) {
+        disagreements.push(`${tool}: absent from TOOL_RIGHTS but its route ${route} is area-scoped`);
+        continue;
+      }
+      if (actual.area !== expected.area || actual.needs !== expected.needs) {
+        disagreements.push(
+          `${tool}: holds ${actual.area}:${actual.needs}, route ${route} needs ${expected.area}:${expected.needs}`);
+      }
+    }
+    assert.deepEqual(disagreements, [],
+      'one capability priced differently depending on which door the caller picked');
+  });
+
+  it('names only tools that exist', () => {
+    // A row for a renamed or deleted tool enforces nothing and reads like coverage.
+    const live = new Set(ALL_TOOLS.map(t => t.name));
+    const ghosts = TOOL_RIGHTS.filter(r => !live.has(r.tool)).map(r => r.tool);
+    assert.deepEqual(ghosts, []);
+  });
+
+  it('covers every tool that takes a space', () => {
+    // `spaceRequired` is the tool's own statement that it operates inside one space, so it is the honest
+    // definition of "must be area-scoped" — independent of the map this file derives its rungs from, so
+    // the two cannot be wrong together.
+    const covered = new Set(TOOL_RIGHTS.map(r => r.tool));
+    const uncovered = ALL_TOOLS
+      .filter(t => t.spaceRequired && !covered.has(t.name) && !t.admin)
+      .map(t => t.name);
+    assert.deepEqual(uncovered, [],
+      'a space-scoped tool with no rights row is ungoverned on MCP');
+  });
+});
+
+describe('the guard REFUSES and ALLOWS — behaviourally, not by reading the source', () => {
+  // The first version of this block was a source grep, and it SURVIVED a mutation that made the refusal
+  // unreachable (`if (false && !satisfies(...))`) — the strings it matched were still there. That is why the
+  // decision was moved into a pure function: this now runs the code instead of reading it.
+  const rights = over => ({ instanceAdmin: false, createSpaces: false, floor: 'none', perSpace: {}, ...over });
+
+  it('refuses a delete the token only holds write-below-admin for', () => {
+    // Nothing to refuse at `write`, since S-1 levelled single-record deletes DOWN to write.
+    const r = rights({ perSpace: { general: { knowledge: 'read' } } });
+    const refusal = toolRightsRefusal('delete_memory', r, 'general');
+    assert.ok(refusal, 'read must not reach a delete');
+    assert.match(refusal, /knowledge: write/, 'the refusal must name what was needed');
+    assert.match(refusal, /holds knowledge: read/, 'and what the token actually holds');
+  });
+
+  it('allows the same call once the rung is there', () => {
+    assert.equal(toolRightsRefusal('delete_memory', rights({ perSpace: { general: { knowledge: 'write' } } }), 'general'), null);
+  });
+
+  it('a grant in one space does not carry into another', () => {
+    const r = rights({ perSpace: { general: { knowledge: 'admin' } } });
+    assert.ok(toolRightsRefusal('remember', r, 'other'), 'a per-space grant is per space');
+  });
+
+  it('areas do not leak into each other', () => {
+    // `files: admin` must not buy a knowledge write. Separate areas is the whole point of the matrix.
+    const r = rights({ perSpace: { general: { files: 'admin' } } });
+    assert.ok(toolRightsRefusal('remember', r, 'general'));
+    assert.equal(toolRightsRefusal('write_file', r, 'general'), null);
+  });
+
+  it('does nothing for a token with no matrix, or a tool with no row', () => {
+    // Both are deliberate pass-throughs, and both would be a silent authorisation hole if they were not
+    // stated: OIDC records carry no matrix, and instance-level tools are governed by `instanceAdmin`.
+    assert.equal(toolRightsRefusal('delete_memory', undefined, 'general'), null);
+    assert.equal(toolRightsRefusal('list_spaces', rights({ floor: 'none' }), 'general'), null);
+    assert.equal(toolRightsRefusal('delete_memory', rights({ floor: 'none' }), ''), null);
+  });
+
+  it('the dispatcher RETURNS the refusal rather than computing and dropping it', () => {
+    // A lens computed and discarded is this repo's signature defect — it happened on three routes at once.
+    const src = readFileSync('server/src/mcp/router.ts', 'utf8')
+      .replace(/(^|[^:])\/\/.*/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
+    assert.match(src, /const rightsRefusal = toolRightsRefusal\(name, rights, rawSpace\);/);
+    assert.match(src, /if \(rightsRefusal\) \{[\s\S]{0,160}?return \{[\s\S]{0,120}?text: rightsRefusal/);
+  });
+});
+
+describe('the rung comparison itself', () => {
+  const rights = over => ({ instanceAdmin: false, createSpaces: false, floor: 'none', perSpace: {}, ...over });
+
+  it('write does not satisfy admin, and admin satisfies write', () => {
+    assert.equal(satisfies('write', 'admin'), false);
+    assert.equal(satisfies('admin', 'write'), true);
+    assert.equal(satisfies('read', 'write'), false);
+    assert.equal(satisfies('write', 'read'), true);
+  });
+
+  it('a per-space grant is what the tool is measured against', () => {
+    const r = rights({ perSpace: { general: { knowledge: 'write' } } });
+    assert.equal(effectiveRung(r, 'general', 'knowledge'), 'write');
+    // The S-1 case in one line: this is the token that could delete over MCP and not over REST.
+    assert.equal(satisfies(effectiveRung(r, 'general', 'knowledge'), 'write'), true);
+    assert.equal(satisfies(effectiveRung(r, 'general', 'knowledge'), 'admin'), false);
+    // And it reaches nothing in a space it was not granted.
+    assert.equal(satisfies(effectiveRung(r, 'other', 'knowledge'), 'read'), false);
+  });
+});


### PR DESCRIPTION
**BREAKING.** An MCP tool call is now checked against the token's per-space, per-area rung. A token that has
been reaching a tool its matrix does not cover **will start being refused**.

This is **S-1**, and the first half of row 1.7 — the half that unblocks removing the legacy token fields.

## The defect, measured

MCP gated on two **booleans** — `readOnly`, and the tool's `admin` flag — while REST enforced a rung through
`effectiveRung`/`satisfies`. One policy, two implementations, and the weaker one was reachable.

Not a reading of the code. Measured against a running instance:

| same token, same record | result |
|---|---|
| `DELETE /api/brain/spaces/general/memories/:id` | **403** |
| `delete_memory` over MCP | **"Memory deleted"** |

The token's matrix said `perSpace.general.knowledge = 'write'`.

## The table is derived, not written

`TOOL_RIGHTS` was **generated** from the `ROUTE_RIGHTS` entry of the route each tool mirrors, using the
capability map in `scripts/surface-matrix.mjs`. The gate re-derives it independently and fails if the two
disagree — so a rung changed on a route moves its tool **in the same commit**, or the build goes red.

A second hand-written copy of one rule is the defect this repo produces most.

**36 tools are area-scoped. Eight are not, and that is stated rather than left as an absence:**
`list_spaces`, `create_space`, `update_space`, `list_tokens`, `list_peers`, `sync_now`, `wipe_space`, `help`
map to capabilities that are not scoped to a space at all, and stay governed by `instanceAdmin` and the
tool's `admin` flag.

## The guard is a pure function, and that is not a style choice

The first version was inline in the dispatcher with a source-reading test. **That test survived a mutation
that made the refusal unreachable** — `if (false && !satisfies(...))` — because the strings it matched were
still there.

A guard testable only by reading it has a test that cannot tell live code from dead. `toolRightsRefusal` is
now exercised directly:

- refuses at too low a rung, with a message naming what was needed **and** what the token holds;
- allows once the rung is there;
- does not carry a grant from one space into another;
- does not let `files: admin` buy a knowledge write.

The same mutation now **kills three tests**.

One source assertion remains, and it is the one worth keeping: that the dispatcher **returns** the refusal
rather than computing and dropping it. A lens computed and discarded is this repo's signature defect — it
happened on three routes at once.

## Two deliberate pass-throughs

Both are stated in source, because either would otherwise read as a hole:

- **a token with no matrix** — the OIDC path builds its record per request from the identity. Still governed
  by `readOnly` and the `admin` flag.
- **a tool with no row** — instance-level, governed by `instanceAdmin`.

## Scope note

The rung is checked against the space the **caller named**. For a proxy that is the proxy's own id, which is
where an operator grants proxy access; narrowing to members happens inside the tools. Checking a member here
would let a proxy grant be bypassed by naming the member instead.

Dropping the legacy `admin`/`readOnly`/`spaces` fields is **D-8b**, now unblocked — the OIDC path still
writes them.
