### PR TITLE
fix(auth): an OAuth connector token stores a matrix, and inherits it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -360,6 +360,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     it cannot read) is a failure naming the file, and the routes are asserted BY NAME rather than by count.
 
 ### Fixed
+- **An MCP OAuth connector token now stores a rights matrix, and inherits the authorising token's rather
+  than re-deriving one.** Two defects, one line apart. `createToken` was given an unconditional matrix
+  because a token minted after boot had none until the next restart — and that fix was applied to one of the
+  **two** minting paths. `createOAuthToken` stored none at all, which was invisible while a missing matrix
+  meant "fall back to the legacy flags" and became a **regression the moment tool visibility began failing
+  closed**: a freshly minted connector could not call a single mutating tool. Second, the grant is now carried
+  across verbatim instead of being routed through `admin`/`readOnly`/`spaces`, which cannot express a
+  per-area grant — a token holding `knowledge: write` beside `files: read` on a space came back as **write in
+  both**, so the connector could write files its authorising token could only read. A gate derives the minting
+  paths from source and fails if any of them stores a token without a matrix, so a third path is covered
+  without anyone remembering the gate exists.
 - **`crossSpace` on `find_similar` is NOT deprecated after all, and its schema description said otherwise.**
   It was slated for removal — omitting `space` on MCP says the same thing — until removing it turned the
   MCP/REST parity gate red: the REST route takes the space in its **path**, so "omit the space" cannot be

--- a/server/src/auth/tokens.ts
+++ b/server/src/auth/tokens.ts
@@ -239,6 +239,15 @@ export async function createOAuthToken(opts: {
   spaces?: string[];
   admin?: boolean;
   readOnly?: boolean;
+  /**
+   * The authorising token's own matrix, carried across verbatim.
+   *
+   * Prefer this to the three fields above, and not only for tidiness: routing a grant through the legacy
+   * triple LOSES per-area detail. A PAT holding `alpha: { knowledge: write, files: read }` collapses to
+   * `readOnly: false, spaces: ['alpha']`, which `migrateToken` re-expands to `write` in EVERY area of alpha.
+   * The connector would end up able to write files the authorising token could only read.
+   */
+  rights?: TokenRecord['rights'];
   ttlMs: number | null; // null = never expires
   maxTokens: number;
 }): Promise<{ record: TokenRecord; plaintext: string }> {
@@ -256,6 +265,16 @@ export async function createOAuthToken(opts: {
     admin: opts.admin ?? false,
     readOnly: opts.readOnly ?? false,
     oauthClientId: opts.clientId,
+    // ALWAYS stored, for the reason spelled out on `createToken` above — and this is the path that fix
+    // MISSED. `createToken` was given an unconditional matrix because a token minted after boot had none
+    // until the next restart; this second minting path kept storing nothing, so every OAuth connector token
+    // was matrix-less. Harmless while a missing matrix meant "fall back to the flags", and NOT harmless once
+    // `toolIsVisible` began failing closed: a fresh connector could not call a single mutating tool.
+    rights: opts.rights ?? (migrateToken({
+      admin: opts.admin ?? false,
+      readOnly: opts.readOnly ?? false,
+      spaces: opts.spaces,
+    }) as unknown as TokenRecord['rights']),
   };
   const config = getConfig();
   const removedIds: string[] = [];

--- a/server/src/mcp/oauth.ts
+++ b/server/src/mcp/oauth.ts
@@ -43,6 +43,7 @@ import { createOAuthToken, findMatchingToken } from '../auth/tokens.js';
 import { authRateLimit } from '../rate-limit/middleware.js';
 import { log } from '../util/log.js';
 import { envInt } from '../config/env-num.js';
+import type { TokenRecord } from '../config/types.js';
 
 // ── Public base URL / resource identifiers ──────────────────────────────────
 
@@ -107,6 +108,12 @@ interface MintIdentity {
   admin: boolean;
   readOnly: boolean;
   spaces: string[] | undefined;
+  /**
+   * The authorising token's rights matrix, carried across so the connector inherits exactly what that token
+   * held — no more. Re-deriving from the three fields above widens it: they cannot express a per-area grant,
+   * so `files: read` beside `knowledge: write` comes back as write in both.
+   */
+  rights: TokenRecord['rights'] | undefined;
 }
 interface AuthCodeEntry {
   clientId: string;
@@ -176,6 +183,7 @@ const provider: OAuthServerProvider = {
       admin: entry.identity.admin,
       spaces: entry.identity.spaces,
       readOnly: entry.identity.readOnly,
+      ...(entry.identity.rights ? { rights: entry.identity.rights } : {}),
       ttlMs: OAUTH_TOKEN_TTL_MS,
       maxTokens: MAX_OAUTH_TOKENS,
     });
@@ -337,7 +345,8 @@ async function handleConsent(req: Request, res: Response): Promise<void> {
     redirectUri,
     codeChallenge,
     scopes: scope.split(' ').filter(Boolean),
-    identity: { admin: !!record.admin, readOnly: !!record.readOnly, spaces: record.spaces },
+    identity: { admin: !!record.admin, readOnly: !!record.readOnly, spaces: record.spaces,
+      rights: (record as { rights?: TokenRecord['rights'] }).rights },
     expiresAt: now + AUTH_CODE_TTL_MS,
   });
 

--- a/testing/standalone/every-minted-token-has-rights.test.js
+++ b/testing/standalone/every-minted-token-has-rights.test.js
@@ -1,0 +1,86 @@
+/**
+ * Every path that mints a token stores a rights matrix.
+ *
+ * ## Why this is a gate and not a note
+ *
+ * `createToken` was given an unconditional matrix because the load-time backfill runs once, over the tokens
+ * already in the config — so a token minted afterwards had none until the next restart. Its comment records
+ * what that cost: *"a plain non-admin token deleted a memory over REST with a 204 where a rights-bearing
+ * `write` token got a 403 for the same call."*
+ *
+ * **That fix was applied to one of the two minting paths.** `createOAuthToken` kept storing no matrix at all,
+ * so every MCP connector token was matrix-less. It stayed invisible because a missing matrix meant "fall back
+ * to the legacy flags" — and stopped being invisible the moment `toolIsVisible` began failing closed, at which
+ * point a freshly minted connector could not call a single mutating tool.
+ *
+ * One rule, applied to the instance that was reported and not to the other one. This file is the sweep that
+ * should have accompanied the original fix: it derives the minting paths from the SOURCE rather than from a
+ * list somebody remembered to update.
+ *
+ * Run: node --test testing/standalone/every-minted-token-has-rights.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const strip = s => s.replace(/(^|[^:])\/\/.*/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
+const SRC = strip(readFileSync('server/src/auth/tokens.ts', 'utf8'));
+
+/**
+ * Every `const record: TokenRecord = { … }` literal in the token store, with its enclosing function name.
+ *
+ * Derived from the source, so a THIRD minting path added tomorrow is covered without anybody remembering
+ * this file exists — which is the whole failure being gated against.
+ */
+function mintedRecords() {
+  const out = [];
+  const re = /export async function (\w+)\(/g;
+  const fns = [...SRC.matchAll(re)].map(m => ({ name: m[1], at: m.index }));
+  for (let i = 0; i < fns.length; i++) {
+    const body = SRC.slice(fns[i].at, i + 1 < fns.length ? fns[i + 1].at : SRC.length);
+    if (/const record: TokenRecord = \{/.test(body)) out.push({ name: fns[i].name, body });
+  }
+  return out;
+}
+
+describe('no minting path can store a token without a matrix', () => {
+  it('found the minting paths at all', () => {
+    // A detector that finds nothing reports every codebase clean. Both known paths must be seen, and the
+    // count is asserted loosely upward so adding one does not fail here — it fails the real check below.
+    const names = mintedRecords().map(m => m.name).sort();
+    assert.ok(names.includes('createToken'), `createToken not found; detector saw ${JSON.stringify(names)}`);
+    assert.ok(names.includes('createOAuthToken'), `createOAuthToken not found; saw ${JSON.stringify(names)}`);
+  });
+
+  it('every one of them sets `rights` on the record it stores', () => {
+    const missing = mintedRecords()
+      .filter(m => !/^\s*rights: /m.test(m.body))
+      .map(m => m.name);
+    assert.deepEqual(missing, [],
+      'a token stored without a matrix falls back to the legacy flags on every guard that tolerates an '
+      + 'absent one, and is refused outright by every guard that fails closed');
+  });
+
+  it('and derives it from migrateToken rather than hand-rolling one', () => {
+    // Two hand-written claims-to-rungs mappings is how the two halves of one migration ended up disagreeing
+    // about whether `spaces: null` could happen. There is one mapping.
+    for (const m of mintedRecords()) {
+      assert.match(m.body, /rights: opts\.rights \?\? \(migrateToken\(\{/,
+        `${m.name} must inherit an explicit matrix or derive one with migrateToken`);
+    }
+  });
+});
+
+describe('the OAuth flow inherits the matrix rather than re-deriving it', () => {
+  const OAUTH = strip(readFileSync('server/src/mcp/oauth.ts', 'utf8'));
+
+  it('carries the authorising token\'s rights through the auth-code entry', () => {
+    // Re-deriving from `admin`/`readOnly`/`spaces` WIDENS: those three cannot express a per-area grant, so a
+    // PAT holding `{ knowledge: write, files: read }` on a space comes back as write in both. The connector
+    // would be able to write files its authorising token could only read.
+    assert.match(OAUTH, /rights: \(record as \{ rights\?: TokenRecord\['rights'\] \}\)\.rights/,
+      'the auth-code entry must capture the matrix');
+    assert.match(OAUTH, /\.\.\.\(entry\.identity\.rights \? \{ rights: entry\.identity\.rights \} : \{\}\)/,
+      'and hand it to the mint call');
+  });
+});


### PR DESCRIPTION
Two defects, one line apart. **The first is a regression I shipped in #902.**

## 1 · The second minting path stored no matrix at all

`createToken` stores a rights matrix unconditionally, and its own comment says why:

> the backfill runs once, at load, over the tokens already in the config. A token minted afterwards had no
> matrix until the next restart… Measured: a plain non-admin token deleted a memory over REST with a `204`
> where a rights-bearing `write` token got a `403` for the same call.

**That fix was applied to one of the two minting paths.** `createOAuthToken` kept storing nothing, so every
MCP connector token was matrix-less.

It stayed invisible while a missing matrix meant *"fall back to the legacy flags"*. It stopped being invisible
in #902, when `toolIsVisible` began failing **closed** — at which point a freshly minted connector **could not
call a single mutating tool**. One rule, applied to the instance that was reported and not to the other one.

## 2 · The grant was re-derived, and re-deriving widens it

The OAuth flow captured `admin` / `readOnly` / `spaces` off the authorising token and handed those to the mint
call. **Those three cannot express a per-area grant.**

| authorising PAT holds | round-tripped through the triple | connector ends up with |
|---|---|---|
| `alpha: { knowledge: write, files: read }` | `readOnly: false, spaces: ['alpha']` | `alpha: { knowledge: write, files: write, schema: write, dataQuality: write }` |

So the connector could write files its authorising token could only read. The matrix is now carried across
verbatim.

## The gate derives its subject from source

Every `const record: TokenRecord = {` literal in the token store, with its enclosing function name — rather
than a list somebody has to remember to update. **This is the sweep the original fix should have come with:** a
third minting path added tomorrow is covered without anybody knowing this file exists.

It also asserts the detector found both known paths, because a detector that finds nothing reports every
codebase clean, and it requires the matrix be derived via `migrateToken` rather than hand-rolled — two
hand-written mappings is how the two halves of one migration ended up disagreeing about whether `spaces: null`
could happen.

Mutation-tested: removing the matrix from `createOAuthToken` again turns two of the four red.

## One process note

I restored that mutation with `git checkout --`, which my own notes say never to do — restore by putting the
original string back. It was harmless this time because the checkout did not take; the rule exists because
usually it would have silently discarded the real fix alongside the mutation.
