### PR TITLE
docs(find_similar): name the two ways it comes back empty for a reason that is not 'nothing is similar'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`find_similar` now names the two ways it can come back empty for a reason that is not "nothing is
+  similar".** It compares against a record's **stored** embedding rather than working from a query, which has
+  two consequences that were nowhere in its reference: a source record that has been retired from semantic
+  ranking has no embedding at all, so there is nothing to compare from and the answer is empty; and a record
+  written moments ago may not be indexed yet, with no way to ask for it anyway, because the source's own
+  embedding has to exist before the search can start. Both used to look like a finding. The minimum-score
+  setting also now says that it means something **different** here than on `recall` — similarity is the only
+  ranking in this tool, so raising it narrows the answer honestly, and near-duplicates sit well above 0.9. And
+  the type of the source record is distinguished from the types you want back: a memory can legitimately be
+  most similar to an entity.
+
 - **`query` now says what it is *for*, and what a page of results means.** Its whole description was one
   line — what it does, never when to choose it. It is the exact counterpart to `recall`: a predicate and
   every row that satisfies it, with no embedding, no ranking and no score, and it reaches records `recall`

--- a/server/src/mcp/tools/search.ts
+++ b/server/src/mcp/tools/search.ts
@@ -292,14 +292,19 @@ export const recallTool: ToolHandler = {
 
 export const find_similarTool: ToolHandler = {
   name: 'find_similar',
-  description: 'Find entries with high vector similarity to an existing entry. Use for deduplication, "more like this", and merge detection. Uses the entry\'s stored embedding — no re-embedding. Provide `space` to scope to one space, or omit it to search across all accessible spaces (like recall).',
+  description: 'Find entries with high vector similarity to an EXISTING entry — deduplication, "more like this", merge detection. It uses that entry\'s STORED embedding rather than re-embedding anything, which is what separates it from `recall`: no query string, no BM25 half, no reranker. Pure cosine distance from one record to the rest.\n\n'
+    + 'Two consequences of using the stored vector, and both are silent if you do not know them:\n'
+    + '• A source entry retired from semantic ranking has NO vector, so there is nothing to be similar to and the answer is empty — not an error, and not evidence that nothing resembles it.\n'
+    + '• A record written seconds ago may not be indexed yet. There is no `includeFreshWrites` here as there is on `recall`, because the source entry\'s own embedding has to exist before this can start.\n\n'
+    + 'Provide `space` to scope to one space, or omit it to search every space the token can reach. `score` is raw cosine similarity — the same number `recall` reports, but here it is the ONLY ranking, so `minScore` is a genuine relevance gate rather than the vector-side gate it is on `recall`.\n\n'
+    + 'With `traverse: 0` the answer is a plain-text summary; above 0 it is JSON, because a graph does not summarise.',
   spaceRequired: false,
   inputSchema: (s: ToolSchemas) => ({
           type: 'object',
           properties: {
             space: s.optionalSpace,
-            entryId: uuidSchema('UUID v4 of the source entry.'),
-            entryType: { type: 'string', enum: ['memory', 'entity', 'edge', 'chrono', 'file'], description: 'Knowledge type of the source entry.' },
+            entryId: uuidSchema('UUID v4 of the source entry — the record everything else is compared AGAINST. It is never itself in the results.'),
+            entryType: { type: 'string', enum: ['memory', 'entity', 'edge', 'chrono', 'file'], description: 'Knowledge type of the SOURCE entry, which is how the id is resolved — a wrong type is a not-found rather than a wrong answer. It does not constrain what comes back: use `targetTypes` for that, and note a memory can legitimately be most similar to an entity.' },
             includeContent: { type: 'boolean', default: true, description: 'Whether to return each file chunk’s `content` (default true). Same meaning as on `recall`: false returns locations and metadata only.' },
             targetTypes: {
               type: 'array',
@@ -307,7 +312,7 @@ export const find_similarTool: ToolHandler = {
               description: 'Which knowledge types to search in. Omit to search all types.',
             },
             topK: { type: 'number', minimum: 1, maximum: 100, default: 10, description: 'Max results to return (clamped to 1–100). Default 10.' },
-            minScore: unitScoreSchema('Minimum cosine similarity threshold (0.0–1.0). Results below this are excluded.'),
+            minScore: unitScoreSchema('Minimum cosine similarity (0.0–1.0). Results below it are excluded. Unlike on `recall`, this IS the relevance gate — cosine distance is the only ranking here, so raising it narrows the answer honestly rather than cutting candidates a reranker would have rescued. For deduplication, start high: near-duplicates sit well above 0.9 and everything below that is a topic match rather than a repeat.'),
             traverse: {
               type: 'number', minimum: 0, maximum: MAX_RECALL_TRAVERSE, default: 0,
               description: `Optional graph-expansion depth (integer 0–${MAX_RECALL_TRAVERSE}, default 0). When > 0, each similar match is expanded along knowledge-graph edges up to this many hops and what the walk reached is NESTED under the match that reached it in a \`_graph\` array — {edge, node, paths} per node, identical to \`recall\`'s shape: \`edge\` is the whole edge document, \`node\` the reached entity, \`paths\` every route to it as record ids with the match first. \`count\` is the number of matches and \`graphNodes\` how many nodes were reached. A neighbourhood past the inline cap is written out in full and reported as \`graphTruncated\` + \`graphComplete\` (an authenticated download, valid one day), exactly as on \`recall\`. With traverse > 0 the response is JSON instead of the plain text summary.`,

--- a/testing/standalone/search-tool-schemas-document-their-response.test.js
+++ b/testing/standalone/search-tool-schemas-document-their-response.test.js
@@ -100,6 +100,42 @@ describe('query says what it is FOR and what comes back', () => {
   });
 });
 
+/** The `find_similar` tool object, scoped the same way. */
+const FIND_SIMILAR = (() => {
+  const at = SRC.indexOf("name: 'find_similar'");
+  assert.ok(at > 0, 'the find_similar tool was not found — the scanner is wrong, not the code');
+  const next = SRC.indexOf("name: '", at + 20);
+  return next === -1 ? SRC.slice(at) : SRC.slice(at, next);
+})();
+
+describe('find_similar names the two silent empties', () => {
+  it('a source entry with no vector cannot be similar to anything', () => {
+    // The failure that looks like a fact: an empty answer reads as "nothing resembles this", when the real
+    // cause is that the SOURCE was retired from ranking and has no embedding to compare from.
+    assert.match(FIND_SIMILAR, /retired from semantic ranking/,
+      'an empty answer from a vector-less source must not read as "nothing is similar"');
+  });
+
+  it('says there is no includeFreshWrites here, and why', () => {
+    assert.match(FIND_SIMILAR, /includeFreshWrites/,
+      "a caller who knows recall's escape hatch will look for it here");
+    assert.match(FIND_SIMILAR, /has to exist before this can start/,
+      'say why it cannot exist rather than leaving its absence to be discovered');
+  });
+
+  it('says minScore means something DIFFERENT here than on recall', () => {
+    // Same parameter name, same units, different job: on recall it gates before the reranker; here cosine is
+    // the only ranking, so it is the relevance gate itself.
+    assert.match(FIND_SIMILAR, /this IS the relevance gate/,
+      'the same parameter behaving differently across two tools is exactly what a schema must say');
+  });
+
+  it('distinguishes the source type from the target types', () => {
+    assert.match(FIND_SIMILAR, /It does not constrain what comes back/,
+      '`entryType` resolves the id; `targetTypes` filters the answer, and conflating them is the obvious error');
+  });
+});
+
 describe('the parameters carry their traps', () => {
   it('types: edges are searchable records and compete for topK', () => {
     assert.match(RECALL, /EDGES ARE SEARCHABLE RECORDS/,


### PR DESCRIPTION
X-2, third tool. `find_similar` — and the theme here is **empty answers that read as findings**.

## It works from a stored vector, and that has two silent consequences

The tool compares against a record's **stored** embedding rather than embedding a query. Neither consequence
of that was anywhere in its reference:

- **A source record retired from semantic ranking has no embedding at all.** There is nothing to be similar
  *to*, so the answer is empty — not an error, and not evidence that nothing resembles it.
- **A record written seconds ago may not be indexed yet.** There is no `includeFreshWrites` escape hatch here
  as there is on `recall`, and the reason is structural rather than an omission: the source's own embedding
  has to exist before the search can start. A caller who knows recall's hatch will look for this one, so the
  schema says why it cannot exist.

Both used to look like a result.

## The same parameter, a different job

`minScore` is on `recall` too, with the same units — and a different meaning. On `recall` it gates on the
vector score *before* the reranker, so it can cut a result the reranker would have promoted. Here cosine
distance is the **only** ranking, so it is the relevance gate itself: raising it narrows the answer honestly.

For deduplication that matters practically — near-duplicates sit well above 0.9, and everything below is a
topic match rather than a repeat.

A parameter that behaves differently across two tools is exactly the thing a schema has to say out loud.

## Source type is not target type

`entryType` resolves the id — a wrong one is a not-found, not a wrong answer — and does **not** constrain what
comes back. `targetTypes` does that. Conflating them is the obvious error, and a memory can legitimately be
most similar to an entity.

## Verification

The gate is now 15 assertions across three tools. `npm run preflight` green. ~37 remain;
`todo/_MCP-SCHEMA-TEMPLATE.md` carries the standard and the order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
