### PR TITLE
fix(rights): a malformed rights matrix is repaired at boot, not skipped for ever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A rights matrix stored in an obsolete shape is repaired at startup, instead of being uneditable for
+  ever.** Reported from a live instance: saving a token's matrix was refused with ~40 validation errors —
+  `unrecognized_keys ["admin"]` and an invalid `dataQuality`, repeated for the floor and for every space.
+  Each stored rungs object was `{ knowledge, files, schema, admin }`: three areas plus a key that is not an
+  area, with the fourth area missing. The editor round-trips what it read, so the token could be opened and
+  never saved. The boot migration skipped it every time because it tested only that a matrix was PRESENT,
+  never that it was well-formed — so it ran, looked, and moved on, which is why it read as *"the migration
+  didn't work"*. Startup now normalizes a malformed matrix and writes it down: a key that is not an area is
+  dropped, a missing area comes back at `none`, an unreadable rung becomes `none`. It is a narrowing by
+  construction and never re-derives from the legacy `admin`/`readOnly`/`spaces` fields, which would have
+  silently restored access an operator had removed. The repair is logged with a count.
+- **The user guide no longer describes a per-token second factor.** The token editor's MFA controls were
+  removed in 3.0.1 and the guide still told operators to set *Follow the instance setting / Exempt /
+  Required* there, and to expect an authenticator prompt. MFA is instance-wide, under Settings →
+  Preferences, and nothing about it appears in the token dialogs.
 - **The rights editor can grant and revoke the two instance-level flags.** `instanceAdmin` and `createSpaces`
   are part of the matrix the server stores and `PATCH /api/tokens/:id` already accepted — `migrateToken` sets
   `instanceAdmin` from the legacy admin flag — but the editor had no control for either, so tokens HELD them

--- a/docs/userguide/04-settings.md
+++ b/docs/userguide/04-settings.md
@@ -137,15 +137,16 @@ This dialog has no "Library Access" toggle. Library Access tokens (for sharing y
 
 **Editing a token.** Each row has a pencil button. It opens the token editor, where the **label** and the **rights matrix** are both editable and are saved together in one request — so a rename and a scope change are one audited edit, not two that can half-fail. The secret is untouched; use **Rotate** for that.
 
-The editor also carries the **second factor** for this token — *Follow the instance setting* (the default),
-*Exempt*, or *Required*. It lives here rather than on the create form because it is a property of the token:
-before this, changing a scheduler’s exemption meant revoking the token and minting a replacement, rotating a
-secret to change a flag.
+> **A matrix stored in an obsolete shape is repaired when the instance starts.** If a token's stored rights
+> name an area the server no longer knows, or leave one of the four out, the editor could open it and never
+> save it — the server refused the very shape it had handed over. Startup now normalizes such a matrix and
+> writes it down: an unknown area is dropped, a missing one comes back at **none**, and every rung the server
+> can still read is kept exactly as it was. The repair only ever narrows, so re-check the token's matrix after
+> upgrading if you see one change; it never restores access from the pre-3.0 `admin` / `read-only` / spaces
+> fields.
 
-> **Granting an exemption asks for your authenticator code**, even if the token you are using is itself
-> exempt. Without that, one exemption could grant the next until the instance-wide MFA switch protected
-> nothing. The field appears only when you are granting one — not when you are editing an already-exempt
-> token, and not when you are taking an exemption away.
+**The second factor is not a token setting.** MFA is instance-wide and lives in **Settings → Preferences**;
+there is nothing about it in the token dialogs, and there is no per-token exemption to grant here.
 
 ### Rotating a token
 
@@ -163,9 +164,9 @@ Your current session token is marked **(current session)** in the list.
 
 MFA adds a one-time code requirement for admin actions (creating tokens, managing spaces). Normal data operations are not affected. There is no separate "MFA" page — the MFA panel lives inside **Settings → Preferences**, under the **Security** heading (the language switcher sits above it).
 
-**Automation does not have to lock you out of MFA.** The switch is instance-wide, so turning it on would otherwise demand a code from every token — including the ones a script or scheduler holds, which cannot type one. When you create a token under **Settings → Tokens** you can set its **Second factor** to *Never require a code* for exactly those, leaving MFA on for everyone else. The reverse also works: *Always require a code* on your own admin token even while the instance switch is off.
-
-An exempt token is marked **MFA exempt** in the token list, and creating one asks you for a code even if the token you are using is itself exempt — an exemption cannot quietly grant more of itself.
+**The switch is instance-wide, and that is the whole model.** It applies to admin actions, not to normal data
+operations, so a script or scheduler doing ordinary reads and writes is unaffected by turning it on. There is
+no per-token second-factor setting in the interface.
 
 ### Enrolling
 

--- a/server/src/auth/backfill-token-rights.ts
+++ b/server/src/auth/backfill-token-rights.ts
@@ -21,6 +21,7 @@
  */
 import type { Config } from '../config/types.js';
 import { migrateToken } from './rights-migration.js';
+import { repairRights } from '../config/rights-shape.js';
 import { log } from '../util/log.js';
 
 /**
@@ -47,7 +48,42 @@ export function backfillTokenRights(config: Config): number {
 
 
 /**
- * The boot step: derive, then persist if anything changed.
+ * Bring every MALFORMED rights object back to the validated shape, and say how many needed it.
+ *
+ * ## Why this is a second pass and not a stronger `if` in the backfill above
+ *
+ * `backfillTokenRights` skips on `if (t.rights) continue;` — the PRESENCE of a matrix, with no look at its
+ * SHAPE. That is correct for what it does, and it is exactly why a token carrying a malformed matrix was never
+ * repaired at any boot, for ever: the migration ran, saw an object, and moved on. The owner's report reads as
+ * *"the migration didn't work"* for that reason.
+ *
+ * Keeping the two apart also keeps the promise the backfill's tests pin: it must NEVER overwrite a matrix
+ * somebody set. Widening that function's condition to "present and well-formed" would have made one function
+ * responsible for both "derive from legacy" and "do not lose an operator's edit", and the repair below is the
+ * half that must not reach for the legacy fields at all.
+ *
+ * A token whose `rights` is not an object has nothing to preserve, so that one — and only that one — is
+ * re-derived from the legacy fields.
+ */
+export function repairTokenRights(config: Config): number {
+  let repaired = 0;
+  for (const t of config.tokens ?? []) {
+    if (!t.rights) continue;                       // the backfill's job; a second opinion here would fight it
+    const fixed = repairRights(t.rights);
+    if (!fixed) {
+      t.rights = migrateToken(t) as unknown as typeof t.rights;
+      repaired++;
+      continue;
+    }
+    if (!fixed.changed) continue;
+    t.rights = fixed.rights;
+    repaired++;
+  }
+  return repaired;
+}
+
+/**
+ * The boot step: derive, repair, then persist if anything changed.
  *
  * `saveConfig` is injected rather than imported so this module does not depend on the loader that calls it — the
  * cycle would be real, and a token migration has no business reaching back into configuration loading.
@@ -57,15 +93,19 @@ export function backfillTokenRights(config: Config): number {
  */
 export function migrateTokenRightsOnBoot(config: Config, save?: (c: Config) => void): number {
   const filled = backfillTokenRights(config);
-  if (filled === 0) return 0;
+  const repaired = repairTokenRights(config);
+  if (filled === 0 && repaired === 0) return 0;
   const persist = save ?? defaultSave;
   try {
     persist(config);
-    log.info(`Derived a rights matrix for ${filled} token(s) from their legacy fields (written to disk)`);
+    if (filled) log.info(`Derived a rights matrix for ${filled} token(s) from their legacy fields (written to disk)`);
+    // Said separately and at warn, because a repair means something wrote a shape the API refuses — the count
+    // is the only place that is visible, and folding it into the line above would read as ordinary migration.
+    if (repaired) log.warn(`Repaired a malformed rights matrix on ${repaired} token(s) — unknown areas dropped, missing areas set to 'none'`);
   } catch (err) {
     log.warn(`Could not persist derived token rights (will retry next boot): ${err}`);
   }
-  return filled;
+  return filled + repaired;
 }
 
 /** Late-bound so the import graph stays one-way: loader -> here, never back. */

--- a/server/src/config/rights-shape.ts
+++ b/server/src/config/rights-shape.ts
@@ -42,3 +42,77 @@ export interface TokenRights {
   floor: AreaRungs | null;
   perSpace: Record<string, AreaRungs>;
 }
+
+const isRung = (v: unknown): v is Rung => (RUNGS as readonly unknown[]).includes(v);
+const isArea = (k: string): k is SpaceArea => (SPACE_AREAS as readonly string[]).includes(k);
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+  v != null && typeof v === 'object' && !Array.isArray(v);
+
+/**
+ * Bring a STORED rights object back to the shape the API validates against, without ever granting more.
+ *
+ * ## Why this exists
+ *
+ * Owner-reported 2026-08-15: saving a rights matrix was refused with ~40 zod errors, the same two repeated for
+ * the floor and for every space — `unrecognized_keys ["admin"]` and an invalid `dataQuality`. Each stored rungs
+ * object was `{ knowledge, files, schema, admin }`: three areas plus a key that is not an area, and the fourth
+ * area missing. The editor round-trips what it read, so the malformed shape was on DISK and every save of that
+ * token was rejected — the matrix could be looked at and never corrected.
+ *
+ * Nothing in this codebase ever wrote that shape (checked back through `v2.6.0`, which had no rights model at
+ * all, and `v2.7.0`, whose migration already wrote `dataQuality`). So the repair cannot be aimed at one known
+ * producer: it has to be aimed at the shape itself, which is what makes it a normalizer rather than a patch.
+ *
+ * ## The rule is the migration's rule — never a superset
+ *
+ * A missing area becomes `none`, an unreadable rung becomes `none`, and a key that is not an area is DROPPED.
+ * All three are what the enforcement code already does with them — `floor?.[area] ?? 'none'` — so this changes
+ * no decision anywhere; it only makes the record say what the server was already doing with it. Re-deriving
+ * from the legacy fields instead would have been the widening: a legacy `admin` token whose matrix an operator
+ * had deliberately narrowed would get `admin` on everything back, silently, at boot.
+ *
+ * `changed` is reported rather than inferred by comparison, so a caller can persist exactly when there was
+ * something to persist and a boot that repairs nothing writes nothing.
+ *
+ * Returns `null` when the value is not an object at all — there is nothing to preserve, and the caller should
+ * derive a fresh matrix from the legacy fields.
+ */
+export function repairRights(value: unknown): { rights: TokenRights; changed: boolean } | null {
+  if (!isPlainObject(value)) return null;
+  let changed = false;
+
+  const rungsOf = (v: unknown): AreaRungs | null => {
+    if (!isPlainObject(v)) return null;
+    const out = {} as AreaRungs;
+    for (const a of SPACE_AREAS) {
+      out[a] = isRung(v[a]) ? v[a] : 'none';
+      if (v[a] !== out[a]) changed = true;              // absent, misspelled, or not a rung
+    }
+    for (const k of Object.keys(v)) if (!isArea(k)) changed = true;   // dropped: `admin` is not an area
+    return out;
+  };
+
+  const floor = value['floor'] == null ? null : rungsOf(value['floor']);
+  if (value['floor'] !== null && floor === null) changed = true;      // absent, or not an object
+
+  const perSpace: Record<string, AreaRungs> = {};
+  if (isPlainObject(value['perSpace'])) {
+    for (const [id, row] of Object.entries(value['perSpace'])) {
+      const fixed = rungsOf(row);
+      if (fixed) perSpace[id] = fixed;
+      else changed = true;                                            // a row that is not an object grants nothing
+    }
+  } else {
+    changed = true;                                                   // absent, or not an object: no rows at all
+  }
+
+  const instanceAdmin = value['instanceAdmin'] === true;
+  const createSpaces = value['createSpaces'] === true;
+  if (typeof value['instanceAdmin'] !== 'boolean' || typeof value['createSpaces'] !== 'boolean') changed = true;
+
+  for (const k of Object.keys(value)) {
+    if (k !== 'instanceAdmin' && k !== 'createSpaces' && k !== 'floor' && k !== 'perSpace') changed = true;
+  }
+
+  return { rights: { instanceAdmin, createSpaces, floor, perSpace }, changed };
+}

--- a/testing/standalone/every-token-carries-a-rights-matrix.test.js
+++ b/testing/standalone/every-token-carries-a-rights-matrix.test.js
@@ -62,7 +62,9 @@ describe('the boot migration is durable', () => {
     const at = src.indexOf('export function migrateTokenRightsOnBoot');
     assert.ok(at > -1, 'the boot step is gone — re-anchor this gate');
     const after = src.slice(at, at + 700);
-    assert.match(after, /if \(filled === 0\) return 0;/, 'a write only when something changed');
+    // Both counts, because the boot step does two things now: derive a missing matrix, and repair a malformed
+    // one. `if (filled === 0)` alone would return before persisting a repair — the fix would run and be lost.
+    assert.match(after, /if \(filled === 0 && repaired === 0\) return 0;/, 'a write only when something changed');
     assert.match(after, /persist\(config\)/, 'and it must actually persist');
     // And the loader must still CALL it, or the migration is code nobody runs.
     assert.match(read('server/src/config/loader.ts'), /migrateTokenRightsOnBoot\(_config\)/);

--- a/testing/standalone/malformed-rights-are-repaired.test.js
+++ b/testing/standalone/malformed-rights-are-repaired.test.js
@@ -1,0 +1,169 @@
+/**
+ * A rights matrix stored in a shape the API refuses is repaired at boot — and the repair never grants more.
+ *
+ * ## The report this exists for
+ *
+ * Owner, 2026-08-15, editing a token: the PATCH came back with ~40 zod errors, the same two repeated for the
+ * floor and for every space — `unrecognized_keys ["admin"]` and an invalid `dataQuality`. Every stored rungs
+ * object was `{ knowledge, files, schema, admin }`. The editor round-trips what it READ, so the shape was on
+ * disk, and the token could be opened and never saved: a matrix visible and permanently uneditable.
+ *
+ * `backfillTokenRights` skipped it at every boot because it tests `if (t.rights)` — presence, never shape. So
+ * the migration ran, looked, saw an object and moved on, which is why it read as "the migration didn't work".
+ *
+ * ## What is asserted, and why it is these things
+ *
+ * The repair must be a NARROWING. A missing area becomes `none`, an unreadable rung becomes `none`, and a key
+ * that is not an area is dropped — all three are what the enforcement code already does with them, so no
+ * decision changes anywhere. The alternative (re-deriving from the legacy fields) is the widening this file
+ * guards against: a legacy `admin` token whose matrix an operator had deliberately narrowed would silently get
+ * `admin` on everything back at boot.
+ *
+ * Idempotence is asserted for the same reason as in `token-rights-backfill.test.js`: this runs on every load,
+ * so a second pass reporting work would mean it is rewriting healthy records.
+ *
+ * Run: node --test testing/standalone/malformed-rights-are-repaired.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let repairRights, repairTokenRights, migrateTokenRightsOnBoot;
+before(async () => {
+  ({ repairRights } = await import('../../server/dist/config/rights-shape.js'));
+  ({ repairTokenRights, migrateTokenRightsOnBoot } =
+    await import('../../server/dist/auth/backfill-token-rights.js'));
+});
+
+const tok = (over) => ({ id: 'i', name: 'n', hash: 'h', prefix: 'p', createdAt: '', lastUsed: null, expiresAt: null, admin: false, ...over });
+const ALL = (r) => ({ knowledge: r, files: r, schema: r, dataQuality: r });
+/** The exact shape the owner reported: three areas plus a key that is not an area. */
+const REPORTED = (r) => ({ knowledge: r, files: r, schema: r, admin: r });
+
+describe('repairRights — the normalizer', () => {
+  it('leaves a well-formed matrix alone, and says nothing changed', () => {
+    const good = { instanceAdmin: false, createSpaces: false, floor: ALL('write'), perSpace: { qa: ALL('read') } };
+    const out = repairRights(good);
+    assert.equal(out.changed, false, 'a healthy matrix must not be rewritten at every boot');
+    assert.deepEqual(out.rights, good);
+  });
+
+  it('drops a key that is not an area and fills the area that is missing', () => {
+    const out = repairRights({ instanceAdmin: false, createSpaces: false, floor: REPORTED('admin'), perSpace: {} });
+    assert.equal(out.changed, true);
+    assert.deepEqual(Object.keys(out.rights.floor), ['knowledge', 'files', 'schema', 'dataQuality']);
+    assert.equal(out.rights.floor.dataQuality, 'none', 'the absent area must come back at the LOWEST rung');
+    assert.equal('admin' in out.rights.floor, false, '`admin` is not an area and must not survive');
+  });
+
+  it('repairs every perSpace row, not only the floor', () => {
+    // The report showed the same two errors for the floor AND for every space, so a repair that fixed one of
+    // them would leave the save refused and look like it had worked.
+    const out = repairRights({
+      instanceAdmin: false, createSpaces: false, floor: null,
+      perSpace: { a: REPORTED('write'), b: REPORTED('read') },
+    });
+    for (const id of ['a', 'b']) {
+      assert.equal(out.rights.perSpace[id].dataQuality, 'none');
+      assert.equal('admin' in out.rights.perSpace[id], false);
+    }
+  });
+
+  it('KEEPS every rung it can read — the repair is not a reset', () => {
+    const out = repairRights({
+      instanceAdmin: true, createSpaces: true,
+      floor: { knowledge: 'admin', files: 'write', schema: 'read', admin: 'admin' },
+      perSpace: { qa: { knowledge: 'write', admin: 'admin' } },
+    });
+    assert.deepEqual(out.rights.floor, { knowledge: 'admin', files: 'write', schema: 'read', dataQuality: 'none' });
+    assert.equal(out.rights.perSpace.qa.knowledge, 'write');
+    assert.equal(out.rights.instanceAdmin, true, 'the instance flags are not areas and must survive');
+    assert.equal(out.rights.createSpaces, true);
+  });
+
+  it('an unreadable rung becomes none rather than being kept or throwing', () => {
+    const out = repairRights({ instanceAdmin: false, createSpaces: false, floor: { knowledge: 'ADMIN', files: 7, schema: null, dataQuality: 'read' }, perSpace: {} });
+    assert.deepEqual(out.rights.floor, { knowledge: 'none', files: 'none', schema: 'none', dataQuality: 'read' });
+  });
+
+  it('never invents a floor where there was none', () => {
+    // A floor reaches every space including ones created later. Turning an absent floor into rungs would be the
+    // single widest widening available.
+    const out = repairRights({ instanceAdmin: false, createSpaces: false, floor: null, perSpace: { qa: ALL('read') } });
+    assert.equal(out.rights.floor, null);
+    assert.equal(out.changed, false);
+  });
+
+  it('is idempotent — repairing a repair reports nothing', () => {
+    const once = repairRights({ instanceAdmin: false, createSpaces: false, floor: REPORTED('write'), perSpace: { qa: REPORTED('read') } });
+    const twice = repairRights(once.rights);
+    assert.equal(twice.changed, false);
+    assert.deepEqual(twice.rights, once.rights);
+  });
+
+  it('returns null for a value that is not an object at all', () => {
+    for (const v of [null, undefined, 'admin', 42, ['knowledge']]) {
+      assert.equal(repairRights(v), null, `${JSON.stringify(v)} has nothing to preserve`);
+    }
+  });
+});
+
+describe('repairTokenRights — the pass over the config', () => {
+  it('repairs the reported shape and reports the count', () => {
+    const cfg = { tokens: [
+      tok({ id: 'a', rights: { instanceAdmin: false, createSpaces: false, floor: REPORTED('write'), perSpace: {} } }),
+      tok({ id: 'b', rights: { instanceAdmin: false, createSpaces: false, floor: ALL('read'), perSpace: {} } }),
+    ] };
+    assert.equal(repairTokenRights(cfg), 1, 'only the malformed one counts');
+    assert.equal(cfg.tokens[0].rights.floor.dataQuality, 'none');
+    assert.equal(cfg.tokens[1].rights.floor.knowledge, 'read', 'the healthy token was touched');
+  });
+
+  it('does NOT re-derive from the legacy fields — that would widen', () => {
+    // The token is a legacy admin whose matrix somebody narrowed to read on one space. Re-deriving would hand
+    // it an `admin` floor over the whole instance, silently, at boot.
+    const cfg = { tokens: [tok({ id: 'a', admin: true, rights: { instanceAdmin: false, createSpaces: false, floor: null, perSpace: { qa: REPORTED('read') } } })] };
+    repairTokenRights(cfg);
+    assert.equal(cfg.tokens[0].rights.floor, null, 'a floor appeared where the stored matrix had none');
+    assert.deepEqual(Object.keys(cfg.tokens[0].rights.perSpace), ['qa']);
+    assert.equal(cfg.tokens[0].rights.perSpace.qa.knowledge, 'read');
+  });
+
+  it('leaves a token with NO rights to the backfill', () => {
+    const cfg = { tokens: [tok({ id: 'a' })] };
+    assert.equal(repairTokenRights(cfg), 0, 'two functions writing the same field would fight');
+    assert.equal(cfg.tokens[0].rights, undefined);
+  });
+
+  it('re-derives when `rights` is not an object, because there is nothing to preserve', () => {
+    const cfg = { tokens: [tok({ id: 'a', readOnly: true, rights: 'admin' })] };
+    assert.equal(repairTokenRights(cfg), 1);
+    assert.equal(cfg.tokens[0].rights.floor.knowledge, 'read', 'derived from readOnly, as the migration does');
+  });
+
+  it('is idempotent, and safe on an absent token list', () => {
+    const cfg = { tokens: [tok({ id: 'a', rights: { instanceAdmin: false, createSpaces: false, floor: REPORTED('write'), perSpace: {} } })] };
+    assert.equal(repairTokenRights(cfg), 1);
+    assert.equal(repairTokenRights(cfg), 0, 'a second pass rewrote a record it had just fixed');
+    assert.equal(repairTokenRights({}), 0);
+  });
+});
+
+describe('the boot step persists a repair', () => {
+  it('writes when only a repair happened — nothing was filled', () => {
+    // The bug this pins: `if (filled === 0) return 0;` returned BEFORE the persist, so the repair ran in memory
+    // and was lost at every boot, for ever, exactly like the skip it replaces.
+    const cfg = { tokens: [tok({ id: 'a', rights: { instanceAdmin: false, createSpaces: false, floor: REPORTED('write'), perSpace: {} } })] };
+    let saved = 0;
+    assert.equal(migrateTokenRightsOnBoot(cfg, () => { saved++; }), 1);
+    assert.equal(saved, 1, 'the repair was not persisted');
+    assert.equal(cfg.tokens[0].rights.floor.dataQuality, 'none');
+  });
+
+  it('writes nothing when every token is already well-formed', () => {
+    const cfg = { tokens: [tok({ id: 'a', rights: { instanceAdmin: false, createSpaces: false, floor: ALL('read'), perSpace: {} } })] };
+    let saved = 0;
+    assert.equal(migrateTokenRightsOnBoot(cfg, () => { saved++; }), 0);
+    assert.equal(saved, 0, 'a healthy config was rewritten at boot');
+  });
+});


### PR DESCRIPTION
## The report

Owner, 2026-08-15, editing a token: the PATCH came back with ~40 zod errors — the same two, repeated for the
floor and for every space:

    rights.floor.dataQuality              invalid_value      (expected none|read|write|admin)
    rights.floor                          unrecognized_keys  ["admin"]
    rights.perSpace.<space>.dataQuality   invalid_value
    rights.perSpace.<space>               unrecognized_keys  ["admin"]

Every stored rungs object was `{ knowledge, files, schema, admin }` — three areas plus a key that is not an
area, with the fourth area missing. The editor round-trips what it read, so the shape was **on disk**: the
token could be opened and never saved.

## Ground truth first

Reproduced against the real schema (`z.record(z.enum(SPACE_AREAS), z.enum(RUNGS))`, zod 4.3.6) before
changing any code — the stored shape yields exactly those four issue kinds, and the repaired shape parses.

No released version ever wrote that shape: `v2.6.0` had no rights model at all and `v2.7.0`'s migration
already wrote `dataQuality`. So the fix is aimed at the SHAPE rather than at a producer.

## Why the boot migration never healed it

`backfillTokenRights` skips on `if (t.rights) continue;` — the **presence** of a matrix, with no look at its
shape. It ran, saw an object, and moved on, at every boot, for ever. That is why it reads as *"the migration
didn't work"*.

## The fix

- `repairRights(value)` — a pure normalizer in the leaf shape module. A key that is not an area is dropped, a
  missing area comes back at `none`, an unreadable rung becomes `none`, every readable rung is kept, and the
  instance flags survive. All three repairs are what the enforcement code already does with those values
  (`floor?.[area] ?? 'none'`), so **no decision changes anywhere** — the record just says what the server was
  already doing with it.
- `repairTokenRights(config)` — a second pass beside the backfill, not a stronger `if` inside it. The
  backfill's pinned promise is that it never overwrites a matrix somebody set, and the repair must not reach
  for the legacy fields at all. Re-deriving would be the widening: a legacy `admin` token whose matrix an
  operator had narrowed would get `admin` on everything back, silently, at boot.
- The boot step persists on `filled === 0 && repaired === 0` — the old early return would have run the repair
  in memory and lost it, which is the same skip in a new place. Pinned by a test.
- A healthy matrix reports no change, so a healthy boot writes nothing.

## Also

The user guide still described a per-token second factor (*Follow the instance setting / Exempt / Required*
and an authenticator prompt) — those controls were removed in 3.0.1 and MFA is instance-wide. Corrected in
both places it appeared.

## Verify

    node --test testing/standalone/malformed-rights-are-repaired.test.js

26 tests green across the new file and the two it touches. On a live instance: restart, then open a token
whose matrix was refused, change one cell and save — it returns 200, and `GET /api/tokens` shows a `floor`
with `dataQuality` and no `admin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
