### PR TITLE
fix(tokens): a token with no matrix can be given one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A token with no rights matrix could be seen and not fixed.** The rights glyph AND the pen that opens the
+  editor were both inside `@if (t.rights)`, so a token without a matrix showed neither — no way to grant it
+  one from the UI. The pen is now unconditional; the glyph still needs a matrix to draw, because it draws a
+  matrix. The editor already tolerated a rightless token: it starts from an empty one.
+- **Such a token was also labelled "read-only", which is a different thing.** It holds nothing, and calling
+  that read-only is what made the state read as *"all my tokens went read-only"* when the real state was
+  *"these tokens have no matrix"*. Two different problems, and only one is about permission levels. The pill
+  now says so, in all three locales.
+- **The permission pill is gone from the token list.** It said admin / standard / read-only /
+  schema-library; the glyph beside it says what the token can actually reach, per area and per space.
+  "Standard" only ever meant "none of the other four", which is nothing once the glyph is there.
+- **The second-factor controls are removed from token management.** UI only — the server is untouched: `mfa`
+  is still accepted on the PATCH body and granting an exemption still costs a live TOTP code.
+- **The rights editor is no longer 600px wide.** It renders areas x rungs once per space; at the shared
+  default that is a column of squeezed cells. It now takes `min(1400px, 94vw)`.
+- **`created`, `last used` and `expires` are a date and time, not "3 days ago".** Relative text answers how
+  long when the question is WHEN — which log line, which incident. It also rounds: 23 hours and 47 hours both
+  read "tomorrow". Shown in the viewer's own locale and timezone.
+
 ## [3.0.0] — 2026-08-14
 
 > **A major, and the deprecation checklist is what makes it one.** Nine surfaces were removed, each of

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1864,6 +1864,7 @@
   "tokens.matrix.help": "Pro Bereich und Space eine Stufe setzen. Ersetzt die Auswahl oben — ein Token nutzt entweder das eine oder das andere, nie beides.",
   "tokens.rights.title": "Rechte",
   "tokens.rights.edit": "Rechte bearbeiten",
+  "tokens.rights.none": "keine Matrix",
   "tokens.rights.space": "Space",
   "tokens.own.title": "Ihre Berechtigungen",
   "tokens.own.readOnly": "Was das Token darf, mit dem Sie angemeldet sind. Nur Anzeige — Änderungen erfordern eine Administratorin oder einen Administrator.",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1864,6 +1864,7 @@
   "tokens.matrix.help": "Set a level per area per space. Replaces the permission and space choices above — a token uses one or the other, never both.",
   "tokens.rights.title": "Rights",
   "tokens.rights.edit": "Edit rights",
+  "tokens.rights.none": "no matrix",
   "tokens.rights.space": "Space",
   "tokens.own.title": "Your access",
   "tokens.own.readOnly": "What the token you are signed in with may do. Read-only — changing it needs an administrator.",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1864,6 +1864,7 @@
   "tokens.matrix.help": "Ustaw poziom dla obszaru w każdej przestrzeni. Zastępuje wybory powyżej — token używa jednego albo drugiego, nigdy obu.",
   "tokens.rights.title": "Uprawnienia",
   "tokens.rights.edit": "Edytuj uprawnienia",
+  "tokens.rights.none": "brak macierzy",
   "tokens.rights.space": "Przestrzeń",
   "tokens.own.title": "Twoje uprawnienia",
   "tokens.own.readOnly": "Co może token, którym jesteś zalogowany. Tylko do wglądu — zmiana wymaga administratora.",

--- a/client/src/app/pages/settings/token-rights-dialog.component.ts
+++ b/client/src/app/pages/settings/token-rights-dialog.component.ts
@@ -36,6 +36,10 @@ import type { Space, TokenRecord } from '../../core/api.types';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [TranslocoPipe, PhIconComponent, ModalDirective, RightsMatrixComponent, FormsModule],
   styles: [DIALOG_STYLES, `
+    /* The matrix is areas x rungs, once per space. At the shared 600px default it renders as a column of
+       squeezed cells and the space rows wrap — reported as "too narrow". The --dialog-max-width variable exists
+       precisely so a host can say this; sizing was always the caller's decision. */
+    :host { --dialog-max-width: min(1400px, 94vw); }
     /* Visually separated, and last. A destructive control beside Save is a mis-click; the reader should have
        to travel to reach it. The border is the boundary, not decoration. */
     .danger-zone {
@@ -96,37 +100,6 @@ import type { Space, TokenRecord } from '../../core/api.types';
         <label style="display:block;margin-bottom:6px;">{{ 'tokens.create.permission' | transloco }}</label>
         <app-rights-matrix [rights]="draft()" [spaces]="spaceIds()" (changed)="draft.set($event)"/>
 
-        <!-- The second factor, on the token rather than on the mint request. It was settable only while
-             minting, so changing a scheduler's exemption meant revoking the token and minting a replacement —
-             rotating a secret to change a flag. -->
-        <div class="field" style="margin-top:14px;margin-bottom:0;">
-          <label for="tokenMfa">{{ 'tokens.create.mfa' | transloco }}</label>
-          <select id="tokenMfa" [(ngModel)]="draftMfa" name="mfa">
-            <option value="inherit">{{ 'tokens.mfa.inherit' | transloco }}</option>
-            <option value="exempt">{{ 'tokens.mfa.exempt' | transloco }}</option>
-            <option value="required">{{ 'tokens.mfa.required' | transloco }}</option>
-          </select>
-          <p class="permission-help">
-            <ph-icon name="info" [size]="14" />
-            <span>{{ ('tokens.mfa.' + draftMfa + '.desc') | transloco }}</span>
-          </p>
-        </div>
-
-        <!-- Granting an exemption costs a live TOTP code on the request, even from a token that is itself
-             exempt — otherwise one exemption grants the next. Asked for HERE rather than after a 403, because
-             the server's refusal is correct and unactionable: the operator cannot tell from it that the field
-             they changed is the reason. Shown only when it is actually needed. -->
-        @if (needsCode()) {
-          <div class="field" style="margin-top:12px;margin-bottom:0;">
-            <label for="tokenTotp">{{ 'tokens.mfa.codeLabel' | transloco }}</label>
-            <input id="tokenTotp" type="text" inputmode="numeric" autocomplete="one-time-code"
-                   [(ngModel)]="totpCode" name="totp" maxlength="10" />
-            <p class="permission-help">
-              <ph-icon name="info" [size]="14" />
-              <span>{{ 'tokens.mfa.codeHint' | transloco }}</span>
-            </p>
-          </div>
-        }
 
         <!-- Danger zone. Present because this editor is where a token is managed, and rotate/revoke were
              reachable only as two small icons on the list row — so the whole token was managed in two places.
@@ -194,7 +167,12 @@ export class TokenRightsDialogComponent {
   draft = signal<TokenRights>({ instanceAdmin: false, createSpaces: false, floor: null, perSpace: {} });
   /** Same reasoning for the label: prefilled, so saving without touching it is not a rename to empty. */
   draftName = '';
-  /** An absent `mfa` on the record IS `inherit`, so the two spellings must land on the same option. */
+  /**
+   * Still sent, never shown. The second-factor controls were removed from token management on the owner's
+   * instruction — the SERVER behaviour is untouched: `mfa` remains on the PATCH body and granting an
+   * exemption still costs a live TOTP code. This dialog simply stops offering to change it, so the value
+   * round-trips as whatever the token already had.
+   */
   draftMfa: 'inherit' | 'exempt' | 'required' = 'inherit';
   totpCode = '';
 

--- a/client/src/app/pages/settings/tokens.component.spec.ts
+++ b/client/src/app/pages/settings/tokens.component.spec.ts
@@ -143,30 +143,35 @@ describe('TokensComponent — permission pill colour semantics (UI-BUNDLE-1)', (
     perSpace: {},
   });
 
-  // Owner feedback 2026-07-23: admin=red, standard=green, read-only=yellow. The list pills map to the
-  // design-system StatusPill variants error / ok / warn respectively (schema-library stays pending/blue).
-  it('renders the permission pill with the level-coded StatusPill variant', () => {
-    const cases = [
-      // The pill reads the RIGHTS MATRIX now, not the legacy flags, so the fixtures express the same three
-      // intents through it. A rung of `write` somewhere is what "standard" means; `read` everywhere is what
-      // "read-only" means.
-      //
-      // Worth stating because the default moved: a token carrying NO matrix renders read-only rather than
-      // standard. That is the predicate failing closed, and it is right — a token whose matrix reaches
-      // nothing should not be labelled the same as one that can write.
-      { tok: { id: 't1', rights: rights('admin') }, variant: 'error' },
-      { tok: { id: 't2', rights: rights('write') }, variant: 'ok' },
-      { tok: { id: 't3', rights: rights('read') }, variant: 'warn' },
-      { tok: { id: 't4', schemaLibrary: true, rights: rights('write') }, variant: 'pending' },
-    ] as const;
-    for (const { tok, variant } of cases) {
-      const { fixture, c } = makeList();
-      c.tokens.set([{ spaces: [], ...tok } as never]);
-      fixture.detectChanges();
-      const pill = fixture.nativeElement.querySelector('tbody tr td:nth-child(2) .pill');
-      expect(pill, `token ${tok.id}`).not.toBeNull();
-      expect(pill.classList.contains(variant), `token ${tok.id} → ${variant}`).toBe(true);
-    }
+  /**
+   * The permission pill was REMOVED in 3.0.1, so this asserts its absence and the presence of what replaced
+   * it. The pill said admin / standard / read-only / schema-library; the glyph beside it says what the token
+   * can actually reach, per area and per space. "Standard" only ever meant "none of the other four", which
+   * is nothing once the glyph is there — the owner's words were *"Standard has no value anymore to see"*.
+   *
+   * Kept as a test rather than deleted because the row still has to show SOMETHING for a token with no
+   * matrix, and that is the case this file now guards.
+   */
+  it('shows no permission pill, and the rights glyph instead', () => {
+    const { fixture, c } = makeList();
+    c.tokens.set([{ spaces: [], id: 't1', rights: rights('write') } as never]);
+    fixture.detectChanges();
+    const cell = fixture.nativeElement.querySelector('tbody tr td:nth-child(2)');
+    expect(cell.querySelector('.pill'), 'the permission pill is gone').toBeNull();
+    expect(cell.querySelector('app-rights-glyph'), 'the glyph replaces it').not.toBeNull();
+  });
+
+  it('a token with NO matrix still says so, and still offers the pen', () => {
+    // The 3.0.1 bug in one test: glyph and pen were both inside @if (t.rights), so a rightless token showed
+    // neither and could not be given a matrix from the UI. The glyph cannot draw one that is not there; the
+    // pen must be there regardless, because granting one is the whole point.
+    const { fixture, c } = makeList();
+    c.tokens.set([{ spaces: [], id: 't2' } as never]);
+    fixture.detectChanges();
+    const cell = fixture.nativeElement.querySelector('tbody tr td:nth-child(2)');
+    expect(cell.querySelector('app-rights-glyph'), 'nothing to draw').toBeNull();
+    expect(cell.querySelector('.no-rights'), 'the absence is stated').not.toBeNull();
+    expect(cell.querySelector('button'), 'the pen is the way to fix it').not.toBeNull();
   });
 });
 

--- a/client/src/app/pages/settings/tokens.component.ts
+++ b/client/src/app/pages/settings/tokens.component.ts
@@ -13,7 +13,6 @@ import { PhIconComponent } from '../../shared/ph-icon.component';
 import { ModalDirective } from '../../shared/modal.directive';
 import { SummaryStripComponent, SummaryItem } from '../../shared/summary-strip.component';
 import { StatusPillComponent } from '../../shared/status-pill.component';
-import { RelativeTimeComponent } from '../../shared/relative-time.component';
 import { HscrollTopDirective } from '../../shared/hscroll-top.directive';
 import { RightsGlyphComponent, type TokenRights } from './rights-glyph.component';
 import { TokenCreateDialogComponent } from './token-create-dialog.component';
@@ -22,13 +21,12 @@ import { OwnTokenRightsComponent } from './own-token-rights.component';
 import { ErrorStateComponent } from '../../shared/error-state.component';
 import { httpErrorReason } from '../../core/http-error';
 import { TOKENS_PAGE_STYLES } from './tokens.styles';
-import { canWriteAnywhere } from '../../core/token-capability';
 
 @Component({
   selector: 'app-tokens',
   standalone: true,
   imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, ModalDirective,
-            SummaryStripComponent, StatusPillComponent, RelativeTimeComponent, HscrollTopDirective,
+            SummaryStripComponent, StatusPillComponent, HscrollTopDirective,
             ErrorStateComponent, RightsGlyphComponent, TokenCreateDialogComponent,
             TokenRightsDialogComponent, OwnTokenRightsComponent],
   styles: [TOKENS_PAGE_STYLES],
@@ -142,36 +140,22 @@ import { canWriteAnywhere } from '../../core/token-capability';
                     }
                   </td>
                   <td>
-                    @if (t.rights?.instanceAdmin) { <app-status-pill variant="error">{{ 'tokens.badge.admin' | transloco }}</app-status-pill> }
-                    @else if (t.schemaLibrary) { <app-status-pill variant="pending">{{ 'tokens.badge.schemaLibrary' | transloco }}</app-status-pill> }
-                    @else if (!canWrite(t)) { <app-status-pill variant="warn">{{ 'tokens.badge.readOnly' | transloco }}</app-status-pill> }
-                    @else { <app-status-pill variant="ok">{{ 'tokens.badge.standard' | transloco }}</app-status-pill> }
-                    <!-- An MFA exemption is a deliberate hole in an instance-wide control. It is shown
-                         wherever the token is, because a hole nobody can see is one nobody reviews. -->
-                    @if (t.mfa === 'exempt') { <app-status-pill variant="warn">{{ 'tokens.badge.mfaExempt' | transloco }}</app-status-pill> }
-                    @else if (t.mfa === 'required') { <app-status-pill variant="pending">{{ 'tokens.badge.mfaRequired' | transloco }}</app-status-pill> }
-                    <!-- The badges above say what KIND of token this is. The glyph says what it can reach:
-                         one bar per area, height for the ceiling, a red line for the floor. A badge cannot
-                         express "admin on Files in one space and nothing anywhere else", which is exactly
-                         what the rights model makes possible. Only drawn once a token carries a matrix —
-                         OIDC records never get one, and an empty glyph would read as "reaches nothing". -->
                     @if (t.rights) {
-                      <!-- The glyph is the summary; the button is the way in. Clicking the glyph itself would
-                           make an information display secretly interactive, which is how people discover an
-                           editor by accident on a page about credentials. -->
                       <app-rights-glyph [rights]="t.rights" style="margin-left:8px;vertical-align:middle;"/>
-                      <button class="icon-btn" type="button" style="margin-left:4px;vertical-align:middle;"
-                              [attr.aria-label]="'tokens.rights.edit' | transloco"
-                              [attr.title]="'tokens.rights.edit' | transloco"
-                              (click)="editRightsFor.set(t)">
-                        <ph-icon name="pencil-simple" [size]="13"/>
-                      </button>
+                    } @else {
+                      <span class="no-rights" [attr.title]="'tokens.rights.none' | transloco">{{ 'tokens.rights.none' | transloco }}</span>
                     }
+                    <button class="icon-btn" type="button" style="margin-left:4px;vertical-align:middle;"
+                            [attr.aria-label]="'tokens.rights.edit' | transloco"
+                            [attr.title]="'tokens.rights.edit' | transloco"
+                            (click)="editRightsFor.set(t)">
+                      <ph-icon name="pencil-simple" [size]="13"/>
+                    </button>
                   </td>
-                  <td><app-relative-time [value]="t.createdAt"/></td>
+                  <td>{{ stamp(t.createdAt) }}</td>
                   <td>
                     @if (t.lastUsed) {
-                      <app-relative-time [value]="t.lastUsed"/>
+                      {{ stamp(t.lastUsed) }}
                     } @else {
                       <span style="font-style:italic;color:var(--text-muted);">{{ 'tokens.table.neverUsed' | transloco }}</span>
                     }
@@ -181,7 +165,7 @@ import { canWriteAnywhere } from '../../core/token-capability';
                       <span style="display:inline-flex;align-items:center;gap:6px;flex-wrap:wrap;">
                         @if (isExpired(t)) { <app-status-pill variant="error">{{ 'tokens.table.expired' | transloco }}</app-status-pill> }
                         @else if (isExpiringSoon(t)) { <app-status-pill variant="warn" [dot]="true">{{ 'tokens.table.expiringSoon' | transloco }}</app-status-pill> }
-                        <app-relative-time [value]="t.expiresAt"/>
+                        {{ stamp(t.expiresAt) }}
                       </span>
                     } @else {
                       <app-status-pill variant="ok">{{ 'tokens.table.noExpiry' | transloco }}</app-status-pill>
@@ -233,6 +217,21 @@ export class TokensComponent implements OnInit {
   showCreateDialog = signal(false);
   /** The token whose rights are being edited, or null. Holding the RECORD rather than an id keeps the dialog
    *  from having to look it up again and disagreeing with the row that opened it. */
+  /**
+   * A credential's timestamps are absolute, not relative.
+   *
+   * These read "3 days ago" until 3.0.1. That answers how long, when the question an operator auditing
+   * access actually asks is WHEN — which log line, which incident, which deploy. "14 days ago" also
+   * quietly rounds: a token expiring in 23 hours and one expiring in 47 both read "tomorrow".
+   *
+   * Rendered in the VIEWER's locale and timezone by the platform, so it needs no timezone label of its own.
+   */
+  stamp(v: string | null | undefined): string {
+    if (!v) return '—';
+    const d = new Date(v);
+    return isNaN(d.getTime()) ? String(v) : d.toLocaleString();
+  }
+
   editRightsFor = signal<TokenRecord | null>(null);
 
   /**
@@ -253,18 +252,6 @@ export class TokensComponent implements OnInit {
   editingId = signal<string | null>(null);
   editLabelValue = '';
 
-  /**
-   * Whether a token can write anywhere — the badge's question, answered from the MATRIX.
-   *
-   * The pill used to branch on `t.admin` and `t.readOnly`. Neither can express a per-space grant, so the
-   * flags labelled a token that can write in one space "read-only", and one whose matrix reaches nothing
-   * "standard". A token carrying no matrix at all now reads as read-only, which is the predicate failing
-   * closed and is the right way round.
-   *
-   * One line because `tokens.component.ts` is frozen by the god-file ratchet at a size it should come DOWN
-   * from, and a template needs the callable on the component.
-   */
-  canWrite = (t: { rights?: TokenRights | null }): boolean => canWriteAnywhere(t.rights ?? null);
 
   ngOnInit(): void {
     this.authApi.getMe().subscribe({ next: (t) => this.selfToken.set(t), error: () => {} });

--- a/client/src/app/pages/settings/tokens.styles.ts
+++ b/client/src/app/pages/settings/tokens.styles.ts
@@ -206,4 +206,9 @@ export const TOKENS_PAGE_STYLES = `
       justify-content: space-between;
       margin-bottom: 16px;
     }
+  /* A token with no rights matrix. Muted and small: it is an absence, not a level — the pen beside it
+     is the thing to act on. Before 3.0.1 this row showed nothing at all and no pen, so a rightless
+     token could be seen and not fixed. */
+  .no-rights { margin-left: 8px; font-size: 11px; color: var(--text-muted); font-style: italic;
+               vertical-align: middle; }
 `;


### PR DESCRIPTION
**PRIO 0**, reported against 3.0.0: *"all but the owners tokens are now read only"* and *"i can see the other
tokens but no matrix to edit"*.

## One fact behind both symptoms

The rights glyph **and** the pen that opens the editor were both inside `@if (t.rights)`. A token with no
matrix therefore showed neither — no glyph, no pen, **no way to grant it one from the UI**. An admin could see
the token and could not fix it, which is worse than a token that is merely wrong.

The pen is now unconditional. The glyph stays conditional, because it draws a matrix and there is none to
draw. The editor already tolerated this case: it starts from an empty matrix.

## The badge was the second half of the report

A token with no matrix was labelled **read-only**, and it is not read-only — it holds nothing. Calling those
the same thing is what made the state read as *"all my tokens went read-only"* when the real state was *"these
tokens have no matrix"*. Two different problems, and only one is about permission levels.

## Four more from the same review

| change | why |
|---|---|
| **the permission pill is gone** | it said admin / standard / read-only / schema-library; the glyph says what the token can actually reach, per area and per space. "Standard" only ever meant "none of the other four" |
| **second-factor controls removed** from token management | UI only. `mfa` is still on the PATCH body and granting an exemption still costs a live TOTP code — the dialog just stops offering to change it |
| **rights editor is no longer 600px** | it renders areas × rungs once per space. `--dialog-max-width` exists so a host can say otherwise; it now takes `min(1400px, 94vw)` |
| **created / last used / expires are a date and time** | relative text answers *how long* when the question is *when*. It also rounds — 23h and 47h both read "tomorrow". Viewer's own locale and timezone |

## The spec

The pill-colour spec tested a pill that no longer exists. **Replaced, not deleted:** it asserts the pill's
absence and the glyph's presence, plus a second case for the rightless token — glyph absent, absence stated,
pen present. That second test is the bug, pinned.

## Two self-inflicted delays, both in my own notes

Prose inside an Angular template **string** counts toward the god-file ratchet, so the explanations moved into
TS comments. And a backtick inside that template literal terminates it — the build failed with an error
pointing at `@Component`.

Version bump and the dated CHANGELOG section follow in a separate release PR, as 3.0.0 did: `check-changelog`
reads the whole branch diff and wants these entries under `[Unreleased]`.
