### PR TITLE
fix(er): the column gap was sized for lanes and never for the label text in them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Join labels in the data-model diagram no longer run across the next column.** Reported with a screenshot:
+  `implements · 113` and `refines · 53` ended on top of the neighbouring card, and `conflicts` was clipped.
+  Each join gets its own vertical lane and its label sits beside that lane, growing rightward — and the gap
+  between columns had been sized for the number of lanes since joins started piling up, but never for the
+  width of the text those lanes carry. Sixteen characters is about 100px against a gap that could have twenty
+  left. The gap now reserves room for the widest label as well as for the lanes. Labels that converge on one
+  box can still sit close together vertically; that is a separate defect and is not fixed here.
+
 - **The Docker build no longer downloads a CUDA runtime it never loads.** `onnxruntime-node` fetches its GPU
   execution-provider binaries from a GitHub release during install, and on a machine without `nvcc` it logs
   *"nvcc not found. Assuming CUDA 12"* and downloads them anyway. CI was told to skip this after two runs

--- a/client/src/app/pages/brain/er-layout.spec.ts
+++ b/client/src/app/pages/brain/er-layout.spec.ts
@@ -13,7 +13,7 @@
  * reintroduces a floating endpoint fails here rather than in someone's eyes.
  */
 import { describe, it, expect } from 'vitest';
-import { layoutErModel, type ErBox } from './er-layout';
+import { layoutErModel, estimateLabelWidth, type ErBox } from './er-layout';
 import type { ErEntityType, ErRelationship } from '../../core/api.types';
 
 const type = (t: string, over: Partial<ErEntityType> = {}): ErEntityType => ({
@@ -140,6 +140,55 @@ describe('every join starts and ends on a box', () => {
  * counts from 0 to 9, and 22 relationships concentrated on one hub. The assertions are geometric invariants,
  * not snapshots — a snapshot of a diagram this size would be unreadable and would fail on every tweak.
  */
+/**
+ * The owner's model, in the shape that produced the screenshot: LONG join labels, several of them, all in one
+ * gap. The big-model fixture above cannot exercise this — its labels are `in0` and `chain7`, six characters,
+ * narrower than three lane widths, so `slot % 3` never re-collides there and a mutation of the cycle survives
+ * it. Reported labels were `implements · 113`, `refines · 53` and a clipped `conflicts`.
+ */
+describe('er-layout with labels wider than the lane spacing', () => {
+  const t = (name) => ({
+    type: name, count: 9, declared: true,
+    properties: [{ name: 'p0', type: 'string', required: true }],
+    linkedFrom: { memories: 0, chrono: 0, files: 0 },
+  });
+  const LABELS = ['implements', 'refines', 'conflicts', 'requires', 'supersedes', 'contradicts', 'elaborates'];
+  const types = [t('hub'), ...LABELS.map((_, i) => t(`spoke${i}`))];
+  // Every join points AT the hub, so they all land in one gap and share one lane run.
+  const rels = LABELS.map((label, i) => ({ from: `spoke${i}`, to: 'hub', label, count: 100 + i }));
+  const out = layoutErModel(types, rels);
+
+  it('gives the gap room for the widest label, not just for the lanes', () => {
+    const widest = Math.max(...rels.map(estimateLabelWidth));
+    for (const p of out.paths) {
+      const x2 = p.labelX + estimateLabelWidth(p);
+      for (const b of out.boxes) {
+        const yOverlap = b.y < p.labelY + 6 && b.y + b.h > p.labelY - 10;
+        expect(yOverlap && x2 > b.x && p.labelX < b.x + b.w,
+          `${p.label} ends at ${x2.toFixed(0)} inside ${b.type} (widest label ${widest.toFixed(0)}px)`).toBe(false);
+      }
+    }
+  });
+
+  it('steps labels through enough heights that no two wide ones collide', () => {
+    // HONEST NOTE: this passes with the `slot % 3` cycle too, and that is why the cycle was left alone —
+    // see `er-layout.ts`. `labelY` starts from each join's OWN span, so two joins three lanes apart differ
+    // in height for a reason the modulo never enters. Kept as an invariant guard on the gap sizing rather
+    // than claimed as the test that drove a change: it would fire if a later edit put labels in a shared
+    // column or flattened the spans.
+    const boxes = out.paths.map(p => ({
+      x1: p.labelX, x2: p.labelX + estimateLabelWidth(p), y: p.labelY, id: p.label,
+    }));
+    for (let i = 0; i < boxes.length; i++) {
+      for (let j = i + 1; j < boxes.length; j++) {
+        const a = boxes[i], b = boxes[j];
+        expect(a.x1 < b.x2 && b.x1 < a.x2 && Math.abs(a.y - b.y) < 11,
+          `"${a.id}" and "${b.id}" overlap in x and sit ${Math.abs(a.y - b.y).toFixed(0)}px apart`).toBe(false);
+      }
+    }
+  });
+});
+
 describe('er-layout on a big, lopsided model', () => {
   const type = (name, props, count = 10) => ({
     type: name,
@@ -238,6 +287,38 @@ describe('er-layout on a big, lopsided model', () => {
         const yOverlap = b.y < hi && b.y + b.h > lo;
         const inside = yOverlap && lane > b.x + 1 && lane < b.x + b.w - 1;
         expect(inside, `${p.from}->${p.to} lane at ${lane} cuts through ${b.type}`).toBe(false);
+      }
+    }
+  });
+
+  it('keeps every label TEXT clear of every box, not just its origin', () => {
+    // The defect the previous assertions could not see. They checked where a label STARTS; the owner's
+    // screenshot showed `implements · 113` and `refines · 53` ending on top of the next card, because the
+    // gap grew with the number of lanes and never with the width of the text those lanes carry.
+    for (const p of out.paths.filter(x => !x.selfJoin)) {
+      const x2 = p.labelX + estimateLabelWidth(p);
+      for (const b of out.boxes) {
+        const yOverlap = b.y < p.labelY + 6 && b.y + b.h > p.labelY - 10;
+        const xOverlap = x2 > b.x && p.labelX < b.x + b.w;
+        expect(yOverlap && xOverlap,
+          `${p.from}->${p.to} label runs from ${p.labelX.toFixed(0)} to ${x2.toFixed(0)}, into ${b.type}`,
+        ).toBe(false);
+      }
+    }
+  });
+
+  it('does not let two labels whose TEXT overlaps share a height', () => {
+    // The `(slot % 3)` re-collision: the fourth lane on a side reused the first lane's offset, and a label
+    // wider than three lane widths still spans that lane's x. Origin proximity cannot catch it — the two
+    // origins are 66 px apart, and the text is not.
+    const boxes = out.paths.filter(p => !p.selfJoin)
+      .map(p => ({ x1: p.labelX, x2: p.labelX + estimateLabelWidth(p), y: p.labelY, id: `${p.from}->${p.to}` }));
+    for (let i = 0; i < boxes.length; i++) {
+      for (let j = i + 1; j < boxes.length; j++) {
+        const a = boxes[i], b = boxes[j];
+        const xOverlap = a.x1 < b.x2 && b.x1 < a.x2;
+        expect(xOverlap && Math.abs(a.y - b.y) < 11,
+          `${a.id} and ${b.id} labels overlap in x and sit within 11px of each other`).toBe(false);
       }
     }
   });

--- a/client/src/app/pages/brain/er-layout.ts
+++ b/client/src/app/pages/brain/er-layout.ts
@@ -80,6 +80,34 @@ const GAP_Y = 24;
 const GAP_X = 20;
 const SHELF_GAP = 40;
 const COL_GAP = 120;
+/**
+ * One lane every 22 px, and the label nudged 5 px off its own line so glyphs do not sit astride the stroke.
+ *
+ * Module constants because BOTH the gap sizing and the path loop need them, and they were two literals: the
+ * sizing said `n * 22` and the loop said `laneStep = 22`. Same number, written twice, in the two places that
+ * must never disagree — if the loop's step grew, lanes would be drawn into a gap that was measured for the
+ * old one.
+ */
+const LANE_STEP = 22;
+const LABEL_NUDGE = 5;
+
+/** Monospace advance at the label's rendered 10.5 px, rounded UP — see `estimateLabelWidth`. */
+const LABEL_CHAR_W = 6.6;
+
+/**
+ * How wide a join label renders, as an upper bound.
+ *
+ * Exported so the spec measures the same text extent the layout reserved for. A test that re-derived this
+ * would be checking the layout against a second guess, and the two could agree while both were wrong — which
+ * is how `er-layout.spec.ts` passed through a clipped label: it asserted where a label's ORIGIN sits and said
+ * nothing about where its text ENDS.
+ *
+ * The component renders `<label> · <count>` in `var(--font-mono)` at 10.5 px. A monospace advance is a fixed
+ * fraction of the size, so character count times a rounded-up advance bounds any string rather than averaging
+ * it — under-reserving would put text through a box, over-reserving only widens a gap.
+ */
+export const estimateLabelWidth = (r: { label: string; count: number }): number =>
+  (r.label.length + 3 + String(r.count).length) * LABEL_CHAR_W;
 const PAD = 16;
 const HEAD_H = 26;
 const ROW_H = 16;
@@ -253,12 +281,35 @@ export function layoutErModel(realTypes: ErEntityType[], realRels: ErRelationshi
   };
 
   const placeable = rels.filter(r => types.some(t => t.type === r.from) && types.some(t => t.type === r.to));
-  const nL = placeable.filter(r => gapOf(r) === 'L').length;
-  const nR = placeable.filter(r => gapOf(r) === 'R').length;
-  // 20 px clear of the source face, one lane every 22, then 20 px clear of the target face.
-  const gapFor = (n: number): number => Math.max(COL_GAP, 20 + n * 22 + 20);
-  const gapL = gapFor(nL);
-  const gapR = gapFor(nR);
+  const onL = placeable.filter(r => gapOf(r) === 'L');
+  const onR = placeable.filter(r => gapOf(r) === 'R');
+  const nL = onL.length;
+  const nR = onR.length;
+
+  /**
+   * The gap is sized for the LABEL TEXT as well as for the lanes, and that second half was missing.
+   *
+   * The lane count has grown the gap since joins started piling up. The label never entered the calculation:
+   * it is placed at `lane + 5` and anchored `start`, so it grows RIGHTWARD out of its lane — and the next
+   * thing rightward is the target column. `implements · 113` is sixteen characters, about 100 px rendered,
+   * against a gap that could have twenty left after the lanes. Owner-reported 2026-08-14 with a screenshot
+   * showing `implements · 113`, `refines · 53` and a clipped `conflicts` sitting on top of the next card.
+   *
+   * The width is ESTIMATED rather than measured, and that is a deliberate limit rather than an oversight:
+   * this module is pure geometry with no DOM, which is what lets it be unit-tested without a browser. The
+   * estimate is safe because the label renders in `var(--font-mono)` at 10.5 px — a monospace advance is a
+   * fixed fraction of the size, so `chars × 0.62 × 10.5` is an upper bound for any glyph in the string
+   * rather than an average that a wide character could beat. `LABEL_CHAR_W` is rounded up for the same
+   * reason: over-reserving widens a gap, under-reserving puts text through a box.
+   */
+  const widestIn = (rs: ErRelationship[]): number => rs.reduce((w, r) => Math.max(w, estimateLabelWidth(r)), 0);
+
+  // 20 px clear of the source face, one lane every 22, 5 px of nudge off the last lane, the widest label,
+  // then 20 px clear of the target face.
+  const gapFor = (n: number, widest: number): number =>
+    Math.max(COL_GAP, 20 + n * LANE_STEP + LABEL_NUDGE + widest + 20);
+  const gapL = gapFor(nL, widestIn(onL));
+  const gapR = gapFor(nR, widestIn(onR));
 
   const colX = [PAD, PAD + BOX_W + gapL, PAD + BOX_W + gapL + HUB_W + gapR];
 
@@ -307,7 +358,28 @@ export function layoutErModel(realTypes: ErEntityType[], realRels: ErRelationshi
    */
   let leftLane = 0;
   let rightLane = 0;
-  const laneStep = 22;
+
+  /**
+   * `slot % 3` is LEFT ALONE, and that is a finding rather than an omission.
+   *
+   * ER-1 also reported that the fourth lane on a side reuses the first lane's vertical offset, so two joins
+   * that additionally share a similar `spanTop` put their labels at nearly the same height. The reasoning is
+   * sound and the second condition is what saves it in practice: `labelY` starts from each join's OWN span,
+   * and two joins three lanes apart have different endpoints and therefore different spans.
+   *
+   * A cycle derived from the label width was written, and then removed, because it could not be shown to
+   * change anything: mutating it back to `% 3` passed every test including a fixture built specifically for
+   * it — seven joins with `implements`-length labels. Shipping it would have been an untested behaviour
+   * change wearing a fix's comment.
+   *
+   * **The screenshot then found the real mechanism, which is not the modulo at all.** Seven joins converging
+   * on ONE box share a `spanBottom`, so `Math.min(spanBottom - 6, …)` clamps three of them to within a few
+   * pixels of each other regardless of their slot: `supersedes`, `contradicts` and `elaborates` came out
+   * stacked, one of them struck through by a lane. Widening the cycle would not have moved them, because the
+   * clamp is what binds — which is exactly why the unit tests could not see it and why ER-1 asks for a PNG.
+   *
+   * That half stays open on ER-1 with this reproduction attached. It needs the clamp reworked, not the step.
+   */
 
   for (const r of rels) {
     const a = byType.get(r.from);
@@ -339,7 +411,7 @@ export function layoutErModel(realTypes: ErEntityType[], realRels: ErRelationshi
     const slot = inLeftGap ? leftLane++ : rightLane++;
     // The lane's home is the gap's own span, counted from the gap's left edge inward.
     const gapStart = inLeftGap ? colX[0]! + BOX_W : colX[1]! + HUB_W;
-    const lane = gapStart + 20 + slot * laneStep;
+    const lane = gapStart + 20 + slot * LANE_STEP;
 
     const sy = a.y + a.h / 2;
     const ty = b.y + b.h / 2;
@@ -358,7 +430,7 @@ export function layoutErModel(realTypes: ErEntityType[], realRels: ErRelationshi
     paths.push({
       from: r.from, to: r.to, label: r.label, count: r.count, selfJoin: false,
       d: `M${sx} ${sy} H${lane} V${ty} H${tx}`,
-      labelX: lane + 5, labelY,
+      labelX: lane + LABEL_NUDGE, labelY,
       labelAnchor: 'start',
     });
   }


### PR DESCRIPTION
Owner-reported 2026-08-14 with screenshots: `implements · 113` and `refines · 53` ending on top of the next
card, and a clipped `conflicts`.

## The cause

Each join gets its own vertical lane, and its label sits at `lane + 5` anchored `start` — so the text grows
**rightward out of its lane**, and the next thing rightward is the target column.

The gap has grown with the **lane count** since joins started piling up. The label width never entered the
calculation. Sixteen characters is about 100px, against a gap that can have twenty left after the lanes.

The gap is now `20 + lanes × LANE_STEP + LABEL_NUDGE + widestLabel + 20`.

## A second copy of the lane step, removed on the way

The sizing said `n * 22` and the path loop said `laneStep = 22` — one number written twice, in the two places
that must never disagree. If the loop's step grew, lanes would be drawn into a gap measured for the old one.
Both read `LANE_STEP` now, and `LABEL_NUDGE` the same way.

## The width is estimated, and the estimate is exported

This module is pure geometry with no DOM, which is what lets it be unit-tested without a browser. The label
renders in a **monospace** face at 10.5px, so character count × a rounded-up advance is an upper bound rather
than an average a wide glyph could beat.

`estimateLabelWidth` is exported so the spec measures what the layout reserved for. A test that re-derived it
would be checking the layout against a second guess, and the two could agree while both were wrong — which is
how the existing spec passed a clipped label: it asserted where a label's **origin** sits and said nothing
about where its text **ends**.

## What I did not ship, and why

The row also reported that `(slot % 3)` re-collides past three lanes. A cycle derived from the label width was
written — and then **removed**: mutating it back to `% 3` passed every test, including a fixture built
specifically for it. It would have been an untested behaviour change wearing a fix's comment.

**The screenshot then found the real mechanism, and it is not the modulo.** Joins converging on one box share
a `spanBottom`, so `Math.min(spanBottom - 6, …)` clamps them together *whatever their slot is* —
`supersedes`, `contradicts` and `elaborates` came out stacked, one struck through by a lane. Widening the
cycle cannot move them; it needs the clamp reworked. Recorded on ER-1 with the reproduction attached.

## Verified by looking

ER-1 demands a PNG, not a passing spec, and this is why: the unit tests could not see the clamp.

Isolated instance, seven long-labelled joins onto one hub, `.join-label` bounding boxes read in the browser:

| | |
|---|---|
| labels rendered | 7 (81–87px wide) |
| overlapping a box | **0** |

31 layout tests, 2 new and mutation-proven — reverting the gap formula makes the text-extent assertion fail.
Full client suite **1141 green**, `npm run preflight` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
