### PR TITLE
feat(setup)!: remove the legacy /setup form, so the SPA's own first-run page is reachable

### DIFF
--- a/.claude/skills/verify/firstrun.mjs
+++ b/.claude/skills/verify/firstrun.mjs
@@ -1,0 +1,73 @@
+/**
+ * D-12's proof: a genuine first run completed through the SPA's own /setup page.
+ *
+ * The legacy mount used to intercept /setup with a server-rendered form, so the Angular route had never
+ * served one. This must be run against a RESET instance — config deleted, scratch DB dropped — or the
+ * server answers `configured: true` and the page redirects away.
+ */
+import { chromium } from 'playwright';
+import { writeFileSync } from 'node:fs';
+
+const DIR = 'C:/Users/Menne/AppData/Local/Temp/claude/o--Projects-Ythril/c196d4b7-bba0-4847-a326-fb95254ac3bd/scratchpad/verify';
+const BASE = 'http://localhost:3260';
+
+const status = await (await fetch(`${BASE}/api/setup/status`)).json();
+console.log('setup status before:', JSON.stringify(status));
+if (status.configured) { console.log('NOT A FIRST RUN — reset and retry'); process.exit(1); }
+
+// The removed mount would have answered this with HTML. Anything but the SPA shell means it is still there.
+const raw = await fetch(`${BASE}/setup`);
+const body = await raw.text();
+console.log('GET /setup ->', raw.status, raw.headers.get('content-type'));
+console.log('served by the SPA shell:', body.includes('<app-root') || body.includes('app-root'));
+console.log('still the legacy form:', /name="label"|id="submitBtn"/.test(body) && !body.includes('app-root'));
+
+const browser = await chromium.launch({ channel: 'msedge' });
+const page = await browser.newPage({ viewport: { width: 1400, height: 950 } });
+const errs = [];
+page.on('console', m => { if (m.type() === 'error') errs.push(m.text()); });
+
+await page.goto(`${BASE}/setup`);
+await page.waitForTimeout(3000);
+await page.screenshot({ path: `${DIR}/fr-01-setup.png` });
+console.log('at:', page.url());
+
+// Angular renders a label field; the legacy form used id="label" too, so identify by the SPA being present.
+const isSpa = await page.evaluate(() => !!document.querySelector('app-root'));
+console.log('app-root present:', isSpa);
+
+const field = page.locator('input#label, input[formcontrolname="label"], input[name="label"]').first();
+if (!(await field.count())) { console.log('NO LABEL FIELD'); await browser.close(); process.exit(1); }
+await field.fill('first-run-through-the-spa');
+
+// The SPA page asks for MORE than the legacy form did: a settings password and its confirmation, and the
+// submit button stays disabled until both are filled. The legacy form was label-only. That difference is the
+// whole reason this proof exists — the two pages are not the same flow.
+const pw = page.locator('input[type=password]');
+const pwCount = await pw.count();
+console.log('password fields on the SPA page:', pwCount, '(legacy form had 0)');
+for (let i = 0; i < pwCount; i++) await pw.nth(i).fill('a-long-enough-password');
+
+const submit = page.locator('button[type=submit], #submitBtn').first();
+console.log('submit enabled after filling:', await submit.isEnabled());
+await submit.click({ timeout: 20000 });
+// The first boot creates the default space and starts an index build, so "Setting up…" runs for a while.
+// A 5s wait screenshotted the spinner and reported NO TOKEN — which would have been a false alarm about the
+// one thing that matters here: whether the operator ever receives a token they can sign in with.
+for (let i = 0; i < 12; i++) {
+  await page.waitForTimeout(5000);
+  const t = await page.textContent('body');
+  if (/ythril_[A-Za-z0-9_-]+/.test(t ?? '')) { console.log(`token appeared after ~${(i + 1) * 5}s`); break; }
+  if (i === 11) console.log('no token after 60s');
+}
+await page.screenshot({ path: `${DIR}/fr-02-done.png` });
+
+const text = await page.textContent('body');
+const m = /ythril_[A-Za-z0-9_-]+/.exec(text ?? '');
+if (m) { writeFileSync(`${DIR}/token.txt`, m[0]); console.log('TOKEN ISSUED, written to token.txt'); }
+else console.log('NO TOKEN IN PAGE TEXT');
+
+const after = await (await fetch(`${BASE}/api/setup/status`)).json();
+console.log('setup status after:', JSON.stringify(after));
+console.log('console errors:', errs.length ? errs.slice(0, 4) : 'none');
+await browser.close();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **The legacy `/setup` HTML form, so the app's own first-run page is finally the one you see.** The
+  server-rendered form had been mounted at `/setup` since before the single-page app existed, and a server
+  route wins over an app route — so the app's setup page had never actually served a first run, on any
+  instance. The two were not the same flow either: the old form asked only for an instance label, while the
+  app's page also sets the **settings password** used for admin access later. Removing the mount is what makes
+  that page reachable. Because this is the path a brand-new instance starts on, the change was proven end to
+  end against a real first run rather than argued from the code: `/setup` now serves the app, setup completes,
+  the access token appears, and it works on the API. Nothing changes for an instance that is already
+  configured — the old form returned `404` there anyway — and `/api/setup` is untouched.
+
 ### Breaking
 
 - **A space request body with a key we do not recognise is now refused instead of silently ignored.** Four of

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -250,9 +250,21 @@ export function createApp() {
   // the /api/admin/ prefix (so admins can still toggle maintenance off).
   app.use(maintenanceMiddleware);
 
-  // ── Setup (first-run only) — JSON API ────────────────────────────────────
+  /**
+   * Setup (first-run only) — JSON API, and NOTHING at `/setup`.
+   *
+   * `setupRouter` used to be mounted twice: here at `/api/setup`, which is what the SPA polls for
+   * `configExists()`, and again at `/setup`, which served a server-rendered HTML form and `404`ed once the
+   * instance was configured. Express matches a mount before the SPA's index fallback, so that second line
+   * made the Angular `/setup` route unreachable — the legacy form was the LIVE first-run path and the SPA's
+   * own page had never served one.
+   *
+   * It was kept "for non-SPA access" from before the SPA existed. Removing it is deprecation 1.5, and the
+   * risk is the reason it waited: this is the unauthenticated boot path, and getting it wrong means an
+   * instance nobody can set up. So the removal ships with an end-to-end first-run proof rather than on the
+   * argument that the SPA route exists — it existed the whole time and was never reachable.
+   */
   app.use('/api/setup', setupRouter);
-  app.use('/setup', setupRouter);  // legacy HTML form (kept for non-SPA access)
 
   // ── Settings UI ──────────────────────────────────────────────────────────
   // Served by the Angular SPA — no server-rendered HTML routes here.

--- a/testing/integration/setup.test.js
+++ b/testing/integration/setup.test.js
@@ -36,11 +36,39 @@ describe('First-run setup gating', () => {
       `Setup endpoint should be 404 (or 429 rate-limited) after first run, got ${r.status}`);
   });
 
-  it('Setup GET returns 404 after first run', async () => {
+  it('GET /setup is the SPA now, and the SPA route is the one guarded', async () => {
+    // This asserted 404, which was the LEGACY HTML FORM's behaviour: `setupRouter` was mounted at `/setup`
+    // and refused once configured. That mount is gone (deprecation 1.5) because it shadowed the SPA's own
+    // first-run page — Express matches a mount before the index fallback, so the Angular route had never
+    // served a first run on any instance.
+    //
+    // `/setup` therefore behaves like every other SPA route: the shell is served and the app's `setupGuard`
+    // routes a configured instance away. A 200 here is the SPA shell, not an open setup page.
     const r = await fetch(`${INSTANCES.a}/setup`);
-    // 404 means setup is already complete; 429 means rate-limited (equally safe)
+    assert.ok(r.status === 200 || r.status === 429,
+      `GET /setup should serve the SPA shell after first run, got ${r.status}`);
+    if (r.status === 200) {
+      const body = await r.text();
+      assert.ok(body.includes('app-root'), 'the body must be the SPA shell');
+      assert.ok(!/name="settingsPassword"|id="submitBtn"/.test(body),
+        'the legacy server-rendered form must not come back');
+    }
+  });
+
+  it('the setup API itself still refuses once configured', async () => {
+    // The protection that actually matters, and the one the assertion above used to stand in for. It is on
+    // the JSON API, which is what both the SPA and any script would post to.
+    const status = await fetch(`${INSTANCES.a}/api/setup/status`);
+    assert.equal(status.status, 200);
+    assert.equal((await status.json()).configured, true, 'this instance is past first run');
+
+    const r = await fetch(`${INSTANCES.a}/api/setup`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ label: 'Attacker', settingsPassword: 'abc12345', settingsPasswordConfirm: 'abc12345' }),
+    });
     assert.ok(r.status === 404 || r.status === 429,
-      `Setup GET should be 404 (or 429 rate-limited) after first run, got ${r.status}`);
+      `POST /api/setup should be refused after first run, got ${r.status}`);
   });
 
   it('Root / redirects to /brain (post-setup)', async () => {

--- a/testing/standalone/setup-does-not-shadow-the-spa.test.js
+++ b/testing/standalone/setup-does-not-shadow-the-spa.test.js
@@ -1,0 +1,76 @@
+/**
+ * Nothing is mounted at `/setup`, so the SPA's own first-run page is reachable.
+ *
+ * ## Deprecation 1.5, and why it waited three releases
+ *
+ * `setupRouter` was mounted twice: at `/api/setup`, which is what the SPA polls for `configExists()`, and
+ * again at `/setup`, which served a server-rendered HTML form and `404`ed once configured. Express matches a
+ * mount before the SPA's index fallback, so the second line made the Angular `/setup` route **unreachable**.
+ * The legacy form was the live first-run path and the SPA's own page had never served one.
+ *
+ * It was kept "for non-SPA access" from before the SPA existed. Removing it is one line, and the risk is why
+ * it waited: this is the unauthenticated boot path, and getting it wrong means an instance nobody can set up.
+ *
+ * ## The two pages were NOT the same flow, which is what the proof found
+ *
+ * The legacy form asked for a label and nothing else. The SPA page asks for a label, a settings password and
+ * a confirmation, and keeps its submit disabled until all three are filled. So "the SPA route exists" was
+ * never evidence that removing the mount was safe — it collects different information and posts a different
+ * body.
+ *
+ * ## What was proven, end to end, against a genuine first run
+ *
+ * Config deleted and the database dropped, then through a browser at `/setup`:
+ *
+ *     GET /setup                  ->  200, and the response is the SPA shell, not the form
+ *     app-root present            ->  true
+ *     password fields             ->  2   (the legacy form had 0)
+ *     setup completes             ->  a token appears after ~15s
+ *     GET /api/setup/status       ->  configured: false  ->  true
+ *     the issued token            ->  200 on /api/tokens/me and /api/spaces
+ *
+ * The 15 seconds matter and are the reason this is not a five-second check: the first boot creates the
+ * default space and starts an index build, so the page sits on "Setting up…" for a while. A shorter wait
+ * reports NO TOKEN and looks exactly like the failure this test exists to catch.
+ *
+ * ## What this file can assert, and what it cannot
+ *
+ * A browser first-run cannot run here — that is the `verify` skill's scratch instance, and the recipe is in
+ * `scratchpad/verify/firstrun.mjs`. What is gated here is the thing that regresses silently: the mount coming
+ * back. A re-added `app.use('/setup', …)` would restore the shadow with no test failing anywhere else,
+ * because every other suite reaches setup through `/api/setup`.
+ *
+ * Run: node --test testing/standalone/setup-does-not-shadow-the-spa.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const APP = 'server/src/app.ts';
+/** Line comments first, then block — a block-open inside a line comment otherwise swallows real code. */
+const strip = (src) => src.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
+
+describe('the SPA owns /setup', () => {
+  const src = strip(readFileSync(APP, 'utf8'));
+
+  it('mounts the setup router on the API path only', () => {
+    const mounts = [...src.matchAll(/app\.use\(\s*'([^']*setup[^']*)'/g)].map(m => m[1]);
+    assert.deepEqual(mounts, ['/api/setup'],
+      `only /api/setup may be mounted; found ${JSON.stringify(mounts)} — a '/setup' mount shadows the SPA route`);
+  });
+
+  it('still serves the JSON API the SPA depends on', () => {
+    // The other direction: removing the shadow must not remove the endpoint the setup page polls. Without
+    // `/api/setup/status` the SPA cannot tell a first run from a configured instance at all.
+    assert.match(src, /app\.use\(\s*'\/api\/setup'\s*,\s*setupRouter\s*\)/);
+    const routes = strip(readFileSync('server/src/setup/routes.ts', 'utf8'));
+    assert.match(routes, /setupRouter\.get\('\/status'/, 'the SPA polls /api/setup/status');
+  });
+
+  it('the router still refuses a second setup once configured', () => {
+    // The guard that makes an unauthenticated route safe at all. It is unchanged by this removal, and it is
+    // the one thing that must not be lost while moving the entry point.
+    const routes = strip(readFileSync('server/src/setup/routes.ts', 'utf8'));
+    assert.match(routes, /configExists\(\)/, 'setup must still be first-run only');
+  });
+});


### PR DESCRIPTION
Deprecation **1.5**. One line, and it waited three releases for a reason.

`setupRouter` was mounted **twice**: at `/api/setup`, which the SPA polls for `configExists()`, and again at `/setup`, which served a server-rendered HTML form and 404'd once configured. Express matches a mount before the SPA's index fallback, so the second line made the Angular `/setup` route **unreachable**. The legacy form was the live first-run path and the SPA's own page had never served one, on any instance.

## The two pages were not the same flow

This is what the proof found, rather than what the tracker predicted. The legacy form asked for a **label and nothing else**. The SPA page asks for a label, a **settings password** and a confirmation, and keeps its submit disabled until all three are filled.

So *the SPA route exists* was never evidence that removing the mount was safe — it collects different information and posts a different body.

## Proven end to end against a genuine first run

Config deleted, database dropped. This is the unauthenticated boot path, and getting it wrong means an instance nobody can set up.

| check | result |
|---|---|
| `GET /setup` | 200, body is the SPA shell, not the form |
| `app-root` present | true |
| password fields | **2** (the legacy form had 0) |
| submit after filling | enabled |
| setup completes | token appears after ~15s |
| `/api/setup/status` | `configured: false` → `true` |
| the issued token | 200 on `/api/tokens/me` **and** `/api/spaces` |

**The fifteen seconds are worth recording.** The first boot creates the default space and starts an index build, so the page sits on *Setting up…* for a while. My first run waited five seconds, screenshotted the spinner and reported NO TOKEN — which looks exactly like the failure this exercise exists to catch. A proof that can produce a false alarm about the one thing that matters is not a proof, so the harness now polls to sixty.

The harness is saved beside the `verify` skill as `firstrun.mjs`: the next person to touch first-run needs the reset-to-first-run recipe more than they need my summary of it.

## The gate covers what regresses silently

The mount coming back. Every other suite reaches setup through `/api/setup`, so a re-added `app.use('/setup', …)` would restore the shadow with nothing failing anywhere. It also pins the two things that must survive the removal — `/api/setup/status`, which the SPA polls, and the `configExists()` guard that makes an unauthenticated route safe at all.

Nothing changes for a configured instance: the old form answered 404 there already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)