### PR TITLE
fix(schema): a violation the record already had no longer refuses an unrelated edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **A schema violation the record already had no longer refuses an unrelated edit.** Reported by
+  breituai-platform as *"freezes records"*, and reproduced exactly: write a record whose `status` the enum
+  allows, remove that value from the enum, then patch the record's **description** — `422`, naming a field the
+  edit never touched. The record stayed uneditable until `status` was repaired in the same request, and any
+  schema tightening did that retroactively to every record that no longer fitted. In `strict` mode a write is
+  now refused for what it **introduces**; a violation that was already stored is reported and does not block.
+  Refusing it never improved the data — the bad value is already saved — it only stopped the record being
+  maintained. Nothing is hidden: `preExisting` is in every response exactly as before, so a client that wants
+  to insist on full compliance still can, and a patch that introduces a violation is refused exactly as
+  before, including when the record also has an older one. The MCP guide had promised this behaviour before
+  the code was found to disagree; both now say the same thing.
 - **Hovering a rung in the rights grid now says what it grants.** The tooltip read *"Set write"* — a
   description of what the click does, which is not what anyone hovering a permissions cell is asking. The
   answer was already written and already translated: the plain-language sentence the column header shows

--- a/docs/integration-guide/06a-schema-api.md
+++ b/docs/integration-guide/06a-schema-api.md
@@ -214,11 +214,17 @@ the answer would be meaningless. In `strict` mode a violating update is refused 
 | `preExisting` | Present before and still present. Your change neither caused nor fixed it. |
 
 A record can be non-compliant before you touch it — written before the schema tightened, imported, or
-synced from a peer with different meta. Both kinds block, because the merged record is what gets stored
-and storing a known-invalid record is how a space drifts permanently out of conformance. The record is
-**not** trapped: validation is of the merged result, so including the offending field in the same request
-repairs it and the write succeeds. The `message` says which of the two situations applies, so you are not
-sent after a field you did not touch.
+synced from a peer with different meta.
+
+**Only `introduced` blocks.** A violation the record already had is reported and does not refuse your patch.
+It is already stored, so refusing would not improve the data; it would only stop the record being maintained.
+Until 3.1 both kinds blocked, and the consequence was that tightening a schema retroactively froze every
+record that no longer fitted — an operator could not correct a typo in a description without also resolving a
+field their edit never touched.
+
+Validation is still of the merged result, so including the offending field in a write repairs it. The
+`message` says which of the two situations applies, so you are not sent after a field you did not touch, and
+`preExisting` is in every response — a client that wants to insist on full compliance can refuse on it itself.
 
 In `warn` mode the write proceeds and the same three lists are reported.
 

--- a/docs/integration-guide/16-mcp.md
+++ b/docs/integration-guide/16-mcp.md
@@ -27,10 +27,13 @@ On connect, the server sends global instructions listing all available space IDs
 > fix the patch. `preExisting` means the stored record already violated the schema there and your write
 > neither caused nor fixed it.
 >
-> **In a `strict` space, BOTH block the write.** The merged record is what would be stored, so a write is refused
-> while any violation remains — including one your patch neither caused nor touched. The remedy is in the message:
-> include the offending field in the same request and the write repairs the record. `content` still carries the same
-> information as a sentence, so a client that reads only text loses nothing.
+> **In a `strict` space, only `introduced` blocks the write.** A violation the record already had is reported and
+> does not refuse your patch: it is already stored, so refusing would not improve the data — it would only stop the
+> record being maintained. Until 3.1 both kinds blocked, which meant tightening a schema made every record that no
+> longer fitted uneditable until an unrelated field was repaired in the same request.
+>
+> `preExisting` is still in every response, so a client that wants to insist on full compliance can refuse on it
+> itself. `content` carries the same information as a sentence, so a client that reads only text loses nothing.
 >
 > **`query` puts its rows in BOTH places.** `content[0].text` is the JSON array it has always been, and
 > `structuredContent` carries `results` (the same array) plus `count`, `total`, `limit`, `skip` and the

--- a/docs/userguide/04-settings.md
+++ b/docs/userguide/04-settings.md
@@ -58,11 +58,15 @@ Click the gear icon on any space row to open its settings panel. Changes save an
   > could save a value the same space would have rejected on create. Now the record **as it will be** —
   > yours plus the existing fields — is checked before it saves.
   >
-  > This can refuse an edit for a field you did not touch, when the record was already invalid: written
-  > before you tightened the schema, or imported, or synced from another brain. The message says which is
-  > which — *"the change violates…"* versus *"this record was already non-compliant before your
-  > change…"* — so you are not sent looking at the wrong field. To get unstuck, fix the named field in
-  > the same save; validation is of the result, so the record repairs itself.
+  > **`strict` refuses what your edit breaks, not what was already broken.** A record can be invalid before
+  > you touch it — written before you tightened the schema, imported, or synced from another brain. That is
+  > reported, not refused: the problem is already saved, so blocking your edit would not fix it, it would
+  > only stop you maintaining the record. Until 3.1 it did block, which meant tightening a schema quietly
+  > froze every record that no longer fitted.
+  >
+  > The message still says which is which — *"the change violates…"* versus *"this record was already
+  > non-compliant before your change…"* — so you are not sent looking at the wrong field. Validation is of
+  > the result, so fixing the named field in any later save repairs the record.
 - **Strict linkage** — when on, references between items must be valid IDs and deletion of referenced items is blocked.
 - **Type schemas** — define per-type rules under each knowledge type (entity, memory, edge, chrono). For each named type you can set:
   - **Naming pattern** — a regex the name must match.

--- a/server/src/brain/write-validation.ts
+++ b/server/src/brain/write-validation.ts
@@ -89,11 +89,36 @@ export function classifyUpdateViolations(
   const introduced = afterViolations.filter(v => !before.has(key(v)));
   const preExisting = afterViolations.filter(v => before.has(key(v)));
 
-  const verdict = applyValidation(meta, afterViolations);
+  // Two verdicts from one mode, and the split IS the P-6 ruling (owner, 2026-08-15: B).
+  //
+  // `blocked` is decided by what the patch INTRODUCED. `warnings` still reports everything the merged record
+  // fails, because a caller that wants to insist on full compliance needs to be able to see it — and
+  // `preExisting` is in the response either way.
+  //
+  // ## Why blocking on the full list was wrong
+  //
+  // Reported by breituai-platform as *"freezes records"*, and reproduced:
+  //
+  //     write an entity with properties.status = "retired"   (the enum allows it)  -> 201
+  //     remove "retired" from the enum                                             -> 200
+  //     PATCH that record's DESCRIPTION only                                       -> 422
+  //
+  // The record became uneditable until an unrelated field was repaired in the same request, and any schema
+  // tightening did that retroactively to every record that no longer fit. The violation is ALREADY STORED:
+  // refusing the patch does not improve the data, it only blocks maintenance. Strictness is about what a
+  // write introduces.
+  //
+  // It is also what `16-mcp.md` promised integrators before the code was found to disagree, so B is the
+  // behaviour some of them may already have built against.
+  //
+  // What this does NOT weaken: a patch that introduces a violation is refused exactly as before, and a
+  // record that was already broken is still reported as broken on every write that touches it.
+  const surfaced = applyValidation(meta, afterViolations);
+  const blocking = applyValidation(meta, introduced);
 
   return {
-    blocked: verdict.blocked,
-    warnings: verdict.warnings,
+    blocked: blocking.blocked,
+    warnings: surfaced.warnings,
     introduced,
     preExisting,
     all: afterViolations,
@@ -192,14 +217,17 @@ export function describeUpdateViolations(
     return `The change violates this space's schema: ${names(introduced)}.`;
   }
   if (introduced.length === 0 && preExisting.length > 0) {
+    // Reported, not refused (owner ruling P-6 = B). This sentence used to end "so the write is refused until
+    // those field(s) are fixed", which was true and was the freeze itself: an operator could not correct a
+    // typo in a description without also resolving a field their edit never touched.
     return `This record was already non-compliant before your change: ${names(preExisting)}. `
-      + 'Your edit did not cause it, but the merged record is what gets stored, so the write is refused '
-      + 'until those field(s) are fixed — include them in this same request to repair the record.';
+      + 'Your edit did not cause it and is not refused for it, but the record still does not fit the current '
+      + 'schema — include those field(s) in a write to repair it.';
   }
   if (introduced.length > 0 && preExisting.length > 0) {
     return `The change violates this space's schema: ${names(introduced)}. `
       + `Separately, this record was already non-compliant before your change: ${names(preExisting)} — `
-      + 'include those field(s) in the same request to repair them.';
+      + 'that part is reported rather than refused; include those field(s) in a write to repair them.';
   }
   return 'The merged record satisfies this space\'s schema.';
 }

--- a/testing/standalone/update-validation.test.js
+++ b/testing/standalone/update-validation.test.js
@@ -120,6 +120,42 @@ describe('update validation', () => {
       assert.equal(classifyUpdateViolations(undefined, [], after).blocked, false);
     });
 
+    it('blocks on what the patch INTRODUCED, never on what the record already had', () => {
+      // Owner ruling P-6 = B, 2026-08-15, on the report breituai-platform called "freezes records":
+      //
+      //   write an entity with properties.status = "retired"   (the enum allows it)  -> 201
+      //   remove "retired" from the enum                                             -> 200
+      //   PATCH that record's DESCRIPTION only                                       -> 422
+      //
+      // The violation is already stored. Refusing the patch does not improve the data, it only stops the
+      // record being maintained — and any schema tightening did this retroactively to every record that no
+      // longer fit. Strictness is about what a write INTRODUCES.
+      const already = [v('status', 'not in enum')];
+      const out = classifyUpdateViolations(STRICT, already, already);
+      assert.equal(out.blocked, false, 'an unrelated edit must go through');
+      assert.deepEqual(out.introduced, []);
+      assert.deepEqual(out.preExisting.map(x => x.field), ['status']);
+    });
+
+    it('still blocks a patch that introduces one, alongside a pre-existing one', () => {
+      // The half that must NOT weaken. Both lists non-empty is the case where a lenient reading would let a
+      // genuinely bad patch through by pointing at the record's older problem.
+      const out = classifyUpdateViolations(STRICT, [v('owner', 'missing')],
+        [v('owner', 'missing'), v('status', 'not in enum')]);
+      assert.equal(out.blocked, true);
+      assert.deepEqual(out.introduced.map(x => x.field), ['status']);
+    });
+
+    it('reports the pre-existing violation even though it does not block', () => {
+      // Not-blocking must not become not-telling: `preExisting` and the full `all`/`warnings` list are how a
+      // client that wants to insist on compliance still can.
+      const already = [v('status', 'not in enum')];
+      const out = classifyUpdateViolations(STRICT, already, already);
+      assert.deepEqual(out.all.map(x => x.field), ['status']);
+      assert.deepEqual(out.warnings.map(x => x.field), ['status']);
+      assert.match(out.message, /already non-compliant/i);
+    });
+
     it('still classifies in warn mode, so the report says whose fault it is', () => {
       // Warn mode writes the record and reports; a report that cannot tell the operator which field is
       // theirs is the same failure as a blocking error that cannot.
@@ -142,7 +178,12 @@ describe('update validation', () => {
       const m = describeUpdateViolations([], [v('owner', 'x')]);
       assert.match(m, /already non-compliant/i);
       assert.match(m, /did not cause it/i);
-      assert.match(m, /same request/i, 'must say how to get unstuck');
+      // This asserted /same request/ — "must say how to get unstuck" — which was the right demand while a
+      // pre-existing violation BLOCKED the write, because repairing it in the same request was the only way
+      // through. Under P-6 = B nobody is stuck, so the sentence must say the opposite: not refused, and the
+      // repair can happen in any later write.
+      assert.match(m, /not refused/i, 'must say the write is going through');
+      assert.match(m, /repair/i, 'must still say the record needs fixing');
     });
 
     it('says both, and which is which', () => {

--- a/testing/standalone/upsert-validation.test.js
+++ b/testing/standalone/upsert-validation.test.js
@@ -119,7 +119,13 @@ describe('upsert validation', () => {
       assert.deepEqual(out.preExisting.map(x => x.field), ['properties.owner']);
       assert.deepEqual(out.introduced, [], 'the caller touched `rack`, not `owner`');
       assert.match(out.message, /already non-compliant/);
-      assert.equal(out.blocked, true, 'the merged record is still what gets stored');
+      // Owner ruling P-6 = B, 2026-08-15. This asserted `blocked: true` — "the merged record is still what
+      // gets stored" — and that WAS the freeze breituai-platform reported: tightening a schema made every
+      // record that no longer fit uneditable until an unrelated field was repaired in the same request.
+      // The violation is already stored, so refusing the patch does not improve the data; it only blocks
+      // maintenance. Reported, not refused.
+      assert.equal(out.blocked, false, 'a pre-existing violation does not block an unrelated write');
+      assert.ok(out.all.some(x => x.field === 'properties.owner'), 'still reported in `all`');
     });
 
     it('lets the same upsert repair it', () => {


### PR DESCRIPTION
Owner ruled **P-6 = B** on 2026-08-15.

## The report, reproduced exactly

breituai-platform called it *"freezes records"*:

```
1. write an entity with properties.status = "retired"   (the enum allows it)  →  201
2. remove "retired" from the enum                                             →  200
3. PATCH that record's DESCRIPTION only                                       →  422
   { "introduced": [], "preExisting": [ properties.status ] }
```

The record was uneditable until `status` was repaired in the same request, and **any schema tightening did
that retroactively** to every record that no longer fitted. An operator could not correct a typo in a
description without also resolving a field their edit never touched.

Refusing never improved the data. The bad value is *already stored*; the patch is the only thing being
stopped. Strictness is about what a write **introduces**.

## One split

`classifyUpdateViolations` already computed both lists. `blocked` now comes from
`applyValidation(meta, introduced)` while `warnings` still comes from the full merged-record list — two
verdicts from one mode, and the split is the whole ruling.

## What does not weaken — asserted, not argued

- A patch that introduces a violation is refused **exactly as before**, including when the record also carries
  an older one. That is the case where a lenient reading would let a genuinely bad patch through by pointing
  at the record's existing problem.
- `preExisting`, `all` and `warnings` still report everything, so a client that wants to insist on full
  compliance can.

## The message had to change with it

It ended *"so the write is refused until those field(s) are fixed"* — which was true, and **was the freeze**.
It now says the edit is not refused for it, and that the repair can happen in any later write.

Two existing assertions encoded the old rule and were **rewritten by hand rather than renumbered**, because
both were about the thing that changed:

| Assertion | Was |
|---|---|
| `upsert-validation` | `blocked: true, 'the merged record is still what gets stored'` |
| `update-validation` | `/same request/, 'must say how to get unstuck'` — the right demand while it blocked |

## Docs

`16-mcp.md` **promised this behaviour** before the code was found to disagree, and was corrected to describe
the code while this sat parked. Both now say the same thing again. `06a-schema-api.md` and the user guide's
Schema tab section likewise.

## Verification

39 tests across the two suites, 4 of them new — the reported scenario, the both-lists case that must still
block, and that a non-blocking violation is still reported. `npm run preflight` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
