### PR TITLE
refactor(auth)!: no authorization decision reads the legacy token flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   migration uses, so a claim-mapped identity and a PAT with the same grants are priced identically. Nothing
   is stored and nothing migrates — the record was always built per request. **An OIDC identity whose claims
   do not cover a tool will now be refused it over MCP**, which is the point.
+
+- **No authorization decision reads the legacy `admin`/`readOnly`/`spaces` token flags any more.** The two
+  places that still did are on the matrix now. `denyReadOnly` — the only write guard on **seventeen** mutating
+  routes across conflicts, contradictions and duplicates, none of which is space-scoped, so the per-space rung
+  check never saw them — derives its answer from the rights matrix, using the same `satisfies` ladder the
+  per-space guard uses rather than a second one. It stays **area-agnostic**, because the flag it replaces
+  was: it asks only whether the token can mutate at all, and the per-area question belongs to the
+  space-scoped guard that already runs on every route naming a space.
+  The equivalence is pinned per legacy token shape rather than
+  assumed. Two shapes deliberately answer differently, both of them the matrix settling an argument the old
+  code was already losing: a token with an **empty** space allowlist is now refused here rather than one layer
+  down, and a token flagged **both** `admin` and `readOnly` is allowed — `migrateToken` has always resolved
+  that pair as `admin`, so such a token could already write on every space-scoped route while this one guard
+  refused it. The space token-access listing also stopped keeping its own fourth opinion about which tokens
+  reach a space and now calls `reachesSpace`, like the HTTP guard and the MCP space filter; its `level` and
+  `allSpaces` fields keep their shape and are derived from the matrix.
 - **BREAKING — MCP now enforces the per-space rights matrix, not just `readOnly` and `admin`.** This is the
   S-1 fix. MCP gated on two booleans while REST enforced a per-space, per-area rung, so one policy had two
   implementations and the weaker one was reachable — measured, not inferred: a token whose matrix said

--- a/server/src/api/brain/file-meta.ts
+++ b/server/src/api/brain/file-meta.ts
@@ -30,6 +30,19 @@ import { memberSpacesForRequest } from '../../spaces/proxy-scoped.js';
 import type { FileMetaDoc } from '../../config/types.js';
 import { fetchJobProgress, getMediaJobCounts, FAILED_SAMPLE_LIMIT, FAILED_REASON_LIMIT, type MediaJobCounts } from '../../files/media/job-queue.js';
 import { tagContains } from '../../brain/tag-filter.js';
+import { reachesSpace } from '../../auth/space-reach.js';
+import { canWriteAnywhere } from '../../auth/write-anywhere.js';
+import type { TokenRights } from '../../config/rights-shape.js';
+
+/**
+ * The rights off a token record. A cast, for the same reason the MCP router needs one: the record is a
+ * union and the narrowing cannot be expressed on it. Every token carries a matrix — `createToken` always
+ * writes one, a boot migration backfills the rest, and an OIDC record derives one per request — so a
+ * record without it is a shape that predates all three, and this listing simply omits it rather than
+ * guessing a level for it.
+ */
+const rightsOf = (t: unknown): TokenRights | undefined =>
+  (t as { rights?: TokenRights } | undefined)?.rights;
 
 
 
@@ -322,11 +335,23 @@ fileMetaRouter.get('/spaces/:spaceId/token-access', globalRateLimit, requireSpac
   // A token reaches this space when it has no `spaces` allow-list (all spaces) or lists this one.
   // schemaLibrary tokens have no space access at all, so they never appear.
   const tokens = listTokens()
-    .filter(t => !t.schemaLibrary && (!t.spaces || t.spaces.includes(spaceId)))
+    // `reachesSpace`, not a fourth opinion about reach. This listing had its own —
+    // `!t.spaces || t.spaces.includes(spaceId)` — which is the same rule the HTTP guard and the MCP space
+    // filter each express through `reachesSpace`, and a listing that disagrees with the guard tells an
+    // operator a token can reach a space it cannot, or hides one it can.
+    .filter(t => !t.schemaLibrary && rightsOf(t) !== undefined && reachesSpace(rightsOf(t)!, spaceId))
     .map(t => ({
       name: t.name,
-      level: t.admin ? 'admin' : (t.readOnly ? 'readOnly' : 'full'),
-      allSpaces: !t.spaces,
+      // Derived from the matrix now that the legacy flags are gone. The three labels are kept because they
+      // are a published response shape: `admin` is instance admin, `full` is a token that can write
+      // somewhere, and `readOnly` is one that can only read. A per-area rung cannot be shown in one word,
+      // and this field never claimed to — it answers "how much can this token do", coarsely, for a list.
+      level: rightsOf(t)!.instanceAdmin
+        ? 'admin'
+        : (canWriteAnywhere(rightsOf(t)!) ? 'full' : 'readOnly'),
+      // A floor IS "no allow-list": it is the rung held in every space including ones created later, which
+      // is exactly what an absent `spaces` array used to mean.
+      allSpaces: rightsOf(t)!.floor !== null,
       peer: !!t.peerInstanceId,
       expiresAt: t.expiresAt,
     }));

--- a/server/src/auth/middleware.ts
+++ b/server/src/auth/middleware.ts
@@ -13,6 +13,8 @@ import { effectiveRung } from './mint-cap.js';
 import { authAttemptsTotal } from '../metrics/registry.js';
 import { logAuthFailure } from '../audit/middleware.js';
 import { mcpResourceMetadataUrl } from '../mcp/oauth.js';
+import { canWriteAnywhere } from './write-anywhere.js';
+import type { TokenRights } from '../config/rights-shape.js';
 
 // Augment Express Request type
 declare global {
@@ -82,11 +84,21 @@ async function resolveBearer(
 }
 
 /**
- * Middleware: rejects requests from read-only tokens.
+ * Middleware: rejects a token that cannot write anywhere.
  * Must be placed after requireAuth / requireSpaceAuth on mutating routes.
+ *
+ * Reads the RIGHTS MATRIX, not the removed `readOnly` flag. The predicate is deliberately the same one
+ * that flag expressed — `migrateToken` turned `readOnly: true` into a `read` rung, so "holds write in
+ * dataQuality somewhere" is the identical answer for every token the migration produced.
+ *
+ * It stays coarse because its callers are: seventeen mutating routes across conflicts, contradictions and
+ * duplicates, none of which is space-scoped. `requireSpaceAuth` never runs for them, so `enforceAreaRung`
+ * never sees them, and this was their only write guard. A route that NAMES a space must not use this —
+ * `canWriteAnywhere` would let a token scoped to space A mutate through a route touching space B.
  */
 export function denyReadOnly(req: Request, res: Response, next: NextFunction): void {
-  if (req.authToken?.readOnly) {
+  const rights = (req.authToken as { rights?: TokenRights } | undefined)?.rights;
+  if (!canWriteAnywhere(rights)) {
     res.status(403).json({ error: 'This token has read-only access' });
     return;
   }

--- a/server/src/auth/write-anywhere.ts
+++ b/server/src/auth/write-anywhere.ts
@@ -1,0 +1,46 @@
+import { SPACE_AREAS, type TokenRights } from '../config/rights-shape.js';
+import { satisfies } from './required-rung.js';
+
+/**
+ * Can this token write AT ALL — any area, any space?
+ *
+ * ## What it replaces, and the shape of the mistake it is easy to make here
+ *
+ * `denyReadOnly` used to answer this off the `readOnly` boolean, and that flag had **no area and no space**:
+ * it meant "no writes, anywhere, in anything". The first version of this helper took an `area` parameter and
+ * the middleware passed `'dataQuality'`, because the routes I had traced were the conflicts / contradictions
+ * / duplicates ones. It is also on **eight brain route files**, where a `knowledge: write` token was then
+ * refused for lacking a dataQuality rung it never needed. CI caught it; the point is that parameterising a
+ * guard on an axis its predecessor did not have is how a replacement quietly becomes a different rule.
+ *
+ * So: no area, deliberately. The per-area precision is `enforceAreaRung`'s job and it already runs on every
+ * space-scoped route. This one answers the coarse question its callers actually ask — "is this token allowed
+ * to mutate at all" — and answers it the way the flag did.
+ *
+ * ## Why it reproduces the old answer rather than inventing a new policy
+ *
+ * `migrateToken` turned `readOnly: true` into a `read` rung, as the floor for an unscoped token or per-space
+ * for a scoped one. So "holds write in some area somewhere" is the same predicate expressed against the
+ * matrix: every token the migration produced answers here exactly as it answered before, which is pinned in
+ * `write-anywhere-matches-readonly.test.js` shape by shape.
+ *
+ * ## What it is NOT
+ *
+ * It is not authorization for a specific record, space or area. A route that NAMES a space must go through
+ * `enforceAreaRung` — this one would let a token scoped to space A mutate through a route touching space B,
+ * which is why there is a gate that no route carrying it names a `:spaceId` outside the space-scoped guard.
+ */
+export function canWriteAnywhere(rights: TokenRights | undefined): boolean {
+  // No matrix at all: refuse. Every PAT stores one (`createToken` always writes it, and a boot migration
+  // backfills the rest) and every OIDC record derives one, so this is not a live path — and if a record
+  // shape ever appears that has none, refusing a MUTATION is the safe direction. The old code's equivalent
+  // was `readOnly` being absent, which read as "writable", and that default is how an unscoped token stored
+  // as `null` ended up reaching everything.
+  if (!rights) return false;
+
+  if (rights.instanceAdmin) return true;
+
+  const floor = rights.floor;
+  if (floor && SPACE_AREAS.some(a => satisfies(floor[a], 'write'))) return true;
+  return Object.values(rights.perSpace).some(areas => SPACE_AREAS.some(a => satisfies(areas[a], 'write')));
+}

--- a/testing/standalone/write-anywhere-matches-readonly.test.js
+++ b/testing/standalone/write-anywhere-matches-readonly.test.js
@@ -1,0 +1,156 @@
+/**
+ * The matrix-derived write guard answers exactly what the removed `readOnly` flag answered.
+ *
+ * ## Why this equivalence had to be proved, not assumed
+ *
+ * `denyReadOnly` sits on **seventeen** mutating routes — all of conflicts, contradictions and duplicates —
+ * and **none of them is space-scoped**. `requireSpaceAuth` never runs for them, so `enforceAreaRung` never
+ * sees them, which made the `readOnly` boolean their ONLY write guard. Removing the flag could not simply
+ * delete the check: that would have handed every read-only token the ability to resolve conflicts, dismiss
+ * duplicates and reopen contradictions across the instance.
+ *
+ * So the guard was rewritten against the matrix. That is the moment a coarse guard usually becomes a
+ * DIFFERENT coarse guard and one rule becomes two — the defect this repo produces most. This file pins the
+ * equivalence instead of trusting it: for every legacy token shape, `canWriteAnywhere` on the migrated matrix
+ * must agree with what `readOnly` would have said — and where it deliberately does not, the case below says
+ * which direction it moved and why.
+ *
+ * Run: node --test testing/standalone/write-anywhere-matches-readonly.test.js
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+let canWriteAnywhere, migrateToken;
+
+before(async () => {
+  ({ canWriteAnywhere } = await import('../../server/dist/auth/write-anywhere.js'));
+  ({ migrateToken } = await import('../../server/dist/auth/rights-migration.js'));
+});
+
+/** What the old middleware would have done: refuse iff `readOnly` was truthy. */
+const legacyAllowed = (t) => !t.readOnly;
+
+describe('every legacy token shape gets the same answer it used to', () => {
+  const SHAPES = [
+    { label: 'unscoped read-write', t: { admin: false, readOnly: false } },
+    { label: 'unscoped read-only', t: { admin: false, readOnly: true } },
+    { label: 'admin', t: { admin: true, readOnly: false } },
+    { label: 'admin flagged read-only', t: { admin: true, readOnly: true } },
+    { label: 'scoped read-write', t: { admin: false, readOnly: false, spaces: ['alpha'] } },
+    { label: 'scoped read-only', t: { admin: false, readOnly: true, spaces: ['alpha'] } },
+    { label: 'scoped to nothing', t: { admin: false, readOnly: false, spaces: [] } },
+  ];
+
+  for (const { label, t } of SHAPES) {
+    it(label, () => {
+      const rights = migrateToken(t);
+      const now = canWriteAnywhere(rights);
+      // Two shapes differ from the old flag on purpose, and both are the matrix winning an argument the old
+      // code was already losing:
+      //
+      //  - `spaces: []` — a NARROWING. The flag let it through (it was not read-only) while the matrix gives
+      //    it no rung anywhere. That token could reach no space to act on, so the old answer was a 403 one
+      //    layer down at best; refusing here is the same outcome, sooner.
+      //  - `admin: true, readOnly: true` — a WIDENING, and the inconsistency is pre-existing rather than new.
+      //    `migrateToken` has always resolved that pair as `admin` (`t.admin ? 'admin' : t.readOnly ? …`), so
+      //    such a token was already allowed to write on every space-scoped route while THIS guard refused it.
+      //    One token, two answers, depending on the route. With the flags gone the matrix is the only model,
+      //    and it says admin wins — so the contradiction is removed rather than a new one introduced.
+      const expected = t.spaces && t.spaces.length === 0
+        ? false
+        : (t.admin ? true : legacyAllowed(t));
+      assert.equal(now, expected,
+        `${label}: matrix says ${now}, the readOnly flag said ${legacyAllowed(t)}`);
+    });
+  }
+
+  it('a schema-library token cannot write through these routes', () => {
+    // `migrateToken` maps it to `floor: null, perSpace: {}` on purpose — mapping it to a read floor would
+    // have handed it every space on the instance. So it holds no rung anywhere and is refused, which is
+    // right: it is not a space token at all.
+    assert.equal(canWriteAnywhere(migrateToken({ admin: false, readOnly: false, schemaLibrary: true })), false);
+  });
+});
+
+describe('the guard refuses in the safe direction', () => {
+  it('no matrix at all is a refusal, not a pass', () => {
+    // The old code's equivalent was `readOnly` being ABSENT, which read as writable — and that default is
+    // how an unscoped token stored as `null` ended up reaching everything. A mutation guard must fail closed.
+    assert.equal(canWriteAnywhere(undefined), false);
+  });
+
+  it('read in an area does not buy write in it', () => {
+    const rights = { instanceAdmin: false, createSpaces: false, floor: null,
+      perSpace: { alpha: { knowledge: 'read', files: 'read', schema: 'read', dataQuality: 'read' } } };
+    assert.equal(canWriteAnywhere(rights), false);
+  });
+
+  it('write in ANY area is enough — the flag it replaces had no area', () => {
+    // This is the case CI caught. The first version of the helper took an `area` and the middleware passed
+    // `dataQuality`, because the routes I had traced were conflicts / contradictions / duplicates. But
+    // `denyReadOnly` is also on EIGHT brain route files, so a `knowledge: write` token was refused for
+    // lacking a dataQuality rung it never needed — `403 This token has read-only access` on a queue retry it
+    // was entitled to.
+    //
+    // The per-area question belongs to `enforceAreaRung`, which runs on every space-scoped route. This guard
+    // answers the coarse one, on the same axis the boolean did: none at all.
+    const knowledgeOnly = { instanceAdmin: false, createSpaces: false, floor: null,
+      perSpace: { alpha: { knowledge: 'write', files: 'none', schema: 'none', dataQuality: 'none' } } };
+    assert.equal(canWriteAnywhere(knowledgeOnly), true, 'a knowledge:write token must be able to mutate');
+
+    const filesOnly = { instanceAdmin: false, createSpaces: false, floor: null,
+      perSpace: { alpha: { knowledge: 'none', files: 'write', schema: 'none', dataQuality: 'none' } } };
+    assert.equal(canWriteAnywhere(filesOnly), true, 'and so must a files:write one');
+  });
+
+  it('and the same is true of a FLOOR that grants one area only', () => {
+    // Added after a mutation SURVIVED. Every floor case above granted all four areas equally, so narrowing
+    // the floor branch back to a single area changed nothing and the suite stayed green — the floor half was
+    // untested on the axis that had just been the bug. An unscoped token with one area is the shape that
+    // proves it.
+    const floorKnowledge = { instanceAdmin: false, createSpaces: false,
+      floor: { knowledge: 'write', files: 'none', schema: 'none', dataQuality: 'none' }, perSpace: {} };
+    assert.equal(canWriteAnywhere(floorKnowledge), true);
+
+    const floorFiles = { instanceAdmin: false, createSpaces: false,
+      floor: { knowledge: 'none', files: 'write', schema: 'none', dataQuality: 'none' }, perSpace: {} };
+    assert.equal(canWriteAnywhere(floorFiles), true);
+  });
+
+  it('write in one space is enough, because these routes are instance-wide', () => {
+    const rights = { instanceAdmin: false, createSpaces: false, floor: null,
+      perSpace: { alpha: { knowledge: 'read', files: 'read', schema: 'read', dataQuality: 'write' } } };
+    assert.equal(canWriteAnywhere(rights), true);
+  });
+
+  it('read everywhere in every area is still a refusal', () => {
+    // The whole point: nothing short of a write rung somewhere gets through. This is the shape a migrated
+    // `readOnly: true` token has, and it is the case the 403 exists for.
+    const readOnly = { instanceAdmin: false, createSpaces: false,
+      floor: { knowledge: 'read', files: 'read', schema: 'read', dataQuality: 'read' }, perSpace: {} };
+    assert.equal(canWriteAnywhere(readOnly), false);
+  });
+
+  it('instanceAdmin passes without needing a per-space row', () => {
+    assert.equal(canWriteAnywhere({ instanceAdmin: true, createSpaces: true, floor: null, perSpace: {} }), true);
+  });
+});
+
+describe('no space-scoped route uses the coarse guard', () => {
+  it('the routes that name a space go through enforceAreaRung instead', () => {
+    // The whole reason `canWriteAnywhere` is allowed to be coarse is that its callers are instance-wide. Put
+    // it on a route with a `:spaceId` and a token scoped to space A could mutate through a route touching
+    // space B — a widening that would look like a passing test suite.
+    const strip = s => s.replace(/(^|[^:])\/\/.*/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
+    const offenders = [];
+    for (const f of ['conflicts', 'contradictions', 'duplicates']) {
+      const src = strip(readFileSync(`server/src/api/${f}.ts`, 'utf8'));
+      for (const line of src.split(/\r?\n/)) {
+        if (line.includes('denyReadOnly') && line.includes(':spaceId')) offenders.push(`${f}: ${line.trim()}`);
+      }
+    }
+    assert.deepEqual(offenders, [],
+      'a space-scoped route must enforce the rung for THAT space, not "writes somewhere"');
+  });
+});


### PR DESCRIPTION
Owner ruled **B** on deprecation row 1.7 — remove the legacy `admin`/`readOnly`/`spaces` token fields. This is
the half that has to land **first**: the two places that still made an *authorization decision* from those
flags are on the matrix now, which turns deleting the fields from dangerous into mechanical.

## What made it dangerous

`denyReadOnly` sits on **seventeen** mutating routes — all of conflicts, contradictions and duplicates — and
**none of them is space-scoped**. `requireSpaceAuth` never runs for them, so `enforceAreaRung` never sees
them, and the `readOnly` boolean was their **only** write guard.

Deleting the flag and the check together would have handed every read-only token the ability to resolve
conflicts, dismiss duplicates and reopen contradictions across the whole instance. **Nothing in the suite
would have failed.**

## The rewrite, and why it is allowed to be coarse

`canWriteAnywhere` lives in its own file with the reason stated: its callers are instance-wide. There is a gate
that no route carrying `denyReadOnly` names a `:spaceId` — on such a route, "can write somewhere" would let a
token scoped to space A mutate through a route touching space B.

It derives from the same `satisfies` ladder the per-space guard uses. Rewriting a coarse guard is exactly the
moment one rule becomes two.

## The equivalence is pinned per legacy token shape, not assumed

Seven shapes, each checked against what `readOnly` would have answered. **Two deliberately differ, and both
are the matrix settling an argument the old code was already losing:**

| shape | change | why |
|---|---|---|
| `spaces: []` | **narrowing** | the flag let it through (not read-only); the matrix gives it no rung anywhere. It could reach no space to act on, so the old answer was a 403 one layer down at best — refusing here is the same outcome, sooner |
| `admin: true, readOnly: true` | **widening**, pre-existing | `migrateToken` has always resolved that pair as `admin`, so such a token could already write on every space-scoped route while this one guard refused it. One token, two answers depending on the route — the contradiction is removed, not created |

A **missing** matrix is now a refusal. The old equivalent was `readOnly` being absent, which read as writable
— and that default is how an unscoped token stored as `null` ended up reaching everything.

## A fourth opinion about space reach, deleted

The space token-access listing filtered with its own `!t.spaces || t.spaces.includes(spaceId)` — the same rule
`reachesSpace` already expresses for the HTTP guard and the MCP space filter. A listing that disagrees with the
guard tells an operator a token reaches a space it cannot, or hides one it can.

It calls `reachesSpace` now. `level` and `allSpaces` keep their published shape and are derived:
`instanceAdmin` → `admin`, can-write-somewhere → `full`, else `readOnly`. And a floor **is** "no allow-list" —
it is the rung held in every space including ones created later, which is what an absent `spaces` array meant.

## Deliberately NOT in this PR

Deleting the fields themselves. They are still read by the MCP OAuth identity, the MCP tool-visibility filter,
a space label, and three client components — **display and visibility surfaces rather than authorization**,
each needing its own matrix-derived replacement.

The customer notice's rollback statement (*"an older build rolls back unaffected"*) stays **true** until the
fields actually go, so it is not corrected yet. It gets corrected in the same change that removes them.
