### PR TITLE
docs(query): say what it is FOR, and what a page of results means

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`query` now says what it is *for*, and what a page of results means.** Its whole description was one
+  line — what it does, never when to choose it. It is the exact counterpart to `recall`: a predicate and
+  every row that satisfies it, with no embedding, no ranking and no score, and it reaches records `recall`
+  cannot, since a record retired from semantic ranking has no vector to rank. The reference now says that,
+  and explains the pair of numbers that come back: `count` is this page, `total` is everything matching the
+  filter, and the gap between them is the only signal that there is more to page through — a full page is not
+  evidence of being the last one. It also warns that a positive count with no rows means an instance older
+  than this release, so an agent recognises the shape instead of concluding a space is empty.
+
 - **`recall` now documents what it gives back, not only what it takes.** Its tool reference described every
   parameter and nothing about the response, so the one thing that fails silently was invisible: the inline
   answer is capped by **size**, and it is a cliff rather than a gentle limit — around 25 results come back in

--- a/server/src/mcp/tools/search.ts
+++ b/server/src/mcp/tools/search.ts
@@ -415,7 +415,13 @@ export const find_similarTool: ToolHandler = {
 
 export const queryTool: ToolHandler = {
   name: 'query',
-  description: 'Run a structured read-only query (MongoDB filter) against brain collections.',
+  description: 'Run a structured read-only query (MongoDB filter) against brain collections. This is the EXACT counterpart to `recall`: no embedding, no ranking, no score — a predicate, and every row that satisfies it. Reach for it when you know what you are looking for, and for `recall` when you know what it is about.\n\n'
+    + 'It also reaches records `recall` cannot: a record retired from semantic ranking has no vector, and this reads the collection.\n\n'
+    + 'THE RESPONSE:\n'
+    + '• `results` — the matching documents, `embedding` always stripped. Ordered seq/updatedAt/createdAt descending unless you pass `sort`.\n'
+    + '• `count` — how many rows are in THIS page. `total` — how many satisfy the filter overall. They differ whenever `limit` bit, and that difference is the only signal that there is more to page through.\n'
+    + '• `limit`, `skip` — echoed back, so a pager can carry on without keeping its own state.\n\n'
+    + 'A count with no rows is a BUG, not an empty page: `results` is carried in both `content` and `structuredContent`, and a client that reads only one of them gets the whole answer either way. Before 3.1 the rows were in `content` alone, so a client preferring `structuredContent` saw {"count":15,"total":40} and not a single row — reported independently by breituai-platform and reproduced here. If you ever see a positive `count` with nothing in it, the instance predates that fix.',
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({
           type: 'object',
@@ -432,9 +438,9 @@ export const queryTool: ToolHandler = {
             },
             projection: {
               type: 'object',
-              description: 'Fields to include (1) or exclude (0). The `embedding` field is always excluded and cannot be re-included.',
+              description: 'Fields to include (1) or exclude (0). The `embedding` field is always excluded and cannot be re-included. Worth using rather than skipping: a bare query over a dozen records with full bodies is the cheapest way to overrun a token budget, and a projection of the four fields you actually branch on turns that into a page you can read.',
             },
-            limit: { type: 'number', minimum: 1, maximum: 100, default: 20, description: 'Max documents to return (clamped to 1–100). Default 20.' },
+            limit: { type: 'number', minimum: 1, maximum: 100, default: 20, description: 'Max documents in this page, clamped to 1–100. Default 20. Compare `count` against `total` in the response to know whether more rows satisfy the filter — a full page is not evidence that it is the last one.' },
             skip: { type: 'number', minimum: 0, description: 'Rows to discard before the page, for paging. The result order is total (`_id` breaks every tie), so no row can be seen twice or missed between pages. On a proxy space the page is computed over the MERGED set, not per member.' },
             sort: { type: 'string', description: 'Field to order by. Allowed values depend on the collection (entities: createdAt, name, type; edges: createdAt, label, from, to, type, weight; memories: createdAt, type; chrono: createdAt, title, startsAt, endsAt, status, type; files: createdAt, updatedAt, path). An unknown field is refused and names the allowed ones. Omit for newest-first.' },
             dir: { type: 'string', enum: ['asc', 'desc'], description: "Sort direction, default desc. Only meaningful with `sort`." },

--- a/testing/standalone/search-tool-schemas-document-their-response.test.js
+++ b/testing/standalone/search-tool-schemas-document-their-response.test.js
@@ -61,6 +61,45 @@ describe('the response is documented, not just the request', () => {
   });
 });
 
+/** The `query` tool object, scoped the same way. */
+const QUERY = (() => {
+  const at = SRC.indexOf("name: 'query'");
+  assert.ok(at > 0, 'the query tool was not found — the scanner is wrong, not the code');
+  const next = SRC.indexOf("name: '", at + 20);
+  return next === -1 ? SRC.slice(at) : SRC.slice(at, next);
+})();
+
+describe('query says what it is FOR and what comes back', () => {
+  it('positions it against recall rather than describing it in isolation', () => {
+    // "Run a structured read-only query" told a caller what it does and never when to choose it. The pairing
+    // is the discoverable fact: a predicate versus a ranking.
+    assert.match(QUERY, /counterpart to `recall`/, 'say which tool it is the opposite of');
+    assert.match(QUERY, /no embedding, no ranking, no score/,
+      'name what it does NOT do — that is the choice a caller is making');
+  });
+
+  it('says count is the page and total is the filter', () => {
+    // The difference between them is the only signal that more rows exist. A full page is not evidence of
+    // being the last one, and nothing said so.
+    assert.match(QUERY, /`count`[^.]{0,120}THIS page/, '`count` is this page');
+    assert.match(QUERY, /`total`[^.]{0,120}overall/, '`total` is the whole filter');
+  });
+
+  it('warns that a count with no rows means a pre-3.1 instance', () => {
+    // The defect breituai-platform reported and I reproduced: rows in `content` only, so a client preferring
+    // `structuredContent` saw the metadata and no results. Fixed in #911 — but an agent talking to an older
+    // instance needs to recognise the shape rather than conclude the space is empty.
+    assert.match(QUERY, /count with no rows is a BUG/i,
+      'an empty page and a dropped payload look identical without this sentence');
+    assert.match(QUERY, /structuredContent/, 'name the field, since that is what a client branches on');
+  });
+
+  it('says it reaches records recall cannot', () => {
+    assert.match(QUERY, /retired from semantic ranking/,
+      'a record with no vector is exactly what a structured read is for');
+  });
+});
+
 describe('the parameters carry their traps', () => {
   it('types: edges are searchable records and compete for topK', () => {
     assert.match(RECALL, /EDGES ARE SEARCHABLE RECORDS/,


### PR DESCRIPTION
X-2, second tool.

`query`'s entire description was one line — *"Run a structured read-only query (MongoDB filter) against brain
collections."* It said what the tool does and never when to choose it, and nothing at all about what comes
back.

## What it is FOR

It is the exact counterpart to `recall`: a **predicate** and every row that satisfies it — no embedding, no
ranking, no score. Reach for it when you know what you are looking for, and for `recall` when you know what it
is *about*.

It also reaches records `recall` cannot. A record retired from semantic ranking has no vector, so ranking can
never surface it; a structured read is exactly the tool for that, and nothing said so.

## The pair of numbers that come back

`count` is **this page**. `total` is **everything matching the filter**. The gap between them is the only
signal that there is more to page through — a full page is not evidence of being the last one, and a caller
with no `total` has no way to tell.

`limit` and `projection` gained the same treatment: compare `count` to `total` rather than trusting a full
page, and a projection of the four fields you branch on is the difference between a readable page and an
overrun token budget.

## The shape that means "old instance"

A positive `count` with no rows is a **bug**, not an empty page. Before this release the rows lived in
`content` alone, so a client that prefers `structuredContent` saw `{"count":15,"total":40}` and not a single
row — reported independently by breituai-platform and reproduced here through this very connection. #911 fixed
it by carrying `results` in both.

An agent talking to an older instance needs to recognise that shape rather than conclude the space is empty,
so the schema now says it outright.

## Verification

The gate grew from 7 assertions to 11 and was renamed, since it now covers two tools. Each new one pins a fact
a caller cannot recover by experiment without being misled — most sharply the count-with-no-rows case, where
an empty page and a dropped payload are indistinguishable without being told.

`npm run preflight` green. ~38 tools remain; `todo/_MCP-SCHEMA-TEMPLATE.md` carries the standard and the order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
