### PR TITLE
docs(recall): say which traversals still reach a record retired from ranking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the access token appears, and it works on the API. Nothing changes for an instance that is already
   configured — the old form returned `404` there anyway — and `/api/setup` is untouched.
 
+### Changed
+
+- **Retiring a record from semantic search says plainly that it is still reachable through its links.** The
+  setting removes a record's embedding, so it stops competing in recall's ranked results — but everything
+  that does not rank still reaches it, including recall's own graph expansion, which follows edges out of a
+  match and never looks at an embedding. The wording listed *traverse* among the readers that still see it,
+  which is true of both the traverse tool **and** recall's expansion and reads as neither: you had to already
+  know there were two before the word told you anything. Both the tool reference an agent reads while
+  building a call and the integration guide now name them separately and say the consequence outright — a
+  retired record stops competing on meaning, it does not disappear from the graph. **No behaviour changed**;
+  this is what it always did.
+
 ### Added
 
 - **A space administrator can now manage that space's tokens.** Until now "administers this space" was only

--- a/docs/integration-guide/04-brain-api.md
+++ b/docs/integration-guide/04-brain-api.md
@@ -694,8 +694,18 @@ The consequence is worth stating plainly, because it is the reason to choose thi
 
 | reader | sees an excluded record? |
 |---|---|
-| `recall`, `find_similar`, duplicate/contradiction scans | **no**, and there is no parameter that asks for it back |
-| `GET`/`PATCH` by id, `query`, `list`, `traverse`, exports | **yes**, unchanged and complete |
+| `recall`'s ranked results, `find_similar`, duplicate/contradiction scans | **no**, and there is no parameter that asks for it back |
+| `GET`/`PATCH` by id, `query`, `list`, exports | **yes**, unchanged and complete |
+| the `traverse` tool | **yes** |
+| **`recall(traverse: n)` — the graph expansion** | **yes** |
+
+That last row is the one people ask about, so it is spelled out rather than folded into "traverse". Recall's
+own expansion walks **edges** out of a match: it never consults a vector, so an excluded record is reached
+exactly as it always was and appears in `_graph` like any other neighbour.
+
+**A record retired from ranking is therefore still findable through its relationships.** It stops competing on
+meaning; it does not disappear from the graph. That is usually the point — a record that would otherwise crowd
+recall stays reachable from the things that reference it.
 
 So an audit that must include retired records has to be a **structured read**, not a recall. If you point a
 semantic search at retired records today by applying a filter you control, the flag will not reproduce that

--- a/server/src/mcp/tools/shared.ts
+++ b/server/src/mcp/tools/shared.ts
@@ -30,14 +30,29 @@ export const TTL_DAYS_SCHEMA = {
  * The semantics are stated in the description rather than left to the field name, because "excluded from
  * vector search" reads like a query-time filter and is not one: the vector is REMOVED. Recall cannot reach
  * the record even deliberately; structured reads still return it in full.
+ *
+ * ## "traverse" was ambiguous, and the ambiguity cost a question
+ *
+ * The description used to list `traverse` among the things that still reach an excluded record, which is
+ * true of BOTH traversals and reads as neither. Owner, 2026-08-15: *"excludefromvector does also exclude
+ * from recalls traversal? ambigous and i want entries to be findable via traversal even if they are not
+ * embedded themselves."*
+ *
+ * The answer is no, and the reason is structural rather than a policy anyone chose: recall's `traverse`
+ * expansion walks EDGES out of a match, so it never consults a vector, and `recall-graph.ts` filters on
+ * nothing but the edge. So both the `traverse` tool and `recall(traverse: n)` reach an excluded record.
+ * Saying which two is what the sentence was missing — a reader had to already know there were two.
  */
 export const EXCLUDE_FROM_VECTOR_SEARCH_SCHEMA = {
   type: 'boolean',
   description:
-    'Retire this record from semantic search (true), or return it to it (false). Implemented as the ABSENCE '
-    + 'of a vector, NOT a query-time filter: an excluded record cannot be reached by recall even '
-    + 'deliberately, while query, traverse, list and get still return it unchanged. Toggling back to false '
-    + 're-embeds it. May be the only field you send — retiring a record is a complete edit in itself.',
+    'Retire this record from semantic RANKING (true), or return it to it (false). Implemented as the ABSENCE '
+    + 'of a vector, NOT a query-time filter: an excluded record cannot be RANKED by recall even '
+    + 'deliberately, because there is no vector to rank. Everything that does not rank still reaches it in '
+    + 'full — query, list, get, the `traverse` tool, AND recall\'s own `traverse` expansion, which walks '
+    + 'edges out of a match and never consults a vector. So a record excluded here is still findable through '
+    + 'its relationships; it just stops competing on meaning. Toggling back to false re-embeds it. May be the '
+    + 'only field you send — retiring a record is a complete edit in itself.',
 } as const;
 
 /**

--- a/testing/standalone/exclusion-does-not-hide-from-traversal.test.js
+++ b/testing/standalone/exclusion-does-not-hide-from-traversal.test.js
@@ -1,0 +1,75 @@
+/**
+ * A record retired from semantic ranking is still reachable through its edges — including by recall's own
+ * `traverse` expansion — and every surface that says so must keep saying it.
+ *
+ * ## The question this exists because of
+ *
+ * Owner, 2026-08-15: *"excludefromvector does also exclude from recalls traversal? ambigous and i want
+ * entries to be findable via traversal even if they are not embedded themselves."*
+ *
+ * The answer is no, and it is structural rather than a policy anyone chose: `excludeFromVectorSearch` is
+ * implemented as the ABSENCE of a vector (`brain/embed-record.ts`), not as a query-time filter. Recall's
+ * `traverse` expansion walks EDGES out of a match, so it never consults a vector, and `recall-graph.ts`
+ * filters on nothing but the edge.
+ *
+ * ## Why the question had to be asked at all
+ *
+ * The schema description listed `traverse` among the readers that still reach an excluded record. That is
+ * true of BOTH traversals — the `traverse` tool and `recall(traverse: n)` — and reads as neither, because a
+ * reader has to already know there are two before the word tells them anything.
+ *
+ * `help()` says the tool schema is the authoritative reference, and CLAUDE.md records what a stale sentence
+ * there already cost: aigents read *"filter applied after vector search"*, believed it, and built a skill
+ * that avoided filtered recall. An ambiguous sentence is cheaper than a wrong one and not by much.
+ *
+ * ## What is gated
+ *
+ * That the behaviour stays absent from the read path — no query-time filter creeping in — and that both
+ * surfaces keep naming both traversals. A doc that stops saying it is how the question gets asked again.
+ *
+ * Run: node --test testing/standalone/exclusion-does-not-hide-from-traversal.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const read = (p) => readFileSync(p, 'utf8');
+/** Line comments first, then block — a block-open inside a line comment otherwise swallows real code. */
+const strip = (src) => src.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
+
+describe('the exclusion is a missing vector, never a read-time filter', () => {
+  it('the graph walk does not consult the flag', () => {
+    // If this ever grew a filter on `excludeFromVectorSearch`, an excluded record would silently vanish from
+    // `_graph` — the exact behaviour the owner asked us NOT to have, and invisible from any single result.
+    const src = strip(read('server/src/brain/recall-graph.ts'));
+    assert.doesNotMatch(src, /excludeFromVectorSearch/,
+      'traversal must reach an excluded record; it walks edges and must not read the flag');
+  });
+
+  it('only the embed path reads it, which is what makes it a missing vector', () => {
+    // One writer, no readers. The flag has meaning exactly once — when deciding whether to store a vector.
+    const embed = strip(read('server/src/brain/embed-record.ts'));
+    assert.match(embed, /excludeFromVectorSearch/, 'the embed path is where the flag is honoured');
+    assert.match(embed, /\$unset/, 'setting it must REMOVE the vector, not mark the record');
+  });
+});
+
+describe('both surfaces name both traversals', () => {
+  // "traverse" alone is the ambiguity that produced the question. Each surface has to distinguish the tool
+  // from recall's expansion, in whatever words it uses.
+  it('the MCP schema description does', () => {
+    const d = read('server/src/mcp/tools/shared.ts');
+    assert.match(d, /traverse` tool/, 'name the traverse TOOL');
+    assert.match(d, /traverse` expansion/, "name recall's own expansion");
+    assert.match(d, /walks\s*'?\s*\+?\s*'?edges|walks edges/,
+      'say WHY it still reaches — it walks edges and never consults a vector');
+  });
+
+  it('the integration guide does', () => {
+    const g = read('docs/integration-guide/04-brain-api.md');
+    assert.match(g, /recall\(traverse: n\)/, 'the guide must name recall.s expansion explicitly');
+    assert.match(g, /the `traverse` tool/, 'and the tool, as a separate row');
+    assert.match(g, /still findable through its relationships/i,
+      'state the consequence, which is the half the owner actually wanted');
+  });
+});


### PR DESCRIPTION
Owner, 2026-08-15:

> excludefromvector does also exclude from recalls traversal? ambigous and i want entries to be findable via
> traversal even if they are not embedded themselves

**The answer is no, and the behaviour is already what you want.** This PR changes no behaviour — it makes the
two surfaces say so.

## Why the question had to be asked

The schema description listed `traverse` among the readers that still reach an excluded record. That is true
of **both** traversals — the `traverse` tool and `recall(traverse: n)` — and reads as neither, because you
have to already know there are two before the word tells you anything.

`help()` says the tool schema is the authoritative reference, and it is read *while arguments are being
constructed*. CLAUDE.md records what a stale sentence there already cost: aigents read *"filter applied after
vector search"*, believed it, and built a skill that deliberately avoided filtered recall. An ambiguous
sentence is cheaper than a wrong one, and not by much.

## What is actually true, from source

`excludeFromVectorSearch` is implemented as the **absence of a vector** (`brain/embed-record.ts`), not as a
query-time filter. Recall's `traverse` expansion walks **edges** out of a match, so it never consults a
vector, and `recall-graph.ts` filters on nothing but the edge.

So a record retired from ranking is still reached by:

| reader | sees it? |
|---|---|
| `recall`'s ranked results, `find_similar`, dupe/contradiction scans | no |
| `GET`/`PATCH` by id, `query`, `list`, exports | yes |
| the `traverse` tool | yes |
| **`recall(traverse: n)` — the graph expansion** | **yes** |

It stops competing on meaning; it does not disappear from the graph. That is usually the point — a record that
would otherwise crowd recall stays reachable from the things that reference it.

## The gate

Two halves, because the doc and the code can drift apart in either direction:

- **The behaviour**: `recall-graph.ts` must not read the flag, and `embed-record.ts` must `$unset` the vector
  rather than mark the record. One writer, no readers, is what makes it a missing vector instead of a filter.
- **The wording**: both the MCP schema and the integration guide must name **both** traversals separately, and
  say the consequence — a doc that stops saying it is how the question gets asked again.

`npm run preflight` green. Filed as X-1; the broader naming problem — `excludeFromVectorSearch` and
`suppressEmbeddings` being one mechanism under two names at different tiers — stays open, since a rename of a
stored field is a migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
