### PR TITLE
fix(er): labels arriving at the same box crowded, because a modulo cannot spread a shared origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   between columns had been sized for the number of lanes since joins started piling up, but never for the
   width of the text those lanes carry. Sixteen characters is about 100px against a gap that could have twenty
   left. The gap now reserves room for the widest label as well as for the lanes. Labels that converge on one
-  box can still sit close together vertically; that is a separate defect and is not fixed here.
+  box no longer crowd each other either: they used to step through only three heights before repeating, and
+  every join arriving at the same box starts counting from that box, so several landed 13px apart with a
+  connector drawn between them. They now step down the span they share, far enough apart to read.
 
 - **An embedder outage no longer spends a record's retry budget.** The retry policy allows five attempts over
   about twelve and a half minutes, which is sized for one record failing on its own content. Applied to an

--- a/client/src/app/pages/brain/er-layout.ts
+++ b/client/src/app/pages/brain/er-layout.ts
@@ -360,26 +360,28 @@ export function layoutErModel(realTypes: ErEntityType[], realRels: ErRelationshi
   let rightLane = 0;
 
   /**
-   * `slot % 3` is LEFT ALONE, and that is a finding rather than an omission.
+   * The label steps down by its FULL slot, not by `slot % 3`.
    *
-   * ER-1 also reported that the fourth lane on a side reuses the first lane's vertical offset, so two joins
-   * that additionally share a similar `spanTop` put their labels at nearly the same height. The reasoning is
-   * sound and the second condition is what saves it in practice: `labelY` starts from each join's OWN span,
-   * and two joins three lanes apart have different endpoints and therefore different spans.
+   * ## Why a modulo was wrong here, and why the first diagnosis of it was also wrong
    *
-   * A cycle derived from the label width was written, and then removed, because it could not be shown to
-   * change anything: mutating it back to `% 3` passed every test including a fixture built specifically for
-   * it — seven joins with `implements`-length labels. Shipping it would have been an untested behaviour
-   * change wearing a fix's comment.
+   * ER-1 said the fourth lane on a side reuses the first lane's offset, so two joins sharing a `spanTop` end
+   * up at the same height. A cycle derived from the label width was written to fix that — and removed,
+   * because mutating it back to `% 3` passed every test including a fixture built for it.
    *
-   * **The screenshot then found the real mechanism, which is not the modulo at all.** Seven joins converging
-   * on ONE box share a `spanBottom`, so `Math.min(spanBottom - 6, …)` clamps three of them to within a few
-   * pixels of each other regardless of their slot: `supersedes`, `contradicts` and `elaborates` came out
-   * stacked, one of them struck through by a lane. Widening the cycle would not have moved them, because the
-   * clamp is what binds — which is exactly why the unit tests could not see it and why ER-1 asks for a PNG.
+   * The screenshot showed what neither could: joins CONVERGING on one box all take their `spanTop` from that
+   * box, so every one of them starts counting from the same y. `supersedes`, `contradicts` and `elaborates`
+   * came out 13 px apart with lane lines running between them — not overlapping, which is why the specs were
+   * quiet, and not readable either, which is what was reported.
    *
-   * That half stays open on ER-1 with this reproduction attached. It needs the clamp reworked, not the step.
+   * A modulo is the wrong tool for a shared origin. Three offsets is enough only while the joins that share
+   * an origin are at most three; seven converge here, and a real model converges harder. Stepping by the full
+   * slot spreads them down the span they all share, and `Math.min(spanBottom - 6, …)` still stops a label
+   * leaving its own span — which is the same clamp as before and does the job the modulo was standing in for.
+   *
+   * The step goes to 15 for the same reason: 13 px between two ~11 px lines, with a lane drawn through the
+   * gap, is the crowding the screenshot showed rather than a collision the arithmetic could catch.
    */
+  const LABEL_STEP_Y = 15;
 
   for (const r of rels) {
     const a = byType.get(r.from);
@@ -425,7 +427,7 @@ export function layoutErModel(realTypes: ErEntityType[], realRels: ErRelationshi
     // same height. `labelX` is nudged off the line itself so the glyphs do not sit astride the stroke.
     const spanTop = Math.min(sy, ty);
     const spanBottom = Math.max(sy, ty);
-    const labelY = Math.min(spanBottom - 6, spanTop + 14 + (slot % 3) * 13);
+    const labelY = Math.min(spanBottom - 6, spanTop + 14 + slot * LABEL_STEP_Y);
 
     paths.push({
       from: r.from, to: r.to, label: r.label, count: r.count, selfJoin: false,


### PR DESCRIPTION
ER-1's second half, and it closes the row. #921 stopped labels running **into** the next column; this stops the ones that **converge on a box** from crowding each other.

```
labelY = Math.min(spanBottom - 6, spanTop + 14 + (slot % 3) * 13)
```

Every join arriving at the same box takes its `spanTop` from that box, so all of them start counting from the same y. Three offsets is enough only while at most three joins share an origin; **seven converge** in the reported model. `supersedes`, `contradicts` and `elaborates` came out 13px apart with a connector drawn between them — not overlapping, which is why every spec was quiet, and not readable either, which is what was reported.

Stepping by the **full slot** spreads them down the span they share. `Math.min(spanBottom - 6, …)` still stops a label leaving its own span — the same clamp as before, doing the job the modulo was standing in for. The step goes 13 → 15 for the same reason: 13px between two ~11px lines with a lane through the gap is crowding, not a collision arithmetic can catch.

## Third diagnosis of one defect, and the first two came from the code alone

1. The tracker said `(slot % 3)` re-collides past three lanes. A width-derived cycle was written for that, then **removed** — mutating it back to `% 3` passed every test, including a fixture built for it.
2. The first screenshot suggested the **clamp** was binding. It is not: the spans are large and it never fires there.
3. What is actually true is the shared **origin** — visible only when several joins point at one box, and only in a picture.

## Verified by comparison

| | before | after |
|---|---|---|
| `supersedes` | y=411, struck through by a lane | y=459 |
| `contradicts` | 13px away | y=474 |
| `elaborates` | 13px the other way | y=489 |

Seven labels, **zero box overlaps**, both runs. 31 layout tests green, full client suite green, `npm run preflight` green.

ER-1 is closed and removed from the trackers, along with UI-2's section, which shipped as #917.

🤖 Generated with [Claude Code](https://claude.com/claude-code)