### PR TITLE
fix(schema): the property editor was unstyled, and offered merge functions the API refuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The property editor offered merge functions the API refuses.** Reported by the owner on 2026-08-15, whose
+  words were *"i dont understand what i did wrong"* — and nothing they did was wrong. The merge-function
+  dropdown listed all seven functions for every property type, so a `date` property could be given `min`, and
+  the save came back as a wall of validation JSON about a rule the screen had never mentioned: numeric
+  functions need type `number`, boolean ones need `boolean`, and `string` and `date` accept none at all. The
+  dropdown now offers only what the declared type can hold, is disabled with a short explanation for types
+  that accept none, and clears a function the type can no longer hold when the type is changed — the schema
+  tab's editor had no type-change handler at all, and the other editor's cleared only two of the four cases.
+  A gate compares the client's list against the server's rule on every push, so the two cannot drift apart
+  again.
+- **The schema property editor rendered unstyled in Space Settings.** Reported by the owner with a
+  screenshot: the *Required* control was a bare browser checkbox with its label wrapped underneath it, and an
+  expanded property's detail card had lost both its column layout and its padding, so Type, Default, Merge
+  function and Enum values each ran the full width of the dialog with the label pressed against the border.
+  Nothing was broken — every control worked — it simply had no styling. Angular scopes component styles, and
+  when this editor was split out of the Schema tab so the Brain overview could reuse it, twelve classes it
+  renders were left behind in the stylesheet it no longer carried. The same extraction lost the enum chip
+  styles, which were restored earlier; these went unnoticed for longer. The rules now live in one module that
+  all three renderers share, instead of the two hand-kept copies they were before, and a build gate fails if
+  a component renders a shared class without carrying its stylesheet. Two things were improved rather than
+  restored while they were being moved: the detail card wraps to two columns in a narrow dialog instead of
+  squeezing three, and *Required* is a single pill whose dot fills in, rather than a pill and a native
+  checkbox saying the same thing twice.
+
 - **`query` over MCP returned no rows to a client that reads `structuredContent`.** The tool put the rows in
   `content` and the paging facts — `count`, `total`, `limit`, `skip` — in `structuredContent`, on the
   reasoning that a client ignoring the structured block loses nothing because `content` is complete. The

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1882,6 +1882,7 @@
   "tokens.rights.explain": "Was erlaubt das?",
   "tokens.rights.endpoint": "Endpunkt",
   "tokens.rights.fromRung": "Ab",
+  "spaces.schema.propDetail.mergeFnUnavailable": "— für diesen Typ gibt es keine Merge-Funktion",
   "tokens.rights.endpointsUnavailable": "Die Endpunktliste konnte nicht geladen werden. Die Beschreibungen oben gelten weiterhin.",
   "tokens.rights.clamp.floor": "Durch die Untergrenze für alle Spaces auf {{rung}} gehalten",
   "tokens.rights.clamp.implied": "Auf {{rung}} gehalten, weil {{area}} auf {{cause}} steht und ohne dies nicht funktioniert",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1882,6 +1882,7 @@
   "tokens.rights.explain": "What does this grant?",
   "tokens.rights.endpoint": "Endpoint",
   "tokens.rights.fromRung": "From",
+  "spaces.schema.propDetail.mergeFnUnavailable": "— no merge function applies to this type",
   "tokens.rights.endpointsUnavailable": "The endpoint list could not be loaded. The descriptions above still apply.",
   "tokens.rights.clamp.floor": "Held at {{rung}} by the all-spaces floor",
   "tokens.rights.clamp.implied": "Held at {{rung}} because {{area}} is {{cause}}, which cannot work without it",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1882,6 +1882,7 @@
   "tokens.rights.explain": "Co to daje?",
   "tokens.rights.endpoint": "Punkt końcowy",
   "tokens.rights.fromRung": "Od",
+  "spaces.schema.propDetail.mergeFnUnavailable": "— dla tego typu nie ma funkcji scalania",
   "tokens.rights.endpointsUnavailable": "Nie udało się wczytać listy punktów końcowych. Opisy powyżej nadal obowiązują.",
   "tokens.rights.clamp.floor": "Utrzymane na {{rung}} przez próg dla wszystkich przestrzeni",
   "tokens.rights.clamp.implied": "Utrzymane na {{rung}}, ponieważ {{area}} ma {{cause}} i bez tego nie zadziała",

--- a/client/src/app/pages/settings/schema-styles.ts
+++ b/client/src/app/pages/settings/schema-styles.ts
@@ -70,7 +70,9 @@ export const SCHEMA_MD_STYLES = `
 .sch-add-prop input { max-width:260px; }
 .sch-add-imports { display:flex; gap:6px; flex-wrap:wrap; margin-top:10px; padding-top:8px;
   border-top:1px solid var(--border-muted); }
-.prop-caret { color:var(--text-muted); flex-shrink:0; display:inline-flex; }
+/* .prop-caret moved to PROP_TABLE_STYLES — it belongs with the rows it opens, and a component rendering the
+   caret needs the row rules anyway. Two homes for one class is how the caret survived while the table around
+   it lost its styling. */
 /* One coherent text scale for the tab: guidance, section labels, inline messages.
    Every section label reads the same and every hint hangs off it the same way — the delimiter is an
    em dash in all of them, where it used to be parentheses in some and a dash in others. */

--- a/client/src/app/pages/settings/schema-type-editor.component.ts
+++ b/client/src/app/pages/settings/schema-type-editor.component.ts
@@ -47,16 +47,26 @@ import type { TypeSchemaState } from './space-settings-state.service';
 import { addProp, removeProp, addEnumVal, removeEnumVal } from './type-schema-edits';
 import { SCHEMA_MD_STYLES } from './schema-styles';
 import { CHIP_STYLES } from '../../shared/chip.styles';
+import { PROP_TABLE_STYLES } from '../../shared/prop-table.styles';
+import { mergeFnsFor, mergeFnAfterTypeChange } from '../../shared/merge-fns';
 
 @Component({
   selector: 'app-schema-type-editor',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [FormsModule, TranslocoPipe, PhIconComponent, HscrollTopDirective],
-  // CHIP_STYLES is not decoration here: this component renders `.chip-wrap`/`.chip`/`.chip-rm`/`.chip-field`, and
-  // Angular scopes styles — without it those chips render as browser defaults, which is the oversized remove
-  // button breituai-platform reported. It came loose when this editor was extracted out of the schema TAB.
-  styles: [SCHEMA_MD_STYLES, CHIP_STYLES],
+  // Neither of these is decoration, and BOTH came loose when this editor was extracted out of the schema tab.
+  // Angular scopes styles, so a class this template renders and this array does not define gets browser
+  // defaults — with no error, in a component that still works perfectly.
+  //
+  // CHIP_STYLES: `.chip-wrap`/`.chip`/`.chip-rm`/`.chip-field`, the oversized enum remove button
+  // breituai-platform reported.
+  //
+  // PROP_TABLE_STYLES: `.prop-table`/`.prop-row`/`.prop-caret`/`.pdet`/`.pdet-fields`/`.req-toggle`. Missing
+  // for longer and reported by the owner on 2026-08-15 with a screenshot — the Required pill rendered as a
+  // raw checkbox with its label wrapped under it, and the detail card lost both its column grid and its
+  // padding, so every field ran edge to edge with its label against the dialog border.
+  styles: [SCHEMA_MD_STYLES, CHIP_STYLES, PROP_TABLE_STYLES],
   template: `
 @if (libRef(); as libRef) {
   <!-- Linked library schema — editable only after unlinking; shown read-only meanwhile. -->
@@ -189,10 +199,10 @@ import { CHIP_STYLES } from '../../shared/chip.styles';
             (click)="toggleOpen(p.key)">
             <td><span class="prop-caret"><ph-icon [name]="isOpen(p.key) ? 'caret-up' : 'caret-down'" [size]="13"/></span></td>
             <td>
-              <div style="display:flex;align-items:center;gap:7px;">
-                <span style="font-family:var(--font-mono);font-size:12px;">{{ p.key }}</span>
+              <div class="prop-name">
+                <span class="prop-name-key">{{ p.key }}</span>
                 <label class="req-toggle" [class.is-req]="p.s.required" (click)="$event.stopPropagation()">
-                  <input type="checkbox" [checked]="p.s.required" (change)="p.s.required = !p.s.required" style="pointer-events:none;" />
+                  <input type="checkbox" [checked]="p.s.required" (change)="p.s.required = !p.s.required" />
                   {{ 'spaces.schema.propDetail.required' | transloco }}
                 </label>
               </div>
@@ -217,7 +227,7 @@ import { CHIP_STYLES } from '../../shared/chip.styles';
                   <div class="pdet-fields">
                     <div class="field" style="margin:0;">
                       <label>{{ 'spaces.schema.propDetail.type' | transloco }}</label>
-                      <select [(ngModel)]="p.s.type">
+                      <select [(ngModel)]="p.s.type" (ngModelChange)="onTypeChange(p)">
                         <option [ngValue]="undefined">any</option>
                         <option value="string">string</option>
                         <option value="number">number</option>
@@ -229,15 +239,17 @@ import { CHIP_STYLES } from '../../shared/chip.styles';
                       <label>{{ 'spaces.schema.propDetail.default' | transloco }}</label>
                       <input type="text" [(ngModel)]="p.s.default" placeholder="—" />
                     </div>
+                    <!-- Only the functions the API accepts for this type. Offering all seven is what let a
+                         date + min be chosen and then refused at save with a wall of zod JSON. -->
                     <div class="field" style="margin:0;">
                       <label>{{ 'spaces.schema.propDetail.mergeFn' | transloco }}</label>
-                      <select [(ngModel)]="p.s.mergeFn">
+                      <select [(ngModel)]="p.s.mergeFn" [disabled]="!mergeFnsFor(p.s.type).length">
                         <option [ngValue]="undefined">—</option>
-                        <option value="avg">avg</option><option value="min">min</option>
-                        <option value="max">max</option><option value="sum">sum</option>
-                        <option value="and">and</option><option value="or">or</option>
-                        <option value="xor">xor</option>
+                        @for (fn of mergeFnsFor(p.s.type); track fn) { <option [value]="fn">{{ fn }}</option> }
                       </select>
+                      @if (!mergeFnsFor(p.s.type).length) {
+                        <span class="sch-hint">{{ 'spaces.schema.propDetail.mergeFnUnavailable' | transloco }}</span>
+                      }
                     </div>
                     @if (p.s.type==='string'||p.s.type===undefined) {
                       <div class="field" style="margin:0;">
@@ -339,6 +351,25 @@ export class SchemaTypeEditorComponent {
     next.delete(key);
     this.openRows.set(next);
   }
+  /**
+   * The merge functions this type may declare — the API's own rule, so the control cannot offer a refusal.
+   *
+   * A method rather than a pipe because the answer depends on a field the row owns and changes in place.
+   */
+  mergeFnsFor = mergeFnsFor;
+
+  /**
+   * Changing the type clears a merge function the new type cannot hold.
+   *
+   * This component had NO type-change handler at all — the shared `prop-schema-table` had one and this copy
+   * did not, which is the same one-rule-two-implementations split that lost its stylesheet. Without it,
+   * switching `number` to `date` leaves `min` behind, invisible, until the save is refused for a field the
+   * operator was not editing.
+   */
+  onTypeChange(p: { s: PropertySchema }): void {
+    p.s.mergeFn = mergeFnAfterTypeChange(p.s.type, p.s.mergeFn);
+  }
+
   onAddEnum(key: string): void { addEnumVal(this.draft(), key); }
   onRemoveEnum(key: string, val: string | number | boolean): void { removeEnumVal(this.draft(), key, val); }
   onEnumKey(e: KeyboardEvent, key: string): void {

--- a/client/src/app/pages/settings/space-dialog.styles.ts
+++ b/client/src/app/pages/settings/space-dialog.styles.ts
@@ -9,9 +9,11 @@
  * compiles; if it ever could not, the build would fail loudly rather than drop the styles.
  */
 import { CHIP_STYLES } from '../../shared/chip.styles';
+import { PROP_TABLE_STYLES } from '../../shared/prop-table.styles';
 
 export const SPACE_DIALOG_STYLES = `
 ${CHIP_STYLES}
+${PROP_TABLE_STYLES}
 /* storage bar */
 .st-bar { height:6px; border-radius:3px; background:var(--border); overflow:hidden; }
 .st-bar-fill { height:100%; border-radius:3px; transition:width .3s; }
@@ -61,11 +63,6 @@ ${CHIP_STYLES}
 .sch-section-title { font-size:11px; font-weight:600; text-transform:uppercase; letter-spacing:.06em; color:var(--text-muted); margin-bottom:12px; padding-bottom:6px; border-bottom:1px solid var(--border); }
 .sch-grid { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
 .sch-grid-3 { display:grid; grid-template-columns:repeat(3,1fr); gap:12px; }
-.prop-table { width:100%; border-collapse:collapse; font-size:13px; }
-.prop-table th { text-align:left; font-size:11px; font-weight:600; color:var(--text-muted); padding:5px 8px; border-bottom:1px solid var(--border); }
-.prop-table td { padding:6px 8px; border-bottom:1px solid var(--border); vertical-align:middle; }
-.prop-expand-row td { background:var(--bg-elevated); padding:0; }
-.prop-expand-inner { padding:12px 16px; }
 /* danger zone */
 .dz-section { border:1px solid var(--border); border-radius:var(--radius-md); padding:16px; margin-bottom:16px; }
 .dz-section.dz-red { border-color:var(--danger); }
@@ -93,17 +90,8 @@ ${CHIP_STYLES}
 .type-table th { text-align:left; font-size:11px; font-weight:600; color:var(--text-muted); text-transform:uppercase; letter-spacing:.05em; padding:5px 10px; border-bottom:1px solid var(--border); background:var(--bg-elevated); }
 .type-table td { padding:8px 10px; border-bottom:1px solid var(--border); vertical-align:middle; }
 .type-table tr:hover td { background:var(--bg-elevated); }
-/* ── property rows ── */
-.prop-row { cursor:pointer; user-select:none; }
-.prop-row:hover td { background:var(--bg-elevated); }
-.prop-row.prow-open td { background:color-mix(in srgb,var(--accent) 6%,transparent); }
-/* ── property detail card ── */
-.pdet { background:var(--bg-surface); border-top:2px solid color-mix(in srgb,var(--accent) 30%,transparent); }
-.pdet-fields { display:grid; grid-template-columns:repeat(3,1fr); gap:10px 16px; padding:14px; }
-.pdet-full { padding:0 14px 14px; }
-.req-toggle { display:inline-flex; align-items:center; gap:6px; font-size:12px; cursor:pointer; color:var(--text-muted); background:none; border:1px solid var(--border); font-family:var(--font); padding:3px 10px; border-radius:var(--radius-sm); transition:all .15s; }
-.req-toggle:hover { background:var(--bg-elevated); color:var(--text-primary); border-color:color-mix(in srgb,var(--accent) 40%,transparent); }
-.req-toggle.is-req { color:var(--warning); border-color:color-mix(in srgb,var(--warning) 50%,transparent); background:color-mix(in srgb,var(--warning) 8%,transparent); font-weight:600; }
+/* The property table, its rows, its detail card and the Required toggle are interpolated at the top of this
+   const from PROP_TABLE_STYLES — three components render them, so they are not owned by this file. */
 /* ── schema sub-section headers ── */
 .sch-sub { font-size:11px; font-weight:700; text-transform:uppercase; letter-spacing:.07em; color:var(--text-muted); padding:14px 0 8px; margin-bottom:2px; }
 `;

--- a/client/src/app/shared/merge-fns.ts
+++ b/client/src/app/shared/merge-fns.ts
@@ -1,0 +1,60 @@
+import type { PropertySchema } from '../core/api.types';
+
+/**
+ * Which merge functions a property may declare, given its type.
+ *
+ * ## Why the control needs this at all
+ *
+ * The server refuses an incompatible pair outright: `PropertySchemaZ` in `server/src/spaces/body-schemas.ts`
+ * has a `.refine` that rejects a numeric function on anything but `number`, a boolean function on anything
+ * but `boolean`, and ANY merge function on `string` or `date`.
+ *
+ * The editor offered all seven for every type. So an operator could pick `date` + `min` — a combination the
+ * dropdown presented as available — and the save came back as a wall of zod JSON naming `path: [meta,
+ * typeSchemas, entity, Task, propertySchemas, deadline]`. Reported by the owner on 2026-08-15, whose words
+ * were *"i dont understand what i did wrong"*, which is the correct reaction: nothing they did was wrong. A
+ * control that offers a value its own API rejects has moved a validation rule into the user's head.
+ *
+ * A refusal reached only by choosing something the UI offered is the UI's defect, not the validator's.
+ *
+ * ## Why the list is here and not fetched
+ *
+ * There is no catalog endpoint for property-schema rules the way there is for token rights, and inventing one
+ * for seven strings is a bigger change than the defect. So this is a second copy of a server rule, which this
+ * repo treats as a liability rather than a convenience — and it is pinned: `merge-fns-match-the-server.test.js`
+ * reads the `.refine` in `body-schemas.ts` and fails if the two disagree. A copy nobody compares is the one
+ * that drifts; a copy compared on every push is a cache.
+ *
+ * `undefined` type means NOT STATED, and the server allows any of the seven there — narrowing it in the UI
+ * would refuse a combination the API accepts, which is the same defect pointing the other way.
+ */
+export const NUMERIC_MERGE_FNS = ['avg', 'min', 'max', 'sum'] as const;
+export const BOOLEAN_MERGE_FNS = ['and', 'or', 'xor'] as const;
+
+export type MergeFn = typeof NUMERIC_MERGE_FNS[number] | typeof BOOLEAN_MERGE_FNS[number];
+
+/** Every function, for an undeclared type. Order is numeric-then-boolean, as the server lists them. */
+export const ALL_MERGE_FNS: readonly MergeFn[] = [...NUMERIC_MERGE_FNS, ...BOOLEAN_MERGE_FNS];
+
+export function mergeFnsFor(type: PropertySchema['type'] | undefined): readonly MergeFn[] {
+  if (type === 'number') return NUMERIC_MERGE_FNS;
+  if (type === 'boolean') return BOOLEAN_MERGE_FNS;
+  if (type === 'string' || type === 'date') return [];
+  return ALL_MERGE_FNS;
+}
+
+/**
+ * The merge function a property should hold after its type changes.
+ *
+ * Cleared rather than kept-and-refused: the operator changed the TYPE, so the stale function is a leftover
+ * from a decision they have just replaced, and carrying it forward only surfaces at save time as a refusal
+ * about a field they were not editing.
+ */
+export function mergeFnAfterTypeChange(
+  type: PropertySchema['type'] | undefined,
+  current: string | undefined,
+): MergeFn | undefined {
+  if (!current) return undefined;
+  const allowed = mergeFnsFor(type) as readonly string[];
+  return allowed.includes(current) ? (current as MergeFn) : undefined;
+}

--- a/client/src/app/shared/prop-schema-table.component.ts
+++ b/client/src/app/shared/prop-schema-table.component.ts
@@ -4,6 +4,8 @@ import { TranslocoPipe } from '@jsverse/transloco';
 import { PropertySchema } from '../core/api.types';
 import { PhIconComponent } from './ph-icon.component';
 import { CHIP_STYLES } from './chip.styles';
+import { PROP_TABLE_STYLES } from './prop-table.styles';
+import { mergeFnsFor, mergeFnAfterTypeChange } from './merge-fns';
 
 export interface PropSchemaRow {
   key: string;
@@ -15,20 +17,9 @@ export interface PropSchemaRow {
   selector: 'app-prop-schema-table',
   standalone: true,
   imports: [FormsModule, TranslocoPipe, PhIconComponent],
-  styles: [CHIP_STYLES, `
-    .prop-table { width:100%; border-collapse:collapse; font-size:13px; }
-    .prop-table th { text-align:left; font-size:11px; font-weight:600; color:var(--text-muted); padding:5px 8px; border-bottom:1px solid var(--border); }
-    .prop-table td { padding:6px 8px; border-bottom:1px solid var(--border); vertical-align:middle; }
-    .prop-row { cursor:pointer; }
-    .prop-row:hover td { background:var(--bg-elevated); }
-    .prop-row.prow-open td { background:color-mix(in srgb,var(--accent) 6%,transparent); }
-    .prop-expand-row td { background:var(--bg-elevated); padding:0; }
-    .pdet { background:var(--bg-surface); border-top:2px solid color-mix(in srgb,var(--accent) 30%,transparent); }
-    .pdet-fields { display:grid; grid-template-columns:repeat(3,1fr); gap:10px 16px; padding:14px; }
-    .pdet-full { padding:0 14px 14px; }
-    .req-toggle { display:inline-flex; align-items:center; gap:6px; font-size:12px; cursor:pointer; color:var(--text-muted); background:none; border:1px solid var(--border); font-family:var(--font); padding:3px 10px; border-radius:var(--radius-sm); transition:all .15s; }
-    .req-toggle:hover { background:var(--bg-elevated); color:var(--text-primary); border-color:color-mix(in srgb,var(--accent) 40%,transparent); }
-    .req-toggle.is-req { color:var(--warning); border-color:color-mix(in srgb,var(--warning) 50%,transparent); background:color-mix(in srgb,var(--warning) 8%,transparent); font-weight:600; }
+  // The table, row, detail-card and Required rules were a character-identical SECOND copy of the ones in
+  // `SPACE_DIALOG_STYLES`. Both are now PROP_TABLE_STYLES; only this component's own add-row is local.
+  styles: [CHIP_STYLES, PROP_TABLE_STYLES, `
     .add-prop-row { display:flex; gap:8px; align-items:center; margin-top:10px; padding-top:10px; border-top:1px solid var(--border); }
   `],
   template: `
@@ -44,10 +35,10 @@ export interface PropSchemaRow {
           @for (p of rows; track p.key) {
             <tr class="prop-row" [class.prow-open]="expandedKey() === p.key" (click)="toggleExpand(p.key)">
               <td>
-                <div style="display:flex;align-items:center;gap:7px;">
-                  <span style="font-family:var(--font-mono);font-size:12px;">{{ p.key }}</span>
+                <div class="prop-name">
+                  <span class="prop-name-key">{{ p.key }}</span>
                   <label class="req-toggle" [class.is-req]="p.s.required" (click)="$event.stopPropagation()">
-                    <input type="checkbox" [checked]="p.s.required" (change)="p.s.required = !p.s.required; changed.emit()" style="pointer-events:none;" />
+                    <input type="checkbox" [checked]="p.s.required" (change)="p.s.required = !p.s.required; changed.emit()" />
                     {{ 'spaces.schema.propDetail.required' | transloco }}
                   </label>
                 </div>
@@ -86,14 +77,15 @@ export interface PropSchemaRow {
                         <label>{{ 'spaces.schema.propDetail.default' | transloco }}</label>
                         <input type="text" [(ngModel)]="p.s.default" placeholder="—" (ngModelChange)="changed.emit()" />
                       </div>
+                      <!-- Only what the API accepts for this type — see merge-fns.ts.
+                           NO BACKTICKS in this template, comments included: one ends the string, and the
+                           error points at @Component rather than at the line that caused it. -->
                       <div class="field" style="margin:0;">
                         <label>{{ 'spaces.schema.propDetail.mergeFn' | transloco }}</label>
-                        <select [(ngModel)]="p.s.mergeFn" (ngModelChange)="changed.emit()">
+                        <select [(ngModel)]="p.s.mergeFn" (ngModelChange)="changed.emit()"
+                                [disabled]="!mergeFnsFor(p.s.type).length">
                           <option [ngValue]="undefined">—</option>
-                          <option value="avg">avg</option><option value="min">min</option>
-                          <option value="max">max</option><option value="sum">sum</option>
-                          <option value="and">and</option><option value="or">or</option>
-                          <option value="xor">xor</option>
+                          @for (fn of mergeFnsFor(p.s.type); track fn) { <option [value]="fn">{{ fn }}</option> }
                         </select>
                       </div>
                       @if (p.s.type === 'string' || p.s.type === undefined) {
@@ -175,9 +167,18 @@ export class PropSchemaTableComponent {
     this.changed.emit();
   }
 
+  /** The API's own rule about which merge functions a type may hold. */
+  mergeFnsFor = mergeFnsFor;
+
+  /**
+   * Changing the type clears a merge function the new type cannot hold.
+   *
+   * The two hand-written lists this replaced covered `boolean` and `number` and left `string` and `date`
+   * alone — but the server accepts NO merge function on either, so switching `number` to `date` kept `min`
+   * and the save was refused.
+   */
   onTypeChange(p: PropSchemaRow): void {
-    if (p.s.type === 'boolean' && p.s.mergeFn && ['avg', 'min', 'max', 'sum'].includes(p.s.mergeFn)) p.s.mergeFn = undefined;
-    if (p.s.type === 'number'  && p.s.mergeFn && ['and', 'or', 'xor'].includes(p.s.mergeFn))         p.s.mergeFn = undefined;
+    p.s.mergeFn = mergeFnAfterTypeChange(p.s.type, p.s.mergeFn);
     this.changed.emit();
   }
 

--- a/client/src/app/shared/prop-table.styles.ts
+++ b/client/src/app/shared/prop-table.styles.ts
@@ -1,0 +1,74 @@
+/**
+ * The property-schema table: its rows, its expanded detail card, and the Required toggle.
+ *
+ * ## Why this is its own module
+ *
+ * Angular scopes component styles, so a component that RENDERS `.pdet-fields` and does not carry the rule
+ * defining it gets browser defaults — silently, with no error anywhere. That has now happened twice to this
+ * exact table:
+ *
+ *  - when `schema-type-editor` was extracted out of the schema tab it left `CHIP_STYLES` behind, and the enum
+ *    remove button rendered as an oversized browser control (reported by breituai-platform);
+ *  - and it left THESE behind at the same time, which nobody noticed until the owner sent a screenshot on
+ *    2026-08-15: the Required pill rendered as a raw checkbox with its label wrapped underneath, and the
+ *    detail card lost its three-column grid AND its padding, so every field ran the full width of the dialog
+ *    with its label jammed against the edge.
+ *
+ * Two copies already existed — `SPACE_DIALOG_STYLES` and `prop-schema-table.component.ts` each had their own,
+ * character-identical. So the third consumer needing them was not a new problem: it was the same rules in a
+ * third place, which is the point at which this repo extracts instead of pasting. One const, three importers,
+ * and `prop-table-styles-reach-their-renderers.test.js` fails the build if a fourth renderer forgets it.
+ *
+ * ## What changed in the arrangement, and why
+ *
+ * The owner's report was *"functionality is good, just looks and arrangement sux"*, so restoring the lost
+ * rules is most of it — but two of them were worth fixing rather than restoring:
+ *
+ *  - **The detail grid was three FIXED columns.** In a dialog this narrow that gives a select about 130px and
+ *    then wraps the labels. `auto-fit` with a floor lets it be three columns when there is room and two when
+ *    there is not, instead of three cramped ones always.
+ *  - **The Required toggle showed a native checkbox** inside a pill that already says the same thing with
+ *    colour and weight — two indicators of one state, and the native box is the one that cannot be styled to
+ *    match anything around it. The input stays for keyboard and assistive tech and is visually hidden; the
+ *    pill is the affordance. Focus is drawn on the pill through `:focus-within`, so tabbing to it is still
+ *    visible.
+ *
+ * NO BACKTICKS anywhere in this file — it is one template string, and one backtick ends it.
+ */
+export const PROP_TABLE_STYLES = `
+/* ── the table ── */
+.prop-table { width:100%; border-collapse:collapse; font-size:13px; }
+.prop-table th { text-align:left; font-size:11px; font-weight:600; color:var(--text-muted); padding:5px 8px; border-bottom:1px solid var(--border); }
+.prop-table td { padding:6px 8px; border-bottom:1px solid var(--border); vertical-align:middle; }
+/* ── property rows ── */
+.prop-row { cursor:pointer; user-select:none; }
+.prop-row:hover td { background:var(--bg-elevated); }
+.prop-row.prow-open td { background:color-mix(in srgb,var(--accent) 6%,transparent); }
+.prop-row.prow-open td:first-child { box-shadow:inset 2px 0 0 var(--accent); }
+.prop-caret { color:var(--text-muted); flex-shrink:0; display:inline-flex; transition:color .15s; }
+.prop-row:hover .prop-caret, .prop-row.prow-open .prop-caret { color:var(--accent); }
+/* The name is the row identity, so it does not shrink when the constraint column is long. */
+.prop-name { display:flex; align-items:center; gap:8px; min-width:0; }
+.prop-name-key { font-family:var(--font-mono); font-size:12px; color:var(--text-primary); overflow:hidden; text-overflow:ellipsis; }
+/* ── expanded detail card ── */
+.prop-expand-row td { background:var(--bg-elevated); padding:0; }
+.prop-expand-inner { padding:12px 16px; }
+/* Inset on the left so the card reads as belonging to the row above rather than as a sibling of the table. */
+.pdet { background:var(--bg-surface); border-top:2px solid color-mix(in srgb,var(--accent) 30%,transparent); box-shadow:inset 3px 0 0 color-mix(in srgb,var(--accent) 45%,transparent); }
+/* auto-fit, not repeat(3,1fr): three fixed columns in a narrow dialog wrap every label. */
+.pdet-fields { display:grid; grid-template-columns:repeat(auto-fit,minmax(170px,1fr)); gap:12px 16px; padding:14px 16px; }
+.pdet-fields .field { margin:0; min-width:0; }
+.pdet-fields .field label, .pdet-full .field label { display:block; margin-bottom:4px; font-size:11px; font-weight:600; letter-spacing:.03em; color:var(--text-muted); }
+.pdet-fields .field input, .pdet-fields .field select { width:100%; }
+.pdet-full { padding:0 16px 14px; }
+/* ── the Required toggle ── */
+.req-toggle { display:inline-flex; align-items:center; gap:6px; font-size:11px; line-height:1; white-space:nowrap; cursor:pointer; color:var(--text-muted); background:none; border:1px solid var(--border); font-family:var(--font); padding:4px 9px; border-radius:999px; transition:all .15s; }
+.req-toggle:hover { background:var(--bg-elevated); color:var(--text-primary); border-color:color-mix(in srgb,var(--accent) 40%,transparent); }
+.req-toggle:focus-within { outline:2px solid var(--accent); outline-offset:1px; }
+.req-toggle.is-req { color:var(--warning); border-color:color-mix(in srgb,var(--warning) 50%,transparent); background:color-mix(in srgb,var(--warning) 8%,transparent); font-weight:600; }
+/* Visually hidden, not display:none — a removed input is not focusable and not announced. */
+.req-toggle input { position:absolute; width:1px; height:1px; margin:-1px; padding:0; border:0; overflow:hidden; clip:rect(0 0 0 0); clip-path:inset(50%); white-space:nowrap; }
+/* The dot IS the state, since the native box cannot be styled to match anything around it. */
+.req-toggle::before { content:''; width:6px; height:6px; border-radius:50%; flex-shrink:0; border:1px solid currentColor; transition:background .15s; }
+.req-toggle.is-req::before { background:currentColor; }
+`;

--- a/testing/standalone/merge-fns-match-the-server.test.js
+++ b/testing/standalone/merge-fns-match-the-server.test.js
@@ -1,0 +1,110 @@
+/**
+ * The merge functions the editor OFFERS are the ones the API ACCEPTS.
+ *
+ * ## The report
+ *
+ * Owner, 2026-08-15, editing a type's properties: *"i dont understand what i did wrong..."* — with a
+ * screenshot of the schema dialog showing a wall of zod JSON,
+ *
+ *     mergeFn is incompatible with the declared type
+ *     (numeric fns require type "number", boolean fns require type "boolean")
+ *     path: [ meta, typeSchemas, entity, Task, propertySchemas, deadline ]
+ *
+ * They had done nothing wrong. `deadline` was type `date`, and the merge-function dropdown offered `min` —
+ * all seven functions, for every type, because the control listed them as static `<option>` elements. The
+ * server's `PropertySchemaZ.refine` accepts none at all on `string` or `date`.
+ *
+ * A control that offers a value its own API refuses has moved a validation rule into the user's head, and the
+ * only way to learn it is to be refused. That is the defect; the validator is right.
+ *
+ * ## Why a gate rather than "we fixed the dropdown"
+ *
+ * The fix puts the rule in `client/src/app/shared/merge-fns.ts`, which is a SECOND COPY of a server rule.
+ * This repo's most expensive recurring defect is one rule with two implementations where the weaker one wins
+ * silently — so the copy is only acceptable while something compares it. This reads the server's `.refine`
+ * source and the client's arrays and fails when they disagree, which turns a copy into a cache.
+ *
+ * If a rule is ever added that this cannot parse, it fails LOUDLY rather than passing vacuously: the counts
+ * are asserted before the contents.
+ *
+ * Run: node --test testing/standalone/merge-fns-match-the-server.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const SERVER = 'server/src/spaces/body-schemas.ts';
+const LIBRARY = 'server/src/api/schema-library.ts';
+const CLIENT = 'client/src/app/shared/merge-fns.ts';
+
+const read = (p) => readFileSync(p, 'utf8');
+/** Line comments first, then block — a block-open inside a line comment otherwise swallows real code. */
+const strip = (src) => src.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
+
+/** `new Set(['a','b'])` assigned to a named const, as both servers write it. */
+function setLiteral(src, name) {
+  const m = new RegExp(`${name}\\s*=\\s*new Set\\(\\[([^\\]]*)\\]\\)`).exec(strip(src));
+  if (!m) return null;
+  return m[1].split(',').map((s) => s.trim().replace(/^['"]|['"]$/g, '')).filter(Boolean);
+}
+
+/** `A = ['a','b'] as const` — the client's shape. */
+function arrayLiteral(src, name) {
+  const m = new RegExp(`${name}\\s*=\\s*\\[([^\\]]*)\\]`).exec(strip(src));
+  if (!m) return null;
+  return m[1].split(',').map((s) => s.trim().replace(/^['"]|['"]$/g, '')).filter(Boolean);
+}
+
+describe('the merge-function lists agree across the API and the editor', () => {
+  it('the numeric and boolean sets are the same on both sides', () => {
+    const serverNumeric = setLiteral(read(SERVER), 'numericFns');
+    const serverBoolean = setLiteral(read(SERVER), 'booleanFns');
+    const clientNumeric = arrayLiteral(read(CLIENT), 'NUMERIC_MERGE_FNS');
+    const clientBoolean = arrayLiteral(read(CLIENT), 'BOOLEAN_MERGE_FNS');
+
+    // Parsed at all, before compared — an unparsed side is an empty array, and two empty arrays are equal.
+    assert.ok(serverNumeric?.length, `could not parse numericFns from ${SERVER}`);
+    assert.ok(serverBoolean?.length, `could not parse booleanFns from ${SERVER}`);
+    assert.ok(clientNumeric?.length, `could not parse NUMERIC_MERGE_FNS from ${CLIENT}`);
+    assert.ok(clientBoolean?.length, `could not parse BOOLEAN_MERGE_FNS from ${CLIENT}`);
+
+    assert.deepEqual([...clientNumeric].sort(), [...serverNumeric].sort());
+    assert.deepEqual([...clientBoolean].sort(), [...serverBoolean].sort());
+  });
+
+  it('the two SERVER copies of the rule agree with each other', () => {
+    // `schema-library.ts` carries its own copy, deliberately kept in step so a library entry can express what
+    // an inline schema can. Deliberate or not, two copies still drift.
+    assert.deepEqual(setLiteral(read(LIBRARY), 'numericFns'), setLiteral(read(SERVER), 'numericFns'));
+    assert.deepEqual(setLiteral(read(LIBRARY), 'booleanFns'), setLiteral(read(SERVER), 'booleanFns'));
+  });
+
+  it('string and date still accept NO merge function on the server', () => {
+    // The half the old client lists missed entirely: they cleared an incompatible fn when switching between
+    // number and boolean, and left it alone for string and date, which accept none.
+    assert.match(
+      strip(read(SERVER)),
+      /if \(data\.type === 'string' \|\| data\.type === 'date'\) return false;/,
+      'the string/date refusal changed — merge-fns.ts returns [] for both and must be revisited',
+    );
+  });
+
+  it('an undeclared type still accepts any of the seven', () => {
+    // The client must not narrow here: refusing a combination the API accepts is the same defect pointing the
+    // other way, and it is the one nobody reports because it looks like a missing feature.
+    assert.match(
+      strip(read(SERVER)),
+      /return numericFns\.has\(data\.mergeFn\) \|\| booleanFns\.has\(data\.mergeFn\);/,
+      'the undeclared-type fallback changed — mergeFnsFor(undefined) returns all seven and must be revisited',
+    );
+  });
+
+  it('no component writes its own list of merge functions', () => {
+    // Both editors listed all seven as static options. That is what offered `date` + `min`.
+    const offenders = [
+      'client/src/app/pages/settings/schema-type-editor.component.ts',
+      'client/src/app/shared/prop-schema-table.component.ts',
+    ].filter((f) => /value="(avg|sum|xor)"/.test(strip(read(f))));
+    assert.deepEqual(offenders, [], 'these hard-code merge-function options instead of asking mergeFnsFor()');
+  });
+});

--- a/testing/standalone/shared-styles-reach-their-renderers.test.js
+++ b/testing/standalone/shared-styles-reach-their-renderers.test.js
@@ -1,0 +1,228 @@
+/**
+ * A component that RENDERS a shared class must carry a stylesheet defining it.
+ *
+ * ## The failure this exists for, which has now happened twice to one component
+ *
+ * Angular scopes component styles. So a template using `.pdet-fields` inside a component whose `styles` array
+ * does not define it renders with browser defaults — no error, no warning, no console line, and the component
+ * still works. It is invisible to every other gate here: it type-checks, it builds, its specs pass, and the
+ * only thing that reports it is somebody looking at the screen.
+ *
+ * `schema-type-editor.component.ts` was extracted out of `space-schema-tab.component.ts` and left behind:
+ *
+ *  - `CHIP_STYLES` — the enum remove button rendered as an oversized browser control. Reported by
+ *    breituai-platform, fixed, and a comment was added to the styles array saying why it mattered.
+ *  - `PROP_TABLE_STYLES` — the SAME extraction, undetected for longer. The owner reported it on 2026-08-15
+ *    with a screenshot: the Required pill rendered as a raw checkbox with its label wrapped underneath, and
+ *    the property detail card lost its column grid and its padding, so every field ran the full width of the
+ *    dialog with its label against the border.
+ *
+ * A comment did not prevent the second one, because the comment was on the const that WAS there.
+ *
+ * ## Why it resolves what a component CARRIES rather than naming one const
+ *
+ * The first version of this file asked "does the component mention `CHIP_STYLES`?" and reported five brain
+ * components as broken. They were not: `.chip` is defined twice in this codebase, by `chip.styles.ts` for
+ * schema enum chips and by `brain-form.styles.ts` for record-reference chips, and those five carry the second
+ * one. A gate that cannot tell those apart reports healthy code, and a gate that reports healthy code gets
+ * switched off — at which point it is not protecting the thing it was written for.
+ *
+ * So it resolves the `styles: [...]` array properly: inline literals, imported consts, and consts those
+ * interpolate. A class is covered if ANY of them defines it, which is exactly what the browser will do.
+ *
+ * ## What is deliberately NOT checked
+ *
+ * Global classes. `.field`, `.badge`, `.btn`, `.icon-btn` live in `styles.css` and are correct to use
+ * anywhere, so only classes owned by a SHARED style module are candidates. Everything else is out of scope,
+ * which is what keeps a failure here always real.
+ *
+ * Run: node --test testing/standalone/shared-styles-reach-their-renderers.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, join, normalize } from 'node:path';
+import { execSync } from 'node:child_process';
+
+/** Shared style modules whose classes a renderer must carry. Not every style file — these are the shared ones. */
+const SHARED = [
+  'client/src/app/shared/prop-table.styles.ts',
+  'client/src/app/shared/chip.styles.ts',
+];
+
+const read = (p) => readFileSync(p, 'utf8');
+
+/**
+ * Comment-stripped, or the gate fires on the prose explaining it, and passes on prose that names a const.
+ *
+ * LINE comments first, then block. The other order is itself gated in this suite: a block-open written inside
+ * a line comment opens a phantom block that swallows every line until the next close, and the gate then reads
+ * code that is not there.
+ */
+const strip = (src) => src.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
+const posix = (p) => normalize(p).replace(/\\/g, '/');
+
+/**
+ * Classes a stylesheet OWNS: the subject of each rule, never a descendant it merely reaches into.
+ *
+ * `.pdet-fields .field label` owns `pdet-fields`. It does NOT own `field` — that is a global class this module
+ * styles within its own scope, and treating it as owned made the first run of this gate report nine healthy
+ * components for rendering `.field`, which every form in the app does.
+ *
+ * So: per rule, per comma-separated selector, take the FIRST compound and read its classes. A compound keeps
+ * both halves of `.prop-row.prow-open`, because those are one element.
+ */
+function addOwnedClasses(into, css) {
+  const body = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  for (const m of body.matchAll(/(^|[{}])\s*([^{}@;]+?)\s*\{/g)) {
+    for (const sel of m[2].split(',')) {
+      const first = sel.trim().split(/[\s>+~]/)[0] ?? '';
+      for (const c of first.matchAll(/\.([a-z][a-z0-9-]*)/gi)) into.add(c[1]);
+    }
+  }
+}
+
+/** `import { A, B } from './x'` resolved to the file `A` came from, relative to the importer. */
+function resolveImport(src, ident, fromFile) {
+  const re = /import\s*\{([^}]*)\}\s*from\s*['"]([^'"]+)['"]/g;
+  for (const m of src.matchAll(re)) {
+    const names = m[1].split(',').map((s) => s.trim().split(/\s+as\s+/)[0].trim());
+    if (!names.includes(ident)) continue;
+    if (!m[2].startsWith('.')) return null;                       // a package, never one of ours
+    const p = posix(join(dirname(fromFile), m[2]) + '.ts');
+    return existsSync(p) ? p : null;
+  }
+  return null;
+}
+
+/**
+ * Every class a style module defines, following interpolation into the modules it composes.
+ *
+ * `seen` stops a cycle, and stops re-reading a const that two importers share.
+ */
+function classesFromModule(file, seen = new Set()) {
+  const out = new Set();
+  if (seen.has(file)) return out;
+  seen.add(file);
+  const src = read(file);
+  const body = strip(src);
+  addOwnedClasses(out, body);
+  for (const m of body.matchAll(/\$\{([A-Z][A-Z0-9_]*)\}/g)) {
+    const p = resolveImport(src, m[1], file);
+    if (p) for (const c of classesFromModule(p, seen)) out.add(c);
+  }
+  return out;
+}
+
+/**
+ * The `styles: [...]` array, scanned with balanced brackets rather than a lazy regex.
+ *
+ * A template literal inside the array can contain a closing bracket — an attribute selector does — so a lazy
+ * match stops inside the CSS and silently reports half an array. Reading a gate's input wrong is how it fails
+ * open, which is the failure this whole file exists to prevent.
+ */
+function stylesArray(src) {
+  const at = src.search(/\bstyles\s*:\s*\[/);
+  if (at === -1) return null;
+  const i = src.indexOf('[', at);
+  let depth = 0;
+  for (let j = i; j < src.length; j++) {
+    const ch = src[j];
+    if (ch === '`') { j = src.indexOf('`', j + 1); if (j === -1) return null; continue; }
+    if (ch === '[') depth++;
+    else if (ch === ']' && --depth === 0) return src.slice(i + 1, j);
+  }
+  return null;
+}
+
+/** Everything a component's own stylesheet defines: inline literals plus every const it names. */
+function classesCarriedBy(file) {
+  const src = read(file);
+  const arr = stylesArray(strip(src));
+  const out = new Set();
+  if (!arr) return out;
+  for (const lit of arr.matchAll(/`([\s\S]*?)`/g)) addOwnedClasses(out, lit[1]);
+  for (const m of arr.matchAll(/\b([A-Z][A-Z0-9_]*)\b/g)) {
+    const p = resolveImport(src, m[1], file);
+    if (p) for (const c of classesFromModule(p)) out.add(c);
+  }
+  return out;
+}
+
+/** Component files: tracked `.ts`, not a spec, with a decorator and an inline template. */
+function componentFiles() {
+  // git ls-files, never a directory walk: `dist/` and any untracked scratch component are not the repo.
+  return execSync('git ls-files "client/src/**/*.ts"', { encoding: 'utf8' })
+    .split('\n').map((l) => l.trim()).filter(Boolean)
+    .filter((f) => !f.endsWith('.spec.ts'))
+    .filter((f) => existsSync(f))
+    .filter((f) => { const s = read(f); return s.includes('@Component') && s.includes('template:'); });
+}
+
+/** The inline template, so a class named only in a comment or a plain string does not count as rendered. */
+function templateOf(src) {
+  const at = src.search(/\btemplate\s*:\s*`/);
+  if (at === -1) return '';
+  const open = src.indexOf('`', at);
+  const close = src.indexOf('`', open + 1);
+  return close === -1 ? src.slice(open + 1) : src.slice(open + 1, close);
+}
+
+/** Classes a template puts on an element: a static class attribute, or a bound class binding. */
+function classesUsed(tpl) {
+  const used = new Set();
+  for (const m of tpl.matchAll(/\bclass\s*=\s*"([^"]*)"/g)) {
+    for (const c of m[1].split(/\s+/)) if (/^[a-z][a-z0-9-]*$/i.test(c)) used.add(c);
+  }
+  for (const m of tpl.matchAll(/\[class\.([a-z][a-z0-9-]*)\]/gi)) used.add(m[1]);
+  return used;
+}
+
+describe('shared styles reach the components that render them', () => {
+  it('every component rendering a shared class carries a stylesheet defining it', () => {
+    const owned = new Map();                       // class -> the shared module that owns it
+    for (const f of SHARED) for (const c of classesFromModule(f)) owned.set(c, f);
+    assert.ok(owned.size > 8, `parsed only ${owned.size} shared classes — the parser is wrong, not the code`);
+
+    const missing = [];
+    for (const f of componentFiles()) {
+      const src = read(f);
+      const used = classesUsed(templateOf(src));
+      const candidates = [...used].filter((c) => owned.has(c));
+      if (!candidates.length) continue;
+      const carried = classesCarriedBy(f);
+      const gaps = candidates.filter((c) => !carried.has(c)).sort();
+      if (gaps.length) missing.push(`${f} renders ${gaps.join(', ')} (owned by ${owned.get(gaps[0])})`);
+    }
+
+    assert.deepEqual(missing, [], `unstyled by their own component:\n  ${missing.join('\n  ')}`);
+  });
+
+  it('sees through a const that composes another', () => {
+    // The exemption that makes this gate usable: `SPACE_DIALOG_STYLES` interpolates both shared modules, so a
+    // component carrying only it is correctly covered. If the resolver stopped following interpolation, the
+    // gate would report every such component and be switched off.
+    const viaWrapper = classesFromModule('client/src/app/pages/settings/space-dialog.styles.ts');
+    assert.ok(viaWrapper.has('req-toggle'), 'SPACE_DIALOG_STYLES no longer reaches PROP_TABLE_STYLES');
+    assert.ok(viaWrapper.has('chip-rm'), 'SPACE_DIALOG_STYLES no longer reaches CHIP_STYLES');
+  });
+
+  it('tells two different chip families apart', () => {
+    // The false positive the first version of this gate produced. `.chip` is defined by chip.styles.ts for
+    // schema enum values and by brain-form.styles.ts for record references; a brain component carrying the
+    // second is not missing the first.
+    assert.ok(classesFromModule('client/src/app/pages/brain/brain-form.styles.ts').has('chip'));
+    assert.ok(classesCarriedBy('client/src/app/pages/brain/chrono-ref-field.component.ts').has('chip'));
+  });
+
+  it('the property-table rules are defined in exactly one place', () => {
+    // Two character-identical copies existed before this was extracted, and a third consumer forced the issue.
+    // A re-paste is the regression this catches.
+    const owner = 'client/src/app/shared/prop-table.styles.ts';
+    const dupes = componentFiles()
+      .concat(['client/src/app/pages/settings/space-dialog.styles.ts', 'client/src/app/pages/settings/schema-styles.ts'])
+      .filter((f) => f !== owner)
+      .filter((f) => /^\s*\.(pdet-fields|req-toggle|prop-table)\s*\{/m.test(strip(read(f))));
+    assert.deepEqual(dupes, [], `these files redefine property-table rules that ${owner} owns`);
+  });
+});


### PR DESCRIPTION
Two owner reports on 2026-08-15, both from the schema dialog, both with screenshots.

## 1. It had no styling

> *"functionality is good, just looks and arrangement sux"*

The Required control was a bare browser checkbox with its label wrapped underneath, and an expanded property's
detail card had lost both its column layout and its padding — Type, Default, Merge function and Enum values
each ran the full width of the dialog with the label against the border.

Angular scopes component styles. When `schema-type-editor` was split out of the schema **tab** so the Brain
overview could reuse it, **twelve** classes it renders stayed behind in a stylesheet it no longer carried.
There is no error for this: it type-checks, it builds, its specs pass, every control works, and the only thing
that reports it is somebody looking at the screen.

**This is the second time that extraction has done it.** The first was `CHIP_STYLES` — the oversized enum
remove button breituai-platform reported — fixed by adding a comment to the styles array explaining why it
mattered. The comment did not prevent this one, because the comment was on the const that *was* there.

So the rules are now one shared module instead of the two character-identical copies they were in, and
`shared-styles-reach-their-renderers.test.js` fails the build when a component renders a shared class without
carrying a stylesheet defining it.

That gate resolves what a component actually **carries** — inline literals, imported consts, and consts those
interpolate — rather than asking whether it names a particular one. The first version asked the simpler
question and reported five healthy brain components, because `.chip` is defined twice here for two unrelated
chip families. A gate that reports healthy code gets switched off, at which point it protects nothing.

Two things were improved rather than restored while being moved:

- the detail card wraps to two columns in a narrow dialog instead of squeezing three fixed ones;
- Required is one pill whose dot fills in, rather than a pill and a native checkbox saying the same thing
  twice. The input is visually hidden, not removed, so it stays focusable and announced.

## 2. It offered a combination its own API rejects

> *"i dont understand what i did wrong..."*

Nothing. They set a `date` property's merge function to `min` — which the dropdown offered — and the save came
back as a wall of zod JSON: numeric functions require `number`, boolean ones require `boolean`, and `string`
and `date` accept none at all.

The dropdown listed all seven as static options for every type. **A control that offers a value its own API
refuses has moved a validation rule into the user's head**, and the only way to learn it is to be refused. I
hit the identical 400 seeding a fixture for this branch, which is how it was confirmed rather than assumed.

`mergeFnsFor(type)` now drives the options, the control is disabled with a short explanation for types that
accept none, and changing the type clears a function the new type cannot hold.

That last part existed in `prop-schema-table` and **not** in `schema-type-editor` — the same
one-rule-two-implementations split that lost the stylesheet — and the copy that did exist covered only number
and boolean, leaving `string` and `date` alone when those accept nothing.

The rule is a second copy of a server rule, so `merge-fns-match-the-server.test.js` reads the `.refine` in
`body-schemas.ts` and fails when the two disagree — asserting the lists parsed *before* comparing them, so an
unreadable side cannot pass as an empty match. It also pins the two **server** copies against each other, and
that no component hard-codes the options again.

## Verified by looking, not by measuring

Isolated instance on 3260 against a seeded four-property type, driven with Playwright, PNG read:

| | |
|---|---|
| Required pill | rounded pill with a state dot; the required one is amber-filled |
| detail card | three columns, 16px padding, accent bar down its left edge |
| enum row | full width beneath, chips styled |
| date property's merge control | disabled, one option, explanation beside it |

Computed styles captured alongside — `req-toggle` at radius 999px with its native input 1px wide,
`pdet-fields` a real grid at `272px 272px 272px`.

**Mutation-tested:** removing `PROP_TABLE_STYLES` from the styles array makes the gate name all twelve
unstyled classes. Client suite **1129 green**, `npm run preflight` green.

## One thing I did not change

The server refuses **any** merge function on a `date`. "Earliest deadline wins" is a reasonable thing to want,
and this PR makes the UI match the server rather than deciding that question — widening the server is a
product call, not a defect fix. Flagging it rather than folding it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
