### PR TITLE
docs(traverse): say how the TOOL differs from recall's graph expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The `traverse` tool now says how it differs from the graph expansion built into `recall`.** Two things are
+  called traversal and they answer different questions: recall's expansion walks out from whatever a *search*
+  matched, while this walks out from a record you already name. More decisively, chrono entries, memories and
+  files that *reference* an entity are not relationships in the graph sense, so recall's expansion cannot
+  reach them at any depth — this tool can, and that is what its include options are for. A caller who did not
+  know that would conclude the data was missing rather than that they had used the wrong walk. The reference
+  also now describes the result: each node carries the depth it was found at, the starting record comes back
+  at depth zero so a lone record is not an empty answer, and a walk cut short by the limit is flagged as a
+  **partial** graph — an impact assessment run on one is answering a smaller question than it was asked.
+
 - **`find_similar` now names the two ways it can come back empty for a reason that is not "nothing is
   similar".** It compares against a record's **stored** embedding rather than working from a query, which has
   two consequences that were nowhere in its reference: a source record that has been retired from semantic

--- a/server/src/mcp/tools/edge.ts
+++ b/server/src/mcp/tools/edge.ts
@@ -180,13 +180,19 @@ export const update_edgeTool: ToolHandler = {
 
 export const traverseTool: ToolHandler = {
   name: 'traverse',
-  description: 'Follow edges from a starting entity and return reachable nodes up to maxDepth hops. Chrono entries that reference a reached node come back too (kind:"chrono"), so a timeline can be walked from the entity it is about. Useful for dependency analysis, impact assessment, and lineage queries.',
+  description: 'Follow edges from a starting entity and return reachable nodes up to `maxDepth` hops. For dependency analysis, impact assessment and lineage.\n\n'
+    + 'NOT THE SAME AS `recall(traverse: n)`, and the difference decides which one you want:\n'
+    + '• This starts from a node you ALREADY KNOW, by id. `recall`\'s expansion starts from whatever a search matched, so it answers "what is near the things about X" rather than "what is near THIS".\n'
+    + '• This can follow `entityIds` references — chrono entries, memories and files that point AT a node — which are not edges and are therefore unreachable from `recall`\'s expansion at any depth. That is what `includeChrono`, `includeMemories` and `includeFiles` are for.\n'
+    + '• This returns a flat node list with a depth on each; `recall` nests its walk under the match that reached it.\n\n'
+    + 'It is also blind to meaning, which is the point: a node reached in three hops is reached whether or not it resembles anything, and nothing here is embedded or ranked. A record retired from semantic ranking is reached exactly as any other.\n\n'
+    + 'THE RESPONSE: `nodes` — each with `id`, `name`, `type`, `kind` ("entity" unless it arrived via one of the include flags) and the `depth` it was found at, `startId` itself at depth 0. `edges` — the connecting relationships, unless `includeEdges` is false. `truncated` — true when `limit` cut the walk, and worth reading: a truncated walk is a PARTIAL graph, so an impact assessment run on one is answering a smaller question than it was asked.',
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            startId: { type: 'string', minLength: 1, description: 'UUID of the starting entity.' },
+            startId: { type: 'string', minLength: 1, description: 'UUID of the starting entity. It is returned as the first node at depth 0, so a walk that finds nothing still comes back with one node rather than empty — an empty `nodes` means the id resolved to nothing, which is a different answer from "it has no neighbours".' },
             direction: {
               type: 'string',
               enum: ['outbound', 'inbound', 'both'],

--- a/testing/standalone/traverse-tool-schema-distinguishes-itself.test.js
+++ b/testing/standalone/traverse-tool-schema-distinguishes-itself.test.js
@@ -1,0 +1,78 @@
+/**
+ * The `traverse` TOOL says how it differs from `recall(traverse: n)`, because the names collide.
+ *
+ * ## The collision
+ *
+ * Two things are called traversal and they answer different questions. Recall's expansion walks edges out of
+ * whatever a SEARCH matched; this tool walks out of a node you already name. A caller who reads only one
+ * schema has no way to learn the other exists, and the word gives no hint that it should look.
+ *
+ * That ambiguity has already cost one round trip in this repo — the owner asked whether
+ * `excludeFromVectorSearch` hides a record from "recall's traversal", because the exclusion schema listed
+ * "traverse" among the readers that still reach it and that sentence is true of both.
+ *
+ * ## The difference that actually decides which one you want
+ *
+ * `entityIds` references — a chrono entry, a memory or a file pointing AT an entity — are NOT edges. Recall's
+ * expansion cannot reach them at any depth. This tool can, and that is what `includeChrono`,
+ * `includeMemories` and `includeFiles` are for. A caller who does not know that will conclude the data is
+ * missing rather than that they used the wrong walk.
+ *
+ * ## X-2, fourth tool
+ *
+ * The parameters here were already written to the standard. What was absent was the tool-level framing and
+ * the response, which is the same gap every tool in this sweep has had.
+ *
+ * Run: node --test testing/standalone/traverse-tool-schema-distinguishes-itself.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const SRC = readFileSync('server/src/mcp/tools/edge.ts', 'utf8');
+const TRAVERSE = (() => {
+  const at = SRC.indexOf("name: 'traverse'");
+  assert.ok(at > 0, 'the traverse tool was not found — the scanner is wrong, not the code');
+  const next = SRC.indexOf("name: '", at + 20);
+  return next === -1 ? SRC.slice(at) : SRC.slice(at, next);
+})();
+
+describe('it names the other traversal', () => {
+  it('says outright that it is not recall\'s expansion', () => {
+    assert.match(TRAVERSE, /NOT THE SAME AS `recall\(traverse: n\)`/,
+      'the two share a name and answer different questions; say so before anything else');
+  });
+
+  it('says the difference in STARTING POINT', () => {
+    assert.match(TRAVERSE, /already know/i,
+      'this starts from a node you name; recall starts from whatever a search matched');
+  });
+
+  it('names `entityIds` as the thing recall cannot reach', () => {
+    // The decisive difference. A caller hitting it from the recall side concludes the data is absent.
+    assert.match(TRAVERSE, /entityIds/, 'name the mechanism, not just "more kinds of record"');
+    assert.match(TRAVERSE, /unreachable from `recall`/,
+      'say that recall cannot follow them AT ANY DEPTH — otherwise a caller just tries a deeper traverse');
+  });
+});
+
+describe('it describes what comes back', () => {
+  it('names the node fields including `kind` and `depth`', () => {
+    assert.match(TRAVERSE, /`depth`/, 'a flat list with depths is a different shape from recall\'s nesting');
+    assert.match(TRAVERSE, /"entity" unless it arrived via one of the include flags/,
+      '`kind` is how a caller tells an entity from a chrono/memory/file arrival');
+  });
+
+  it('warns that a truncated walk is a PARTIAL graph', () => {
+    // The quiet failure: an impact assessment run on a cut walk answers a smaller question than it was asked,
+    // and the answer looks complete.
+    assert.match(TRAVERSE, /PARTIAL graph/,
+      'a cut walk is not a short answer, it is a different answer');
+  });
+
+  it('distinguishes "no neighbours" from "no such node"', () => {
+    assert.match(TRAVERSE, /depth 0/, 'startId comes back at depth 0, so a lone node is not an empty result');
+    assert.match(TRAVERSE, /resolved to nothing/,
+      'an empty `nodes` means the id matched nothing — a different answer from an isolated node');
+  });
+});


### PR DESCRIPTION
X-2, fourth tool. **Two things are called traversal**, and a caller reading either schema had no way to learn
the other exists.

## The collision

`recall(traverse: n)` walks edges out of whatever a **search** matched. The `traverse` tool walks out of a
node you **already name**. The word gives no hint that there are two, so nothing prompts a caller to look.

That ambiguity has already cost a round trip in this repo: the owner asked whether
`excludeFromVectorSearch` hides a record from *"recall's traversal"*, because the exclusion schema listed
"traverse" among the readers that still reach it — a sentence true of both.

## The difference that actually decides which one you want

`entityIds` references — a chrono entry, a memory or a file pointing **at** an entity — are **not edges**.
Recall's expansion cannot reach them at any depth. This tool can, which is what `includeChrono`,
`includeMemories` and `includeFiles` are for.

A caller who does not know that concludes the data is missing, rather than that they used the wrong walk. The
schema now says it, and says *at any depth* — otherwise the obvious response is to try a deeper traverse.

## The response

Never described before:

- `nodes` — each with `kind` ("entity" unless it arrived via an include flag) and the `depth` it was found at.
  A flat list with depths, which is a different shape from recall's nesting.
- **`startId` comes back at depth 0**, so a record with no neighbours returns one node. An *empty* `nodes`
  means the id resolved to nothing — a different answer, and previously indistinguishable.
- `truncated` — a walk cut by `limit` is a **partial graph**. An impact assessment run on one is answering a
  smaller question than it was asked, and the answer looks complete.

The parameters here were already written to the standard; the gap was the tool-level framing and the response,
which is the same gap every tool in this sweep has had.

6 tests, `npm run preflight` green. ~36 remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
