### PR TITLE
feat(rights): knowledge:write carries schema:read, resolved in one place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`knowledge: write` now carries `schema: read` with it.** Writing a record against a schema requires
+  reading that schema, so a token granted write on Knowledge and nothing on Schema was not a narrower token —
+  it was one that could not do what it had just been granted, and the failure arrived as a 403 on a route
+  nobody called deliberately. The pair is no longer an operator's to get wrong. It resolves in one place
+  (`effectiveRung`), which is where REST, MCP, space reachability and the minting cap all ask what a token
+  holds, so both doors gained it in the same commit and neither can drift from the other. A minter holding
+  `knowledge: write` may now also delegate `schema: read` — without that, enforcement would grant a rung that
+  minting refused to hand on. The implication is a floor and never an assignment: a Schema rung granted
+  outright is not lowered by it, and it never runs backwards. **Nothing is written to the stored matrix** —
+  `GET /api/tokens` still returns exactly what was set, so lowering Knowledge back to `read` returns Schema to
+  the value that was chosen instead of leaving a permission nobody picked. The rights matrix shows the Schema
+  cell held at `read` with a tooltip naming Knowledge as the reason, rather than showing `none` while the
+  server grants read; `GET /api/tokens/rights-catalog` publishes the rule as `implications` so no client needs
+  a second copy of it.
+
 ### Fixed
 
 - **`query` over MCP returned no rows to a client that reads `structuredContent`.** The tool put the rows in

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1883,6 +1883,8 @@
   "tokens.rights.endpoint": "Endpunkt",
   "tokens.rights.fromRung": "Ab",
   "tokens.rights.endpointsUnavailable": "Die Endpunktliste konnte nicht geladen werden. Die Beschreibungen oben gelten weiterhin.",
+  "tokens.rights.clamp.floor": "Durch die Untergrenze für alle Spaces auf {{rung}} gehalten",
+  "tokens.rights.clamp.implied": "Auf {{rung}} gehalten, weil {{area}} auf {{cause}} steht und ohne dies nicht funktioniert",
   "tokens.rights.area.knowledge": "Wissen",
   "tokens.rights.area.knowledge.desc": "Erinnerungen, Entitäten, Beziehungen und Zeitachsen-Einträge — die Datensätze, aus denen der Space besteht, und deren Suche.",
   "tokens.rights.area.files": "Dateien",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1883,6 +1883,8 @@
   "tokens.rights.endpoint": "Endpoint",
   "tokens.rights.fromRung": "From",
   "tokens.rights.endpointsUnavailable": "The endpoint list could not be loaded. The descriptions above still apply.",
+  "tokens.rights.clamp.floor": "Held at {{rung}} by the all-spaces floor",
+  "tokens.rights.clamp.implied": "Held at {{rung}} because {{area}} is {{cause}}, which cannot work without it",
   "tokens.rights.area.knowledge": "Knowledge",
   "tokens.rights.area.knowledge.desc": "Memories, entities, relationships and timeline entries — the records the space is made of, and searching them.",
   "tokens.rights.area.files": "Files",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1883,6 +1883,8 @@
   "tokens.rights.endpoint": "Punkt końcowy",
   "tokens.rights.fromRung": "Od",
   "tokens.rights.endpointsUnavailable": "Nie udało się wczytać listy punktów końcowych. Opisy powyżej nadal obowiązują.",
+  "tokens.rights.clamp.floor": "Utrzymane na {{rung}} przez próg dla wszystkich przestrzeni",
+  "tokens.rights.clamp.implied": "Utrzymane na {{rung}}, ponieważ {{area}} ma {{cause}} i bez tego nie zadziała",
   "tokens.rights.area.knowledge": "Wiedza",
   "tokens.rights.area.knowledge.desc": "Wspomnienia, encje, relacje i wpisy na osi czasu — rekordy, z których składa się przestrzeń, oraz ich wyszukiwanie.",
   "tokens.rights.area.files": "Pliki",

--- a/client/src/app/pages/settings/own-token-rights.component.spec.ts
+++ b/client/src/app/pages/settings/own-token-rights.component.spec.ts
@@ -18,6 +18,9 @@ const rights = (over: Partial<TokenRights> = {}): TokenRights =>
 const catalogStub = () => ({
   catalog: signal({ areas: ['knowledge', 'files', 'schema', 'dataQuality'], rungs: ['none', 'read', 'write', 'admin'] as const, routes: [] }),
   failed: signal(false), load: () => {}, routesFor: () => [], countFor: () => 0,
+  // No `implications` in this stub's catalog, so the real rule returns null — this view is about rendering
+  // a matrix read-only, and an implication it does not exercise would only make the fixture lie about scope.
+  impliedFor: () => null,
 });
 
 function make(me: unknown, fail = false) {

--- a/client/src/app/pages/settings/rights-catalog.service.ts
+++ b/client/src/app/pages/settings/rights-catalog.service.ts
@@ -10,10 +10,54 @@ export interface CatalogRoute {
   needs: Exclude<Rung, 'none'>;
 }
 
+/**
+ * One area's rung entailing a rung in another, in the same space.
+ *
+ * Published by the server (`RUNG_IMPLICATIONS`) because it is the rule `effectiveRung` ENFORCES. The grid
+ * reads it rather than describing it: a security rule with two descriptions drifts, and the copy people read
+ * is the wrong one.
+ */
+export interface CatalogImplication {
+  when: string;
+  atLeast: Rung;
+  grants: string;
+  rung: Rung;
+}
+
 export interface RightsCatalog {
   areas: readonly string[];
   rungs: readonly Rung[];
+  /** Absent on a server older than this field — treated as "no implications", never as an error. */
+  implications?: readonly CatalogImplication[];
   routes: readonly CatalogRoute[];
+}
+
+/**
+ * The implication rule, as a pure function of a catalog.
+ *
+ * Exported and free-standing so a test double cannot hold a SECOND version of it. A stubbed
+ * `RightsCatalogService` that re-implemented this in the spec file would be a fake rule dressed as the real
+ * one, and the grid's tests would then prove the fake — the failure mode where a measurement shares its
+ * subject's blind spot. Stubs call this; the service calls this.
+ *
+ * `of` reads the GRANTED rung of another area — what an operator wrote, never another inference — matching
+ * the server's `withImplications`. Returns the highest applicable rule, or `null` when the catalog is absent,
+ * has no `implications` field (an older server), or nothing entails anything.
+ */
+export function impliedFrom(
+  catalog: RightsCatalog | null,
+  area: string,
+  of: (a: string) => Rung,
+): { rung: Rung; by: { area: string; rung: Rung } } | null {
+  if (!catalog?.implications) return null;
+  let best: { rung: Rung; by: { area: string; rung: Rung } } | null = null;
+  for (const rule of catalog.implications) {
+    if (rule.grants !== area) continue;
+    if (catalog.rungs.indexOf(of(rule.when)) < catalog.rungs.indexOf(rule.atLeast)) continue;
+    if (best && catalog.rungs.indexOf(best.rung) >= catalog.rungs.indexOf(rule.rung)) continue;
+    best = { rung: rule.rung, by: { area: rule.when, rung: rule.atLeast } };
+  }
+  return best;
 }
 
 /**
@@ -66,5 +110,15 @@ export class RightsCatalogService {
   /** How many routes an area has in total, for a header that says how much is behind it. */
   countFor(area: string): number {
     return (this.catalog()?.routes ?? []).filter(r => r.area === area).length;
+  }
+
+  /**
+   * The minimum `area` is held at, given what the other areas in the same scope are set to.
+   *
+   * The rule itself is `impliedFrom` above — this is the signal-reading wrapper, so the grid asks the service
+   * and the service holds no second copy of the rule.
+   */
+  impliedFor(area: string, of: (a: string) => Rung): { rung: Rung; by: { area: string; rung: Rung } } | null {
+    return impliedFrom(this.catalog(), area, of);
   }
 }

--- a/client/src/app/pages/settings/rights-matrix.component.spec.ts
+++ b/client/src/app/pages/settings/rights-matrix.component.spec.ts
@@ -1,9 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { signal } from '@angular/core';
 import { RightsMatrixComponent } from './rights-matrix.component';
-import { RightsCatalogService } from './rights-catalog.service';
+import { RightsCatalogService, impliedFrom, type RightsCatalog } from './rights-catalog.service';
 import { getTranslocoModule } from '../../testing/transloco-testing';
-import type { TokenRights } from './rights-glyph.component';
+import type { Rung, TokenRights } from './rights-glyph.component';
 
 const rights = (over: Partial<TokenRights> = {}): TokenRights =>
   ({ instanceAdmin: false, createSpaces: false, floor: null, perSpace: {}, ...over });
@@ -14,9 +14,18 @@ const CATALOG_ROUTES = [
   { area: 'knowledge', method: 'DELETE', route: '/api/x/memories/:id', needs: 'write' as const },
   { area: 'files', method: 'GET', route: '/api/x/files', needs: 'read' as const },
 ];
+/** The server's own `RUNG_IMPLICATIONS`, as the catalog publishes them. */
+const CATALOG_IMPLICATIONS = [
+  { when: 'knowledge', atLeast: 'write' as const, grants: 'schema', rung: 'read' as const },
+];
 function stubCatalog(loaded = true) {
   const catalog = signal(loaded
-    ? { areas: ['knowledge', 'files', 'schema', 'dataQuality'], rungs: ['none', 'read', 'write', 'admin'] as const, routes: CATALOG_ROUTES }
+    ? {
+      areas: ['knowledge', 'files', 'schema', 'dataQuality'],
+      rungs: ['none', 'read', 'write', 'admin'] as const,
+      implications: CATALOG_IMPLICATIONS,
+      routes: CATALOG_ROUTES,
+    }
     : null);
   return {
     catalog, failed: signal(!loaded), load: () => {},
@@ -25,6 +34,9 @@ function stubCatalog(loaded = true) {
       return CATALOG_ROUTES.filter(r => r.area === area && ['none', 'read', 'write', 'admin'].indexOf(r.needs) <= order);
     },
     countFor: (area: string) => CATALOG_ROUTES.filter(r => r.area === area).length,
+    // The REAL rule, not a second copy of it. A stub that re-implemented the implication would let these
+    // tests pass against a rule the product does not have.
+    impliedFor: (area: string, of: (a: string) => Rung) => impliedFrom(catalog() as RightsCatalog | null, area, of),
   };
 }
 
@@ -113,6 +125,85 @@ describe('RightsMatrixComponent', () => {
     const el = render(rights(), []);
     expect(el.querySelectorAll('tbody tr').length).toBe(1);
     expect(el.querySelector('tbody tr')!.className).toContain('floor');
+  });
+});
+
+/**
+ * `knowledge: write` entails `schema: read` (owner ruling, 2026-08-15). The server resolves it in
+ * `effectiveRung`; the grid must SHOW it, or the screen says `none` while the API grants read — the direction
+ * that understates access, on the one screen somebody audits access from.
+ *
+ * The rule reaches these tests through the stub's real `impliedFrom`, so a change to the rule breaks them.
+ */
+describe('RightsMatrixComponent — an implied rung', () => {
+  let fixture: ComponentFixture<RightsMatrixComponent>;
+
+  const render = (r: TokenRights, spaces = ['qa']) => {
+    fixture = TestBed.createComponent(RightsMatrixComponent);
+    fixture.componentRef.setInput('rights', r);
+    fixture.componentRef.setInput('spaces', spaces);
+    fixture.detectChanges();
+    return fixture.nativeElement as HTMLElement;
+  };
+  /** Column order is the area order: knowledge, files, schema, dataQuality. */
+  const pickerIn = (el: HTMLElement, row: number, col: number) =>
+    el.querySelectorAll('tbody tr')[row]!.querySelectorAll('app-rung-picker')[col]!;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      // The two REAL English strings, so the interpolation is exercised rather than the key echoed. Asserting
+      // on a bare key would pass with the parameters wired to nothing, which is the half most likely to break.
+      imports: [RightsMatrixComponent, getTranslocoModule({
+        translation: {
+          en: {
+            'tokens.rights.clamp.implied': 'Held at {{rung}} because {{area}} is {{cause}}, which cannot work without it',
+            'tokens.rights.area.knowledge': 'Knowledge',
+          },
+        },
+      })],
+      providers: [{ provide: RightsCatalogService, useValue: stubCatalog() }],
+    }).compileComponents();
+  });
+
+  it('SHOWS the schema cell at read when knowledge is write, though none is stored', () => {
+    const el = render(rights({ perSpace: { qa: { knowledge: 'write', files: 'none', schema: 'none', dataQuality: 'none' } } }));
+    const bs = [...pickerIn(el, 1, 2).querySelectorAll('button')];
+    // Filled up to `read`, not `none`: the segments say what the token can do, and the token can read schemas.
+    expect(bs.map(b => b.className.includes('on'))).toEqual([true, true, false, false]);
+  });
+
+  it('clamps below the implied rung and says which area holds it there', () => {
+    const el = render(rights({ perSpace: { qa: { knowledge: 'write', files: 'none', schema: 'none', dataQuality: 'none' } } }));
+    const bs = [...pickerIn(el, 1, 2).querySelectorAll('button')];
+    expect(bs[0]!.disabled).toBe(true);
+    expect(bs[1]!.disabled).toBe(false);
+    // The title must name the CAUSE and the rung that caused it. "Held at read" alone sends the reader to the
+    // floor row, which is not what is holding it.
+    expect(bs[0]!.getAttribute('title')).toBe('Held at read because Knowledge is write, which cannot work without it');
+  });
+
+  it('leaves schema alone when knowledge is only read', () => {
+    const el = render(rights({ perSpace: { qa: { knowledge: 'read', files: 'none', schema: 'none', dataQuality: 'none' } } }));
+    const bs = [...pickerIn(el, 1, 2).querySelectorAll('button')];
+    expect(bs.map(b => b.disabled)).toEqual([false, false, false, false]);
+    expect(bs.map(b => b.className.includes('on'))).toEqual([true, false, false, false]);
+  });
+
+  it('applies to the FLOOR row too, from the floor own knowledge rung', () => {
+    const el = render(rights({ floor: { knowledge: 'write', files: 'none', schema: 'none', dataQuality: 'none' } }));
+    const bs = [...pickerIn(el, 0, 2).querySelectorAll('button')];
+    expect(bs.map(b => b.className.includes('on'))).toEqual([true, true, false, false]);
+    expect(bs[0]!.disabled).toBe(true);
+  });
+
+  it('does not write the implied rung into the emitted matrix', () => {
+    // The stored matrix keeps saying what the operator set. Persisting an inference would make a rung that
+    // exists only while knowledge is write outlive knowledge dropping back to read.
+    const el = render(rights({ perSpace: { qa: { knowledge: 'write', files: 'none', schema: 'none', dataQuality: 'none' } } }));
+    const emitted: TokenRights[] = [];
+    fixture.componentInstance.changed.subscribe(v => emitted.push(v));
+    pickerIn(el, 1, 1)!.querySelectorAll('button')[1]!.click();   // touch `files`, an unrelated column
+    expect(emitted[0]!.perSpace['qa']!['schema']).toBe('none');
   });
 });
 

--- a/client/src/app/pages/settings/rights-matrix.component.ts
+++ b/client/src/app/pages/settings/rights-matrix.component.ts
@@ -91,7 +91,9 @@ const EMPTY = (): WireRungs => ({ knowledge: 'none', files: 'none', schema: 'non
           <td class="l">{{ 'tokens.rights.allSpaces' | transloco }}<small>{{ 'tokens.rights.allSpacesHint' | transloco }}</small></td>
           @for (a of areas; track a) {
             <td>
-              <app-rung-picker [value]="floorOf(a)" [readonlyView]="readonlyView()" (changed)="setFloor(a, $event)"/>
+              <app-rung-picker [value]="floorShown(a)"
+                               [implied]="floorImplied(a)?.rung ?? 'none'" [impliedBy]="floorImplied(a)?.by ?? null"
+                               [readonlyView]="readonlyView()" (changed)="setFloor(a, $event)"/>
             </td>
           }
         </tr>
@@ -100,7 +102,9 @@ const EMPTY = (): WireRungs => ({ knowledge: 'none', files: 'none', schema: 'non
             <td class="l">{{ s }}</td>
             @for (a of areas; track a) {
               <td>
-                <app-rung-picker [value]="cellOf(s, a)" [floor]="floorOf(a)" [readonlyView]="readonlyView()" (changed)="setCell(s, a, $event)"/>
+                <app-rung-picker [value]="cellShown(s, a)" [floor]="floorOf(a)"
+                                 [implied]="cellImplied(s, a)?.rung ?? 'none'" [impliedBy]="cellImplied(s, a)?.by ?? null"
+                                 [readonlyView]="readonlyView()" (changed)="setCell(s, a, $event)"/>
               </td>
             }
           </tr>
@@ -181,6 +185,23 @@ export class RightsMatrixComponent implements OnInit {
   floorOf = (area: string): Rung => this.rights().floor?.[area] ?? 'none';
 
   /**
+   * What another area entails for this one — read from the catalog, never described here.
+   *
+   * Two scopes, one rule. The floor is compared against the floor's own other areas, a cell against that
+   * space's other areas, which is exactly the split the server makes between `floorRung` and `effectiveRung`.
+   * Passing the WRITTEN rung rather than `cellOf` matters: an implication must be entailed by what somebody
+   * set, or two rules could compose into a grant nobody wrote down.
+   */
+  floorImplied = (area: string) => this.catalog.impliedFor(area, a => this.floorOf(a));
+
+  cellImplied = (space: string, area: string) =>
+    this.catalog.impliedFor(area, a => {
+      const row = this.rights().perSpace[space]?.[a] ?? 'none';
+      const floor = this.floorOf(a);
+      return rank(row) > rank(floor) ? row : floor;
+    });
+
+  /**
    * A cell shows the higher of its own row and the floor.
    *
    * Showing the stored row alone would display `none` for a space the token can in fact reach through the
@@ -191,6 +212,31 @@ export class RightsMatrixComponent implements OnInit {
     const row = this.rights().perSpace[space]?.[area] ?? 'none';
     const floor = this.floorOf(area);
     return rank(row) > rank(floor) ? row : floor;
+  };
+
+  /**
+   * What the cell DISPLAYS: the written rung raised by anything another area entails.
+   *
+   * Same argument as the floor one rung up. A cell showing `none` for schema while the token holds
+   * `knowledge: write` would say one thing and the server do another, in the direction that under-states
+   * access — which is the direction that matters on a screen somebody is auditing.
+   *
+   * Nothing is written down for it. The stored matrix keeps saying what the operator set, and the implication
+   * is resolved at enforcement, so dropping knowledge back to `read` returns schema to whatever it was rather
+   * than leaving a grant nobody chose. Storing the inferred rung is how a temporary implication becomes
+   * permanent access.
+   */
+  cellShown = (space: string, area: string): Rung => {
+    const held = this.cellOf(space, area);
+    const implied = this.cellImplied(space, area);
+    return implied && rank(implied.rung) > rank(held) ? implied.rung : held;
+  };
+
+  /** The floor cell's display value, raised the same way and for the same reason. */
+  floorShown = (area: string): Rung => {
+    const held = this.floorOf(area);
+    const implied = this.floorImplied(area);
+    return implied && rank(implied.rung) > rank(held) ? implied.rung : held;
   };
 
   setFloor(area: string, rung: Rung): void {

--- a/client/src/app/pages/settings/rung-picker.component.spec.ts
+++ b/client/src/app/pages/settings/rung-picker.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RungPickerComponent } from './rung-picker.component';
+import { getTranslocoModule } from '../../testing/transloco-testing';
 import type { Rung } from './rights-glyph.component';
 
 /**
@@ -23,7 +24,11 @@ describe('RungPickerComponent', () => {
   const buttons = (el: HTMLElement) => [...el.querySelectorAll('button')] as HTMLButtonElement[];
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({ imports: [RungPickerComponent] }).compileComponents();
+    // Transloco is needed because the clamp titles are translated — the picker states WHY a cell will not
+    // go lower, and "held by the floor" and "held by an implication" are different sentences.
+    await TestBed.configureTestingModule({
+      imports: [RungPickerComponent, getTranslocoModule()],
+    }).compileComponents();
   });
 
   it('renders one segment per rung', () => {

--- a/client/src/app/pages/settings/rung-picker.component.ts
+++ b/client/src/app/pages/settings/rung-picker.component.ts
@@ -1,4 +1,5 @@
-import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, output } from '@angular/core';
+import { TranslocoService } from '@jsverse/transloco';
 import type { Rung } from './rights-glyph.component';
 
 export const RUNGS: readonly Rung[] = ['none', 'read', 'write', 'admin'];
@@ -22,6 +23,17 @@ const LABEL: Record<Rung, string> = { none: '—', read: 'R', write: 'W', admin:
  *    down by clicking a specific lower segment, which reads as "the control resists being narrowed".
  *  - **Rungs below the floor are clamped, not hidden.** The floor is set on another row entirely, so a cell
  *    that silently refuses to go lower with no visible reason looks broken. Dimmed-and-titled says why.
+ *
+ * ## Two sources of a minimum, one clamp
+ *
+ * A cell also cannot go below what another AREA entails: `knowledge: write` needs `schema: read` to be
+ * exercisable at all, so the server grants it (`RUNG_IMPLICATIONS`, resolved in `effectiveRung`). Both the
+ * floor and an implication are the same thing to this control — a minimum with a reason — so they share one
+ * clamp rather than getting one mechanism each. The title names whichever is BINDING, because a reader who
+ * cannot lower a cell wants the one fact that would let them.
+ *
+ * The implication is not hard-coded here. It arrives from `GET /api/tokens/rights-catalog`, which publishes
+ * what the server enforces; a copy typed into the client would be a second description of a security rule.
  */
 @Component({
   selector: 'app-rung-picker',
@@ -52,9 +64,15 @@ const LABEL: Record<Rung, string> = { none: '—', read: 'R', write: 'W', admin:
   `,
 })
 export class RungPickerComponent {
+  private t = inject(TranslocoService);
+
   value = input.required<Rung>();
   /** The floor for this area. A cell may never sit below it — see the class comment. */
   floor = input<Rung>('none');
+  /** A minimum entailed by another area in the same space, or `none`. See the class comment. */
+  implied = input<Rung>('none');
+  /** Which area entails `implied`, and at what rung — for the title. Ignored when `implied` is `none`. */
+  impliedBy = input<{ area: string; rung: Rung } | null>(null);
   /**
    * Display only: every segment is disabled and no click emits.
    *
@@ -65,9 +83,28 @@ export class RungPickerComponent {
   readonlyView = input(false);
   changed = output<Rung>();
 
+  /** The binding minimum: the higher of the floor and whatever another area entails. */
+  private minRung = computed<Rung>(() =>
+    RANK[this.implied()] > RANK[this.floor()] ? this.implied() : this.floor());
+
+  /**
+   * Why the cell will not go lower — naming the SOURCE that is actually binding.
+   *
+   * When both apply, the higher one wins and is the one worth explaining: telling somebody about the floor
+   * while an implication holds the cell two rungs above it sends them to change the wrong control.
+   */
+  private clampTitle = computed(() => {
+    const by = this.impliedBy();
+    return RANK[this.implied()] > RANK[this.floor()] && by
+      ? this.t.translate('tokens.rights.clamp.implied',
+        { rung: this.implied(), area: this.t.translate('tokens.rights.area.' + by.area), cause: by.rung })
+      : this.t.translate('tokens.rights.clamp.floor', { rung: this.floor() });
+  });
+
   segments = computed(() => {
     const held = RANK[this.value()];
-    const min = RANK[this.floor()];
+    const min = RANK[this.minRung()];
+    const clampTitle = this.clampTitle();
     return RUNGS.map((rung, i) => {
       const clamped = i < min;
       const filled = i <= held;
@@ -77,7 +114,7 @@ export class RungPickerComponent {
         // as one block at one level rather than a gradient nobody asked for.
         classes: `${filled ? `on r${held}` : ''}${clamped ? ' clamped' : ''}`,
         title: clamped
-          ? `Held at ${this.floor()} by the all-spaces floor`
+          ? clampTitle
           : `Set ${rung}${rung === this.value() ? ' — click again to step down' : ''}`,
       };
     });
@@ -86,11 +123,12 @@ export class RungPickerComponent {
   pick(rung: Rung): void {
     // Belt and braces: a disabled button cannot be clicked, but a caller could still call this.
     if (this.readonlyView()) return;
-    if (RANK[rung] < RANK[this.floor()]) return;
-    // Clicking the rung you are already on steps down one, never below the floor. A control that can only
+    const min = this.minRung();
+    if (RANK[rung] < RANK[min]) return;
+    // Clicking the rung you are already on steps down one, never below the minimum. A control that can only
     // climb reads as resisting being narrowed, which is the direction anyone auditing wants to move.
     const next: Rung = rung === this.value()
-      ? (RUNGS[Math.max(RANK[this.floor()], RANK[rung] - 1)] as Rung)
+      ? (RUNGS[Math.max(RANK[min], RANK[rung] - 1)] as Rung)
       : rung;
     if (next !== this.value()) this.changed.emit(next);
   }

--- a/docs/integration-guide/07-tokens-api.md
+++ b/docs/integration-guide/07-tokens-api.md
@@ -51,6 +51,9 @@ Authorization: Bearer <token>
 {
   "areas": ["knowledge", "files", "schema", "dataQuality"],
   "rungs": ["none", "read", "write", "admin"],
+  "implications": [
+    { "when": "knowledge", "atLeast": "write", "grants": "schema", "rung": "read" }
+  ],
   "routes": [
     { "area": "knowledge", "method": "POST", "route": "/api/brain/spaces/:spaceId/recall", "needs": "read" },
     { "area": "files", "method": "DELETE", "route": "/api/files/:spaceId", "needs": "write" }
@@ -67,6 +70,28 @@ Use it instead of maintaining your own map of rights to endpoints.
 would understate what you hold.
 
 `none` reaches nothing, and no route is ever listed with `needs: "none"`.
+
+#### `implications` — a rung one area gives another
+
+One area's rung can entail a rung in another, **in the same space**. Today there is exactly one rule: a token
+holding `knowledge: write` also holds `schema: read`, because writing a record against a schema requires
+reading that schema, so the pair is not an operator's to get wrong.
+
+Read the rule as: *when `when` is at `atLeast` or higher, `grants` is held at no less than `rung`.*
+
+Three properties worth building against:
+
+- **It is a floor, never an assignment.** A `schema` rung granted outright is never lowered by it.
+- **It does not chain.** Each rule is evaluated against what was *granted*, never against another rule's
+  inference, so the order of the array is not load-bearing.
+- **It is scoped to one space**, and applies to the all-spaces floor within the floor's own scope.
+
+The stored matrix is *not* rewritten — `GET /api/tokens` returns what was set. Resolve the effective rung by
+applying this table on read; do not persist the result, or a rung that exists only while `knowledge` is
+`write` will outlive it being lowered.
+
+The same resolution governs both doors. A capability refused over REST is refused over MCP for the identical
+reason, because `effectiveRung` is the single place either surface asks what a token holds.
 
 ---
 

--- a/docs/userguide/04-settings.md
+++ b/docs/userguide/04-settings.md
@@ -137,6 +137,21 @@ This dialog has no "Library Access" toggle. Library Access tokens (for sharing y
 
 **Editing a token.** Each row has a pencil button. It opens the token editor, where the **label** and the **rights matrix** are both editable and are saved together in one request — so a rename and a scope change are one audited edit, not two that can half-fail. The secret is untouched; use **Rotate** for that.
 
+#### Some cells hold each other up
+
+A cell will not always go as low as you click, and the greyed-out segments say why when you hover them. There
+are two reasons a cell is held:
+
+- **The all-spaces floor.** The top row is a *minimum*, not a bulk setting, so no space below it can sit lower.
+- **Another area needs it.** Setting **Knowledge** to **write** holds **Schema** at **read** in the same
+  space, because writing a record against a schema means reading that schema first. A token with write on
+  Knowledge and none on Schema is not a narrower token — it is one that cannot do the thing it was granted.
+
+The second is applied when access is checked, not written into the token. The matrix keeps saying what you
+set, so lowering Knowledge back to **read** returns Schema to whatever you had chosen rather than leaving
+behind a permission nobody picked. This is why the Schema cell can show **read** while the token you exported
+shows `none` — both are correct, and the grid is showing you what the token can actually do.
+
 > **A matrix stored in an obsolete shape is repaired when the instance starts.** If a token's stored rights
 > name an area the server no longer knows, or leave one of the four out, the editor could open it and never
 > save it — the server refused the very shape it had handed over. Startup now normalizes such a matrix and

--- a/server/src/api/tokens.ts
+++ b/server/src/api/tokens.ts
@@ -5,7 +5,7 @@ import { authRateLimit, globalRateLimit } from '../rate-limit/middleware.js';
 import { createToken, listTokens, revokeToken, regenerateToken, renameToken, setTokenRights, setTokenMfa } from '../auth/tokens.js';
 import { isMfaEnabled, verifyMfaCode } from '../auth/totp.js';
 import { z } from 'zod';
-import { SPACE_AREAS, RUNGS } from '../config/rights-shape.js';
+import { SPACE_AREAS, RUNGS, RUNG_IMPLICATIONS } from '../config/rights-shape.js';
 import { ROUTE_RIGHTS } from '../auth/space-rights.js';
 import { refusalsOutsideEditorScope } from '../auth/editor-scope.js';
 import { capRights, describeExcess } from '../auth/mint-cap.js';
@@ -37,11 +37,17 @@ tokensRouter.get('/me', globalRateLimit, requireAuth, (req, res) => {
  *
  * `scope` is deliberately omitted — how a route learns which space it is about is internal, and a tooltip has
  * no use for it.
+ *
+ * `implications` is published for the same reason the routes are: `knowledge: write` entails `schema: read`
+ * (`RUNG_IMPLICATIONS`), the server enforces it in `effectiveRung`, and a grid that hard-coded the pair would
+ * be a second copy of a security rule. With it published, the matrix can hold the schema cell at the implied
+ * rung and say why, instead of showing `none` while the server grants read.
  */
 tokensRouter.get('/rights-catalog', globalRateLimit, requireAuth, (_req, res) => {
   res.json({
     areas: SPACE_AREAS,
     rungs: RUNGS,
+    implications: RUNG_IMPLICATIONS,
     routes: ROUTE_RIGHTS.map(r => ({ area: r.area, method: r.method, route: r.route, needs: r.needs })),
   });
 });

--- a/server/src/auth/mint-cap.ts
+++ b/server/src/auth/mint-cap.ts
@@ -21,7 +21,7 @@
  *  - **Never the instance-administrator switch**, and never `createSpaces`, from a non-administrator. Those
  *    are not areas and do not cap — they are held or they are not.
  */
-import { SPACE_AREAS } from '../config/rights-shape.js';
+import { SPACE_AREAS, RUNG_IMPLICATIONS } from '../config/rights-shape.js';
 import type { TokenRights, AreaRungs, Rung, SpaceArea } from '../config/rights-shape.js';
 
 const ORDER: readonly Rung[] = ['none', 'read', 'write', 'admin'];
@@ -41,16 +41,60 @@ export interface Excess {
 }
 
 /**
- * What the minter actually holds in a given space: the higher of its floor and its explicit row.
+ * What was WRITTEN for an area in a space: the higher of the floor and the explicit row.
  *
  * Both, not either. A token with a `read` floor and a `write` row on `qa` holds write there, and a token
  * with a `write` floor and no row still holds write everywhere — reading only one of them under-reports the
  * minter and refuses grants it was entitled to make.
+ *
+ * Granted, not held: implications are applied on top of this by `effectiveRung`. Kept separate so an
+ * implication is always evaluated against what an operator actually wrote, never against another inference.
  */
-export function effectiveRung(rights: TokenRights, space: string, area: SpaceArea): Rung {
+function grantedRung(rights: TokenRights, space: string, area: SpaceArea): Rung {
   const floor = rights.floor?.[area] ?? 'none';
   const row = rights.perSpace[space]?.[area] ?? 'none';
   return rank(row) > rank(floor) ? row : floor;
+}
+
+/**
+ * Raise a rung by whatever the other areas in the same space entail.
+ *
+ * `held` is what was written for `area`; `of` reads what was written for any OTHER area, in the same scope.
+ * Split this way so one implementation serves both the per-space resolution and the floor, which have
+ * different sources but the identical rule — the defect this repo produces most is one rule with two
+ * implementations, and the weaker one winning silently.
+ */
+function withImplications(area: SpaceArea, held: Rung, of: (a: SpaceArea) => Rung): Rung {
+  let out = held;
+  for (const rule of RUNG_IMPLICATIONS) {
+    if (rule.grants !== area) continue;
+    if (rank(of(rule.when)) >= rank(rule.atLeast) && rank(rule.rung) > rank(out)) out = rule.rung;
+  }
+  return out;
+}
+
+/**
+ * What this token actually holds for an area in a space — the single resolution, for the whole server.
+ *
+ * REST (`middleware.ts`), MCP (`mcp/tool-rights-guard.ts`), `reachable-spaces.ts` and `capRights` below all
+ * read this, which is what makes it the one place an implication can live without becoming two rules. See
+ * `RUNG_IMPLICATIONS` for why `knowledge: write` entails `schema: read`.
+ */
+export function effectiveRung(rights: TokenRights, space: string, area: SpaceArea): Rung {
+  return withImplications(area, grantedRung(rights, space, area), a => grantedRung(rights, space, a));
+}
+
+/**
+ * What a FLOOR holds for an area, implications included.
+ *
+ * The floor is its own scope: it reaches every space including ones created later, so it is compared against
+ * the minter's floor alone and never against an effective rung somewhere. The implication still applies —
+ * a `knowledge: write` floor means schema is readable everywhere, so granting a `schema: read` floor takes
+ * away nothing the minter did not already have. Omitting it here would have been the classic asymmetry:
+ * enforcement grants the implied rung, minting refuses to delegate it.
+ */
+export function floorRung(rights: TokenRights, area: SpaceArea): Rung {
+  return withImplications(area, rights.floor?.[area] ?? 'none', a => rights.floor?.[a] ?? 'none');
 }
 
 /**
@@ -75,7 +119,7 @@ export function capRights(minter: TokenRights, requested: TokenRights): Excess[]
   if (requested.floor) {
     for (const area of AREAS) {
       const want = requested.floor[area];
-      const have = minter.floor?.[area] ?? 'none';
+      const have = floorRung(minter, area);
       if (rank(want) > rank(have)) {
         excess.push({ space: '*', area, requested: want, allowed: have });
       }

--- a/server/src/config/rights-shape.ts
+++ b/server/src/config/rights-shape.ts
@@ -35,6 +35,38 @@ export const RUNGS = ['none', 'read', 'write', 'admin'] as const;
 
 export type AreaRungs = Record<SpaceArea, Rung>;
 
+/**
+ * One area's rung entailing a rung in ANOTHER area, in the same space.
+ *
+ * Owner ruling 2026-08-15: *"whenever someone has write in knowledge he should automatically have read on
+ * schemas."* Writing a record against a schema requires reading that schema, so `knowledge: write` with
+ * `schema: none` is not a narrower grant — it is a grant that cannot be exercised. Leaving the pair to an
+ * operator means the commonest useful token is one checkbox away from being broken, and broken in a way that
+ * surfaces as a 403 on a route nobody deliberately called.
+ *
+ * ## Why the TABLE lives here and the resolution does not
+ *
+ * This module is the leaf both `types.ts` and `auth/` can import, so a table here has exactly one copy. The
+ * APPLICATION lives in `auth/mint-cap.ts` next to `effectiveRung`, which is the single place the whole server
+ * asks "what does this token hold here" — REST middleware, the MCP tool guard, `reachable-spaces.ts` and the
+ * mint cap all route through it. An implication applied anywhere else would be a second security rule.
+ *
+ * The client gets it from `GET /api/tokens/rights-catalog` rather than typing its own copy, for the same
+ * reason the route table is published there: a copy of a security rule drifts, and the copy people read is
+ * the one that is wrong.
+ *
+ * ## Implications do NOT chain, deliberately
+ *
+ * Each rule is evaluated against what the token was GRANTED, never against what an earlier rule inferred. A
+ * chain would make the order of this array load-bearing and let two innocuous rules compose into a grant
+ * nobody wrote down. If a transitive implication is ever wanted, it goes in as its own row, visibly.
+ */
+export const RUNG_IMPLICATIONS = [
+  { when: 'knowledge', atLeast: 'write', grants: 'schema', rung: 'read' },
+] as const satisfies readonly { when: SpaceArea; atLeast: Rung; grants: SpaceArea; rung: Rung }[];
+
+export type RungImplication = typeof RUNG_IMPLICATIONS[number];
+
 export interface TokenRights {
   instanceAdmin: boolean;
   createSpaces: boolean;

--- a/testing/standalone/knowledge-write-implies-schema-read.test.js
+++ b/testing/standalone/knowledge-write-implies-schema-read.test.js
@@ -1,0 +1,169 @@
+/**
+ * `knowledge: write` entails `schema: read`, in ONE place, on every surface that asks.
+ *
+ * ## The ruling
+ *
+ * Owner, 2026-08-15: *"whenever someone has write in knowledge he should automatically have read on
+ * schemas."* Writing a record against a schema requires reading that schema, so `knowledge: write` with
+ * `schema: none` is not a narrower grant — it is a grant that cannot be exercised. Left to an operator, the
+ * commonest useful token is one checkbox away from broken, and broken as a 403 on a route nobody called
+ * deliberately.
+ *
+ * ## Why the tests are aimed at `effectiveRung` and not at a route
+ *
+ * `effectiveRung` is the single resolution of *what does this token hold here*: REST middleware, the MCP tool
+ * guard, `reachable-spaces.ts` and the mint cap all read it. That is what makes it the only place the
+ * implication can live without becoming two rules — the defect this repo produces most is one rule with two
+ * implementations and the weaker one winning silently. Testing it here tests every caller at once; testing one
+ * route would prove nothing about the other three.
+ *
+ * ## The three things that are easy to get wrong
+ *
+ *  - **Direction.** The implication must never run backwards. `schema: write` says nothing about knowledge.
+ *  - **Chaining.** A rule is evaluated against what was GRANTED, never against another inference, or the
+ *    order of the table becomes load-bearing and two innocuous rules can compose into a grant nobody wrote.
+ *  - **The floor.** `capRights` compares a requested floor against the minter's FLOOR alone. If the
+ *    implication were applied to per-space rows and not to the floor, enforcement would grant a rung that
+ *    minting refused to delegate — the asymmetry that reads as "the grid says I have it and the API says no".
+ *
+ * Run: node --test testing/standalone/knowledge-write-implies-schema-read.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let effectiveRung, floorRung, capRights, RUNG_IMPLICATIONS, SPACE_AREAS;
+before(async () => {
+  ({ effectiveRung, floorRung, capRights } = await import('../../server/dist/auth/mint-cap.js'));
+  ({ RUNG_IMPLICATIONS, SPACE_AREAS } = await import('../../server/dist/config/rights-shape.js'));
+});
+
+const ALL = (r) => ({ knowledge: r, files: r, schema: r, dataQuality: r });
+const rights = (over = {}) => ({ instanceAdmin: false, createSpaces: false, floor: null, perSpace: {}, ...over });
+
+describe('the implication table', () => {
+  it('says exactly what the owner ruled, and nothing else', () => {
+    // Pinned as a whole rather than "contains": a second row added without a test is a security rule nobody
+    // reviewed, and this is the file where that would be noticed.
+    assert.deepEqual(RUNG_IMPLICATIONS.map((r) => ({ ...r })), [
+      { when: 'knowledge', atLeast: 'write', grants: 'schema', rung: 'read' },
+    ]);
+  });
+
+  it('names only real areas on both sides', () => {
+    // A misspelt area here would be silently inert, which is how `{"brain": "write"}` once stored at 200 and
+    // granted nothing.
+    for (const rule of RUNG_IMPLICATIONS) {
+      assert.ok(SPACE_AREAS.includes(rule.when), `${rule.when} is not an area`);
+      assert.ok(SPACE_AREAS.includes(rule.grants), `${rule.grants} is not an area`);
+    }
+  });
+});
+
+describe('effectiveRung — what a token holds in a space', () => {
+  it('grants schema:read to a per-space knowledge:write, with schema written as none', () => {
+    const r = rights({ perSpace: { qa: { knowledge: 'write', files: 'none', schema: 'none', dataQuality: 'none' } } });
+    assert.equal(effectiveRung(r, 'qa', 'schema'), 'read');
+  });
+
+  it('grants it through the FLOOR as well, including in a space with no row', () => {
+    // A floor reaches spaces created later, so the implication has to reach them too — otherwise a token
+    // works in every space that existed when it was minted and silently does not in the next one.
+    const r = rights({ floor: { ...ALL('none'), knowledge: 'write' } });
+    assert.equal(effectiveRung(r, 'a-space-nobody-listed', 'schema'), 'read');
+  });
+
+  it('does not apply below the threshold — knowledge:read entails nothing', () => {
+    const r = rights({ perSpace: { qa: { ...ALL('none'), knowledge: 'read' } } });
+    assert.equal(effectiveRung(r, 'qa', 'schema'), 'none');
+  });
+
+  it('never LOWERS a schema rung that was granted outright', () => {
+    // The implication is a floor under the cell, not an assignment to it. Clobbering here would be a silent
+    // revocation, which is the worst direction for an authorization bug to fail in.
+    const r = rights({ perSpace: { qa: { ...ALL('none'), knowledge: 'write', schema: 'admin' } } });
+    assert.equal(effectiveRung(r, 'qa', 'schema'), 'admin');
+  });
+
+  it('does not run backwards: schema:admin entails nothing about knowledge', () => {
+    const r = rights({ perSpace: { qa: { ...ALL('none'), schema: 'admin' } } });
+    assert.equal(effectiveRung(r, 'qa', 'knowledge'), 'none');
+  });
+
+  it('leaves every other area alone', () => {
+    const r = rights({ perSpace: { qa: { ...ALL('none'), knowledge: 'write' } } });
+    assert.equal(effectiveRung(r, 'qa', 'files'), 'none');
+    assert.equal(effectiveRung(r, 'qa', 'dataQuality'), 'none');
+    assert.equal(effectiveRung(r, 'qa', 'knowledge'), 'write');
+  });
+
+  it('is scoped to ONE space — a knowledge:write row does not reach another space', () => {
+    const r = rights({ perSpace: { qa: { ...ALL('none'), knowledge: 'write' } } });
+    assert.equal(effectiveRung(r, 'research', 'schema'), 'none');
+  });
+
+  it('does not chain: an INFERRED schema:read cannot satisfy another rule reading schema', () => {
+    // There is one rule today, so this is asserted through the rule's own input: the implication fires on
+    // what was granted for knowledge, and a schema rung that only exists by inference is not a grant. If a
+    // future row keyed on `schema: read` silently picked up the inferred one, this pins that it must not.
+    const r = rights({ perSpace: { qa: { ...ALL('none'), knowledge: 'write' } } });
+    const inferred = effectiveRung(r, 'qa', 'schema');
+    assert.equal(inferred, 'read');
+    assert.equal(r.perSpace['qa'].schema, 'none', 'the stored matrix is not rewritten by the inference');
+  });
+});
+
+describe('floorRung — the same rule, in the floor\'s own scope', () => {
+  it('reports the implied rung for a floor', () => {
+    assert.equal(floorRung(rights({ floor: { ...ALL('none'), knowledge: 'write' } }), 'schema'), 'read');
+  });
+
+  it('reads the FLOOR only, never a per-space row', () => {
+    // A row grants in one space; a floor grants everywhere including spaces created later. Letting a row
+    // raise the floor's answer would let a minter delegate reach it does not have.
+    const r = rights({ perSpace: { qa: { ...ALL('none'), knowledge: 'write' } } });
+    assert.equal(floorRung(r, 'schema'), 'none');
+  });
+});
+
+describe('capRights — a minter may delegate what the implication gives it', () => {
+  const minted = (floor, perSpace = {}) => ({ instanceAdmin: false, createSpaces: false, floor, perSpace });
+
+  it('lets a knowledge:write FLOOR grant a schema:read floor', () => {
+    // The asymmetry this pins: enforcement grants the implied rung, so minting must be able to delegate it.
+    // Comparing the request against the raw stored floor instead would refuse a grant the minter can already
+    // exercise in every space.
+    const minter = minted({ ...ALL('none'), knowledge: 'write' });
+    const request = minted({ ...ALL('none'), knowledge: 'write', schema: 'read' });
+    assert.deepEqual(capRights(minter, request), []);
+  });
+
+  it('lets a knowledge:write ROW grant a schema:read row in the same space', () => {
+    const minter = minted(null, { qa: { ...ALL('none'), knowledge: 'write' } });
+    const request = minted(null, { qa: { ...ALL('none'), schema: 'read' } });
+    assert.deepEqual(capRights(minter, request), []);
+  });
+
+  it('still refuses schema:WRITE from a knowledge:write minter', () => {
+    // The implication grants `read` and stops. A cap that widened to the whole area would turn one ruling
+    // into an escalation ladder.
+    const minter = minted(null, { qa: { ...ALL('none'), knowledge: 'write' } });
+    const excess = capRights(minter, minted(null, { qa: { ...ALL('none'), schema: 'write' } }));
+    assert.equal(excess.length, 1);
+    assert.deepEqual(excess[0], { space: 'qa', area: 'schema', requested: 'write', allowed: 'read' });
+  });
+
+  it('still refuses a schema:read row from a knowledge:write minter in a DIFFERENT space', () => {
+    const minter = minted(null, { qa: { ...ALL('none'), knowledge: 'write' } });
+    const excess = capRights(minter, minted(null, { research: { ...ALL('none'), schema: 'read' } }));
+    assert.deepEqual(excess.map((e) => `${e.space}.${e.area}`), ['research.schema']);
+  });
+
+  it('still refuses a FLOOR from a minter that only holds the row', () => {
+    // The pre-existing rule, re-asserted because the floor comparison is the line this change touched: a
+    // floor reaches spaces the minter has no row for, so a row can never buy one.
+    const minter = minted(null, { qa: { ...ALL('none'), knowledge: 'write' } });
+    const excess = capRights(minter, minted({ ...ALL('none'), schema: 'read' }));
+    assert.deepEqual(excess.map((e) => `${e.space}.${e.area}`), ['*.schema']);
+  });
+});


### PR DESCRIPTION
Owner ruling 2026-08-15: *"whenever someone has write in knowledge he should automatically have read on
schemas."*

Writing a record against a schema means reading that schema first. So `knowledge: write` with `schema: none`
is not a narrower grant — it is a grant that cannot be exercised, and it fails as a 403 on a route nobody
called deliberately. Left to an operator, the commonest useful token is one checkbox away from broken.

## One place, or it is two rules

`effectiveRung` is the single resolution of *what does this token hold here*. Everything reads it:

| Caller | Line |
|---|---|
| REST middleware | `auth/middleware.ts:360` |
| MCP tool guard | `mcp/tool-rights-guard.ts:45` |
| space reachability | `auth/reachable-spaces.ts:41` |
| the minting cap | `auth/mint-cap.ts:132` |

So both doors gained the implication in the same commit, by construction rather than by remembering. The
table lives in `config/rights-shape.ts` — the leaf module both `types.ts` and `auth/` can import — so there is
exactly one copy of it.

## The floor is the half that would have rotted

`capRights` compares a requested floor against the minter's **floor alone**, correctly: a floor reaches spaces
created later, so a per-space row can never buy one.

But comparing against the *raw stored* floor would mean enforcement grants the implied rung while minting
refuses to delegate it — the grid says you hold it and the API says you may not pass it on. `floorRung`
applies the identical rule in the floor's own scope. Both are `withImplications`, one implementation.

## Three properties, each pinned by a test

- **A floor, never an assignment.** A `schema` rung granted outright is not lowered by it.
- **No chaining.** A rule reads what was *granted*, never another rule's inference — otherwise the order of
  the table becomes load-bearing and two innocuous rows compose into a grant nobody wrote down.
- **Never backwards, never cross-space.** `schema: admin` says nothing about knowledge; a `knowledge: write`
  row in `qa` does nothing in `research`.

## Nothing is written to the stored matrix

The record keeps saying what the operator set; the implication resolves on read. Lowering knowledge back to
`read` returns schema to the value that was chosen. Persisting the inference is how a conditional rung becomes
permanent access.

## Client

The grid **shows** the implied rung instead of showing `none` while the server grants read — the same argument
the floor already made, one rung up, and understating access is the wrong direction on the screen people audit
from. The rule arrives from `GET /api/tokens/rights-catalog`, which now publishes `implications`; a security
rule typed into the client is a second copy, and the copy people read is the one that drifts.

The picker's floor clamp and the implication clamp are **one mechanism** — a minimum with a reason — and the
title names whichever is *binding*. Telling somebody about the floor while an implication holds the cell two
rungs above it sends them to the wrong control. Clamp titles are translated (en/de/pl).

`impliedFrom` is exported as a pure function so the spec's stub catalog calls the **real** rule. A stub that
re-implements the thing under test proves the stub.

## Verification

- **17 new server tests** over `effectiveRung`, `floorRung` and `capRights` — direction, threshold,
  non-clobbering, space scoping, no chaining, and the four cap refusals that must survive the change.
- **5 new client tests** over the grid. One pins the *interpolated* tooltip text, not the translation key —
  asserting the key would pass with the parameters wired to nothing.
- Full client suite **1134 green**, `npm run preflight` green.

## The five places

| Place | Status |
|---|---|
| REST route | `effectiveRung` — every rights-gated route |
| MCP tool | same function, `tool-rights-guard.ts` — no parameter change on either door |
| integration guide | `07-tokens-api.md` — `implications` and the three properties |
| userguide | `04-settings.md` — why a cell will not go lower |
| token rights | no new route, so no row in `auth/space-rights.ts`; this changes how a rung is RESOLVED, not which route needs which |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
