### PR TITLE
fix(embed): a systemic outage no longer stops indexing for ever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   removed in 3.0.1 and the guide still told operators to set *Follow the instance setting / Exempt /
   Required* there, and to expect an authenticator prompt. MFA is instance-wide, under Settings →
   Preferences, and nothing about it appears in the token dialogs.
+- **An embedding outage no longer stops indexing permanently.** Reported from a live instance: *"after
+  updating all space indexing failed and since has not been retried automatically."* The retry policy is
+  sized for a per-record failure — five attempts at 5s / 30s / 120s / 600s, about twelve and a half minutes
+  — and a job that spends that budget goes terminally `failed`, which the claim query never picks up again.
+  Applied to a SYSTEMIC failure, an embedder unreachable for a quarter of an hour during an upgrade takes
+  every queued job in every space terminal at once, and the instance stops indexing without reporting a
+  fault: each job did exactly what it was told. Startup now gives every terminally-failed job **one clean
+  attempt per server version** — attempts reset, backoff cleared, `lastError` kept so it is still visible
+  what it died of, and the count logged. A restart on the SAME version revives nothing, so a record that
+  genuinely cannot be embedded is not re-run for ever. Classifying transient errors so they do not spend the
+  budget at all is tracked separately.
+- **One reader for the server version.** `api/about.ts` and `app.ts` each resolved their own path to
+  `server/package.json`; the revive above needed it too, and three copies of "which manifest do we mean" is
+  the kind of duplication that is right until the release where it is not.
+
 - **The rights editor can grant and revoke the two instance-level flags.** `instanceAdmin` and `createSpaces`
   are part of the matrix the server stores and `PATCH /api/tokens/:id` already accepted — `migrateToken` sets
   `instanceAdmin` from the legacy admin flag — but the editor had no control for either, so tokens HELD them

--- a/docs/userguide/02-brain.md
+++ b/docs/userguide/02-brain.md
@@ -246,6 +246,14 @@ The detail panel below the canvas shows all memories and chrono entries linked t
 
 ## Brain — Review tab
 
+> **A failed embedding job is retried once per upgrade, automatically.** A job that fails is retried five
+> times with a growing pause — about twelve minutes in total — and then marked failed and left alone, which
+> is right for one bad record and wrong for an outage. If the embedding model is unreachable for longer than
+> that (during an upgrade, say), every queued job in every space is marked failed at once and nothing runs
+> again until somebody presses **Retry all failed**. So starting a **new version** now re-queues everything
+> that failed under the old one, once, and says how many in the log. Restarting the same version re-queues
+> nothing — a record that genuinely cannot be embedded must not be retried on every boot for ever.
+
 The **Review** tab inside a space's Brain is that space's record-QA queue, split into sub-tabs:
 **Duplicates**, **Contradictions** and **Suggestions**. (Contradictions needs an NLI model configured
 under **Settings → Media Processing**; until the scanner has run, the tab explains what it needs.)

--- a/server/src/api/about.ts
+++ b/server/src/api/about.ts
@@ -12,10 +12,12 @@ import { getMongo } from '../db/mongo.js';
 import { getLogLines, subscribeLogLines } from '../util/log.js';
 import { computeSecurityPosture, securityStrict } from '../config/security-posture.js';
 import { dirSizeBytes } from '../quota/quota.js';
+import { SERVER_VERSION } from '../util/server-version.js';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const pkgPath = path.resolve(__dirname, '..', '..', 'package.json');
-const version: string = JSON.parse(fs.readFileSync(pkgPath, 'utf8')).version;
+// One reader for the version, in `util/server-version.ts`. This file and `app.ts` each resolved their own
+// path to the same manifest, and a third was about to be added — a version string is exactly the kind of
+// value that goes quietly wrong when two copies disagree about which `package.json` they mean.
+const version = SERVER_VERSION;
 
 const DATA_ROOT = process.env['DATA_ROOT'] ?? '/data';
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import compression from 'compression';
 import { shouldCompress, staticCacheControl } from './util/transfer.js';
+import { SERVER_VERSION } from './util/server-version.js';
 import path from 'path';
 import fs from 'node:fs';
 import crypto from 'node:crypto';
@@ -54,10 +55,10 @@ import {
   httpResponseSizeBytes,
 } from './metrics/registry.js';
 
-// Server version — read once at startup from the package.json that sits two
-// directories up from the compiled output (server/dist → server → root).
-const _pkgPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'package.json');
-const _serverVersion: string = JSON.parse(fs.readFileSync(_pkgPath, 'utf8')).version;
+// Server version — one reader, in `util/server-version.ts`. This file and `api/about.ts` each resolved
+// their own path to the same manifest; a third reader (the embed-job revive) is what made the duplication
+// worth removing rather than copying again.
+const _serverVersion: string = SERVER_VERSION;
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 /** Path to the compiled Angular SPA — configurable via env for Docker flexibility */

--- a/server/src/brain/embed-queue.ts
+++ b/server/src/brain/embed-queue.ts
@@ -86,6 +86,8 @@ export const EMBED_JOB_INDEXES: Array<Record<string, 1>> = [
   { status: 1, claimableAfter: 1, createdAt: 1 },
   // resetStalledEmbedJobs: { status, progressAt < cutoff }, and the per-status counts.
   { status: 1, progressAt: 1 },
+  // reviveFailedEmbedJobs: { status: 'failed', revivedForVersion != running }.
+  { status: 1, revivedForVersion: 1 },
 ];
 
 /** Idempotent — safe on every boot for every space, including spaces that predate this queue. */
@@ -262,6 +264,59 @@ export async function failEmbedJob(
       $set: { status: 'failed', claimedAt: null, claimToken: null, lastError, updatedAt: now },
     }),
   );
+}
+
+/**
+ * Give every terminally-failed job one clean attempt per server VERSION.
+ *
+ * ## The failure this repairs, reported from a live instance
+ *
+ * Owner, 2026-08-15: *"after updating all space indexing failed and since has not been retried
+ * automatically."*
+ *
+ * The retry policy above is sized for a PER-RECORD failure and was being applied to a SYSTEMIC one. Five
+ * attempts at 5s / 30s / 120s / 600s is a budget of about **twelve and a half minutes** from the first
+ * failure to terminal `failed` — and `claimNextEmbedJob` filters on `status: 'pending'`, so terminal means
+ * never claimed again. An embedder that is unreachable for a quarter of an hour during an upgrade therefore
+ * takes every queued job in every space terminal, at once, and the instance stops indexing without ever
+ * reporting a fault: each individual job did exactly what it was told to do.
+ *
+ * `resetStalledEmbedJobs` does not help — it revives `processing` jobs whose worker died, which is a
+ * different accident. Nothing revived `failed`.
+ *
+ * ## Why the key is the version and not a timer
+ *
+ * A periodic sweep would re-run genuinely-bad records for ever, and a boot sweep would do it on every
+ * restart. Keying on the running version bounds it exactly where the owner's report points: **a new version
+ * is new evidence**, so it earns one honest retry of everything that failed under the old one, and a restart
+ * on the same version revives nothing. `revivedForVersion` absent matches `$ne`, so jobs that failed before
+ * this existed are included once.
+ *
+ * `attempts` is reset with it: a job kept at 5 would fail again on its first error and go straight back to
+ * terminal, which is a revive that does nothing. `lastError` is deliberately KEPT — an operator looking at a
+ * re-queued job should still be able to see what it died of last time.
+ *
+ * This does not make the retry policy right, only survivable: an "embedder unreachable" and a "this text is
+ * malformed" still cost the same one attempt. Classifying them is the other half, tracked as EJ-1.
+ */
+export async function reviveFailedEmbedJobs(spaceIds: string[], version: string): Promise<number> {
+  let revived = 0;
+  for (const spaceId of spaceIds) {
+    const res = await jobs(spaceId).updateMany(
+      asFilter<BrainEmbedJobDoc>({ status: 'failed', revivedForVersion: { $ne: version } as unknown as string }),
+      asUpdate<BrainEmbedJobDoc>({
+        $set: {
+          status: 'pending', attempts: 0, claimedAt: null, claimToken: null, claimableAfter: null,
+          revivedForVersion: version, updatedAt: new Date().toISOString(),
+        },
+      }),
+    );
+    if (res.modifiedCount > 0) {
+      revived += res.modifiedCount;
+      _signal.markSpaceMayHaveWork(spaceId);
+    }
+  }
+  return revived;
 }
 
 /**

--- a/server/src/brain/embed-worker.ts
+++ b/server/src/brain/embed-worker.ts
@@ -14,9 +14,10 @@
  */
 
 import {
-  claimNextEmbedJob, completeEmbedJob, failEmbedJob, resetStalledEmbedJobs,
+  claimNextEmbedJob, completeEmbedJob, failEmbedJob, resetStalledEmbedJobs, reviveFailedEmbedJobs,
   currentEmbedWorkEpoch, waitForEmbedWork, wakeEmbedWorkers,
 } from './embed-queue.js';
+import { SERVER_VERSION } from '../util/server-version.js';
 import { embedStoredRecord } from './embed-record.js';
 import { getConfig } from '../config/loader.js';
 import { log } from '../util/log.js';
@@ -96,6 +97,15 @@ export function startBrainEmbeddingWorker(): void {
   // than making the first records of the new run wait out the stall window.
   void resetStalledEmbedJobs(spaceIds(), 0).catch(err =>
     log.warn(`Brain embedding worker: startup stall sweep failed: ${err}`));
+
+  // One clean attempt per VERSION for anything that went terminally `failed` under an older one. A systemic
+  // outage — an embedder unreachable for a quarter of an hour during an upgrade — spends every job's whole
+  // attempt budget at once, and a terminal job is never claimed again. Reported from a live instance:
+  // "after updating all space indexing failed and since has not been retried automatically."
+  // Logged at INFO with a count, because a silent mass requeue is indistinguishable from nothing happening.
+  void reviveFailedEmbedJobs(spaceIds(), SERVER_VERSION)
+    .then(n => { if (n > 0) log.info(`Brain embedding worker: re-queued ${n} job(s) that failed under an earlier version (now ${SERVER_VERSION})`); })
+    .catch(err => log.warn(`Brain embedding worker: startup revive sweep failed: ${err}`));
 
   stallTimer = setInterval(() => {
     void resetStalledEmbedJobs(spaceIds(), STALL_TIMEOUT_MS).catch(err =>

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -1835,6 +1835,15 @@ export interface BrainEmbedJobDoc {
   claimableAfter?: string | null;
   /** Identifies THIS run of THIS job, so a recovered job's old holder learns it was replaced. */
   claimToken?: string | null;
+  /**
+   * The server version this job was last revived FOR — see `reviveFailedEmbedJobs`.
+   *
+   * A terminal `failed` job is never claimed again, so a systemic outage during an upgrade could take every
+   * job in every space terminal and nothing would ever run them. This field is what makes the repair
+   * bounded: one clean attempt per version, absent meaning "never revived", so a restart on the same
+   * version cannot churn a genuinely-bad record.
+   */
+  revivedForVersion?: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/server/src/util/server-version.ts
+++ b/server/src/util/server-version.ts
@@ -1,0 +1,38 @@
+/**
+ * The running server's version, read once, from one place.
+ *
+ * ## Why this file exists
+ *
+ * Two modules already read `server/package.json` themselves — `api/about.ts` for the About payload and
+ * `app.ts` for the banner — with different relative paths to the same file. A third reader was about to be
+ * added for the embed-job revive, and "one rule, two implementations, and the weaker one wins silently" is
+ * the defect this repo produces most. A version string is exactly the kind of thing that goes quietly wrong:
+ * a reader resolving the wrong `package.json` gets the ROOT manifest, which usually carries the same number,
+ * so it is right until a release where it is not.
+ *
+ * ## Why it never throws
+ *
+ * `about.ts` lets a read failure propagate, which is survivable there — the module is imported during route
+ * setup. This is also read at boot by a background worker, and taking an instance down because a version
+ * string could not be read would be housekeeping killing the service. `unknown` is a legitimate answer: the
+ * one caller that compares versions treats it as a value like any other, so a broken read means "revive once
+ * and then stop", not a crash and not a loop.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// dist/util → dist → server. The manifest is `server/package.json`, never the repo root's.
+const pkgPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', 'package.json');
+
+function read(): string {
+  try {
+    const v: unknown = (JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as { version?: unknown }).version;
+    return typeof v === 'string' && v.length > 0 ? v : 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+/** Read once at load — the file cannot change under a running process in any supported deployment. */
+export const SERVER_VERSION: string = read();

--- a/testing/standalone/failed-embed-jobs-revive-per-version-db.test.js
+++ b/testing/standalone/failed-embed-jobs-revive-per-version-db.test.js
@@ -1,0 +1,163 @@
+/**
+ * A terminally-failed embedding job gets one clean attempt per server VERSION — and never more.
+ *
+ * ## The report
+ *
+ * Owner, from a live instance, 2026-08-15: *"after updating all space indexing failed and since has not been
+ * retried automatically."*
+ *
+ * The retry policy is sized for a PER-RECORD failure and was being applied to a SYSTEMIC one. Five attempts
+ * at 5s / 30s / 120s / 600s is a budget of about twelve and a half minutes from the first failure to terminal
+ * `failed`, and `claimNextEmbedJob` filters on `status: 'pending'` — so terminal means never claimed again.
+ * An embedder unreachable for a quarter of an hour during an upgrade takes every job in every space terminal,
+ * at once, and the instance stops indexing without reporting a fault: each job did exactly what it was told.
+ *
+ * ## Why the version, and why this suite has to prove BOTH directions
+ *
+ * The repair is only safe because it is bounded. A boot sweep would re-run genuinely-bad records on every
+ * restart; a timer would do it for ever. Keyed on the running version, a new version earns one honest retry
+ * and a restart on the same version earns none — so the two assertions that matter are "it revives" and "it
+ * does not revive twice". A test that only proved the first would pass on a sweep that churns for ever.
+ *
+ * Against a real MongoDB, because the whole mechanism is one `updateMany` filter — `{ status: 'failed',
+ * revivedForVersion: { $ne: version } }` — and the half that is easy to get wrong is that an ABSENT field
+ * must match `$ne`. A mock would answer whatever the author assumed.
+ *
+ * Run: `npm run test:up` first, then
+ *      node --test testing/standalone/failed-embed-jobs-revive-per-version-db.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { openTestMongo, closeTestMongo, mongoSkipReason } from './_mongo-harness.mjs';
+
+const skip = await mongoSkipReason();
+
+const SPACE = 'general';
+const OTHER = 'research';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ythril-embed-revive-'));
+const CONFIG_PATH = path.join(tmpDir, 'config.json');
+process.env['CONFIG_PATH'] = CONFIG_PATH;
+
+let mongo, queue;
+
+const jobs = (space) => mongo.col(`${space}_embed_jobs`);
+
+/** A job row as `failEmbedJob` leaves one when the attempt budget is spent. */
+const failedJob = (space, id, over = {}) => ({
+  _id: `memory:${id}`,
+  spaceId: space,
+  recordType: 'memory',
+  recordId: id,
+  status: 'failed',
+  attempts: 5,
+  maxAttempts: 5,
+  lastError: 'embedder unreachable',
+  claimedAt: null,
+  progressAt: null,
+  claimableAfter: null,
+  claimToken: null,
+  createdAt: '2026-08-15T00:00:00.000Z',
+  updatedAt: '2026-08-15T00:00:00.000Z',
+  ...over,
+});
+
+describe('failed embed jobs revive once per version (real MongoDB)', { skip }, () => {
+  before(async () => {
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify(
+      { spaces: [{ id: SPACE, label: 'General' }, { id: OTHER, label: 'Research' }], networks: [], tokens: [] },
+      null, 2,
+    ));
+    mongo = await openTestMongo('embedrevive');
+    const loader = await import('../../server/dist/config/loader.js');
+    loader.loadConfig();
+    queue = await import('../../server/dist/brain/embed-queue.js');
+  });
+
+  after(async () => {
+    await closeTestMongo();
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  beforeEach(async () => {
+    await jobs(SPACE).deleteMany({});
+    await jobs(OTHER).deleteMany({});
+  });
+
+  it('revives a job that never carried the marker, and says how many', async () => {
+    // The field is ABSENT on every job that failed before this existed — which is all of them on the
+    // instance that reported this. If `$ne` did not match an absent field, the fix would help nobody.
+    await jobs(SPACE).insertOne(failedJob(SPACE, 'a'));
+    assert.equal(await queue.reviveFailedEmbedJobs([SPACE], '3.1.0'), 1);
+
+    const row = await jobs(SPACE).findOne({ _id: 'memory:a' });
+    assert.equal(row.status, 'pending', 'a terminal job is never claimed again — it has to go back to pending');
+    assert.equal(row.attempts, 0, 'kept at 5 it would fail once and go straight back to terminal');
+    assert.equal(row.claimableAfter, null, 'and it must be claimable now, not after the old backoff');
+    assert.equal(row.revivedForVersion, '3.1.0');
+  });
+
+  it('KEEPS lastError, so an operator can still see what it died of', async () => {
+    await jobs(SPACE).insertOne(failedJob(SPACE, 'a'));
+    await queue.reviveFailedEmbedJobs([SPACE], '3.1.0');
+    assert.equal((await jobs(SPACE).findOne({ _id: 'memory:a' })).lastError, 'embedder unreachable');
+  });
+
+  it('does NOT revive the same job twice on the same version', async () => {
+    // The whole safety argument. A restart on the same version must be a no-op, or a genuinely-bad record
+    // is re-run on every boot for ever — which is the churn a plain boot sweep would have caused.
+    await jobs(SPACE).insertOne(failedJob(SPACE, 'a'));
+    assert.equal(await queue.reviveFailedEmbedJobs([SPACE], '3.1.0'), 1);
+    await jobs(SPACE).updateOne({ _id: 'memory:a' }, { $set: { status: 'failed', attempts: 5 } });
+    assert.equal(await queue.reviveFailedEmbedJobs([SPACE], '3.1.0'), 0, 'the same version revived it again');
+    assert.equal((await jobs(SPACE).findOne({ _id: 'memory:a' })).status, 'failed');
+  });
+
+  it('a NEW version revives it again — that is the owner\'s case', async () => {
+    await jobs(SPACE).insertOne(failedJob(SPACE, 'a', { revivedForVersion: '3.1.0' }));
+    assert.equal(await queue.reviveFailedEmbedJobs([SPACE], '3.2.0'), 1);
+    assert.equal((await jobs(SPACE).findOne({ _id: 'memory:a' })).status, 'pending');
+  });
+
+  it('touches only FAILED jobs — pending and processing are somebody else\'s business', async () => {
+    // `processing` belongs to `resetStalledEmbedJobs`, which measures a stall from progressAt. Reviving one
+    // here would return a job its worker is still holding.
+    await jobs(SPACE).insertMany([
+      failedJob(SPACE, 'p', { status: 'pending', attempts: 2, claimableAfter: '2999-01-01T00:00:00.000Z' }),
+      failedJob(SPACE, 'w', { status: 'processing', claimedAt: '2026-08-15T00:00:00.000Z' }),
+    ]);
+    assert.equal(await queue.reviveFailedEmbedJobs([SPACE], '3.1.0'), 0);
+
+    const pending = await jobs(SPACE).findOne({ _id: 'memory:p' });
+    assert.equal(pending.attempts, 2, 'a pending job kept its attempt count');
+    assert.equal(pending.claimableAfter, '2999-01-01T00:00:00.000Z', 'and its backoff');
+    assert.equal((await jobs(SPACE).findOne({ _id: 'memory:w' })).status, 'processing');
+  });
+
+  it('sweeps every space it is given, and counts across all of them', async () => {
+    // Jobs live in a per-space collection, so a loop that reads only the first space would repair one space
+    // and report success — the exact shape of "all space indexing failed".
+    await jobs(SPACE).insertOne(failedJob(SPACE, 'a'));
+    await jobs(OTHER).insertMany([failedJob(OTHER, 'b'), failedJob(OTHER, 'c')]);
+    assert.equal(await queue.reviveFailedEmbedJobs([SPACE, OTHER], '3.1.0'), 3);
+    assert.equal(await jobs(OTHER).countDocuments({ status: 'pending' }), 2);
+  });
+
+  it('is safe on a space that has no job collection at all', async () => {
+    assert.equal(await queue.reviveFailedEmbedJobs(['never-used'], '3.1.0'), 0);
+  });
+
+  it('wakes the workers, or the revived jobs sit until the idle poll', async () => {
+    // The queue is event-driven: `waitForEmbedWork` returns when an enqueue announces work. A revive that
+    // did not announce would leave a repaired queue idle for up to the 30s backstop, per space, at boot —
+    // which reads as "it still is not indexing".
+    const before = queue.currentEmbedWorkEpoch();
+    await jobs(SPACE).insertOne(failedJob(SPACE, 'a'));
+    await queue.reviveFailedEmbedJobs([SPACE], '3.1.0');
+    assert.notEqual(queue.currentEmbedWorkEpoch(), before, 'the revive did not announce the work');
+  });
+});


### PR DESCRIPTION
## The report

Owner, from a live instance, 2026-08-15: *"after updating all space indexing failed and since has not been
retried automatically."*

## Measured, not guessed

`server/src/brain/embed-queue.ts`:

| | |
|---|---|
| `MAX_EMBED_ATTEMPTS` | 5 |
| backoff | 5s / 30s / 120s / 600s |
| budget to terminal | **~12.5 minutes** |
| `claimNextEmbedJob` filter | `status: 'pending'` — so terminal is never claimed again |
| `resetStalledEmbedJobs` | revives `processing` only — a different accident |

That policy is sized for a **per-record** failure. Applied to a **systemic** one, an embedder unreachable for
a quarter of an hour during an upgrade takes every queued job in every space terminal at once, and the
instance stops indexing without ever reporting a fault — every individual job did exactly what it was told to
do. The only way back was the manual per-space **Retry failed** button.

## The fix

`reviveFailedEmbedJobs(spaceIds, version)` at worker startup: every terminally-failed job gets **one clean
attempt per server version**.

Keyed on the version rather than a timer or a plain boot sweep, because the repair is only safe if it is
bounded — a new version is new evidence and earns one honest retry, while a restart on the same version
revives nothing, so a record that genuinely cannot be embedded is not re-run for ever.

- `attempts` resets with it. Kept at 5, a revived job fails once and goes straight back to terminal — a
  revive that does nothing.
- `lastError` is deliberately KEPT: an operator looking at a re-queued job should still see what it died of.
- The sweep announces work, or a repaired queue sits idle until the 30s backstop, per space, at boot — which
  reads as "it still is not indexing".
- `revivedForVersion` absent matches `$ne`, which is what covers every job that failed before this existed —
  all of them, on the instance that reported it.

## Also

Extracts `util/server-version.ts`. `api/about.ts` and `app.ts` each resolved their own path to
`server/package.json` and this needed a third — one rule, three implementations, and a version string is
exactly the value that is right until the release where it is not.

## Not fixed here

"Embedder unreachable" and "this text is malformed" still cost the same one attempt. Classifying them so a
systemic error does not spend the budget at all is EJ-1's second half, tracked.

## Verify

    npm run test:up
    node --test testing/standalone/failed-embed-jobs-revive-per-version-db.test.js

8 tests against a real MongoDB — including the two that matter in opposite directions: a new version revives,
the same version does not. A mock would have answered the `$ne`-on-an-absent-field question from my own
assumption, which is the half the whole fix rests on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
