### PR TITLE
chore(release): 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1] — 2026-08-14
+
 ### Fixed
 
 - **A token with no rights matrix could be seen and not fixed.** The rights glyph AND the pen that opens the

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/client",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ythril",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ythril",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "PolyForm-Small-Business-1.0.0",
       "workspaces": [
         "server",
@@ -18,7 +18,7 @@
     },
     "client": {
       "name": "@ythril/client",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@angular/animations": "^21.0.0",
@@ -21022,7 +21022,7 @@
     },
     "server": {
       "name": "@ythril/server",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ythril",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "type": "module",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/server",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "license": "PolyForm-Small-Business-1.0.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Dates the 3.0.1 section and bumps the version. The fix itself is #906.

**What is in it:** a token with no rights matrix can be given one — the glyph and the pen were both inside `@if (t.rights)`, so such a token showed neither. Plus the permission pill removed, the second-factor UI removed from token management (UI only), the rights editor widened to `min(1400px, 94vw)`, and created/last-used/expires shown as a date and time.

**Lockfile:** four lines, located by enclosing key. `tslib` is pinned at `2.8.1` — the version being bumped away from — so a global replace would have rewritten it to something that does not exist. `npm ci --dry-run` passes and tslib still reads 2.8.1.

Release gate green: docs match code, CHANGELOG carries 3.0.1, NOTICE complete.