### PR TITLE
fix(auth): an OIDC identity is governed by the rights matrix too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   every type.
 
 ### Changed
+- **An OIDC identity is now governed by the rights matrix too, not just `readOnly` and `admin`.** The S-1
+  fix made MCP enforce the per-space, per-area rung — and that guard skips a token with no matrix, which
+  every OIDC record was. So the fix covered PATs and left OIDC on the old booleans: one policy with two
+  implementations, on the surface nobody had checked, which is the same shape as the defect it was fixing one
+  authentication method over. An OIDC record now derives its matrix from the same `migrateToken` the boot
+  migration uses, so a claim-mapped identity and a PAT with the same grants are priced identically. Nothing
+  is stored and nothing migrates — the record was always built per request. **An OIDC identity whose claims
+  do not cover a tool will now be refused it over MCP**, which is the point.
 - **BREAKING — MCP now enforces the per-space rights matrix, not just `readOnly` and `admin`.** This is the
   S-1 fix. MCP gated on two booleans while REST enforced a per-space, per-area rung, so one policy had two
   implementations and the weaker one was reachable — measured, not inferred: a token whose matrix said

--- a/server/src/auth/oidc.ts
+++ b/server/src/auth/oidc.ts
@@ -19,6 +19,8 @@ import { allowPrivateOidcIssuer } from '../config/oidc-egress-policy.js';
 import { log } from '../util/log.js';
 import { isSsrfSafeUrl, ssrfSafeFetch, SsrfBlockedError } from '../util/ssrf.js';
 import type { OidcConfig, OidcClaimRule, OidcClaimMapping } from '../config/types.js';
+import { migrateToken } from './rights-migration.js';
+import type { TokenRights } from '../config/rights-shape.js';
 
 /**
  * JWS algorithms accepted for OIDC ID tokens unless `oidc.allowedAlgorithms`
@@ -107,6 +109,19 @@ export interface OidcTokenRecord {
   admin: boolean;
   readOnly?: boolean;
   spaces?: string[];
+  /**
+   * The same rights matrix a PAT carries, derived from the three fields above by `migrateToken` — the very
+   * function the boot migration uses, so an OIDC identity and a PAT with the same claims are governed by
+   * one mapping rather than two.
+   *
+   * It was absent until 3.0, and that absence was a hole rather than a gap: the MCP rights guard skips a
+   * token with no matrix, so every OIDC connection fell back to the old `readOnly`/`admin` booleans while
+   * PATs were enforced per space and per area. The whole point of S-1 was that one policy should not have
+   * two implementations, and this was the third.
+   *
+   * Built per request, like the rest of this record — nothing is stored, so there is nothing to migrate.
+   */
+  rights: TokenRights;
   // Distinguish from PAT records for logging / introspection
   source: 'oidc';
 }
@@ -419,6 +434,14 @@ export async function validateOidcJwt(bearer: string): Promise<OidcTokenRecord |
       admin: perms.admin,
       readOnly: perms.readOnly,
       spaces: perms.spaces,
+      // Derived, never hand-rolled. `migrateToken` already encodes the decisions this mapping needs —
+      // `spaces` ABSENT means every space (a floor) while `spaces: []` reaches nothing, and that
+      // distinction is the one that granted whole instances when it was got wrong before.
+      rights: migrateToken({
+        admin: perms.admin,
+        readOnly: perms.readOnly ?? false,
+        ...(perms.spaces ? { spaces: perms.spaces } : {}),
+      }) as unknown as TokenRights,
       source: 'oidc',
     };
   } catch (err) {

--- a/server/src/mcp/router.ts
+++ b/server/src/mcp/router.ts
@@ -61,9 +61,15 @@ function sessionTag(sessionId: string): string {
 /**
  * The rights off a token record, or `undefined` for one that has none.
  *
- * A cast because `OidcTokenRecord` has no `rights` field: those tokens are built per request from the identity
- * provider and the config backfill never sees them. `undefined` here is the signal to fall back to the legacy
- * allowlist, which is the same answer that path has always given — not a weaker one.
+ * A cast because the record is a UNION and the narrowing cannot be expressed on it. Both arms now carry a
+ * matrix: a PAT stores one (`createToken` always writes it, and a boot migration backfills the rest), and as
+ * of 3.0 an OIDC record derives one per request from the same `migrateToken` the migration uses.
+ *
+ * That second half was a hole rather than a gap. The rights guard skips a token with no matrix, so every OIDC
+ * connection was governed by the old `readOnly`/`admin` booleans while PATs were enforced per space and per
+ * area — one policy with two implementations, which is what S-1 was about, on the surface nobody checked.
+ *
+ * `undefined` therefore now means a record shape that predates both, not "the OIDC path".
  *
  * The same cast appears at every other rights call site (`middleware.ts`, the three `accessibleSpaces` helpers). It is
  * a narrowing the union cannot express, and writing it once here keeps this file from repeating it per transport.

--- a/testing/standalone/oidc-carries-a-rights-matrix.test.js
+++ b/testing/standalone/oidc-carries-a-rights-matrix.test.js
@@ -1,0 +1,101 @@
+/**
+ * An OIDC identity is governed by the same rights matrix a PAT is.
+ *
+ * ## The hole this closes
+ *
+ * 3.0 made MCP enforce the per-space, per-area rung (S-1). That guard **skips a token with no matrix** — a
+ * deliberate pass-through, documented as "the OIDC path builds its record per request from the identity".
+ *
+ * Which means the S-1 fix covered PATs and left OIDC on the old `readOnly`/`admin` booleans. One policy,
+ * two implementations, on the surface nobody had checked — the same shape as the defect it was fixing, one
+ * authentication method over. Fixing MCP for PATs and calling S-1 done would have been the half-fix this
+ * repo keeps producing.
+ *
+ * ## Why it derives rather than maps its own
+ *
+ * `migrateToken` already encodes the decisions this needs, and two of them are the ones that granted whole
+ * instances when they were got wrong: `spaces` **absent** means every space (a floor), while `spaces: []`
+ * reaches **nothing**. A second hand-rolled claims→rungs mapping would be a fresh chance to confuse those.
+ *
+ * Nothing is stored, so nothing migrates: the record is built per request either way.
+ *
+ * Run: node --test testing/standalone/oidc-carries-a-rights-matrix.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+let migrateToken, toolRightsRefusal;
+
+before(async () => {
+  ({ migrateToken } = await import('../../server/dist/auth/rights-migration.js'));
+  ({ toolRightsRefusal } = await import('../../server/dist/mcp/tool-rights-guard.js'));
+});
+
+describe('the matrix an OIDC identity gets', () => {
+  it('an admin identity reaches an admin-rung capability', () => {
+    const rights = migrateToken({ admin: true, readOnly: false });
+    assert.equal(toolRightsRefusal('wipe_space', rights, 'general'), null,
+      'wipe_space carries no area row, so this also proves the instance-level pass-through still holds');
+    assert.equal(toolRightsRefusal('delete_memory', rights, 'general'), null);
+  });
+
+  it('a read-only identity is refused a write, where before it was refused only by the boolean', () => {
+    const rights = migrateToken({ admin: false, readOnly: true });
+    const refusal = toolRightsRefusal('remember', rights, 'general');
+    assert.ok(refusal, 'read-only must not reach a write through the matrix either');
+    assert.match(refusal, /knowledge: write/);
+  });
+
+  it('a scoped identity reaches its spaces and nothing else', () => {
+    const rights = migrateToken({ admin: false, readOnly: false, spaces: ['alpha'] });
+    assert.equal(toolRightsRefusal('remember', rights, 'alpha'), null);
+    assert.ok(toolRightsRefusal('remember', rights, 'beta'), 'a claim-granted allowlist is still an allowlist');
+  });
+
+  it('an EMPTY spaces claim reaches nothing — the widening that must not happen', () => {
+    // `mapOidcClaims` produces `spaces: []` when a `spaces` mapping is configured and the claim is missing
+    // or not an array. That is deny. Reading it as "absent, therefore all spaces" would turn the narrowest
+    // identity into the widest, which is the exact defect the migration's comments warn about.
+    const rights = migrateToken({ admin: false, readOnly: false, spaces: [] });
+    assert.ok(toolRightsRefusal('remember', rights, 'general'));
+    assert.ok(toolRightsRefusal('recall', rights, 'general'));
+  });
+
+  it('an ABSENT spaces claim is a floor, not a denial', () => {
+    // The other direction, and the two must not be conflated: no allowlist at all meant every space in the
+    // old model, including future ones.
+    const rights = migrateToken({ admin: false, readOnly: false });
+    assert.equal(toolRightsRefusal('remember', rights, 'anything-at-all'), null);
+  });
+});
+
+describe('the record actually carries it', () => {
+  const strip = src => src.replace(/(^|[^:])\/\/.*/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
+
+  it('OidcTokenRecord declares rights, and the builder populates it from migrateToken', () => {
+    const src = strip(readFileSync('server/src/auth/oidc.ts', 'utf8'));
+    assert.match(src, /rights: TokenRights;/, 'the record type must carry the matrix');
+    assert.match(src, /rights: migrateToken\(\{/,
+      'and it must be DERIVED — a hand-rolled second mapping is the thing this avoids');
+    assert.match(src, /admin: perms\.admin,[\s\S]{0,400}?readOnly: perms\.readOnly \?\? false/,
+      'derived from the mapped claims, not from the raw payload');
+  });
+
+  it('the spaces key is omitted rather than passed as undefined', () => {
+    // `migrateToken` branches on ABSENCE (`t.spaces == null`), so spreading a `spaces: undefined` would be
+    // read as "no allowlist, therefore every space". Correct here, but only by accident of that check — so
+    // the conditional spread is asserted rather than trusted.
+    const src = strip(readFileSync('server/src/auth/oidc.ts', 'utf8'));
+    assert.match(src, /\.\.\.\(perms\.spaces \? \{ spaces: perms\.spaces \} : \{\}\)/,
+      'pass the key only when there is an allowlist');
+  });
+
+  it('the MCP helper no longer claims OIDC records have no matrix', () => {
+    // That comment was true when it was written and became the documentation of a hole. A stale sentence
+    // next to a security decision is worse than no sentence.
+    const src = readFileSync('server/src/mcp/router.ts', 'utf8');
+    assert.ok(!/`OidcTokenRecord` has no `rights` field/.test(src),
+      'the helper documents a shape that no longer exists');
+  });
+});


### PR DESCRIPTION
**S-1 was half-fixed.** I found this looking for what actually blocked deprecation row 1.7.

[#898](https://github.com/ythril-network/Ythril/pull/898) made MCP enforce the per-space, per-area rung. That
guard **skips a token with no matrix** — a deliberate pass-through, documented in as many words as *"the OIDC
path builds its record per request from the identity"*.

Every OIDC record was exactly that. So the fix covered PATs and left OIDC on the old `readOnly`/`admin`
booleans: **one policy, two implementations, on the surface nobody had checked** — the same shape as the
defect it was fixing, one authentication method over.

## What changed

`OidcTokenRecord` now carries a `rights` matrix, **derived** from its three mapped-claim fields by
`migrateToken` — the same function the boot migration uses. A claim-mapped identity and a PAT with the same
grants are now priced by one mapping instead of two.

Nothing is stored and nothing migrates: the record was always built per request.

## Derived, not hand-rolled — and why that matters here specifically

`migrateToken` already encodes the two decisions that granted whole instances when they were got wrong:

| claim state | means |
|---|---|
| `spaces` **absent** | every space, including future ones — a floor |
| `spaces: []` | **nothing** |

`mapOidcClaims` produces `[]` when a `spaces` mapping is configured and the claim is missing or not an array
— that is **deny**. Conflating the two would turn the narrowest identity into the widest. A second
claims→rungs mapping would be a fresh chance to do precisely that.

Both directions are asserted, because getting either one backwards is silent.

## One subtlety worth the assertion

The `spaces` key is spread **conditionally**, not passed as `undefined`:

```ts
...(perms.spaces ? { spaces: perms.spaces } : {}),
```

`migrateToken` branches on absence (`t.spaces == null`), so `spaces: undefined` would read as *"no allowlist,
therefore every space"*. That is correct here only by accident of that check — so it is asserted rather than
trusted, and mutating the spread to a plain assignment turns the gate red.

## A comment that had become the documentation of a hole

`tokenRights` in the MCP router stated that `OidcTokenRecord` has no `rights` field. True when written, and by
#898 it was describing the gap rather than a design. A stale sentence beside a security decision is worse than
no sentence — corrected, with what `undefined` now means.

## Effect on callers

**An OIDC identity whose claims do not cover a tool will now be refused it over MCP.** That is the point, and
it is the same refusal a PAT with those grants already got.
