### PR TITLE
docs(recall): the tool schema documents its response, and the traps in four params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`recall` now documents what it gives back, not only what it takes.** Its tool reference described every
+  parameter and nothing about the response, so the one thing that fails silently was invisible: the inline
+  answer is capped by **size**, and it is a cliff rather than a gentle limit — around 25 results come back in
+  full, 30 can come back as three. A caller asking for eighty and reading only the results list is working
+  from a handful of records with no error anywhere. The reference now names `truncated` and `complete`, says
+  `count` excludes anything reached by a graph walk, and warns that a result with no edges carries no `_graph`
+  at all — so reading the first result and concluding the feature is missing is the mistake to avoid. Three
+  parameters also gained the trap that makes their behaviour readable: relationships are searchable records
+  and compete for your result slots; the query is tokenised as well as embedded, which is why an exact
+  reference number survives a question written as a sentence; and the minimum-score filter gates on the
+  vector score alone, before the reranker sees anything. First of the tools to be brought to this standard.
+
 - **Retiring a record from semantic search says plainly that it is still reachable through its links.** The
   setting removes a record's embedding, so it stops competing in recall's ranked results — but everything
   that does not rank still reaches it, including recall's own graph expansion, which follows edges out of a

--- a/server/src/mcp/tools/search.ts
+++ b/server/src/mcp/tools/search.ts
@@ -56,22 +56,28 @@ export function resolveFindSimilarScope(
 
 export const recallTool: ToolHandler = {
   name: 'recall',
-  description: 'Search all knowledge types (memories, entities, edges, chrono entries, files) by MEANING and by exact tokens: a semantic vector ranking is fused with a lexical (BM25) ranking, so identifiers such as article numbers or form ids rank even though their embeddings carry little meaning. A cross-encoder refines the top candidates when the operator has configured one. Searches the specified space if provided, otherwise across all accessible spaces. Results carry `score` (vector similarity); `minScore` filters on that score only, never on the fused or rerank ordering. The per-stage scores are deliberately omitted here to keep responses small — the REST endpoint returns them for debugging.',
+  description: 'Search all knowledge types (memories, entities, edges, chrono entries, files) by MEANING and by exact tokens: a semantic vector ranking is fused with a lexical (BM25) ranking, so identifiers such as article numbers or form ids rank even though their embeddings carry little meaning. A cross-encoder refines the top candidates when the operator has configured one. Searches the specified space if provided, otherwise across all accessible spaces.\n\n'
+    + 'THE RESPONSE, because knowing the parameters is only half of it:\n'
+    + '• `results` — the ranked matches. Each carries `_id`, its name/fact/title, type, tags, properties, `spaceId`, timestamps, `seq`, `matchedText` and `score` (vector similarity). The per-stage `lexicalScore`/`fusedScore`/`rerankScore` are omitted HERE to keep responses small; the REST endpoint returns them for debugging.\n'
+    + '• `count` — the number of MATCHES. Traversed nodes are NOT counted in it.\n'
+    + '• `graphNodes` — an integer COUNT of what a traversal reached, not the content. The content is nested per-result under `_graph`, and a result with no edges simply has no `_graph` at all: reading `results[0]` and concluding the feature is absent is the mistake to avoid.\n'
+    + '• `truncated` + `complete` — THE ONE THAT BITES. The inline answer is capped by SIZE, not by count, and it is a cliff rather than a slope: around 25 results answer in full and 30 can come back as three. When it spills, `truncated: true` is set and `complete` carries {matches, records, inline, path, download, expiresAt} — the full set written to the space as JSON, with an authenticated download valid one day. A caller that asks for topK 80 and reads only `results` is silently working from a handful of records. Read `truncated` before you trust the length.\n'
+    + '• `graphTruncated` + `graphComplete` — the same arrangement for an oversized neighbourhood, so a short graph is never silent either.',
   inputSchema: (s: ToolSchemas) => ({
           type: 'object',
           properties: {
             space: s.optionalSpace,
-            query: { type: 'string', minLength: 1, description: 'Natural language search query (required, non-empty).' },
-            topK: { type: 'number', minimum: 1, default: 10, description: 'Max results to return. Default 10; no hard cap, but very large values are slower.' },
+            query: { type: 'string', minLength: 1, description: 'REQUIRED, non-empty. The natural-language search string. It is EMBEDDED for the vector half and TOKENISED for the BM25 half, so it does double duty — which is why an exact identifier (an article number, a form id) survives a query written as a sentence.' },
+            topK: { type: 'number', minimum: 1, default: 10, description: 'Max results to return. Default 10; no hard cap. It is filled from records that SATISFY `filter` — never applied to an already-truncated shortlist — so a filtered recall cannot silently miss a matching record. Large values are slower, and every field of every result is paid for in tokens. Note the response cap: past roughly 25 results the answer spills and `truncated` is set, so asking for 80 does not return 80 inline.' },
             tags: { type: 'array', items: { type: 'string' }, description: 'Optional tag filter — only results bearing ALL of these tags are returned (applies to memories, entities, chrono entries, and files).' },
             types: {
               type: 'array',
               items: { type: 'string', enum: ['memory', 'entity', 'edge', 'chrono', 'file'] },
-              description: 'Optional knowledge-type filter — restrict results to one or more types. Omit to search all types.',
+              description: 'Optional knowledge-type filter — restrict results to one or more types. Omit to search all five. EDGES ARE SEARCHABLE RECORDS and compete for your topK: a topK 20 on a persona space came back with 2 of them, so structural relationships displace knowledge unless you exclude them here.',
             },
             minPerType: {
               type: 'object',
-              description: 'Optional minimum result count per type. Guarantees at least that many results of each type if available (e.g. {"entity": 2, "edge": 1}). Omit to use pure score ranking.',
+              description: 'Optional minimum result count per type — a FLOOR. Guarantees at least that many results of each type if available (e.g. {"entity": 2, "edge": 1}). Omit to use pure score ranking. This is the cheap fix for one type crowding out another: memories are numerous and score well, so principles and entities lose slots to them without a floor.',
               additionalProperties: { type: 'number' },
             },
             maxPerType: {
@@ -84,7 +90,7 @@ export const recallTool: ToolHandler = {
               minimum: 1,
               description: 'Optional deadline for this recall, in milliseconds. It can only LOWER the instance budget, never raise it, and is clamped to a small floor so a tiny value is not a guaranteed empty answer. On expiry you get a PARTIAL answer rather than an error or a hang: whichever collections finished are returned, and the response says it degraded. Use it when a slow recall would cost more than a thin one — a memory that can only ever delay you by a known amount is one you can put in a workflow.',
             },
-            minScore: unitScoreSchema('Minimum cosine similarity score (0.0–1.0). Results below this threshold are excluded.'),
+            minScore: unitScoreSchema('Minimum COSINE SIMILARITY (0.0–1.0). It filters on `score` ONLY — never on the fused or the reranked ordering — so it is a vector-side gate rather than a relevance gate, and a result the reranker would have promoted can be cut by it before the reranker sees it.'),
             includeFreshWrites: { type: 'boolean', default: false, description: 'Also scan the newest records straight from the collection, so a record written seconds ago is findable before the vector index has ingested it. Costs an extra scan per knowledge type — turn it on when searching for something you just wrote, not by default.' },
             includeContent: {
               type: 'boolean',

--- a/testing/standalone/recall-schema-documents-its-response.test.js
+++ b/testing/standalone/recall-schema-documents-its-response.test.js
@@ -1,0 +1,84 @@
+/**
+ * `recall`'s tool schema documents its RESPONSE, not only its parameters.
+ *
+ * ## The standard this is the first instance of
+ *
+ * Owner, 2026-08-15, supplying a fully-written `recall` schema as the template: *"each endpoint should have a
+ * descriptions like: … else its really hard to discover the right options."* X-2 is rolling that across ~40
+ * tools; this file gates the properties that make it a standard rather than more prose, on the one tool that
+ * has been done.
+ *
+ * ## Why the response half is the half that was missing
+ *
+ * Every parameter had a description already. Nothing described what came back — so `truncated` and `complete`
+ * were undocumented on the surface an agent reads while writing the call, and the failure mode is silent:
+ * the inline answer is capped by SIZE and it is a cliff, not a slope. Around 25 results answer in full and 30
+ * can come back as three. A caller asking for topK 80 and reading only `results` is working from a handful
+ * of records with no error anywhere. Three flows in the fleet were doing exactly that.
+ *
+ * `help()` tells callers the tool schema IS the authoritative reference, and CLAUDE.md records what a stale
+ * sentence there already cost: aigents read *"filter applied after vector search"*, believed it, and built a
+ * skill that avoided filtered recall.
+ *
+ * ## What is asserted
+ *
+ * Not prose quality — the specific facts a caller cannot recover by experiment without being misled. Each of
+ * these was either absent or, in the `types` case, absent in a way that made a real result look like a bug.
+ *
+ * Run: node --test testing/standalone/recall-schema-documents-its-response.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const SRC = readFileSync('server/src/mcp/tools/search.ts', 'utf8');
+/** The `recall` tool object: from its name to the next tool's, so a later tool cannot satisfy these. */
+const RECALL = (() => {
+  const at = SRC.indexOf("name: 'recall'");
+  assert.ok(at > 0, "the recall tool was not found — the scanner is wrong, not the code");
+  const next = SRC.indexOf("name: '", at + 20);
+  return next === -1 ? SRC.slice(at) : SRC.slice(at, next);
+})();
+
+describe('the response is documented, not just the request', () => {
+  it('warns that the inline answer is capped and names the flag to read', () => {
+    // The silent failure: asking for 80 and getting a handful, with no error. A caller has to know to look.
+    assert.match(RECALL, /truncated/, '`truncated` must be named');
+    assert.match(RECALL, /complete/, '`complete` must be named');
+    assert.match(RECALL, /cliff|capped by SIZE|not by count/i,
+      'say it is a size cliff rather than a gentle limit — 25 answers in full, 30 can return three');
+  });
+
+  it('says `count` excludes traversed nodes', () => {
+    assert.match(RECALL, /count[^.]{0,80}MATCHES/,
+      '`count` counts matches; a caller comparing it to `graphNodes` needs to know that');
+  });
+
+  it('says `graphNodes` is a number and `_graph` is the content', () => {
+    assert.match(RECALL, /graphNodes/, '`graphNodes` must be named');
+    assert.match(RECALL, /no `_graph`|has no `_graph`/,
+      'a result with no edges has NO `_graph` — reading results[0] and concluding the feature is missing is the trap');
+  });
+});
+
+describe('the parameters carry their traps', () => {
+  it('types: edges are searchable records and compete for topK', () => {
+    assert.match(RECALL, /EDGES ARE SEARCHABLE RECORDS/,
+      'a topK 20 returning 2 edges looks like a bug until you know this');
+  });
+
+  it('query: it is tokenised for BM25 as well as embedded', () => {
+    assert.match(RECALL, /TOKENISED/,
+      'this is why an exact identifier survives a query written as a sentence');
+  });
+
+  it('topK: it is filled from records that SATISFY the filter', () => {
+    assert.match(RECALL, /SATISFY/,
+      'a filtered recall cannot silently miss a match — the opposite belief is what made aigents avoid filters');
+  });
+
+  it('minScore: it gates on the vector score only, before the reranker', () => {
+    assert.match(RECALL, /vector-side gate/,
+      'it is not a relevance gate, and a result the reranker would promote can be cut before it is seen');
+  });
+});


### PR DESCRIPTION
X-2, first tool. Your `recall` template, applied to the tool it describes.

## The response half was the half that was missing

Every parameter already had a description. **Nothing described what comes back** — so the one thing that fails
silently was invisible on the surface an agent reads while writing the call:

> the inline answer is capped by **size**, and it is a cliff rather than a slope — around 25 results answer in
> full, 30 can come back as three

A caller asking for topK 80 and reading only `results` is working from a handful of records, with no error
anywhere. Three flows in the fleet were doing exactly that.

The schema now names `truncated` and `complete`, says `count` excludes traversed nodes, and warns that a
result with no edges carries **no `_graph` at all** — so reading `results[0]` and concluding the feature is
absent is the mistake to pre-empt.

## Four parameters gained the trap that makes them readable

| parameter | what was missing |
|---|---|
| `types` | **edges are searchable records** and compete for topK — a topK 20 returning 2 of them looks like a bug until you know |
| `query` | it is **tokenised for BM25** as well as embedded, which is why an exact identifier survives a query written as a sentence |
| `topK` | it is filled from records that **satisfy** the filter — the opposite belief is what made aigents avoid filtered recall entirely |
| `minScore` | it gates on the **vector score alone**, before the reranker, so a result the reranker would promote can be cut before it is seen |

`minPerType` also now says what it is *for*: memories are numerous and score well, so principles and entities
lose slots to them without a floor.

## Why a gate and not just better prose

`help()` tells callers the tool schema **is** the authoritative reference. CLAUDE.md records what a stale
sentence there already cost: aigents read *"filter applied after vector search"*, believed it, and built a
skill that deliberately avoided filtered recall.

So the test asserts the specific facts a caller cannot recover by experiment without being misled — the size
cliff, `count` vs `graphNodes`, the absent `_graph`, and the four traps above. It scopes itself to the
`recall` tool object so a later tool in the same file cannot satisfy them by accident.

7 tests, `npm run preflight` green. ~39 tools remain; `todo/_MCP-SCHEMA-TEMPLATE.md` carries the standard and
the order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
