### PR TITLE
refactor(client): the permission badge and canEdit read the matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   every type.
 
 ### Changed
+- **The Tokens page badge and the graph editor's edit permission read the rights matrix, not the legacy
+  flags.** The pill branched on `admin` and `readOnly`; neither can express a per-space grant, so it labelled a
+  token that can write in one space **"read-only"**, and one whose matrix reaches nothing **"standard"**. A
+  token carrying no matrix now reads as read-only — the predicate failing closed, which is the right way
+  round for a label about permission. The client's copy of the ladder is deliberate and bounded: it picks a
+  badge and greys out an editor, both cosmetic, and every action it enables is re-checked by the server per
+  space and per area.
 - **MCP tool visibility and its two dispatcher gates read the rights matrix, from ONE predicate.** The
   expression `!(readOnly && t.mutating) && !(!isAdmin && t.admin)` was written out four times: the
   `tools/list` filter, the two call-time refusals, and `help`'s own listing — the last of those under a

--- a/client/src/app/core/token-capability.ts
+++ b/client/src/app/core/token-capability.ts
@@ -1,0 +1,39 @@
+import type { TokenRights } from '../pages/settings/rights-glyph.component';
+
+const AREAS = ['knowledge', 'files', 'schema', 'dataQuality'] as const;
+const RUNGS = ['none', 'read', 'write', 'admin'] as const;
+
+/** Is `held` at least `needs` on the four-rung ladder? Mirrors the server's `satisfies`. */
+function satisfies(held: string | undefined, needs: (typeof RUNGS)[number]): boolean {
+  const h = RUNGS.indexOf((held ?? 'none') as (typeof RUNGS)[number]);
+  return h >= 0 && h >= RUNGS.indexOf(needs);
+}
+
+/**
+ * Can this token write at all — any area, any space?
+ *
+ * ## Why the UI needs this rather than a `readOnly` flag
+ *
+ * The badge on the Tokens page and the graph editor's `canEdit` both asked `!token.readOnly`. That flag is
+ * being removed: it cannot express a per-space, per-area grant, and every guard on the server now reads the
+ * matrix instead. A UI still branching on the flag would show "read-only" for a token that can write in one
+ * space, and "standard" for one whose matrix reaches nothing.
+ *
+ * ## It mirrors the server deliberately, and only this far
+ *
+ * The server's `auth/write-anywhere.ts` answers the same question for the coarse mutation guard, and this is
+ * the same predicate — instance admin, or a write rung in some area of the floor or of any space. Keeping the
+ * ladder here is a duplication, and the alternative is worse: the UI would have to ask the server whether to
+ * draw a badge.
+ *
+ * What it must NOT be used for is deciding whether a specific action is allowed. That is the server's answer,
+ * per space and per area, and the UI's job is to render the outcome — not to pre-empt it. This exists to pick
+ * a LABEL and to grey out an editor, both of which are cosmetic and both of which the server re-checks.
+ */
+export function canWriteAnywhere(rights: TokenRights | undefined | null): boolean {
+  if (!rights) return false;
+  if (rights.instanceAdmin) return true;
+  const floor = rights.floor;
+  if (floor && AREAS.some(a => satisfies(floor[a], 'write'))) return true;
+  return Object.values(rights.perSpace ?? {}).some(areas => AREAS.some(a => satisfies(areas[a], 'write')));
+}

--- a/client/src/app/pages/graph/graph.component.ts
+++ b/client/src/app/pages/graph/graph.component.ts
@@ -57,6 +57,7 @@ import {
   buildElements, createGraphCytoscape, renderElements, type GraphInstance,
 } from './graph-cytoscape';
 import { GRAPH_STYLES } from './graph.styles';
+import { canWriteAnywhere } from '../../core/token-capability';
 
 @Component({
   selector: 'app-graph-view',
@@ -567,7 +568,9 @@ export class GraphComponent implements OnInit, AfterViewInit, OnDestroy {
     }
 
     this.authApi.getMe().pipe(catchError(() => of(null))).subscribe(me => {
-      this.canEdit.set(me ? !me.readOnly : false);
+      // From the matrix, not the removed `readOnly` flag. `canEdit` only greys the editor out; every
+      // action it enables is re-checked by the server per space and per area.
+      this.canEdit.set(canWriteAnywhere(me?.rights ?? null));
     });
   }
 

--- a/client/src/app/pages/settings/tokens.component.spec.ts
+++ b/client/src/app/pages/settings/tokens.component.spec.ts
@@ -135,14 +135,29 @@ function makeList(tokens: unknown[] = []) {
 describe('TokensComponent — permission pill colour semantics (UI-BUNDLE-1)', () => {
   beforeEach(() => TestBed.resetTestingModule());
 
+  /** A matrix holding `rung` in every area, as a floor — the simplest shape that expresses one intent. */
+  const rights = (rung: string) => ({
+    instanceAdmin: rung === 'admin',
+    createSpaces: rung === 'admin',
+    floor: { knowledge: rung, files: rung, schema: rung, dataQuality: rung },
+    perSpace: {},
+  });
+
   // Owner feedback 2026-07-23: admin=red, standard=green, read-only=yellow. The list pills map to the
   // design-system StatusPill variants error / ok / warn respectively (schema-library stays pending/blue).
   it('renders the permission pill with the level-coded StatusPill variant', () => {
     const cases = [
-      { tok: { id: 't1', admin: true }, variant: 'error' },
-      { tok: { id: 't2' }, variant: 'ok' }, // standard = no flags
-      { tok: { id: 't3', readOnly: true }, variant: 'warn' },
-      { tok: { id: 't4', schemaLibrary: true }, variant: 'pending' },
+      // The pill reads the RIGHTS MATRIX now, not the legacy flags, so the fixtures express the same three
+      // intents through it. A rung of `write` somewhere is what "standard" means; `read` everywhere is what
+      // "read-only" means.
+      //
+      // Worth stating because the default moved: a token carrying NO matrix renders read-only rather than
+      // standard. That is the predicate failing closed, and it is right — a token whose matrix reaches
+      // nothing should not be labelled the same as one that can write.
+      { tok: { id: 't1', rights: rights('admin') }, variant: 'error' },
+      { tok: { id: 't2', rights: rights('write') }, variant: 'ok' },
+      { tok: { id: 't3', rights: rights('read') }, variant: 'warn' },
+      { tok: { id: 't4', schemaLibrary: true, rights: rights('write') }, variant: 'pending' },
     ] as const;
     for (const { tok, variant } of cases) {
       const { fixture, c } = makeList();

--- a/client/src/app/pages/settings/tokens.component.ts
+++ b/client/src/app/pages/settings/tokens.component.ts
@@ -22,6 +22,7 @@ import { OwnTokenRightsComponent } from './own-token-rights.component';
 import { ErrorStateComponent } from '../../shared/error-state.component';
 import { httpErrorReason } from '../../core/http-error';
 import { TOKENS_PAGE_STYLES } from './tokens.styles';
+import { canWriteAnywhere } from '../../core/token-capability';
 
 @Component({
   selector: 'app-tokens',
@@ -141,9 +142,9 @@ import { TOKENS_PAGE_STYLES } from './tokens.styles';
                     }
                   </td>
                   <td>
-                    @if (t.admin) { <app-status-pill variant="error">{{ 'tokens.badge.admin' | transloco }}</app-status-pill> }
+                    @if (t.rights?.instanceAdmin) { <app-status-pill variant="error">{{ 'tokens.badge.admin' | transloco }}</app-status-pill> }
                     @else if (t.schemaLibrary) { <app-status-pill variant="pending">{{ 'tokens.badge.schemaLibrary' | transloco }}</app-status-pill> }
-                    @else if (t.readOnly) { <app-status-pill variant="warn">{{ 'tokens.badge.readOnly' | transloco }}</app-status-pill> }
+                    @else if (!canWrite(t)) { <app-status-pill variant="warn">{{ 'tokens.badge.readOnly' | transloco }}</app-status-pill> }
                     @else { <app-status-pill variant="ok">{{ 'tokens.badge.standard' | transloco }}</app-status-pill> }
                     <!-- An MFA exemption is a deliberate hole in an instance-wide control. It is shown
                          wherever the token is, because a hole nobody can see is one nobody reviews. -->
@@ -251,6 +252,19 @@ export class TokensComponent implements OnInit {
   /** Inline label edit: the id of the token whose label is being edited (null = none), + its draft. */
   editingId = signal<string | null>(null);
   editLabelValue = '';
+
+  /**
+   * Whether a token can write anywhere — the badge's question, answered from the MATRIX.
+   *
+   * The pill used to branch on `t.admin` and `t.readOnly`. Neither can express a per-space grant, so the
+   * flags labelled a token that can write in one space "read-only", and one whose matrix reaches nothing
+   * "standard". A token carrying no matrix at all now reads as read-only, which is the predicate failing
+   * closed and is the right way round.
+   *
+   * One line because `tokens.component.ts` is frozen by the god-file ratchet at a size it should come DOWN
+   * from, and a template needs the callable on the component.
+   */
+  canWrite = (t: { rights?: TokenRights | null }): boolean => canWriteAnywhere(t.rights ?? null);
 
   ngOnInit(): void {
     this.authApi.getMe().subscribe({ next: (t) => this.selfToken.set(t), error: () => {} });

--- a/testing/standalone/no-new-god-files.test.js
+++ b/testing/standalone/no-new-god-files.test.js
@@ -88,7 +88,12 @@ const FROZEN = {
   // own rule is to pay that with an extraction rather than raise the number: 199 lines of CSS moved to
   // `tokens.styles.ts`, beside the `dialog.styles.ts` already there. Lowered to what it now measures and KEPT,
   // because deleting the entry is how a file quietly earns the right to grow back.
-  'client/src/app/pages/settings/tokens.component.ts': 341,
+  // RAISED 341 -> 343 to move the permission pill off the removed `admin`/`readOnly` flags: one import
+  // and one accessor. A template needs its callable on the component, so the accessor cannot live in the
+  // shared helper — it is a one-line arrow, and the reasoning went into a TS comment because the prose
+  // would otherwise sit inside the template STRING and count as code. The flags could not express a
+  // per-space grant, so the pill labelled a token that can write in one space "read-only".
+  'client/src/app/pages/settings/tokens.component.ts': 343,
   // RAISED 1617 -> 1618 by one line: the Q-10 timestamp swap replaced a `| date:` cell with `<app-timestamp>` and
   // needed an import, gaining an import line while losing none. At 1618 code lines this file is by far the largest
   // here and wants splitting on its own terms — but not inside a one-cell rendering change, where the split would be
@@ -136,7 +141,10 @@ const FROZEN = {
   // 769 -> 773: `openBrainDrawer` gained two overload signatures and its `lastSaved` effect reads the
   // record inside each branch so the discriminant narrows it. Four lines of TYPES, no new behaviour —
   // raised deliberately rather than worked around, which is what this list is for.
-  'client/src/app/pages/graph/graph.component.ts': 773,
+  // RAISED 773 -> 774 for one import. `canEdit` moved off `me.readOnly` onto the rights matrix, and the
+  // import is the whole cost — the alternative is inlining the predicate, which is a second copy of a
+  // rule the server already owns.
+  'client/src/app/pages/graph/graph.component.ts': 774,
   // 753 -> 764: `backfillTokenRights`. This file is where config migrations already live — the media
   // master-switch and space-description ones are both here — so a fourth belongs beside them rather than in
   // a module only the loader would ever call.


### PR DESCRIPTION
The last readers of the legacy `admin` / `readOnly` flags outside the migration itself.

**Client first, on purpose:** the fields still exist, so nothing breaks at this step and `main` is never left
mid-migration. Removing them from the record is the next PR.

## What the flags were getting wrong

The Tokens page pill branched on `t.admin`, then `t.readOnly`. Neither can express a per-space grant:

| token | old pill | correct |
|---|---|---|
| can write in one space, read elsewhere | **read-only** | standard |
| matrix reaches nothing | **standard** | read-only |

Both now read off `rights`. A token carrying **no** matrix reads as read-only — the predicate failing closed,
which is the right way round for a label about permission. The alternative tells an operator a token can write
when nobody knows whether it can.

## The client's copy of the ladder is deliberate and bounded

`core/token-capability.ts` mirrors the server's `auth/write-anywhere.ts`, and its comment says where the
boundary is: it picks a **badge** and greys out an **editor**, both cosmetic, and every action it enables is
re-checked by the server per space and per area. The alternative is asking the server whether to draw a pill.

## Two frozen files grew, both by the true minimum

- **`tokens.component.ts` 341 → 343** — one import, one accessor. A template needs its callable *on* the
  component, so the accessor cannot live in the shared helper; it is a one-line arrow. The reasoning went into
  a TS comment rather than an HTML one, because a comment inside the template **string** counts as code — and a
  backtick inside it kills the template literal outright, which is how this first failed to build.
- **`graph.component.ts` 773 → 774** — the import, and nothing else.

## A note on how the spec failed

The pill fixtures used the legacy flags, so `t2` (standard) failed, and after fixing that `t1` (admin) failed —
the badge is an `@if / @else if` chain and I had moved only one branch of it. Both are on matrices now,
expressing the same three intents.
