### PR TITLE
fix(embed): an outage costs waiting, not the record's retry budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   left. The gap now reserves room for the widest label as well as for the lanes. Labels that converge on one
   box can still sit close together vertically; that is a separate defect and is not fixed here.
 
+- **An embedder outage no longer spends a record's retry budget.** The retry policy allows five attempts over
+  about twelve and a half minutes, which is sized for one record failing on its own content. Applied to an
+  embedder that is simply unreachable — during an upgrade, say — it took every queued job in every space
+  terminal at once, and a terminal job is never picked up again. This release already gave those jobs one
+  clean retry per server version; this stops them being spent in the first place. A failure that means *the
+  embedder did not answer* — connection refused or reset, DNS, a timeout, a 429, a 502/503/504 — now costs
+  waiting instead of an attempt, backing off to half-hourly and recovering by itself the moment the embedder
+  returns. A failure that means *this record cannot be embedded* — a 400, a 422, no embeddable text — still
+  spends an attempt and still gives up, because that is what the budget is for. Rewriting a record, retrying
+  it, or a new server version all clear the wait as well as the budget.
+
 - **The Docker build no longer downloads a CUDA runtime it never loads.** `onnxruntime-node` fetches its GPU
   execution-provider binaries from a GitHub release during install, and on a machine without `nvcc` it logs
   *"nvcc not found. Assuming CUDA 12"* and downloads them anyway. CI was told to skip this after two runs

--- a/server/src/brain/embed-queue.ts
+++ b/server/src/brain/embed-queue.ts
@@ -137,6 +137,9 @@ export async function enqueueEmbedJob(
           spaceId, recordType, recordId,
           status: 'pending',
           attempts: 0,
+          // Reset with `attempts`, for the same reason: a new write is new content, and it must not inherit
+          // a half-hour backoff earned by an outage that has since ended.
+          transientFailures: 0,
           maxAttempts: MAX_EMBED_ATTEMPTS,
           lastError: null,
           claimedAt: null,
@@ -232,17 +235,84 @@ export async function retireEmbedJob(
   await jobs(spaceId).deleteOne(asFilter<BrainEmbedJobDoc>({ _id: embedJobId(recordType, recordId) }));
 }
 
-/** Requeue with backoff, or leave `failed` once the attempt budget is spent. */
+/**
+ * Is this failure the RECORD's fault, or the embedder's?
+ *
+ * ## Why the distinction has to exist
+ *
+ * `MAX_EMBED_ATTEMPTS` is 5 with a backoff of 5s / 30s / 120s / 600s — about twelve and a half minutes from
+ * the first failure to terminal `failed`. That budget is sized for a PER-RECORD failure. Applied to a
+ * systemic one, an embedder unreachable for a quarter of an hour during an upgrade takes every queued job in
+ * every space terminal at once, and the instance stops indexing without reporting a fault: every job did
+ * exactly what it was told to.
+ *
+ * #910 made that survivable — one clean retry of everything per server version. This makes it right: an
+ * outage costs WAITING rather than the budget.
+ *
+ * ## What counts, and what deliberately does not
+ *
+ * Reachability and availability: the connection never landed, or the far end said "not now". Those are
+ * resolved by waiting and by nothing else the caller can do.
+ *
+ * A `400` or `422` is NOT here, and that is the whole point of keeping a budget at all — a malformed input is
+ * exactly the per-record failure `attempts` exists to bound. Retrying it forever would replace one silent
+ * failure mode with another: a job that never completes and never gives up.
+ *
+ * Matched on the message because that is what reaches us — the embedder is behind `fetch`, an HTTP client or
+ * an in-process model depending on configuration, and there is no one error type across the three.
+ */
+export function isTransientEmbedError(message: string): boolean {
+  const m = message.toLowerCase();
+  return [
+    'econnrefused', 'econnreset', 'etimedout', 'ehostunreach', 'enetunreach', 'eai_again', 'enotfound',
+    'socket hang up', 'fetch failed', 'network error', 'timeout', 'timed out',
+    'too many requests', 'service unavailable', 'bad gateway', 'gateway timeout', 'temporarily unavailable',
+    ' 429', ' 502', ' 503', ' 504', 'status 429', 'status 502', 'status 503', 'status 504',
+  ].some(needle => m.includes(needle));
+}
+
+/**
+ * Requeue with backoff, or leave `failed` once the attempt budget is spent.
+ *
+ * A TRANSIENT failure hands the attempt back and never goes terminal — see `isTransientEmbedError`. It is
+ * given back rather than withheld because `claimNextEmbedJob` increments `attempts` at CLAIM time, before
+ * the outcome is known, so by the time we are here it has already been spent.
+ *
+ * The wait then has to come from somewhere else, which is why `transientFailures` is a second counter and not
+ * a flag: the backoff is a function of the attempt number, so holding `attempts` still would pin every retry
+ * at the first step and hammer a dead embedder every five seconds — the opposite of what this is for.
+ */
 export async function failEmbedJob(
   spaceId: string,
   recordType: BrainEmbedRecordType,
   recordId: string,
   attempts: number,
   errorMessage: string,
+  transientFailures = 0,
 ): Promise<void> {
   const now = new Date().toISOString();
   const _id = embedJobId(recordType, recordId);
   const lastError = errorMessage.slice(0, 500);
+
+  if (isTransientEmbedError(errorMessage)) {
+    const failures = transientFailures + 1;
+    await jobs(spaceId).updateOne(
+      asFilter<BrainEmbedJobDoc>({ _id }),
+      asUpdate<BrainEmbedJobDoc>({
+        $set: {
+          status: 'pending', claimedAt: null, claimToken: null, lastError, updatedAt: now,
+          // The attempt is given back: this failure was not the record's.
+          attempts: Math.max(0, attempts - 1),
+          transientFailures: failures,
+          // Saturates at the last step, so a permanently-dead embedder costs one claim per job per half hour
+          // rather than a spin. It self-heals the moment the embedder answers.
+          claimableAfter: nextClaimableAfter(failures),
+        },
+      }),
+    );
+    _signal.markSpaceMayHaveWork(spaceId);
+    return;
+  }
 
   if (attempts < MAX_EMBED_ATTEMPTS) {
     await jobs(spaceId).updateOne(
@@ -306,7 +376,8 @@ export async function reviveFailedEmbedJobs(spaceIds: string[], version: string)
       asFilter<BrainEmbedJobDoc>({ status: 'failed', revivedForVersion: { $ne: version } as unknown as string }),
       asUpdate<BrainEmbedJobDoc>({
         $set: {
-          status: 'pending', attempts: 0, claimedAt: null, claimToken: null, claimableAfter: null,
+          status: 'pending', attempts: 0, transientFailures: 0,
+          claimedAt: null, claimToken: null, claimableAfter: null,
           revivedForVersion: version, updatedAt: new Date().toISOString(),
         },
       }),
@@ -439,6 +510,7 @@ export async function retryEmbedJob(
       $set: {
         status: 'pending',
         attempts: 0,
+        transientFailures: 0,
         lastError: null,
         claimedAt: null,
         claimableAfter: null,

--- a/server/src/brain/embed-worker.ts
+++ b/server/src/brain/embed-worker.ts
@@ -63,7 +63,9 @@ export async function runOneEmbedJob(): Promise<boolean> {
       .catch(() => { /* best-effort, exactly as it was on the write path */ });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    await failEmbedJob(job.spaceId, job.recordType, job.recordId, job.attempts, msg);
+    // `transientFailures` comes from the job the worker already holds — no second read, and no
+    // `findOneAndUpdate` to recover a post-increment value.
+    await failEmbedJob(job.spaceId, job.recordType, job.recordId, job.attempts, msg, job.transientFailures ?? 0);
     // debug, not warn: an embedder that is down produces one of these per queued record, and a
     // thousand warnings say nothing the first one did not. The failed count is the signal.
     log.debug(`Embed job ${job._id} in ${job.spaceId} failed (attempt ${job.attempts}): ${msg}`);

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -1821,8 +1821,22 @@ export interface BrainEmbedJobDoc {
   recordType: BrainEmbedRecordType;
   recordId: string;
   status: 'pending' | 'processing' | 'failed';
+  /**
+   * The PERMANENT-failure budget. Spent only on errors that a retry cannot fix — a malformed input, a 400
+   * from a reachable embedder. See `transientFailures` for the other kind.
+   */
   attempts: number;
   maxAttempts: number;
+  /**
+   * How many times this job has failed for a reason that is not its own: the embedder unreachable, a 503, a
+   * rate limit. Absent on every job written before this existed, which reads as 0.
+   *
+   * It is separate from `attempts` because the two answer different questions and one counter cannot do
+   * both. `attempts` decides when to give up; this decides how long to wait. Counting an outage against the
+   * budget is what took every queued job in every space terminal at once during an upgrade — five attempts
+   * over twelve and a half minutes, spent on a sidecar that was restarting.
+   */
+  transientFailures?: number;
   lastError: string | null;
   /** ISO8601 — set when a worker claims this job. */
   claimedAt: string | null;

--- a/testing/standalone/embed-outage-does-not-spend-the-budget.test.js
+++ b/testing/standalone/embed-outage-does-not-spend-the-budget.test.js
@@ -1,0 +1,124 @@
+/**
+ * An embedder outage costs WAITING, not the attempt budget.
+ *
+ * ## The report, and the half #910 left
+ *
+ * Owner, live instance: *"after updating all space indexing failed and since has not been retried
+ * automatically."* `MAX_EMBED_ATTEMPTS` is 5 with a backoff of 5s / 30s / 120s / 600s — about twelve and a
+ * half minutes from the first failure to terminal `failed`, and a terminal job is never claimed again. That
+ * budget is sized for a PER-RECORD failure. Applied to a systemic one, an embedder unreachable for a quarter
+ * of an hour during an upgrade takes every queued job in every space terminal at once, and the instance stops
+ * indexing without reporting a fault: every job did exactly what it was told to.
+ *
+ * #910 made that survivable — `reviveFailedEmbedJobs` gives everything one clean attempt per server version.
+ * This is the other half: not spending the budget in the first place.
+ *
+ * ## Why two counters and not a flag
+ *
+ * `claimNextEmbedJob` increments `attempts` at CLAIM time, before anyone knows how the job went. So "hold the
+ * attempt" has to mean giving it back. And the backoff is a function of the attempt number, so holding
+ * `attempts` still would pin every retry at the first step — five seconds, forever, against a dead embedder.
+ * `transientFailures` therefore drives the wait while `attempts` stays the budget.
+ *
+ * ## The line that must not move
+ *
+ * A `400` is not transient. A malformed input is exactly the per-record failure the budget exists to bound,
+ * and retrying it forever would replace one silent failure with another: a job that never completes and never
+ * gives up. Both directions are asserted here.
+ *
+ * Run: node --test testing/standalone/embed-outage-does-not-spend-the-budget.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let isTransientEmbedError;
+before(async () => {
+  ({ isTransientEmbedError } = await import('../../server/dist/brain/embed-queue.js'));
+});
+
+describe('what counts as the embedder being unavailable', () => {
+  const TRANSIENT = [
+    'connect ECONNREFUSED 127.0.0.1:8080',
+    'read ECONNRESET',
+    'connect ETIMEDOUT 10.0.0.5:443',
+    'getaddrinfo EAI_AGAIN embedder.internal',
+    'getaddrinfo ENOTFOUND embedder.internal',
+    'socket hang up',
+    'TypeError: fetch failed',
+    'Embedding request timed out after 30000ms',
+    'Embedder responded 503 Service Unavailable',
+    'HTTP status 429 Too Many Requests',
+    'Bad Gateway',
+    'Gateway Timeout',
+  ];
+
+  for (const msg of TRANSIENT) {
+    it(`treats "${msg.slice(0, 42)}" as the embedder's fault`, () => {
+      assert.equal(isTransientEmbedError(msg), true);
+    });
+  }
+});
+
+describe('what stays the record\'s own fault', () => {
+  // The budget has to keep meaning something. Each of these is answered the same way by every retry, so
+  // spending an attempt is correct and giving up eventually is correct.
+  const PERMANENT = [
+    'Embedder responded 400 Bad Request: input exceeds maximum token length',
+    'HTTP status 422: text field is empty',
+    'Unsupported content type for embedding',
+    'Record has no embeddable text',
+    'TypeError: Cannot read properties of undefined (reading \'chunks\')',
+  ];
+
+  for (const msg of PERMANENT) {
+    it(`spends an attempt on "${msg.slice(0, 42)}"`, () => {
+      assert.equal(isTransientEmbedError(msg), false);
+    });
+  }
+
+  it('does not read a 400 as transient just because a URL contains 503', () => {
+    // The needle is ' 503' with a leading space, not '503', so a port or an id cannot look like an outage.
+    assert.equal(isTransientEmbedError('POST http://embedder:8503/embed returned 400'), false);
+  });
+
+  it('is not fooled by an empty or meaningless message', () => {
+    assert.equal(isTransientEmbedError(''), false);
+    assert.equal(isTransientEmbedError('failed'), false);
+  });
+});
+
+describe('the two counters answer different questions', () => {
+  it('the source spends `attempts` only on a permanent failure', async () => {
+    // Read from source rather than exercised against Mongo: the write shape is the claim, and the
+    // integration suite covers the queue end to end. What matters here is that the transient branch gives
+    // the attempt back and never sets `failed`.
+    const { readFileSync } = await import('node:fs');
+    const src = readFileSync('server/src/brain/embed-queue.ts', 'utf8')
+      .replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
+
+    const branch = src.slice(src.indexOf('isTransientEmbedError(errorMessage)'));
+    const untilNextBranch = branch.slice(0, branch.indexOf('if (attempts < MAX_EMBED_ATTEMPTS)'));
+
+    assert.match(untilNextBranch, /attempts: Math\.max\(0, attempts - 1\)/,
+      'a transient failure must hand the attempt back — it was spent at claim time');
+    assert.match(untilNextBranch, /transientFailures: failures/,
+      'the wait needs its own counter, or the backoff pins at its first step');
+    assert.doesNotMatch(untilNextBranch, /status: 'failed'/,
+      'a transient failure must never go terminal — that is the whole point');
+    assert.match(untilNextBranch, /claimableAfter: nextClaimableAfter\(failures\)/,
+      'the backoff must climb with the transient count, not with the held attempts');
+  });
+
+  it('every place that resets `attempts` resets `transientFailures` too', async () => {
+    // A new write is new content and must not inherit a half-hour backoff earned by an outage that has since
+    // ended. Enqueue, revive-per-version and retry all reset the budget; all three must reset the wait.
+    const { readFileSync } = await import('node:fs');
+    const src = readFileSync('server/src/brain/embed-queue.ts', 'utf8')
+      .replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
+    const resets = [...src.matchAll(/attempts: 0/g)].length;
+    const paired = [...src.matchAll(/transientFailures: 0/g)].length;
+    assert.ok(resets >= 3, `expected at least 3 attempt resets, found ${resets} — the scanner is wrong`);
+    assert.equal(paired, resets, `${resets} places reset attempts but only ${paired} reset transientFailures`);
+  });
+});


### PR DESCRIPTION
EJ-1's second half. #910 made a systemic outage **survivable** — one clean retry of everything per server
version. This stops the budget being spent on it in the first place.

## The mismatch

`MAX_EMBED_ATTEMPTS` is 5, backing off 5s / 30s / 120s / 600s: about **twelve and a half minutes** from the
first failure to terminal `failed`, and a terminal job is never claimed again.

That is sized for a **per-record** failure. Applied to a systemic one — an embedder unreachable during an
upgrade — it takes every queued job in every space terminal at once, and the instance stops indexing without
reporting a fault, because every job did exactly what it was told to.

## Two counters, and the shape is forced rather than chosen

- **The attempt is spent at CLAIM time.** `claimNextEmbedJob` does `$inc: { attempts: 1 }` before anyone knows
  how the job went, so "hold the attempt" cannot mean withholding it. The transient branch hands it back.
- **The backoff is a function of the attempt number.** Holding `attempts` still would pin every retry at the
  first step — five seconds, forever, against a dead embedder, which is the opposite of the point. So
  `transientFailures` drives the wait while `attempts` stays the budget.

It saturates at the last step, so a permanently-dead embedder costs one claim per job per half hour and
self-heals the moment it answers. The worker passes the counter from the job it already holds — no second
read, no `findOneAndUpdate` to recover a post-increment value.

## The line that must not move

A `400` or `422` is **not** transient. A malformed input is exactly the per-record failure the budget exists
to bound, and retrying it forever would replace one silent failure mode with another: a job that never
completes and never gives up.

Both directions are asserted, including that a URL containing `8503` is not read as an outage — the needle is
`' 503'` with a leading space, not `'503'`.

Matched on the message because that is what reaches us: the embedder sits behind `fetch`, an HTTP client or an
in-process model depending on configuration, and there is no one error type across the three.

## Resets stay paired

Every place that resets `attempts` now resets `transientFailures` too — enqueue, revive-per-version, retry. A
new write is new content and must not inherit a half-hour backoff earned by an outage that has since ended.

That pairing is itself gated by counting both in the source, so a fourth reset site cannot be added with only
half of it.

## Verification

21 tests. **Mutation-tested:** removing the attempt hand-back makes the source assertion fail. `npm run
preflight` green; the queue's end-to-end behaviour is covered by the integration suite in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
