### PR TITLE
fix(docker): the image build downloaded a CUDA runtime nothing loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The Docker build no longer downloads a CUDA runtime it never loads.** `onnxruntime-node` fetches its GPU
+  execution-provider binaries from a GitHub release during install, and on a machine without `nvcc` it logs
+  *"nvcc not found. Assuming CUDA 12"* and downloads them anyway. CI was told to skip this after two runs
+  failed 35 minutes apart on that download alone; the image build was not, so every image build still
+  depended on github.com being reachable and fast — in the build most likely to run somewhere that neither is
+  true. All three install steps in the Dockerfile now skip it, and a build gate keeps them that way, checking
+  each stage separately because the setting does not carry across a stage boundary. **A GPU deployment loses
+  the CUDA execution provider** and would need its own image variant; nothing in the published image used it,
+  as the bundled embedder runs on CPU.
 - **The property editor offered merge functions the API refuses.** Reported by the owner on 2026-08-15, whose
   words were *"i dont understand what i did wrong"* — and nothing they did was wrong. The merge-function
   dropdown listed all seven functions for every property type, so a `date` property could be given `min`, and

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,19 @@ WORKDIR /build
 COPY package.json package-lock.json* ./
 COPY client/package.json ./client/
 
-# Install client dependencies
+# Install client dependencies.
+#
+# ONNXRUNTIME_NODE_INSTALL_CUDA=skip is not an optimisation, it is what makes this step hermetic — the same
+# reasoning that put it on both `npm ci` steps in CI. `onnxruntime-node` fetches its CUDA execution-provider
+# binaries from a GitHub release on postinstall, and on a machine with no `nvcc` it logs "nvcc not found.
+# Assuming CUDA 12" and downloads the GPU tarball anyway. Two CI runs failed 35 minutes apart on that
+# download alone; a Docker build has the same dependency on github.com being reachable and fast, and it is
+# the build most likely to run somewhere that neither is true.
+#
+# Owner ruled P-5 = A on 2026-08-15: skip it in the image too. A GPU deployment loses the execution provider
+# and needs its own image variant — nothing in the published image uses it, since the bundled embedder runs
+# on CPU.
+ENV ONNXRUNTIME_NODE_INSTALL_CUDA=skip
 RUN npm ci --workspace=client
 
 # Copy source and build.
@@ -35,7 +47,10 @@ COPY package.json package-lock.json* ./
 COPY tsconfig.base.json ./
 COPY server/package.json ./server/
 
-# Install all dependencies (including devDependencies for TypeScript compiler)
+# Install all dependencies (including devDependencies for TypeScript compiler).
+# ONNXRUNTIME_NODE_INSTALL_CUDA=skip — see the client stage for why. Repeated because ENV does not cross a
+# stage boundary, which is exactly the kind of thing a reader assumes and a build silently disproves.
+ENV ONNXRUNTIME_NODE_INSTALL_CUDA=skip
 RUN npm ci --workspace=server
 
 # Copy source
@@ -68,6 +83,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends python3 make g+
 WORKDIR /app
 COPY package.json package-lock.json* ./
 COPY server/package.json ./server/
+# ONNXRUNTIME_NODE_INSTALL_CUDA=skip — see the client stage. This is the `npm ci` that produces the tree the
+# published image actually SHIPS, so it is the one where a GPU tarball would be both downloaded and carried.
+ENV ONNXRUNTIME_NODE_INSTALL_CUDA=skip
 RUN npm ci --workspace=server --omit=dev
 
 # ── Stage 1c: Warm the embedding model, in a stage of its own ─────────────────

--- a/testing/standalone/cuda-download-is-skipped-everywhere.test.js
+++ b/testing/standalone/cuda-download-is-skipped-everywhere.test.js
@@ -1,0 +1,70 @@
+/**
+ * No build step downloads the CUDA execution provider — not CI, not the image.
+ *
+ * ## Why this is a gate and not a comment
+ *
+ * `onnxruntime-node` fetches its CUDA binaries from a GitHub release on postinstall. On a machine with no
+ * `nvcc` it logs *"nvcc not found. Assuming CUDA 12"* and downloads the GPU tarball **anyway**. Two CI runs
+ * failed 35 minutes apart on that download alone, which is what put `ONNXRUNTIME_NODE_INSTALL_CUDA=skip` on
+ * both `npm ci` steps in the workflows.
+ *
+ * The Dockerfile was left out at the time and parked as P-5, because skipping it in the image is a product
+ * decision rather than a build fix: a GPU deployment loses the execution provider and would need its own
+ * image variant. Owner ruled A on 2026-08-15 — skip it there too. Nothing in the published image uses it; the
+ * bundled embedder runs on CPU.
+ *
+ * A build that reaches github.com for a tarball nothing loads is a build that fails for a reason unrelated to
+ * the change being built, and the image build is the one most likely to run somewhere with neither a fast nor
+ * a reliable route there.
+ *
+ * ## What it checks, and the trap it is built around
+ *
+ * Every `npm ci` in the Dockerfile must be preceded by the skip. `ENV` does **not** cross a stage boundary, so
+ * one declaration at the top would silently cover only the first stage — exactly the kind of thing a reader
+ * assumes and a build disproves quietly, by working on a fast connection.
+ *
+ * Run: node --test testing/standalone/cuda-download-is-skipped-everywhere.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+
+const SKIP = 'ONNXRUNTIME_NODE_INSTALL_CUDA';
+const read = (p) => readFileSync(p, 'utf8');
+
+/** Dockerfile lines, comments dropped — a `#` line naming the variable must not satisfy the check. */
+const dockerLines = () =>
+  read('Dockerfile').split('\n').map((l) => l.trim()).filter((l) => l && !l.startsWith('#'));
+
+describe('the CUDA download is skipped in every build', () => {
+  it('every npm ci in the Dockerfile has the skip in force', () => {
+    // Walked in order and reset at each FROM, because ENV does not survive a stage boundary. Checking mere
+    // PRESENCE anywhere in the file would pass on one declaration covering one of three stages.
+    const lines = dockerLines();
+    let active = false;
+    const unguarded = [];
+    for (const l of lines) {
+      if (/^FROM\s/i.test(l)) { active = false; continue; }
+      if (new RegExp(`^ENV\\s+${SKIP}\\s*=\\s*skip`, 'i').test(l)) { active = true; continue; }
+      if (/^RUN\s+.*npm ci/.test(l) && !active && !l.includes(SKIP)) unguarded.push(l);
+    }
+    assert.deepEqual(unguarded, [], `these run npm ci with the CUDA download still enabled:\n  ${unguarded.join('\n  ')}`);
+  });
+
+  it('finds the npm ci steps at all — the scanner before the property', () => {
+    const count = dockerLines().filter((l) => /^RUN\s+.*npm ci/.test(l)).length;
+    assert.ok(count >= 3, `parsed only ${count} npm ci steps — the scanner is wrong, not the Dockerfile`);
+  });
+
+  it('both workflows still carry it', () => {
+    // The half that was already true, re-asserted: this gate exists because the setting was applied in one
+    // place and not another, and a gate that only watches the new place would let the old one lapse.
+    const wf = execSync('git ls-files ".github/workflows/*.yml"', { encoding: 'utf8' })
+      .split('\n').map((l) => l.trim()).filter(Boolean);
+    const withCi = wf.filter((f) => read(f).includes('npm ci'));
+    assert.ok(withCi.length >= 2, `expected at least two workflows running npm ci, found ${withCi.length}`);
+    const missing = withCi.filter((f) => !read(f).includes(`${SKIP}: skip`));
+    assert.deepEqual(missing, [], `these workflows run npm ci without the skip: ${missing.join(', ')}`);
+  });
+});


### PR DESCRIPTION
Owner ruled **P-5 = A** on 2026-08-15: skip the CUDA download in the image too.

## What was happening

`onnxruntime-node` fetches its CUDA execution-provider binaries from a GitHub release on postinstall. On a
machine with no `nvcc` it logs *"nvcc not found. Assuming CUDA 12"* and downloads the GPU tarball **anyway**.

Two CI runs failed 35 minutes apart on that download alone, which is what put
`ONNXRUNTIME_NODE_INSTALL_CUDA=skip` on both `npm ci` steps in the workflows. The Dockerfile was left out and
parked, because skipping it there is a product decision rather than a build fix.

Nothing in the published image uses it — the bundled embedder runs on CPU — so the cost is an image variant
nobody has asked for, against a build that reaches github.com for a tarball it then carries and never loads.

## Three ENV lines, and that is the point of the gate

`ENV` does not cross a `FROM`. A single declaration at the top would cover the first stage and silently leave
the other two — which works fine on a fast connection, which is where it would be written and not where it
would be run.

All three `npm ci` steps carry it, including the `--omit=dev` one. That is the install producing the tree the
published image actually **ships**, so it is the one where the tarball would be both downloaded *and* kept.

## The gate

Walks the Dockerfile **in order** and resets at each `FROM`, rather than checking the variable appears
somewhere in the file — the latter passes on one declaration covering one stage of three.

- **Mutation-tested:** replacing the `ENV` lines makes it name the unguarded steps.
- Comments are stripped before scanning, or a `#` line explaining the setting would satisfy the check that the
  setting is present.
- It also re-asserts **both workflows** still carry theirs. This whole class of bug is "applied in one place
  and not another", and a gate watching only the new place lets the old one lapse.

## Verification

3 tests, `npm run preflight` green. The image build itself is exercised by CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
