### PR TITLE
chore(release): 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0] — 2026-08-14
+
+> **A major, and the deprecation checklist is what makes it one.** Nine surfaces were removed, each of
+> which had been announced or was reachable only through a spelling we had replaced. Four rows on that
+> checklist were deliberately reclassified as PERMANENT rather than removed — every one of them because
+> dropping it would silently re-enable something an operator had switched off, or silently narrow a
+> capability we had told an integrator we would keep.
+>
+> The other half of this release is the S-1 fix: one authorization policy was being enforced by three
+> different mechanisms depending on which door a caller used. It is one mechanism now, on REST, on MCP and
+> for OIDC identities, and two privilege defects surfaced in the OAuth mint path while closing it.
+
 ### Removed
 
 *The 3.0 deprecation checklist. Each entry names its replacement; `todo/_DEPRECATIONS.md` carries the row.*

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/client",
-  "version": "2.8.1",
+  "version": "3.0.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ythril",
-  "version": "2.8.1",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ythril",
-      "version": "2.8.1",
+      "version": "3.0.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "workspaces": [
         "server",
@@ -18,7 +18,7 @@
     },
     "client": {
       "name": "@ythril/client",
-      "version": "2.8.1",
+      "version": "3.0.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@angular/animations": "^21.0.0",
@@ -21022,7 +21022,7 @@
     },
     "server": {
       "name": "@ythril/server",
-      "version": "2.8.1",
+      "version": "3.0.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ythril",
-  "version": "2.8.1",
+  "version": "3.0.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "type": "module",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/server",
-  "version": "2.8.1",
+  "version": "3.0.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
**Owner ruling C:** 3.0.0 performs the deprecation checklist.

Nine surfaces removed, four checklist rows deliberately reclassified as **permanent**, and the S-1
authorization hole closed on REST, MCP and OIDC identities.

## The lockfile bump, done the careful way

`tslib` is pinned at **2.8.1** — the version we are bumping away from. A global replace would have rewritten it
to a version that does not exist, and `npm ci` would never have mentioned it.

So: line 3 of the three `package.json` files, and exactly **four** lines of `package-lock.json` — the lockfile
root plus the `""`, `client` and `server` workspace entries, located by their **enclosing key** rather than by
matching the version string.

Verified: `npm ci --dry-run` passes, and `tslib` still reads `2.8.1`.

## Step 5 of the release procedure: 3.0 introduces no new deprecation

That is a finding rather than an omission. Nine removals and **no alias, no second spelling, no compatibility
shim.** The one thing that could have become one — `TOOL_RIGHTS` — is derived from `ROUTE_RIGHTS` with a gate
that re-derives it and fails on disagreement.

## Three rows carry into 3.1, with measurements attached

Not quietly dropped — each is recorded in `_DEPRECATIONS.md` with the number that made it too big for a release
tail:

| row | why it did not ship |
|---|---|
| **1.7** the legacy token *fields* | deleting them produces **55 type errors across 14 files**; `spaces` is still the scoping input in the sync path, search and rename. A scope-unification job, and the enforcement half already shipped |
| **1.5** the `/setup` HTML form | it **shadows the SPA's own setup route** and is the live first-run path. Removing it switches first-run onto a page that has never served one, on the unauthenticated boot path |
| **P-4** `.strict()` on space bodies | breaking, and this was the release for it |

## The outgoing message is rewritten, not adapted

`_CUSTOMER-MESSAGE-NEXT.md` was a 2.x draft with the `traverse` break as its lead. It now opens with a table of
what is gone and what to send instead, marks which removals were **announced** and which are **automatic at
boot**, and states what to check before upgrading — a token whose rungs may not cover what it has been doing.

It also names the two deletions we decided **not** to make, because one of them (`crossSpace`) had a schema
description telling integrators it was going away.

The rollback section says plainly that the legacy token fields are **still stored**, so that statement stays
true rather than being corrected into something we then have to correct back.
