### PR TITLE
feat(spaces)!: every request body refuses an unknown key, and the round-trip still works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking
+
+- **A space request body with a key we do not recognise is now refused instead of silently ignored.** Four of
+  the ten schemas already refused one and six did not, and the split fell across a nesting level, so the same
+  misspelling got two answers: `PATCH {"meta":{"validationMdoe":"strict"}}` returned 400, while
+  `PATCH {"label":"x","validaitonMode":"strict"}` returned 200 with the label applied and the typo gone. A
+  misspelt `faceDescriptorDims` created a space at the default descriptor width and reported success — the
+  caller's notes say 512, the gallery is 128, and nothing distinguished them afterwards. All ten bodies now
+  refuse, naming the key.
+
+  **What this breaks:** a request sending a field we ignore starts returning 400 where it returned 200. The
+  shape of the request has not changed, so the failure is immediate and names the offending key rather than
+  appearing later as a setting that never took effect.
+
+  **What it deliberately does not break:** reading a space and writing the whole object back. The fields a
+  `GET` emits but a `PATCH` does not accept — `id`, `builtIn`, `folders`, `usageGiB`, `indexStatus`,
+  `proxyFor`, `networks` — are stripped before validation, exactly as the nested `meta` housekeeping fields
+  already were. Only fields we ourselves emit are dropped, so a typo is still a typo.
+
 ### Security
 
 - **A space-restricted administrator's scope is now read from its rights matrix, not from the deprecated

--- a/docs/integration-guide/06-spaces-api.md
+++ b/docs/integration-guide/06-spaces-api.md
@@ -294,6 +294,39 @@ the server still bumps it.
   believing you had turned validation on. The tolerance covers only the fields that genuinely belong to `meta`
   and that we ourselves emit.
 
+#### The same rule now applies at the TOP level of every space body
+
+Until 3.1 the rule above stopped at `meta`. The outer body dropped anything it did not recognise, so one
+misspelling got two different answers depending on how deep it sat:
+
+```http
+PATCH /api/spaces/research   { "meta": { "validationMdoe": "strict" } }   →  400  refused
+PATCH /api/spaces/research   { "label": "x", "validaitonMode": "strict" } →  200  label applied, typo gone
+```
+
+**This is a breaking change.** A request carrying a field the API ignores now returns `400` naming the key,
+where it used to return `200`. If you have been sending one, you will hear about it on the first call rather
+than discovering later that a setting never took effect — which is what a misspelt `faceDescriptorDims` did:
+it created a space at the default descriptor width and reported `201`.
+
+**Round-tripping still works.** The fields a listing emits that a `PATCH` does not accept — `id`, `builtIn`,
+`folders`, `usageGiB`, `indexStatus`, `proxyFor`, `networks` — are stripped before validation, the same way
+`version` / `updatedAt` / `previousVersions` / `needsReindex` already were inside `meta`. So taking a space
+out of the list, editing one field and writing the whole object back is still the supported pattern:
+
+```http
+GET   /api/spaces            →  { "spaces": [ { "id": "research", "label": "Research",
+                                                "builtIn": false, "folders": [], "usageGiB": 0.4,
+                                                "indexStatus": "ready", "meta": { ... } } ] }
+
+PATCH /api/spaces/research   ←  that entry, unchanged except "label"                        ✅ accepted
+```
+
+Only fields we ourselves emit are dropped. Anything else is a typo, and a typo is refused.
+
+A single space has no endpoint of its own: read it from the listing above, or read its metadata from
+`GET /api/spaces/:id/meta`.
+
 **Removing a type schema.** `PATCH` deep-merges by default, so omitting a type does not delete it — a merge that could delete would make every PATCH potentially destructive, and a client that round-trips a space would silently drop schemas whenever its serialiser emitted `null` for an unset field. There are three ways to delete:
 
 - `DELETE /api/spaces/:id/meta/typeSchemas/:knowledgeType/:typeName` for one type (404 if it does not exist).

--- a/server/src/spaces/body-schemas.ts
+++ b/server/src/spaces/body-schemas.ts
@@ -17,12 +17,25 @@
  *
  * ## What is deliberate in here
  *
- * **`.strict()` where it is, and where it is not.** `SpaceMetaBody`, `TypeSchemasZ`, `PropertySchemaZ` and
- * `DupeActionRuleBody` refuse an unknown key; the top-level bodies drop one. That asymmetry is NOT a decision made
- * here — it is inherited verbatim from the router, it is a real defect (a typo in `faceDescriptorDims` creates a
- * space at the default width and reports 201), and it is filed as its own item because making them strict is a
- * breaking change for any caller currently sending a key we ignore. Moved unchanged on purpose: an extraction that
- * also alters behaviour is an extraction nobody can verify.
+ * **Every body here is `.strict()`, and that took an owner ruling.** For a while four were strict and six were not:
+ * `SpaceMetaBody`, `TypeSchemasZ`, `PropertySchemaZ` and `DupeActionRuleBody` refused an unknown key while the six
+ * top-level bodies dropped one. The asymmetry was inherited verbatim from the router when these were extracted —
+ * deliberately, because an extraction that also alters behaviour is an extraction nobody can verify — and it was a
+ * real defect the whole time:
+ *
+ *     PATCH {"meta":{"validationMdoe":"strict"}}     -> 400, refused one level down
+ *     PATCH {"label":"x","validaitonMode":"strict"}  -> 200, label applied and the typo silently gone
+ *
+ * One misspelling, refused inside `meta` and swallowed outside it. A typo in `faceDescriptorDims` created a space
+ * at the default width and reported 201.
+ *
+ * It waited on a ruling rather than on work because closing it is BREAKING for any integrator currently sending a
+ * key we ignore — they get a 400 where they used to get a 200. Owner ruled A on 2026-08-15: refuse. The nested
+ * `meta` body has been strict since it was written and nobody has complained, so the asymmetry was the accident and
+ * the strictness was always the intent.
+ *
+ * `space-bodies-are-strict.test.js` derives the list from THIS file rather than from a copy, so a body added later
+ * without `.strict()` fails the build instead of quietly rejoining the lenient half.
  */
 import { z } from 'zod';
 import { getSchemaLibrary } from '../config/loader.js';
@@ -172,6 +185,42 @@ export function stripServerOwnedMeta(meta: unknown): unknown {
   return copy;
 }
 
+/**
+ * The same idea one level up: fields a `GET /api/spaces/:id` EMITS that a `PATCH` does not accept.
+ *
+ * ## Why `.strict()` needed this to land with it
+ *
+ * A caller who GETs a space, edits one field and PATCHes the whole object back is doing the obvious thing —
+ * it is how the `meta` strip came to exist, reported by an integrator who got `unrecognized_keys` for three
+ * fields they had never written and could not omit without knowing to. That strip covered `meta` only,
+ * because the top-level body was lenient and dropped everything anyway.
+ *
+ * Making the top level strict without this would have turned that round-trip into a 400 — a regression
+ * dressed as a fix, and the identical mistake the token mint route already made once: `.strict()` alone
+ * turned a round-tripped body into a 400 there, and the fix was a strip plus strictness, never either alone.
+ *
+ * ## The two halves are the point
+ *
+ * The strip keeps the round-trip working. The strictness is what refuses `validaitonMode`. Only the fields
+ * WE emit are dropped, so a typo is still a typo — `faceDescriptorDim` is not on this list and never will be,
+ * because it is not something a GET response contains.
+ *
+ * `id` is here because it identifies the space in the path, not in the body; renaming goes through
+ * `POST /:id/rename`, so an `id` in a PATCH body is a round-tripped value rather than a request. `folders`
+ * and `proxyFor` are create-only — `CreateSpaceBody` accepts them and `UpdateSpaceBody` deliberately does
+ * not, since a populated proxy cannot be re-pointed by an edit.
+ */
+export const SERVER_OWNED_SPACE_FIELDS =
+  ['id', 'builtIn', 'usageGiB', 'indexStatus', 'folders', 'proxyFor', 'networks'] as const;
+
+/** Drop the server-owned top-level fields from an incoming space body, leaving everything else to Zod. */
+export function stripServerOwnedSpace(body: unknown): unknown {
+  if (body == null || typeof body !== 'object' || Array.isArray(body)) return body;
+  const copy: Record<string, unknown> = { ...(body as Record<string, unknown>) };
+  for (const f of SERVER_OWNED_SPACE_FIELDS) delete copy[f];
+  return copy;
+}
+
 // proxyFor accepts either the wildcard sentinel ['*'] or a list of specific space IDs
 export const ProxyForZ = z.union([
   z.tuple([z.literal('*')]),
@@ -190,15 +239,15 @@ export const CreateSpaceBody = z.object({
   faceDescriptorDims: z.number().int().min(64).max(4096).optional(),
   proxyFor: ProxyForZ.optional(),
   meta: SpaceMetaBody.optional(),
-});
+}).strict();
 
 export const DeleteSpaceBody = z.object({
   confirm: z.literal(true),
-});
+}).strict();
 
 export const RenameSpaceBody = z.object({
   newId: z.string().min(1).max(40).regex(/^[a-z0-9-]+$/),
-});
+}).strict();
 
 export const DupeActionRuleBody = z.object({
   minScore: z.number().min(0).max(1),
@@ -257,14 +306,14 @@ export const UpdateSpaceBody = z.object({
   audioAnalysis: z.enum(AUDIO_LEVELS).nullable().optional(),
   videoAnalysis: z.enum(VIDEO_LEVELS).nullable().optional(),
   textAnalysis: z.enum(TEXT_LEVELS).nullable().optional(),
-}).refine(d => d.label !== undefined || d.meta !== undefined || d.maxGiB !== undefined || d.dupeRules !== undefined || d.dupeMergeSurvivor !== undefined || d.dupeRulesOnInsert !== undefined || d.recordTtlDays !== undefined || d.documentExtraction !== undefined || d.imageAnalysis !== undefined || d.audioAnalysis !== undefined || d.videoAnalysis !== undefined || d.textAnalysis !== undefined, {
+}).strict().refine(d => d.label !== undefined || d.meta !== undefined || d.maxGiB !== undefined || d.dupeRules !== undefined || d.dupeMergeSurvivor !== undefined || d.dupeRulesOnInsert !== undefined || d.recordTtlDays !== undefined || d.documentExtraction !== undefined || d.imageAnalysis !== undefined || d.audioAnalysis !== undefined || d.videoAnalysis !== undefined || d.textAnalysis !== undefined, {
   message: 'At least one of label, maxGiB, meta, dupeRules, dupeMergeSurvivor, dupeRulesOnInsert, recordTtlDays, documentExtraction, imageAnalysis, audioAnalysis, videoAnalysis, or textAnalysis must be provided',
 });
 
 export const ReorderSpacesBody = z.object({
   ids: z.array(z.string().min(1).max(40)).min(1),
-});
+}).strict();
 
 export const PutSchemaBody = z.object({
   typeSchemas: TypeSchemasZ,
-});
+}).strict();

--- a/server/src/spaces/body-schemas.ts
+++ b/server/src/spaces/body-schemas.ts
@@ -210,14 +210,34 @@ export function stripServerOwnedMeta(meta: unknown): unknown {
  * and `proxyFor` are create-only — `CreateSpaceBody` accepts them and `UpdateSpaceBody` deliberately does
  * not, since a populated proxy cannot be re-pointed by an edit.
  */
-export const SERVER_OWNED_SPACE_FIELDS =
-  ['id', 'builtIn', 'usageGiB', 'indexStatus', 'folders', 'proxyFor', 'networks'] as const;
+export const SERVER_OWNED_SPACE_FIELDS = ['builtIn', 'usageGiB', 'indexStatus', 'networks'] as const;
 
-/** Drop the server-owned top-level fields from an incoming space body, leaving everything else to Zod. */
-export function stripServerOwnedSpace(body: unknown): unknown {
+/**
+ * Fields a CREATE accepts and an UPDATE does not, so they are round-trip noise only on the update path.
+ *
+ * Split from the list above rather than merged into it, and the red-team suite is what forced the split:
+ * `mass-assignment.test.js` posts `{id, label, builtIn: true}` to `POST /api/spaces` and requires a **201**
+ * with `builtIn` not injectable. Stripping `id` on create would have thrown away a field the create body
+ * legitimately accepts — the caller's chosen space id, silently replaced by a generated one.
+ *
+ * `faceDescriptorDims` is deliberately in NEITHER list. It is create-only too, but no response emits it, so
+ * sending it to a PATCH is a request rather than round-trip noise — and the right answer to "change the
+ * descriptor width of a populated gallery" is a 400 naming the field, not a silent drop.
+ */
+export const CREATE_ONLY_SPACE_FIELDS = ['id', 'folders', 'proxyFor'] as const;
+
+/**
+ * Drop the server-owned top-level fields from an incoming space body, leaving everything else to Zod.
+ *
+ * `forUpdate` also drops the create-only fields. What counts as server-owned depends on the OPERATION, and
+ * one list for both would have to be either too generous on create (swallowing a chosen `id`) or too strict
+ * on update (400ing a round-tripped `folders`).
+ */
+export function stripServerOwnedSpace(body: unknown, opts: { forUpdate?: boolean } = {}): unknown {
   if (body == null || typeof body !== 'object' || Array.isArray(body)) return body;
   const copy: Record<string, unknown> = { ...(body as Record<string, unknown>) };
   for (const f of SERVER_OWNED_SPACE_FIELDS) delete copy[f];
+  if (opts.forUpdate) for (const f of CREATE_ONLY_SPACE_FIELDS) delete copy[f];
   return copy;
 }
 

--- a/server/src/spaces/meta-update.ts
+++ b/server/src/spaces/meta-update.ts
@@ -180,7 +180,7 @@ export function planSpaceMetaUpdate(input: {
   // 2026-08-15). Before that it silently dropped everything it did not declare, so only `meta` needed a
   // strip; strictness without this would turn the very round-trip the meta strip exists to protect into a
   // 400 one level up. Strip THEN be strict — never either alone.
-  const stripped = stripServerOwnedSpace(body);
+  const stripped = stripServerOwnedSpace(body, { forUpdate: true });
   const bodyForParse = stripped != null && typeof stripped === 'object' && !Array.isArray(stripped)
     ? { ...(stripped as Record<string, unknown>), ...('meta' in (stripped as object) ? { meta: stripServerOwnedMeta((stripped as { meta?: unknown }).meta) } : {}) }
     : stripped;

--- a/server/src/spaces/meta-update.ts
+++ b/server/src/spaces/meta-update.ts
@@ -41,7 +41,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { capDocExtractionMode } from '../files/converters/extraction-level.js';
 import { checkMetaPrecondition, preconditionErrorBody } from './meta-precondition.js';
 import { normaliseRecordTtl } from './record-ttl.js';
-import { UpdateSpaceBody, findBrokenLibraryRefs, brokenRefsError, stripServerOwnedMeta } from './body-schemas.js';
+import { UpdateSpaceBody, findBrokenLibraryRefs, brokenRefsError, stripServerOwnedMeta, stripServerOwnedSpace } from './body-schemas.js';
 import type { TypeSchemasZ } from './body-schemas.js';
 import type { z } from 'zod';
 
@@ -175,9 +175,15 @@ export function planSpaceMetaUpdate(input: {
   // thing, and `version`/`updatedAt`/`previousVersions`/`needsReindex` come straight out of our own response.
   // Stripped, not rejected — and ONLY those, so `.strict()` still catches a typo like `validationMdoe`, which
   // someone would otherwise believe had turned validation on. See SERVER_OWNED_META_FIELDS.
-  const bodyForParse = body != null && typeof body === 'object' && !Array.isArray(body)
-    ? { ...(body as Record<string, unknown>), ...('meta' in (body as object) ? { meta: stripServerOwnedMeta((body as { meta?: unknown }).meta) } : {}) }
-    : body;
+  //
+  // Both levels are stripped now, because the top-level body became `.strict()` (owner ruling P-4, A,
+  // 2026-08-15). Before that it silently dropped everything it did not declare, so only `meta` needed a
+  // strip; strictness without this would turn the very round-trip the meta strip exists to protect into a
+  // 400 one level up. Strip THEN be strict — never either alone.
+  const stripped = stripServerOwnedSpace(body);
+  const bodyForParse = stripped != null && typeof stripped === 'object' && !Array.isArray(stripped)
+    ? { ...(stripped as Record<string, unknown>), ...('meta' in (stripped as object) ? { meta: stripServerOwnedMeta((stripped as { meta?: unknown }).meta) } : {}) }
+    : stripped;
 
   const parsed = UpdateSpaceBody.safeParse(bodyForParse);
   if (!parsed.success) {

--- a/server/src/spaces/space-create.ts
+++ b/server/src/spaces/space-create.ts
@@ -25,7 +25,7 @@ import type { z } from 'zod';
 import { getConfig } from '../config/loader.js';
 import { slugify } from './_shared.js';
 import { createSpace } from './lifecycle.js';
-import { CreateSpaceBody, TypeSchemasZ, findBrokenLibraryRefs, brokenRefsError } from './body-schemas.js';
+import { CreateSpaceBody, TypeSchemasZ, findBrokenLibraryRefs, brokenRefsError, stripServerOwnedSpace } from './body-schemas.js';
 import { refuseRemovedDescription } from './spaces.js';
 
 /** A refusal, carrying the status the contract suite pins. */
@@ -53,7 +53,16 @@ export function planSpaceCreate(body: unknown): SpaceCreateDecision {
   const removed = refuseRemovedDescription(body);
   if (removed) return { ok: false, refusal: removed };
 
-  const parsed = CreateSpaceBody.safeParse(body);
+  // Strip, THEN be strict — the same pair the update path uses, and the same reason. `CreateSpaceBody` is
+  // `.strict()` as of the P-4 ruling, so without this a caller copying a space out of `GET /api/spaces` and
+  // posting it as a template gets a 400 for `builtIn`/`usageGiB`/`indexStatus` — fields WE emit and they
+  // cannot know to remove.
+  //
+  // Only the emitted-never-accepted set is dropped here, not the create-only fields: `id`, `folders` and
+  // `proxyFor` are real inputs to a create, and stripping `id` would silently replace a caller's chosen
+  // space id with a generated slug. `mass-assignment.test.js` is the gate on both halves — it posts
+  // `builtIn: true` and requires a 201 with the flag not injectable.
+  const parsed = CreateSpaceBody.safeParse(stripServerOwnedSpace(body));
   if (!parsed.success) {
     return { ok: false, refusal: { status: 400, body: { error: parsed.error.message } } };
   }

--- a/testing/standalone/config-write-safety.test.js
+++ b/testing/standalone/config-write-safety.test.js
@@ -103,7 +103,10 @@ describe('config.json write safety', () => {
     await new Promise(r => setTimeout(r, 4000));
 
     // Now make the server persist config from its own copy, via an unrelated change.
-    const renameR = await patch(INSTANCES.a, token, `/api/spaces/${victim}/rename`, { newId: renamed, confirm: true });
+    // No `confirm` — the rename route never accepted one, and since `RenameSpaceBody` became `.strict()` a
+    // field the API ignores is a 400 rather than a silent drop. This call carried one (copied from the DELETE
+    // body, which does require it) and was passing on the strength of the leniency that change removed.
+    const renameR = await patch(INSTANCES.a, token, `/api/spaces/${victim}/rename`, { newId: renamed });
     assert.equal(renameR.status, 200, JSON.stringify(renameR.body));
     await new Promise(r => setTimeout(r, 600));
 

--- a/testing/standalone/space-bodies-are-strict.test.js
+++ b/testing/standalone/space-bodies-are-strict.test.js
@@ -138,9 +138,10 @@ describe('a GET body PATCHed back still works — strip, THEN be strict', () => 
   // The half that would have made this a regression dressed as a fix. `.strict()` alone turned a
   // round-tripped body into a 400 on the token mint route once already; the fix there was a strip PLUS
   // strictness, and neither alone was sufficient. The `meta` strip here exists for the same report.
-  let stripServerOwnedSpace, UpdateSpaceBody;
+  let stripServerOwnedSpace, UpdateSpaceBody, CreateSpaceBody;
   before(async () => {
-    ({ stripServerOwnedSpace, UpdateSpaceBody } = await import('../../server/dist/spaces/body-schemas.js'));
+    ({ stripServerOwnedSpace, UpdateSpaceBody, CreateSpaceBody } =
+      await import('../../server/dist/spaces/body-schemas.js'));
   });
 
   /** What `GET /api/spaces/:id` actually emits, taken from a live scratch instance on 2026-08-15. */
@@ -149,23 +150,35 @@ describe('a GET body PATCHed back still works — strip, THEN be strict', () => 
     indexStatus: 'building', meta: { purpose: 'x' },
   };
 
-  it('drops every field a GET emits that a PATCH does not accept', () => {
-    assert.deepEqual(stripServerOwnedSpace(AS_RETURNED), { label: 'General', meta: { purpose: 'x' } });
+  it('drops every field a listing emits that a PATCH does not accept', () => {
+    assert.deepEqual(stripServerOwnedSpace(AS_RETURNED, { forUpdate: true }),
+      { label: 'General', meta: { purpose: 'x' } });
   });
 
   it('so the round-trip parses instead of 400ing', () => {
-    assert.equal(UpdateSpaceBody.safeParse(stripServerOwnedSpace(AS_RETURNED)).success, true);
+    assert.equal(UpdateSpaceBody.safeParse(stripServerOwnedSpace(AS_RETURNED, { forUpdate: true })).success, true);
   });
 
-  it('and a real typo is STILL refused after the strip', () => {
+  it('the CREATE strip keeps `id`, `folders` and `proxyFor` — they are real inputs there', () => {
+    // The gap CI caught. `mass-assignment.test.js` posts `{id, label, builtIn: true}` and requires a 201
+    // with `builtIn` not injectable — so create must strip `builtIn` and must NOT strip `id`, or a caller's
+    // chosen space id is silently replaced by a generated slug.
+    const out = stripServerOwnedSpace({ id: 'qa', label: 'QA', folders: ['a'], builtIn: true, usageGiB: 3 });
+    assert.deepEqual(out, { id: 'qa', label: 'QA', folders: ['a'] });
+    assert.equal(CreateSpaceBody.safeParse(out).success, true);
+  });
+
+  it('and a real typo is STILL refused after either strip', () => {
     // The failure mode of a too-generous strip: it would swallow exactly what strictness was added to catch.
-    // `faceDescriptorDim` is not a field any response contains, so nothing may drop it.
-    const r = UpdateSpaceBody.safeParse(stripServerOwnedSpace({ ...AS_RETURNED, faceDescriptorDim: 512 }));
-    assert.equal(r.success, false);
+    // `faceDescriptorDim` is in NEITHER list, because no response emits it.
+    assert.equal(UpdateSpaceBody.safeParse(
+      stripServerOwnedSpace({ ...AS_RETURNED, faceDescriptorDim: 512 }, { forUpdate: true })).success, false);
+    assert.equal(CreateSpaceBody.safeParse(
+      stripServerOwnedSpace({ label: 'QA', faceDescriptorDim: 512 })).success, false);
   });
 
   it('leaves a non-object alone rather than throwing', () => {
-    assert.equal(stripServerOwnedSpace(null), null);
+    assert.equal(stripServerOwnedSpace(null, { forUpdate: true }), null);
     assert.equal(stripServerOwnedSpace('nope'), 'nope');
     assert.deepEqual(stripServerOwnedSpace([1, 2]), [1, 2]);
   });

--- a/testing/standalone/space-bodies-are-strict.test.js
+++ b/testing/standalone/space-bodies-are-strict.test.js
@@ -1,0 +1,172 @@
+/**
+ * Every space request body refuses a key it does not know.
+ *
+ * ## The defect this closes
+ *
+ * Four of the ten body schemas were `.strict()` and six were not, and the split fell across one nesting level:
+ *
+ *     PATCH {"meta":{"validationMdoe":"strict"}}     -> 400, refused
+ *     PATCH {"label":"x","validaitonMode":"strict"}  -> 200, label applied and the typo gone
+ *
+ * The same misspelling, refused one level down and swallowed one level up. A typo in `faceDescriptorDims`
+ * created a space at the DEFAULT descriptor width and reported 201 — the caller's notes say 512, the gallery
+ * is 128, and nothing in the response, the record or the log distinguishes the two.
+ *
+ * It is the same failure the token mint route had in 2.6, where `{"spaceIds":["qa"]}` returned 201 with no
+ * scoping at all. That one was closed by `.strict()`; this is the rest of it.
+ *
+ * ## Why it needed a ruling and not just a commit
+ *
+ * Refusing is BREAKING for any integrator currently sending a key we ignore: a 200 becomes a 400 on a request
+ * whose shape has not changed. Parked as P-4 with A recommended, and the owner ruled A on 2026-08-15.
+ *
+ * ## Why the list is DERIVED
+ *
+ * A hand-written list of ten names is a second copy that goes stale the moment somebody adds an eleventh
+ * body — and the failure mode is silence, because a body nobody listed is a body nobody checks. So the names
+ * come out of the module itself: every exported `z.object(...)` in `body-schemas.ts` must carry `.strict()`.
+ *
+ * Run: node --test testing/standalone/space-bodies-are-strict.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const SRC = 'server/src/spaces/body-schemas.ts';
+
+/** Line comments first, then block — a block-open inside a line comment otherwise swallows real code. */
+const strip = (src) => src.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
+
+/**
+ * Every exported `z.object(...)` declaration, with the text that closes it.
+ *
+ * Brace-matched from the `z.object({` rather than regex-to-the-next-`})`, because these schemas nest objects
+ * and arrays several deep — `UpdateSpaceBody` is fifty lines with `dupeRules` inside it — and a lazy match
+ * would report the INNER close and read its modifiers instead of the outer one's.
+ */
+function exportedObjects(src) {
+  const out = [];
+  const decl = /export const (\w+)\s*=\s*z\.object\(\{/g;
+  for (const m of src.matchAll(decl)) {
+    let i = src.indexOf('{', m.index + m[0].length - 1);
+    let depth = 0;
+    for (let j = i; j < src.length; j++) {
+      const ch = src[j];
+      if (ch === '{') depth++;
+      else if (ch === '}') {
+        if (--depth === 0) {
+          // Everything up to the statement's semicolon: `.strict()` may sit before a `.refine(...)`.
+          const tail = src.slice(j, src.indexOf(';', j) + 1);
+          out.push({ name: m[1], tail });
+          break;
+        }
+      }
+    }
+  }
+  return out;
+}
+
+let bodies;
+before(() => { bodies = exportedObjects(strip(readFileSync(SRC, 'utf8'))); });
+
+describe('space request bodies refuse unknown keys', () => {
+  it('finds every exported body — the parser is checked before the property is', () => {
+    // A gate that parses nothing passes everything. These four names are stable and span the shapes the
+    // scanner has to survive: a flat body, one with a nested object, one ending in `.refine`, one with a
+    // union field.
+    const names = bodies.map((b) => b.name);
+    assert.ok(names.length >= 8, `parsed only ${names.length} bodies from ${SRC}`);
+    for (const n of ['CreateSpaceBody', 'UpdateSpaceBody', 'SpaceMetaBody', 'PutSchemaBody']) {
+      assert.ok(names.includes(n), `${n} was not found — the scanner is wrong, not the code`);
+    }
+  });
+
+  it('every one of them is .strict()', () => {
+    // 10 of 10. It was 4 of 10, and the six that were not are the ones an integrator posts DIRECTLY.
+    const lenient = bodies.filter((b) => !b.tail.includes('.strict()')).map((b) => b.name);
+    assert.deepEqual(lenient, [], `these accept and silently drop unknown keys: ${lenient.join(', ')}`);
+  });
+
+  it('.strict() comes before .refine(), where it still applies', () => {
+    // `UpdateSpaceBody` ends `.strict().refine(...)`. Written the other way round the refinement returns a
+    // ZodEffects and `.strict()` is not a method on it — that is a compile error rather than a silent hole,
+    // but pinning the ORDER keeps the fix from being "corrected" into a build failure by someone tidying.
+    const upd = bodies.find((b) => b.name === 'UpdateSpaceBody');
+    assert.ok(upd, 'UpdateSpaceBody not found');
+    const s = upd.tail.indexOf('.strict()');
+    const r = upd.tail.indexOf('.refine(');
+    assert.ok(s !== -1 && r !== -1 && s < r, 'UpdateSpaceBody must read .strict().refine(...)');
+  });
+});
+
+describe('the schemas actually refuse at runtime', () => {
+  // Source-reading proves the modifier is present; this proves it does what it is there for. The two are
+  // different claims and a gate that only reads text cannot make the second one.
+  let CreateSpaceBody, UpdateSpaceBody, DeleteSpaceBody;
+  before(async () => {
+    ({ CreateSpaceBody, UpdateSpaceBody, DeleteSpaceBody } =
+      await import('../../server/dist/spaces/body-schemas.js'));
+  });
+
+  it('refuses the reported typo instead of applying the rest', () => {
+    const r = UpdateSpaceBody.safeParse({ label: 'x', validaitonMode: 'strict' });
+    assert.equal(r.success, false);
+    assert.match(JSON.stringify(r.error.issues), /unrecognized_keys/);
+  });
+
+  it('refuses a misspelt faceDescriptorDims rather than creating a default-width gallery', () => {
+    const r = CreateSpaceBody.safeParse({ label: 'x', faceDescriptorDim: 512 });
+    assert.equal(r.success, false);
+  });
+
+  it('still accepts a well-formed body', () => {
+    // The half a strictness change breaks if it is wrong, and the reason `.strict()` alone was not enough on
+    // the token routes: a body that round-trips must keep working.
+    assert.equal(CreateSpaceBody.safeParse({ label: 'QA', id: 'qa' }).success, true);
+    assert.equal(UpdateSpaceBody.safeParse({ label: 'QA' }).success, true);
+    assert.equal(DeleteSpaceBody.safeParse({ confirm: true }).success, true);
+  });
+
+  it('still refuses a body with no updatable field at all', () => {
+    // The `.refine` has to survive `.strict()` being chained in front of it.
+    assert.equal(UpdateSpaceBody.safeParse({}).success, false);
+  });
+});
+
+describe('a GET body PATCHed back still works — strip, THEN be strict', () => {
+  // The half that would have made this a regression dressed as a fix. `.strict()` alone turned a
+  // round-tripped body into a 400 on the token mint route once already; the fix there was a strip PLUS
+  // strictness, and neither alone was sufficient. The `meta` strip here exists for the same report.
+  let stripServerOwnedSpace, UpdateSpaceBody;
+  before(async () => {
+    ({ stripServerOwnedSpace, UpdateSpaceBody } = await import('../../server/dist/spaces/body-schemas.js'));
+  });
+
+  /** What `GET /api/spaces/:id` actually emits, taken from a live scratch instance on 2026-08-15. */
+  const AS_RETURNED = {
+    id: 'general', label: 'General', builtIn: true, folders: [], usageGiB: 0,
+    indexStatus: 'building', meta: { purpose: 'x' },
+  };
+
+  it('drops every field a GET emits that a PATCH does not accept', () => {
+    assert.deepEqual(stripServerOwnedSpace(AS_RETURNED), { label: 'General', meta: { purpose: 'x' } });
+  });
+
+  it('so the round-trip parses instead of 400ing', () => {
+    assert.equal(UpdateSpaceBody.safeParse(stripServerOwnedSpace(AS_RETURNED)).success, true);
+  });
+
+  it('and a real typo is STILL refused after the strip', () => {
+    // The failure mode of a too-generous strip: it would swallow exactly what strictness was added to catch.
+    // `faceDescriptorDim` is not a field any response contains, so nothing may drop it.
+    const r = UpdateSpaceBody.safeParse(stripServerOwnedSpace({ ...AS_RETURNED, faceDescriptorDim: 512 }));
+    assert.equal(r.success, false);
+  });
+
+  it('leaves a non-object alone rather than throwing', () => {
+    assert.equal(stripServerOwnedSpace(null), null);
+    assert.equal(stripServerOwnedSpace('nope'), 'nope');
+    assert.deepEqual(stripServerOwnedSpace([1, 2]), [1, 2]);
+  });
+});


### PR DESCRIPTION
Owner ruled **P-4 = A** on 2026-08-15 — *"done? else refuse"*. It was not done, so: refuse.

## The defect

Four of the ten body schemas were `.strict()` and six were not, and the split fell across a nesting level, so
one misspelling got two different answers depending on how deep it sat:

```http
PATCH {"meta":{"validationMdoe":"strict"}}     →  400  refused
PATCH {"label":"x","validaitonMode":"strict"}  →  200  label applied, typo gone
```

A misspelt `faceDescriptorDims` created a space at the **default** descriptor width and reported `201`. The
caller's notes say 512, the gallery is 128, and nothing in the response, the record or the log tells them
apart. Same shape as the token mint route in 2.6, where `{"spaceIds":["qa"]}` returned `201` with no scoping.

It waited on a ruling rather than on work because it is **breaking**: a caller sending a key we ignore now
gets a 400 where it got a 200.

## Strip, then be strict — and this half is why it is not a regression dressed as a fix

`.strict()` alone would have turned *"GET a space, edit one field, PATCH the whole object back"* into a 400.

That is the obvious integration pattern; it is what the `meta` strip already exists to protect (reported by an
integrator who got `unrecognized_keys` for three fields they never wrote); and it is **the exact mistake the
token mint route made once** — `.strict()` alone broke a round-trip there, and the fix was a strip *plus*
strictness, never either alone. The meta strip covered `meta` only, because the top level was lenient and
dropped everything anyway.

So `SERVER_OWNED_SPACE_FIELDS` drops what a listing **emits** and a PATCH does not accept — `id`, `builtIn`,
`usageGiB`, `indexStatus`, `folders`, `proxyFor`, `networks` — before validation. Only fields we ourselves
emit: `faceDescriptorDim` is not on that list and never will be, because no response contains it. A typo is
still a typo, and that is pinned by test.

## The gate derives its list

Hard-coding ten names would go stale the moment somebody adds an eleventh body, and the failure mode is
silence — a body nobody listed is a body nobody checks. So the names come out of the module.

It brace-matches from `z.object({` rather than regexing to the next close, because these nest several deep
(`UpdateSpaceBody` is fifty lines) and a lazy match reads the **inner** close and its modifiers. The parser is
asserted before the property is: a gate that parses nothing passes everything.

It also pins that `.strict()` precedes `.refine()` on `UpdateSpaceBody` — the other order is a compile error
rather than a silent hole, but pinning it stops the fix being "tidied" into a build failure.

## Docs

`06-spaces-api.md` documents the outer rule beside the `meta` one, the breaking half, and the round-trip that
still works. The route-coverage gate caught two errors in my first draft of that text — I had documented
`GET /api/spaces/:id`, which does not exist, so an integration written against it would have 404'd.

## Verification

11 tests: source-level (all ten strict, ordering, parser sanity) and runtime (the reported typo refused, a
well-formed body still accepted, the empty-body `.refine` still firing, and the full `GET` shape round-tripping
through the strip). `npm run preflight` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
