### PR TITLE
refactor(mcp): tool visibility is one predicate, and it reads the matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   every type.
 
 ### Changed
+- **MCP tool visibility and its two dispatcher gates read the rights matrix, from ONE predicate.** The
+  expression `!(readOnly && t.mutating) && !(!isAdmin && t.admin)` was written out four times: the
+  `tools/list` filter, the two call-time refusals, and `help`'s own listing — the last of those under a
+  comment reading *"the exact predicate tools/list uses — one source of truth, so this text can never
+  advertise a tool the dispatcher would deny."* It was four copies claiming to be one, inside the mechanism
+  built to stop a listing promising what the dispatcher refuses. They are now literally the same function,
+  and the gate asserts the SHARING rather than matching two regexes that could both pass while having
+  drifted. It also closes a narrower gap: a token holding a write rung in one space used to be shown every
+  mutating tool, because `readOnly` was false instance-wide, and the per-space check then refused the call.
+  The connection scope signature is keyed on the matrix too — it used to hash the legacy triple, so a token
+  edited through the rights editor kept serving its previous scope for the life of an SSE stream.
 - **An OIDC identity is now governed by the rights matrix too, not just `readOnly` and `admin`.** The S-1
   fix made MCP enforce the per-space, per-area rung — and that guard skips a token with no matrix, which
   every OIDC record was. So the fix covered PATs and left OIDC on the old booleans: one policy with two
@@ -93,7 +104,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is stored and nothing migrates — the record was always built per request. **An OIDC identity whose claims
   do not cover a tool will now be refused it over MCP**, which is the point.
 
-- **No authorization decision reads the legacy `admin`/`readOnly`/`spaces` token flags any more.** The two
+- **No authorization decision on REST reads the legacy `admin`/`readOnly`/`spaces` token flags any more.** The two
   places that still did are on the matrix now. `denyReadOnly` — the only write guard on **seventeen** mutating
   routes across conflicts, contradictions and duplicates, none of which is space-scoped, so the per-space rung
   check never saw them — derives its answer from the rights matrix, using the same `satisfies` ladder the

--- a/server/src/mcp/router.ts
+++ b/server/src/mcp/router.ts
@@ -34,13 +34,15 @@ interface SessionBinding {
 }
 const sessionBindings = new Map<string, SessionBinding>();
 
-/** Stable signature of a token's authorization scopes, order-independent. */
-function scopeSignature(t: { admin?: boolean; readOnly?: boolean; spaces?: string[] } | undefined): string {
-  return JSON.stringify([
-    Boolean(t?.admin),
-    Boolean(t?.readOnly),
-    [...(t?.spaces ?? [])].sort(),
-  ]);
+/**
+ * Stable signature of a token's authorization scope, order-independent.
+ *
+ * Keyed on the RIGHTS MATRIX. It used to hash the legacy `admin`/`readOnly`/`spaces` triple, which meant a
+ * token edited through the rights-matrix editor produced the same signature and kept serving its previous
+ * scope for the life of an SSE stream — the matrix could change without any of the three fields moving.
+ */
+function scopeSignature(t: unknown): string {
+  return rightsSignature((t as { rights?: TokenRights } | undefined)?.rights);
 }
 
 /** Short, non-reversible tag for correlating an SSE session in logs without
@@ -129,7 +131,9 @@ function createGlobalMcpServer(tokenSpaces?: string[], readOnly?: boolean, isAdm
 
   // Tools this token may see: read-only tokens lose mutating tools, non-admin
   // tokens lose instance-level tools. Both gates are re-enforced on dispatch.
-  const visibleTools = ALL_TOOLS.filter(t => !(readOnly && t.mutating) && !(!isAdmin && t.admin));
+  // One predicate, shared with `help` and with the two dispatcher gates below. It used to be this
+  // expression written out four times, twice under a comment claiming they were one source of truth.
+  const visibleTools = ALL_TOOLS.filter(t => toolIsVisible(t, rights));
 
   // ── tools/list ────────────────────────────────────────────────────────────
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
@@ -178,19 +182,20 @@ function createGlobalMcpServer(tokenSpaces?: string[], readOnly?: boolean, isAdm
     // reported inside the try block, preserving the original dispatch behaviour.
     const tool = TOOLS_BY_NAME.get(name);
 
-    // Block mutating tools for read-only tokens
-    if (readOnly && tool?.mutating) {
+    // Reachability, from the same predicate that built `tools/list` — so the listing cannot advertise a
+    // tool this refuses, which is what two hand-copied expressions could not guarantee. Filtering the list
+    // stays advisory; the dispatcher is still the enforcement point.
+    //
+    // An unknown tool carries no flags and falls through, as it always did, to be reported inside the try
+    // block below.
+    if (tool && !toolIsVisible(tool, rights)) {
       return {
-        content: [{ type: 'text' as const, text: 'Error: this token has read-only access' }],
-        isError: true,
-      };
-    }
-
-    // Block instance-level tools for non-admin tokens (filtering them out of
-    // tools/list is advisory — the dispatcher is the enforcement point).
-    if (!isAdmin && tool?.admin) {
-      return {
-        content: [{ type: 'text' as const, text: `Error: tool '${name}' requires an admin token` }],
+        content: [{
+          type: 'text' as const,
+          text: tool.admin
+            ? `Error: tool '${name}' requires a token with instance-admin rights`
+            : `Error: tool '${name}' mutates, and this token holds no write rung in any space`,
+        }],
         isError: true,
       };
     }
@@ -262,6 +267,10 @@ function createGlobalMcpServer(tokenSpaces?: string[], readOnly?: boolean, isAdm
         tokenSpaces,
         isAdmin,
         readOnly,
+        // Populated, not merely declared. `toolIsVisible(t, undefined)` hides every mutating and admin
+        // tool, so an unpopulated `rights` here would empty `help`'s listing while `tools/list` stayed
+        // correct — the two disagreeing again, in the one mechanism built to stop that.
+        rights,
         actor: { tokenId, tokenLabel },
       });
       // A tool that returns `isError` failed on its own terms — the transport still answered 200, so
@@ -295,6 +304,7 @@ import { logAuditEntry } from '../audit/audit.js';
 import { auditAuthMethod, auditOidcSubject } from '../audit/middleware.js';
 import { mcpAuditOperation, isMcpReadOperation } from './audit-map.js';
 import { mcpConnectionsActive, mcpToolCallsTotal } from '../metrics/registry.js';
+import { toolIsVisible, rightsSignature } from './tool-visibility.js';
 
 export const mcpRouter = Router();
 

--- a/server/src/mcp/tool-visibility.ts
+++ b/server/src/mcp/tool-visibility.ts
@@ -1,0 +1,61 @@
+import type { TokenRights } from '../config/rights-shape.js';
+import { canWriteAnywhere } from '../auth/write-anywhere.js';
+
+/** The shape this needs off a tool — the two flags that decide whether it is reachable at all. */
+export interface VisibilityFlags {
+  mutating?: boolean;
+  admin?: boolean;
+}
+
+/**
+ * Could this token invoke this tool at all?
+ *
+ * ## Why this is one function and not two identical expressions
+ *
+ * `router.ts` filtered `tools/list` with
+ * `!(readOnly && t.mutating) && !(!isAdmin && t.admin)`, and `help.ts` filtered its own listing with the
+ * same expression — under a comment reading *"the exact predicate tools/list uses (router.ts) — one source
+ * of truth, so this text can never advertise a tool the dispatcher would deny."*
+ *
+ * It was two copies claiming to be one. The dispatcher then made the same decision a third time, in two more
+ * `if` statements. Four expressions of one rule, and the comment asserting otherwise is what made it
+ * invisible — this is the defect this repo produces most, and it was sitting inside the mechanism meant to
+ * prevent advertising a tool that would be refused.
+ *
+ * ## What changed beyond the extraction
+ *
+ * All four read the legacy `readOnly` / `admin` booleans. They read the RIGHTS MATRIX now, which is what
+ * makes `admin`/`readOnly` deletable from the token record — and it closes a narrower gap in passing: a
+ * token with a write rung in one space used to be shown every mutating tool because `readOnly` was false
+ * instance-wide, and the per-space rung guard then refused the call. Now the listing and the refusal come
+ * from one predicate, so the list stops promising what the dispatcher will deny.
+ *
+ * **Coarse on purpose.** Visibility is a question about the token, not about a space — `tools/list` is
+ * answered once per connection, before any space is named. `toolRightsRefusal` does the per-space, per-area
+ * check at call time, and that is the one that decides whether a specific invocation is allowed.
+ */
+export function toolIsVisible(tool: VisibilityFlags, rights: TokenRights | undefined): boolean {
+  if (tool.admin) return rights?.instanceAdmin === true;
+  if (tool.mutating) return canWriteAnywhere(rights);
+  return true;
+}
+
+/**
+ * A stable key for a connection's scope, used to decide when a cached MCP server can be reused.
+ *
+ * Keyed on the MATRIX rather than the legacy `admin`/`readOnly`/`spaces` triple. It has to change whenever
+ * anything that alters what the connection may see or do changes, or a token edited through the rights
+ * editor keeps serving the previous scope for the life of its SSE stream.
+ */
+export function rightsSignature(rights: TokenRights | undefined): string {
+  if (!rights) return 'none';
+  // Sorted, because `perSpace` key order is not meaningful and an order change is not a scope change.
+  const perSpace = Object.keys(rights.perSpace).sort()
+    .map(id => `${id}:${JSON.stringify(rights.perSpace[id])}`).join(',');
+  return [
+    rights.instanceAdmin ? 'ia' : '-',
+    rights.createSpaces ? 'cs' : '-',
+    rights.floor ? JSON.stringify(rights.floor) : 'nofloor',
+    perSpace,
+  ].join('|');
+}

--- a/server/src/mcp/tools/help.ts
+++ b/server/src/mcp/tools/help.ts
@@ -49,9 +49,10 @@ export const helpTool: ToolHandler = {
     // top-level import would be circular. By call time the registry is complete.
     const { ALL_TOOLS } = await import('./index.js');
 
-    // The exact predicate tools/list uses (router.ts) — one source of truth, so
-    // this text can never advertise a tool the dispatcher would deny.
-    const visible = ALL_TOOLS.filter(t => !(ctx.readOnly && t.mutating) && !(!ctx.isAdmin && t.admin));
+    // The exact predicate tools/list uses — now literally the same function rather than the same
+    // expression retyped, which is what the previous version of this comment claimed and was not.
+    const { toolIsVisible } = await import('../tool-visibility.js');
+    const visible = ALL_TOOLS.filter(t => toolIsVisible(t, ctx.rights));
     const sections = helpSections(ctx, visible, ALL_TOOLS.length - visible.length);
 
     const rawQuery = ctx.args['query'];

--- a/server/src/mcp/tools/types.ts
+++ b/server/src/mcp/tools/types.ts
@@ -1,5 +1,6 @@
 import type { Config, SpaceConfig } from '../../config/types.js';
 import type { WebhookActor } from '../../webhooks/dispatcher.js';
+import type { TokenRights } from '../../config/rights-shape.js';
 
 /**
  * The space schemas injected into each tool's `inputSchema`. The `space` enum is
@@ -29,6 +30,14 @@ export interface ToolContext {
   isAdmin?: boolean;
   /** True when the calling token is read-only (mutating tools are gated out). */
   readOnly?: boolean;
+  /**
+   * The calling token's rights matrix — what tool visibility and the per-call rung check are decided from.
+   *
+   * Present for every connection: a PAT stores one, a boot migration backfills the rest, and an OIDC record
+   * derives one per request. `isAdmin` and `readOnly` above are the legacy pair it replaces and are on their
+   * way out; nothing should read them for a new decision.
+   */
+  rights?: TokenRights;
   /** Identity of the calling token, for webhook attribution. Passed to shared brain/file
    *  mutation functions so agent-driven writes emit attributed webhooks like REST writes. */
   actor?: WebhookActor;

--- a/testing/integration/mcp-tools.test.js
+++ b/testing/integration/mcp-tools.test.js
@@ -1148,7 +1148,12 @@ describe('MCP security � read-only token cannot call mutating tools', () => {
     });
     assert.ok(result?.isError, 'update_memory must be rejected by read-only token');
     const text = result?.content?.[0]?.text ?? '';
-    assert.ok(text.toLowerCase().includes('read-only'), `Expected read-only message: ${text}`);
+    // The refusal now names WHAT the token lacks rather than a flag it no longer has: mutating tools are
+    // gated on holding a write rung somewhere, so the message says so. Asserted on the substance —
+    // 'mutates' and 'write rung' — rather than loosened to `isError`, because a refusal that does not
+    // tell the caller which grant is missing sends them to the docs to guess.
+    assert.match(text, /mutates/i, `Expected a mutation refusal: ${text}`);
+    assert.match(text, /write rung/i, `Expected the missing grant named: ${text}`);
   });
 
   it('delete_memory is rejected with read-only token', async () => {
@@ -1158,7 +1163,12 @@ describe('MCP security � read-only token cannot call mutating tools', () => {
     });
     assert.ok(result?.isError, 'delete_memory must be rejected by read-only token');
     const text = result?.content?.[0]?.text ?? '';
-    assert.ok(text.toLowerCase().includes('read-only'), `Expected read-only message: ${text}`);
+    // The refusal now names WHAT the token lacks rather than a flag it no longer has: mutating tools are
+    // gated on holding a write rung somewhere, so the message says so. Asserted on the substance —
+    // 'mutates' and 'write rung' — rather than loosened to `isError`, because a refusal that does not
+    // tell the caller which grant is missing sends them to the docs to guess.
+    assert.match(text, /mutates/i, `Expected a mutation refusal: ${text}`);
+    assert.match(text, /write rung/i, `Expected the missing grant named: ${text}`);
   });
 
   it('get_stats works with read-only token', async () => {
@@ -1473,7 +1483,12 @@ describe('MCP security � read-only token cannot call bulk_write', () => {
     });
     assert.ok(result?.isError, 'bulk_write must be rejected by read-only token');
     const text = result?.content?.[0]?.text ?? '';
-    assert.ok(text.toLowerCase().includes('read-only'), `Expected read-only message: ${text}`);
+    // The refusal now names WHAT the token lacks rather than a flag it no longer has: mutating tools are
+    // gated on holding a write rung somewhere, so the message says so. Asserted on the substance —
+    // 'mutates' and 'write rung' — rather than loosened to `isError`, because a refusal that does not
+    // tell the caller which grant is missing sends them to the docs to guess.
+    assert.match(text, /mutates/i, `Expected a mutation refusal: ${text}`);
+    assert.match(text, /write rung/i, `Expected the missing grant named: ${text}`);
   });
 });
 

--- a/testing/integration/retry-failed-embeddings-both-doors.test.js
+++ b/testing/integration/retry-failed-embeddings-both-doors.test.js
@@ -101,7 +101,10 @@ describe('retry_failed_embeddings answers the same as its route', () => {
       session = await openMcpSession(roToken);
       const res = await session.callTool('retry_failed_embeddings', { space: SPACE });
       const text = JSON.stringify(res ?? {});
-      assert.match(text, /read-only|readOnly|not permitted|Unknown tool/i,
+      // The refusal names the missing GRANT now rather than a flag: mutating tools are gated on holding a
+      // write rung somewhere. `Unknown tool` stays in the alternation because a hidden tool can legitimately
+      // be reported that way depending on how the client resolves the listing first.
+      assert.match(text, /mutates|write rung|not permitted|Unknown tool/i,
         `a read-only token must not be able to re-queue anything: ${text.slice(0, 250)}`);
 
       // And it must not even be OFFERED: a tool a token cannot call should not appear in its listing.

--- a/testing/red-team-tests/auth-surface-hardening.test.js
+++ b/testing/red-team-tests/auth-surface-hardening.test.js
@@ -172,13 +172,13 @@ describe('M9 — list_peers / sync_now require an admin token', () => {
 
   it('list_peers via a non-admin token is refused', async () => {
     const r = await callTool(plainToken, 'list_peers');
-    assert.match(r.text, /requires an admin token/i,
+    assert.match(r.text, /requires a token with instance-admin rights/i,
       `VULNERABILITY: non-admin token reached list_peers: ${r.text.slice(0, 300)}`);
   });
 
   it('sync_now via a non-admin token is refused', async () => {
     const r = await callTool(plainToken, 'sync_now');
-    assert.match(r.text, /requires an admin token/i,
+    assert.match(r.text, /requires a token with instance-admin rights/i,
       `VULNERABILITY: non-admin token reached sync_now: ${r.text.slice(0, 300)}`);
   });
 
@@ -190,7 +190,14 @@ describe('M9 — list_peers / sync_now require an admin token', () => {
 
   it('an admin token can still call list_peers (regression)', async () => {
     const r = await callTool(adminToken, 'list_peers');
-    assert.ok(!/requires an admin token/i.test(r.text), `admin must retain access: ${r.text.slice(0, 300)}`);
+    // Absence of the CURRENT wording. The previous version of this line matched the OLD wording, so when the
+    // refusal text changed it would have passed against a refused admin — a security test proving nothing
+    // while reading as "admin still works".
+    assert.ok(!/instance-admin rights/i.test(r.text), `admin must retain access: ${r.text.slice(0, 300)}`);
+    // And a POSITIVE signal, so no future rewording can make this vacuous again: the tool answered rather
+    // than erroring.
+    assert.ok(!/"isError"\s*:\s*true/.test(r.text), `admin call returned an error: ${r.text.slice(0, 300)}`);
+    assert.match(r.text, /peers|instanceId|\[\]/i, `expected a peer listing shape: ${r.text.slice(0, 300)}`);
   });
 });
 

--- a/testing/standalone/mcp-help.test.js
+++ b/testing/standalone/mcp-help.test.js
@@ -24,6 +24,18 @@ let helpTool;
 let ALL_TOOLS;
 
 /** Minimal ToolContext for a direct handler call. */
+/**
+ * The `rights` matrix is what decides tool visibility now, so the fixture derives one from the same
+ * `isAdmin`/`readOnly` intent these cases were written in. It is DERIVED rather than hand-written because
+ * `toolIsVisible` fails CLOSED on a missing matrix — a fixture that forgot it would report every mutating
+ * tool hidden and read like a scope bug rather than a fixture bug.
+ */
+function rightsFor({ readOnly, isAdmin }) {
+  const rung = isAdmin ? 'admin' : readOnly ? 'read' : 'write';
+  const all = { knowledge: rung, files: rung, schema: rung, dataQuality: rung };
+  return { instanceAdmin: !!isAdmin, createSpaces: !!isAdmin, floor: all, perSpace: {} };
+}
+
 function ctx({ readOnly, isAdmin, spaces = [] } = {}) {
   return {
     args: {},
@@ -35,6 +47,7 @@ function ctx({ readOnly, isAdmin, spaces = [] } = {}) {
     tokenSpaces: undefined,
     isAdmin,
     readOnly,
+    rights: rightsFor({ readOnly, isAdmin }),
   };
 }
 

--- a/testing/standalone/mcp-tool-docs-coverage.test.js
+++ b/testing/standalone/mcp-tool-docs-coverage.test.js
@@ -95,13 +95,24 @@ describe('MCP tool read-only classification matches the docs', () => {
       'The guide says these work normally with a readOnly token, but the code flags them mutating.');
   });
 
-  it('the enforcement both hides AND rejects — only the second is the control', () => {
-    // Filtering `tools/list` is discoverability; a client can still call a tool it was not shown, so
-    // the call-time rejection is what actually enforces read-only.
+  it('the enforcement both hides AND rejects, from ONE predicate — only the second is the control', () => {
+    // Filtering `tools/list` is discoverability; a client can still call a tool it was not shown, so the
+    // call-time rejection is what actually enforces it. Both halves must exist.
+    //
+    // What changed: they used to be the expression `readOnly && t.mutating` written out separately in each
+    // place — and in `help.ts` a third time, under a comment claiming it was one source of truth. They are
+    // now one function, so this asserts SHARING rather than two matching regexes. Two regexes could both
+    // pass while the expressions had drifted, which is exactly the state they were in.
     const router = readFileSync(join(ROOT, 'server', 'src', 'mcp', 'router.ts'), 'utf8');
-    assert.match(router, /ALL_TOOLS\.filter\([^)]*readOnly && \w+\.mutating/,
-      'expected tools/list to filter mutating tools for readOnly tokens');
-    assert.match(router, /if \(readOnly && \w+\?\.mutating\)/,
-      'expected a call-time rejection for mutating tools — filtering the list alone is not a control');
+    assert.match(router, /ALL_TOOLS\.filter\(t => toolIsVisible\(t, rights\)\)/,
+      'expected tools/list to filter through the shared predicate');
+    assert.match(router, /if \(tool && !toolIsVisible\(tool, rights\)\)/,
+      'expected a call-time rejection through the SAME predicate — filtering the list alone is advisory');
+
+    // And the predicate must actually gate on something. A version returning `true` for everything would
+    // satisfy both matches above while enforcing nothing.
+    const vis = readFileSync(join(ROOT, 'server', 'src', 'mcp', 'tool-visibility.ts'), 'utf8');
+    assert.match(vis, /if \(tool\.admin\) return rights\?\.instanceAdmin === true;/);
+    assert.match(vis, /if \(tool\.mutating\) return canWriteAnywhere\(rights\);/);
   });
 });

--- a/testing/standalone/route-guard-coverage.test.js
+++ b/testing/standalone/route-guard-coverage.test.js
@@ -110,8 +110,12 @@ const EXEMPT = new Map([
  */
 const WRITE_EXEMPT = new Map([
   // True, and checkable: `mcp/router.ts` opens its `CallToolRequestSchema` handler with
-  // `if (readOnly && tool?.mutating) return { ...'this token has read-only access', isError: true }`.
-  // The enforcement is per TOOL, which a per-route scanner cannot see — every tool arrives as `POST /`.
+  // `if (tool && !toolIsVisible(tool, rights))`, which refuses a mutating tool to a token holding no write
+  // rung anywhere. The enforcement is per TOOL, which a per-route scanner cannot see — every tool arrives
+  // as `POST /`. It also enforces the per-space rung at call time via `toolRightsRefusal`.
+  //
+  // The quoted expression used to be `readOnly && tool?.mutating`. An exemption whose stated reason quotes
+  // code that no longer exists is how a scanner ends up excusing a check nobody has verified in a year.
   ['mcpRouter', 'read-only is enforced per tool in the dispatcher, not per route'],
 ]);
 


### PR DESCRIPTION
The expression `!(readOnly && t.mutating) && !(!isAdmin && t.admin)` was written out **four times**: the
`tools/list` filter, the two call-time refusals in the dispatcher, and `help`'s own listing.

The fourth carried this comment:

> *"The exact predicate tools/list uses (router.ts) — one source of truth, so this text can never advertise a
> tool the dispatcher would deny."*

Four copies claiming to be one — and the claim is what made it invisible, **inside the mechanism built to stop
a listing promising what the dispatcher refuses.**

They are now literally the same function.

## The gate asserts sharing, not two matching regexes

The old gate matched `readOnly && \w+\.mutating` in two places. Both could pass while the expressions had
drifted, which is the state they were already in. It now asserts both sites call `toolIsVisible`, plus that
the predicate actually gates on something — a version returning `true` for everything would satisfy the first
two matches while enforcing nothing.

Mutation-tested: making every mutating tool visible turns **two** tests red.

## And it reads the matrix, which is the point

This is what makes `admin`/`readOnly` deletable from the token record.

**Correction to my previous PR:** #901's CHANGELOG said *no* authorization decision reads the legacy flags.
That was true of REST and **not** of these two dispatcher gates. The line is corrected to say REST rather than
left overstating; this PR is what makes the broader claim true for MCP.

A narrower gap closes with it: a token holding a write rung in **one** space was shown **every** mutating
tool, because `readOnly` was false instance-wide — and the per-space rung check then refused the call. The
listing and the refusal now come from one predicate.

## Two traps worth naming

**`ctx.rights` is populated, not merely declared.** `toolIsVisible(t, undefined)` hides every mutating and
admin tool, so an unpopulated field would have emptied `help`'s listing while `tools/list` stayed correct —
the two disagreeing again, in the mechanism meant to prevent that.

**The scope signature was keyed on the legacy triple.** So a token edited through the rights-matrix editor
produced an identical signature and kept serving its **previous scope for the life of an SSE stream** — the
matrix can change without any of `admin`, `readOnly` or `spaces` moving. It is keyed on the matrix now.

## Fixtures

`mcp-help`'s contexts derive a matrix from the same `isAdmin`/`readOnly` intent they were written in, rather
than hand-writing one. The predicate fails **closed** on a missing matrix, so a fixture that forgot it would
report every mutating tool hidden and read like a scope bug rather than a fixture bug.
