### PR TITLE
fix(mcp): query returned no rows to a client that reads structuredContent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`query` over MCP returned no rows to a client that reads `structuredContent`.** The tool put the rows in
+  `content` and the paging facts — `count`, `total`, `limit`, `skip` — in `structuredContent`, on the
+  reasoning that a client ignoring the structured block loses nothing because `content` is complete. The
+  opposite client is the one that breaks: one that SURFACES `structuredContent` in preference to `content`
+  saw `{"count": 25, "total": 32, …}` and not a single row. Observed against Claude Code, four calls in a
+  row, while a tool returning no `structuredContent` rendered its whole body in the same session. It is the
+  worst shape a result can have — the answer absent while the metadata reports how many rows were returned,
+  so it reads as an empty page rather than as a dropped payload. `structuredContent` now carries `results`
+  as well, identical to `content`, and `count` describes it. Nothing changes for a client built on
+  `content`, which was and remains complete.
+
 - **A rights matrix stored in an obsolete shape is repaired at startup, instead of being uneditable for
   ever.** Reported from a live instance: saving a token's matrix was refused with ~40 validation errors —
   `unrecognized_keys ["admin"]` and an invalid `dataQuality`, repeated for the floor and for every space.

--- a/docs/integration-guide/16-mcp.md
+++ b/docs/integration-guide/16-mcp.md
@@ -32,6 +32,16 @@ On connect, the server sends global instructions listing all available space IDs
 > include the offending field in the same request and the write repairs the record. `content` still carries the same
 > information as a sentence, so a client that reads only text loses nothing.
 >
+> **`query` puts its rows in BOTH places.** `content[0].text` is the JSON array it has always been, and
+> `structuredContent` carries `results` (the same array) plus `count`, `total`, `limit`, `skip` and the
+> `sort`/`dir` in force. Read whichever suits your client — they are the same answer, and `count` always
+> describes `results`.
+>
+> Until this release `structuredContent` held the paging facts alone. A client that surfaces
+> `structuredContent` in preference to `content` therefore saw `{"count": 25, "total": 32, ...}` and no
+> rows, which reads as a page that returned nothing rather than as a payload the client dropped. If you
+> built against the old shape nothing changes: `content` was, and remains, complete.
+>
 > **The consequence to plan for: tightening a schema freezes the records that no longer fit it.** Remove a value from
 > an `enum` and every stored record still carrying it is uneditable until that field is repaired — even an edit to an
 > unrelated field like `description`. Under `warn` the same violations are reported and the write proceeds. Branch on

--- a/server/src/mcp/tools/search.ts
+++ b/server/src/mcp/tools/search.ts
@@ -482,9 +482,21 @@ export const queryTool: ToolHandler = {
     let total = 0;
     for (const mid of members) total += await countBrain(mid, coll, filter, maxTimeMS);
 
-    // `structuredContent` carries the paging facts; `content` stays the bare array it has always been, so a client
-    // parsing the text is unaffected. Without `total` a caller sweeping with `skip` cannot tell a short last page from a
-    // truncated one, which is the number aigents ended up fabricating.
+    // `content` stays the bare array it has always been, so a client parsing the text is unaffected. Without `total`
+    // a caller sweeping with `skip` cannot tell a short last page from a truncated one, which is the number aigents
+    // ended up fabricating.
+    //
+    // **`results` is in `structuredContent` too, and that is not redundancy.** This block used to carry the paging
+    // facts ALONE, on the stated assumption that "a client that ignores structuredContent loses nothing because
+    // `content` remains the whole answer". True — and the opposite client is the one that breaks: a client that
+    // SURFACES structuredContent in preference to content showed the caller `{count: 25, total: 32, limit, skip}` and
+    // not one row. Observed against Claude Code on 2026-08-15, four calls in a row, while `get_space_meta` — which
+    // returns no structuredContent — rendered its whole body in the same session.
+    //
+    // That is the worst shape a result can have: the answer is absent and the metadata says how many rows were
+    // returned, so it reads as a successful empty-ish page rather than as a client that dropped the payload. It is
+    // also the only tool with that shape — every other structuredContent in this layer carries its own payload.
+    // The MCP spec's own framing is that structuredContent is the structured form of the SAME result, not a sidecar.
     return {
       content: [
         {
@@ -493,6 +505,7 @@ export const queryTool: ToolHandler = {
         },
       ],
       structuredContent: {
+        results: docs,
         count: docs.length, total, limit, skip,
         ...(sortParse.sort ? { sort: sortParse.sort.field, dir: sortParse.sort.dir === 1 ? 'asc' : 'desc' } : {}),
       },

--- a/server/src/mcp/tools/types.ts
+++ b/server/src/mcp/tools/types.ts
@@ -51,6 +51,14 @@ export type ToolResult = {
    * show it. Optional in the MCP spec and unvalidated when a tool declares no `outputSchema`, so a client
    * that ignores it loses nothing — `content` remains the complete answer.
    *
+   * **The opposite client is the one to design for, and that half was missing here.** A client may SURFACE
+   * `structuredContent` in preference to `content`, and then whatever is not in this object does not exist.
+   * `query` carried the paging facts alone on the reasoning above, and against such a client it answered
+   * `{count: 25, total: 32, limit, skip}` with not one row — the answer absent while the metadata says how
+   * many rows were returned, which reads as a thin page rather than a dropped payload. So: **if `content`
+   * carries the ANSWER, `structuredContent` must carry it too.** It is the structured form of the same
+   * result, never a sidecar to it.
+   *
    * Added because a schema refusal distinguishes violations the write INTRODUCED from ones the record
    * already carried, and over MCP that distinction survived only as a sentence: the arrays were flattened
    * into the message text (the create paths appended `JSON.stringify`) or dropped entirely (the update

--- a/testing/integration/query-skip-and-strict-bodies.test.js
+++ b/testing/integration/query-skip-and-strict-bodies.test.js
@@ -286,6 +286,21 @@ describe('the match TOTAL and a caller-chosen order, on both surfaces', () => {
     assert.deepEqual(times, [...times].sort());
   });
 
+  it('the ROWS are in structuredContent, not only in content', async () => {
+    // A client that surfaces structuredContent in preference to content used to see
+    // `{count, total, limit, skip}` and not one row — observed against Claude Code, four calls in a row,
+    // while a tool returning no structuredContent rendered its whole body in the same session. That is the
+    // worst shape available: the answer is absent while the metadata reports how many rows were returned,
+    // so it reads as a thin page rather than as a dropped payload.
+    const r = await session.callTool('query', { space: SPACE, collection: 'memories', filter: {}, limit: 3 });
+    assert.ok(!r?.isError, JSON.stringify(r));
+    assert.ok(Array.isArray(r.structuredContent.results), 'structuredContent carries no rows at all');
+    assert.equal(r.structuredContent.results.length, r.structuredContent.count,
+      'count must describe the rows beside it, not rows the caller cannot see');
+    // And the two views must be the same answer, or a caller gets a different result per client.
+    assert.deepEqual(r.structuredContent.results, JSON.parse(r.content[0].text));
+  });
+
   it('MCP refuses an unsortable field with the same message', async () => {
     const r = await session.callTool('query', { space: SPACE, collection: 'memories', filter: {}, sort: 'fact' });
     assert.ok(r?.isError, `MCP accepted an unlisted sort field: ${JSON.stringify(r)}`);


### PR DESCRIPTION
## Found by using it

Four `query` calls against the shared dev board answered

```json
{"count":25,"total":32,"limit":25,"skip":0}
```

and not one row. `get_space_meta` — which returns no `structuredContent` — rendered its whole body in the
same session, same server, same token. The client was Claude Code, 2026-08-15.

## Why

The tool put the rows in `content` and the paging facts in `structuredContent`, on the reasoning recorded in
`ToolResult`:

> a client that ignores it loses nothing — `content` remains the complete answer

True, and only half the contract. The client that breaks is the **opposite** one: a client that *surfaces*
`structuredContent` in preference to `content`. For it, whatever is not in that object does not exist.

It is the worst shape a result can have. The answer is absent while the metadata reports how many rows were
returned — so it reads as a page that legitimately returned little, rather than as a payload the client
dropped. Nothing is in error. There is nothing to notice.

## The fix

`results` beside the counts, identical to `content`.

`query` was the **only** tool with that shape — every other `structuredContent` in this layer carries its own
payload (the embed tools their counts and jobs, the file tools the updated record, the refusals their
violation arrays). So this is one site, not a sweep.

The type's own doc-comment now states the rule in both directions: **if `content` carries the ANSWER,
`structuredContent` carries it too.** It is the structured form of the same result, never a sidecar to it.

Nothing changes for a client built on `content`, which was and remains complete.

## Verify

    node --test testing/integration/query-skip-and-strict-bodies.test.js

The new case asserts three things, and the third is the one that matters: `structuredContent.results` exists,
`count` describes the rows beside it, and the two views are **deepEqual** — otherwise a caller gets a
different answer depending on which client they happen to use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
