### PR TITLE
fix(loop): the turn gate counted 2 of 11 open queue rows

### DIFF
--- a/scripts/loop-check.mjs
+++ b/scripts/loop-check.mjs
@@ -78,6 +78,14 @@ const NOT_WORK_HEADING = /watch|parked|not work|release|reference|note/i;
 const DONE_ONLY = /^(?:done|shipped|merged)\b[^a-z]*$/i;
 
 /**
+ * A queue row's ID: `B-3`, `RX-1`, `P0-1`, `D-8d`.
+ *
+ * Loose on purpose — see `parseRows`. No `g` flag: `test()` on a global regex advances `lastIndex` between calls
+ * and would skip every other row.
+ */
+const ROW_ID = /^[A-Z][A-Z0-9]{0,3}-\d+[a-z]?$/;
+
+/**
  * Open rows in the ordered queue.
  *
  * The file is a table, one task per line (owner, 2026-08-09), so a row is a `|`-delimited line whose first cell
@@ -89,6 +97,19 @@ const DONE_ONLY = /^(?:done|shipped|merged)\b[^a-z]*$/i;
  * queue is drained* with eleven rows open, in green. Sections are what the owner maintains by hand, and `W-8`
  * proves the ID cannot stand in for one — it is open work carrying a watch-tier ID because its home tracker keyed
  * it that way.
+ *
+ * **The ID SHAPE drifted the same way the prefix did, and cost the same eleven rows.** The replacement rule was
+ * `^[A-Z]-\d+$` — one letter, a dash, digits — which was every ID that existed when it was written. The queue
+ * has since keyed rows by domain initials and by sub-item: `RX-1` reindex, `EJ-1` embed jobs, `SA-1` space admin,
+ * `P0-1` for a priority-zero report, `D-8d` for the fourth part of deprecation row 8. None of those are one
+ * letter, so none of them were rows. On 2026-08-15 the file held eleven open rows and the gate reported two —
+ * the identical failure, in the identical direction, one regex further along.
+ *
+ * So the pattern is now deliberately loose: an uppercase letter, up to three more uppercase-or-digit characters,
+ * a dash, digits, and an optional lowercase sub-item letter. It is written to admit an ID nobody has invented
+ * yet, because the two failure directions are not symmetric — over-counting says *keep working* on a drained
+ * queue, which costs a wasted lens; under-counting says *drained* on a full one, which is what this file exists
+ * to prevent and what it has now shipped twice.
  *
  * A row whose status is *only* a done marker is not open either — the queue is what is left, not what was listed.
  * That test used to match `done|shipped|merged` anywhere in the cell, which read `2 wrappers shipped (#842,
@@ -104,7 +125,7 @@ export function parseRows(text) {
     if (!inWork || !line.trim().startsWith('|')) continue;
     const cells = line.split('|').map((c) => c.trim()).filter((_, i, a) => i > 0 && i < a.length - 1);
     const id = cells[0];
-    if (!id || !/^[A-Z]-\d+$/.test(id)) continue;
+    if (!id || !ROW_ID.test(id)) continue;
     if (DONE_ONLY.test(cells[3] ?? '')) continue;
     rows.push({ id, what: cells[1] ?? '', status: cells[3] ?? '' });
   }

--- a/testing/standalone/loop-check.test.js
+++ b/testing/standalone/loop-check.test.js
@@ -25,6 +25,9 @@ const TABLE = `# Ordered queue
 | B-3 | Split config/types.ts | ARCH | open | |
 | U-9 | token rights: admin edit tier | UX | tiers 1+3 done, #840 shipped the self-view | own PR |
 | W-8 | Dockerfile still fetches CUDA | QA | fixed in CI, owner call on the image | 3x npm ci |
+| RX-1 | Reindex reports the ACK as a result | UI | open | two-letter domain key |
+| P0-1 | Rights matrix save rejected | UI | open | letter+digit priority key |
+| D-8d | Unify scope, delete legacy fields | DEPR | open | sub-item suffix |
 
 ## 2 · Watch items — NOT work
 
@@ -51,7 +54,26 @@ describe('the queue rows', () => {
     // queue was later re-keyed per domain — `B-` architecture, `U-` UX, `T-` sync — and the gate went on counting
     // a prefix that no longer existed. It reported "the queue is drained" with eleven rows open, which is the
     // exact state it was written to refuse, and it reported it in green.
-    assert.deepEqual(parseRows(TABLE).map((r) => r.id), ['Q-2', 'B-3', 'U-9', 'W-8']);
+    assert.deepEqual(parseRows(TABLE).map((r) => r.id), ['Q-2', 'B-3', 'U-9', 'W-8', 'RX-1', 'P0-1', 'D-8d']);
+  });
+
+  it('counts an ID that is not one letter and one number', () => {
+    // The SAME under-count, one regex further along. `^[A-Z]-\d+$` described every ID that existed when it was
+    // written, and the queue then keyed rows by domain initials (`RX-`, `EJ-`, `SA-`), by priority (`P0-`) and by
+    // sub-item (`D-8d`). On 2026-08-15 the file held eleven open rows and the gate reported two — in the same
+    // direction as the prefix bug, which is the direction that says "drained" on a full queue.
+    const ids = parseRows(TABLE).map((r) => r.id);
+    assert.ok(ids.includes('RX-1'), 'a two-letter domain key is a row');
+    assert.ok(ids.includes('P0-1'), 'a letter+digit priority key is a row');
+    assert.ok(ids.includes('D-8d'), 'a sub-item suffix is a row');
+  });
+
+  it('still refuses cells that are not IDs at all', () => {
+    // The looseness has to stop somewhere, or a header cell or a stray prose table elsewhere in the file becomes
+    // work. Anything without the `<KEY>-<number>` shape is not a row.
+    const noise = ['| # | Task | Home | Status |', '| Total | 11 | | |', '| see D-8 | note | | |', '| 8d | x | | |']
+      .join('\n');
+    assert.deepEqual(parseRows(noise), []);
   });
 
   it('reads the SECTION, not the prefix — so a W- row of real work counts', () => {
@@ -92,7 +114,7 @@ describe('the queue rows', () => {
     // The queue is what is left, not what was listed. `todo/` is supposed to hold open items only, but a status
     // cell is the one place a shipped row can linger before the tracker reconcile catches it.
     const done = TABLE.replace('| B-3 | Split config/types.ts | ARCH | open |', '| B-3 | Split config/types.ts | ARCH | shipped (#812) |');
-    assert.deepEqual(parseRows(done).map((r) => r.id), ['Q-2', 'U-9', 'W-8']);
+    assert.deepEqual(parseRows(done).map((r) => r.id), ['Q-2', 'U-9', 'W-8', 'RX-1', 'P0-1', 'D-8d']);
   });
 
   it('a status reporting PARTIAL progress is still open', () => {


### PR DESCRIPTION
`loop:check` decides whether a turn may end — something in flight, or the queue is drained. It reads
`todo/_TODO-ORDERED.md` and treats a table line as a task when its first cell looks like a row ID.

That test was `^[A-Z]-\d+$`: one letter, a dash, digits. It described every ID that existed on the day it was
written.

## What it missed

The queue has since keyed rows by domain initials, by priority and by sub-item:

| ID | Row | Counted before |
|---|---|---|
| `P0-1` | Matrix save rejected (PRIO 0) | no |
| `SA-1` | Space admin: per-space token management | no |
| `UI-2` | Rung tooltip says the action, not the capability | no |
| `ER-1` | ER diagram gaps sized for lines, not text | no |
| `D-8d` | Unify scope, then delete the legacy fields | no |
| `EJ-1` | Embed jobs go terminal in an outage | no |
| `RS-1` | `knowledge:write` must imply `schema:read` | no |
| `D-12`, `B-6` | | yes |

Eleven open rows, two counted. The gate named `D-12` as next while a PRIO-0 row sat above it unseen.

## Why the fix is loose rather than tight

This is the second failure of this kind in the file's short life, in the same direction. The first was
`id.startsWith('Q-')` surviving a re-key per domain — it reported *the queue is drained* with eleven rows open,
in green. Both times the rule was replaced by a rule that described the IDs present on the day it was written.

The two directions are not symmetric:

- over-counting says *keep working* on a drained queue — costs a wasted audit lens;
- under-counting says *drained* on a full one — which is the state this file exists to refuse.

So the pattern now admits an ID nobody has invented yet: an uppercase letter, up to three more
uppercase-or-digit characters, a dash, digits, an optional lowercase sub-item letter. The comment states the
asymmetry, so the next person widening it does not have to re-derive why.

## Verification

- Mutation-tested against the pre-fix regex: **3 assertions go red**, including the exact-list one that would
  otherwise have absorbed the change silently.
- A new test pins the other direction — a header cell, a `| Total | 11 |` row, `see D-8` in prose and a bare
  `8d` are still not tasks.
- `npm run loop:check` against the real queue now reports 11 rows, listing `P0-1` first.
- `npm run preflight` passed.

## No CHANGELOG entry, deliberately

This is repo tooling that reads a gitignored folder. Nothing a user or an integrator can observe changes, and
`docs/` does not mention `loop:check` anywhere. Saying so here rather than leaving the omission to be inferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
