### PR TITLE
fix(rights): the rung tooltip described the click, not what the rung grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Hovering a rung in the rights grid now says what it grants.** The tooltip read *"Set write"* — a
+  description of what the click does, which is not what anyone hovering a permissions cell is asking. The
+  answer was already written and already translated: the plain-language sentence the column header shows
+  ("Your agent can add, edit and delete single records"), in all three languages. The control could not reach
+  it for one reason — it did not know which area it belonged to. It does now, so the tooltip leads with the
+  capability and keeps the click description after it. On a cell held at a minimum, the explanation of *why*
+  is appended rather than substituted: what it would grant and why it cannot go lower are both live questions
+  in that state.
 - **`knowledge: write` now carries `schema: read` with it.** Writing a record against a schema requires
   reading that schema, so a token granted write on Knowledge and nothing on Schema was not a narrower token —
   it was one that could not do what it had just been granted, and the failure arrived as a 403 on a route

--- a/client/src/app/pages/settings/rights-matrix.component.spec.ts
+++ b/client/src/app/pages/settings/rights-matrix.component.spec.ts
@@ -196,6 +196,34 @@ describe('RightsMatrixComponent — an implied rung', () => {
     expect(bs[0]!.disabled).toBe(true);
   });
 
+  it('gives each COLUMN its own capability tooltip', () => {
+    // The failure this pins: a tooltip identical across areas means [area] was never wired and the picker
+    // fell back to the action-only string. Per-rung difference is not enough to catch that — the old control
+    // already differed per rung, which is why the gap survived so long.
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [RightsMatrixComponent, getTranslocoModule({
+        translation: {
+          en: {
+            'tokens.rights.plain.knowledge.read': 'Search and read records.',
+            'tokens.rights.plain.files.read': 'List and download files.',
+          },
+        },
+      })],
+      providers: [{ provide: RightsCatalogService, useValue: stubCatalog() }],
+    });
+    const f = TestBed.createComponent(RightsMatrixComponent);
+    f.componentRef.setInput('rights', rights());
+    f.componentRef.setInput('spaces', ['qa']);
+    f.detectChanges();
+    const el = f.nativeElement as HTMLElement;
+    const titleAt = (col: number) => el.querySelectorAll('tbody tr')[1]!
+      .querySelectorAll('app-rung-picker')[col]!.querySelectorAll('button')[1]!.getAttribute('title');
+    expect(titleAt(0)).toContain('Search and read records.');
+    expect(titleAt(1)).toContain('List and download files.');
+    expect(titleAt(0)).not.toBe(titleAt(1));
+  });
+
   it('does not write the implied rung into the emitted matrix', () => {
     // The stored matrix keeps saying what the operator set. Persisting an inference would make a rung that
     // exists only while knowledge is write outlive knowledge dropping back to read.

--- a/client/src/app/pages/settings/rights-matrix.component.ts
+++ b/client/src/app/pages/settings/rights-matrix.component.ts
@@ -91,7 +91,7 @@ const EMPTY = (): WireRungs => ({ knowledge: 'none', files: 'none', schema: 'non
           <td class="l">{{ 'tokens.rights.allSpaces' | transloco }}<small>{{ 'tokens.rights.allSpacesHint' | transloco }}</small></td>
           @for (a of areas; track a) {
             <td>
-              <app-rung-picker [value]="floorShown(a)"
+              <app-rung-picker [value]="floorShown(a)" [area]="a"
                                [implied]="floorImplied(a)?.rung ?? 'none'" [impliedBy]="floorImplied(a)?.by ?? null"
                                [readonlyView]="readonlyView()" (changed)="setFloor(a, $event)"/>
             </td>
@@ -102,7 +102,7 @@ const EMPTY = (): WireRungs => ({ knowledge: 'none', files: 'none', schema: 'non
             <td class="l">{{ s }}</td>
             @for (a of areas; track a) {
               <td>
-                <app-rung-picker [value]="cellShown(s, a)" [floor]="floorOf(a)"
+                <app-rung-picker [value]="cellShown(s, a)" [area]="a" [floor]="floorOf(a)"
                                  [implied]="cellImplied(s, a)?.rung ?? 'none'" [impliedBy]="cellImplied(s, a)?.by ?? null"
                                  [readonlyView]="readonlyView()" (changed)="setCell(s, a, $event)"/>
               </td>

--- a/client/src/app/pages/settings/rung-picker.component.spec.ts
+++ b/client/src/app/pages/settings/rung-picker.component.spec.ts
@@ -31,6 +31,31 @@ describe('RungPickerComponent', () => {
     }).compileComponents();
   });
 
+  it('says what the rung GRANTS before what the click does', () => {
+    // Owner, 2026-08-15: "the tooltip on hovering a rung is still missing." It was not absent — it read
+    // "Set write", which describes the CLICK. A reader hovering a permissions cell is asking what the rung
+    // grants; the click is confirmation of a choice already made.
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [RungPickerComponent, getTranslocoModule({
+        translation: { en: { 'tokens.rights.plain.files.write': 'Your agent can upload and delete files.' } },
+      })],
+    });
+    const f = TestBed.createComponent(RungPickerComponent);
+    f.componentRef.setInput('value', 'read');
+    f.componentRef.setInput('area', 'files');
+    f.detectChanges();
+    const title = [...(f.nativeElement as HTMLElement).querySelectorAll('button')][2]!.getAttribute('title');
+    expect(title).toBe('Your agent can upload and delete files. Set write');
+  });
+
+  it('falls back to the action alone when no area is wired', () => {
+    // A caller that forgets [area] must degrade to the old tooltip, not print a raw translation key at a
+    // user — and must not leave a leading space where the capability half would have been.
+    const el = render('read');
+    expect([...el.querySelectorAll('button')][2]!.getAttribute('title')).toBe('Set write');
+  });
+
   it('renders one segment per rung', () => {
     expect(buttons(render('none')).map(b => b.textContent?.trim())).toEqual(['—', 'R', 'W', 'A']);
   });

--- a/client/src/app/pages/settings/rung-picker.component.ts
+++ b/client/src/app/pages/settings/rung-picker.component.ts
@@ -34,6 +34,21 @@ const LABEL: Record<Rung, string> = { none: '—', read: 'R', write: 'W', admin:
  *
  * The implication is not hard-coded here. It arrives from `GET /api/tokens/rights-catalog`, which publishes
  * what the server enforces; a copy typed into the client would be a second description of a security rule.
+ *
+ * ## The tooltip says what the rung GRANTS, then what the click does
+ *
+ * Owner, 2026-08-15: *"the tooltip on hovering a rung is still missing."* It was not absent — it was
+ * answering the wrong question. It read `Set write` and `Set write — click again to step down`, which
+ * describes the CLICK. Somebody hovering a cell in a permissions grid is asking what the rung grants; the
+ * click is confirmation of a choice they have already made.
+ *
+ * The answer was already written and already translated — sixteen `tokens.rights.plain.<area>.<rung>` strings
+ * in all three locales, which the column-header glyph has been using all along. This control could not reach
+ * them for one reason: it did not know its own area. Both call sites have it in scope, so it is now an input.
+ *
+ * Capability first, action second, and when a cell is clamped the clamp explanation is APPENDED rather than
+ * substituted — "why can I not go lower" is still a live question in that state, but so is "what would it
+ * give me if I could".
  */
 @Component({
   selector: 'app-rung-picker',
@@ -67,6 +82,13 @@ export class RungPickerComponent {
   private t = inject(TranslocoService);
 
   value = input.required<Rung>();
+  /**
+   * Which area this cell is for, so the tooltip can say what the rung GRANTS.
+   *
+   * Both call sites already have it in scope. Without it the control could only describe its own click, which
+   * is the defect — see the class comment.
+   */
+  area = input<string>('');
   /** The floor for this area. A cell may never sit below it — see the class comment. */
   floor = input<Rung>('none');
   /** A minimum entailed by another area in the same space, or `none`. See the class comment. */
@@ -113,12 +135,39 @@ export class RungPickerComponent {
         // The colour comes from the SELECTED rung, not from each segment's own level, so a filled bar reads
         // as one block at one level rather than a gradient nobody asked for.
         classes: `${filled ? `on r${held}` : ''}${clamped ? ' clamped' : ''}`,
-        title: clamped
-          ? clampTitle
-          : `Set ${rung}${rung === this.value() ? ' — click again to step down' : ''}`,
+        // Capability FIRST, action second. Somebody hovering a rung is asking what it grants, not what the
+        // click does — the click is confirmation, and it was all this control used to say.
+        //
+        // Joined through a filter rather than by interpolation: with no `[area]` wired the capability half is
+        // empty, and interpolating it would leave a leading space on every tooltip in the grid.
+        title: [this.grants(rung), clamped ? clampTitle : this.action(rung)].filter(Boolean).join(' '),
       };
     });
   });
+
+  /**
+   * What this rung GRANTS in this area, in the words the glyph tooltip already uses.
+   *
+   * Sixteen `tokens.rights.plain.<area>.<rung>` strings exist in all three locales and this control was not
+   * reading any of them — it described the CLICK instead ("Set write", "Set write — click again to step
+   * down"), which answers a question nobody hovering has. Owner, 2026-08-15: *"the tooltip on hovering a rung
+   * is still missing."* It was not absent; it was answering the wrong question.
+   *
+   * Falls back to the empty string when the area is not wired or the key is missing, so a caller that forgot
+   * `[area]` degrades to the old action-only tooltip rather than printing a raw translation key at a user.
+   */
+  private grants(rung: Rung): string {
+    const a = this.area();
+    if (!a) return '';
+    const key = `tokens.rights.plain.${a}.${rung}`;
+    const text = this.t.translate(key);
+    return text === key ? '' : `${text}`;
+  }
+
+  /** What the click will do. Kept, because a reader still needs to know a second click steps down. */
+  private action(rung: Rung): string {
+    return `Set ${rung}${rung === this.value() ? ' — click again to step down' : ''}`;
+  }
 
   pick(rung: Rung): void {
     // Belt and braces: a disabled button cannot be clicked, but a caller could still call this.

--- a/docs/userguide/04-settings.md
+++ b/docs/userguide/04-settings.md
@@ -137,6 +137,14 @@ This dialog has no "Library Access" toggle. Library Access tokens (for sharing y
 
 **Editing a token.** Each row has a pencil button. It opens the token editor, where the **label** and the **rights matrix** are both editable and are saved together in one request — so a rename and a scope change are one audited edit, not two that can half-fail. The secret is untouched; use **Rotate** for that.
 
+#### Hover a rung to see what it grants
+
+Each of the four segments in a cell carries a tooltip, and it leads with what that level actually allows —
+*"Your agent can add, edit and delete single records"* — in the same words as the column header's `?`. The
+description differs per column, because `write` on Files and `write` on Knowledge are not the same permission.
+What clicking will do follows after it, including the fact that clicking the level you are already on steps
+down one.
+
 #### Some cells hold each other up
 
 A cell will not always go as low as you click, and the greyed-out segments say why when you hover them. There


### PR DESCRIPTION
Owner, 2026-08-15: *"the tooltip on hovering a rung is still missing."*

It was not missing. It was answering the wrong question:

```
clamped -> "Held at read by the all-spaces floor"
else    -> "Set write"  /  "Set write — click again to step down"
```

That describes what the **click** does. Somebody hovering a cell in a permissions grid is asking what the rung
**grants**; the click is confirmation of a choice they have already made.

## Nothing new needed authoring

The answer was already written, already translated, and already on screen elsewhere — sixteen
`tokens.rights.plain.<area>.<rung>` strings in all three locales, which the column-header `?` has been showing
all along:

> *"Your agent can add, edit and delete single records — what normal MCP use needs."*

The control could not reach them for exactly one reason: **it did not know its own area.** Both call sites
have it in scope — the floor row passes `a`, the cell passes `s, a` — so it is now an `area` input.

## Composition

Capability first, action second. On a **clamped** cell the clamp explanation is *appended* rather than
substituted: "why can I not go lower" is still live in that state, but so is "what would it give me if I
could", and the previous version answered only the first.

The join filters empties instead of interpolating. A caller that forgets `[area]` degrades to the old
action-only tooltip rather than printing a raw translation key at a user — and without the filter every
tooltip in the grid would carry a leading space, which is how the first run of the new spec failed.

## The test that matters is per-COLUMN

The old control **already differed per rung**, so a per-rung assertion would have passed against the defect. A
tooltip identical across areas is the signature of `[area]` not being wired, and that is what is pinned —
knowledge and files must not produce the same string.

Plus a fallback test: no `[area]` gives exactly `Set write`, with no leading space.

## Verification

Client suite **1137 green**, `npm run preflight` green. `docs/userguide/04-settings.md` gains the paragraph,
since a tooltip nobody knows to hover is a capability nobody finds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
