### PR TITLE
docs(write): say what a validation refusal means, and what a write does to an existing record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The two most-used write tools now explain what a validation refusal means, and what the write does to a
+  record that already exists.** A refusal is the only response a caller has to branch on, and it has two
+  halves: what *this* write broke, and what was already broken before it. Only the first refuses — that
+  changed in this release — so a caller treating any reported violation as failure would now report a
+  successful write as an error. The reference says which field to branch on. Storing an entity also now says
+  that supplying no id always creates a **new** record, that two entities may share a name, and that an
+  update **merges** into what is stored and is checked in its merged form — which is why setting one field of
+  a valid record is accepted even though that one field alone would not be. Storing a fact says it is always
+  an insert and nothing deduplicates, so the same fact written twice competes with itself in search; that it
+  should be written as a self-contained sentence, because a fact retrieved months later arrives without the
+  conversation it was written in; and that **indexing is asynchronous**, so a search issued seconds later can
+  miss it unless you ask that search to include fresh writes.
+
 - **The `traverse` tool now says how it differs from the graph expansion built into `recall`.** Two things are
   called traversal and they answer different questions: recall's expansion walks out from whatever a *search*
   matched, while this walks out from a record you already name. More decisively, chrono entries, memories and

--- a/server/src/mcp/tools/entity.ts
+++ b/server/src/mcp/tools/entity.ts
@@ -12,7 +12,9 @@ import { mergePropertiesOrKeep, mergeTagsOrKeep } from '../../brain/merge-fields
 
 export const upsert_entityTool: ToolHandler = {
   name: 'upsert_entity',
-  description: 'Create or update a named entity in the knowledge graph. Identity is by `id` — if `id` is supplied the matching record is updated (or a new record with that ID is created); if `id` is omitted a new record is always inserted regardless of name.',
+  description: 'Create or update a named entity in the knowledge graph. Identity is by `id` — supply one and the matching record is updated, omit it and a NEW record is always inserted regardless of name. Two entities may share a name; nothing deduplicates for you. Use `find_entities_by_name` first if you meant to update.\n\n'
+    + 'An upsert onto an existing record MERGES: properties and tags are merged over what is stored, so you can set one field without restating the rest, and the record is validated in its MERGED form rather than as the fragment you sent. That is why a partial upsert of a conformant record is accepted even when the fragment alone would fail a required-property rule.\n\n'
+    + 'IF THE SPACE VALIDATES, a refusal names WHOSE FAULT it is. `introduced` are violations your write caused — fix those. `preExisting` were already stored and your write neither caused nor fixed them; in `strict` mode they are REPORTED and do NOT refuse the write, so an unrelated edit is never blocked by a field somebody else broke. Branch on `introduced` and treat `preExisting` as a repair opportunity rather than an error.',
   mutating: true,
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({

--- a/server/src/mcp/tools/memory.ts
+++ b/server/src/mcp/tools/memory.ts
@@ -23,7 +23,10 @@ import { mergePropertiesOrKeep } from '../../brain/merge-fields.js';
 
 export const rememberTool: ToolHandler = {
   name: 'remember',
-  description: 'Store a fact or memory in the knowledge graph with semantic embedding.',
+  description: 'Store a fact in the knowledge graph. It is embedded for semantic search, so write it as a SENTENCE that carries its own context — a memory retrieved months later arrives without the conversation it was written in, and "he agreed to the change" is unusable on its own.\n\n'
+    + 'Always an INSERT. There is no id to update and nothing deduplicates: remembering the same fact twice stores it twice, and both then compete for the same result slots in a recall. Search before writing if a fact may already be there, and use `update_memory` when you mean to revise one.\n\n'
+    + 'Embedding is ASYNCHRONOUS. The write returns as soon as the record is stored, and a queued job computes the vector — so a `recall` issued seconds later may not find what you just wrote. Pass `includeFreshWrites: true` on that recall to read straight from the collection instead of waiting.\n\n'
+    + 'IF THE SPACE VALIDATES, a refusal names WHOSE FAULT it is: `introduced` are violations this write caused and are what refuses it; `preExisting` were already stored, are reported, and do NOT block. Branch on `introduced`.',
   mutating: true,
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({

--- a/testing/standalone/write-tools-say-what-a-refusal-means.test.js
+++ b/testing/standalone/write-tools-say-what-a-refusal-means.test.js
@@ -1,0 +1,89 @@
+/**
+ * A write tool's schema says what a validation refusal MEANS, and which half is the caller's fault.
+ *
+ * ## Why this is the write tools' version of the X-2 gap
+ *
+ * The read tools were missing their response shape. The write tools are missing their REFUSAL shape, which is
+ * worse: a refusal is the only response a caller has to branch on, and `introduced` versus `preExisting` is
+ * the branch. Nothing said so.
+ *
+ * It changed underneath callers this release, too. Until #920 both halves refused the write; now a violation
+ * the record already carried is REPORTED and does not block, so an unrelated edit is never stopped by a field
+ * somebody else broke. A caller that treats any `violations` array as failure is now wrong in a new way —
+ * it will report a successful write as an error.
+ *
+ * ## The other two facts a write tool must state
+ *
+ * **What the write DOES to an existing record.** `upsert_entity` merges and validates the merged form, which
+ * is why a partial upsert of a conformant record is accepted when the fragment alone would fail. `remember`
+ * is always an insert and deduplicates nothing, so the same fact stored twice competes with itself in recall.
+ *
+ * **That embedding is asynchronous.** The write returns before the vector exists, so a recall seconds later
+ * can miss it — and `includeFreshWrites` is the escape hatch. This one is measurable as a broken feature: a
+ * probe that writes and immediately searches finds nothing and concludes search is down.
+ *
+ * Run: node --test testing/standalone/write-tools-say-what-a-refusal-means.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const toolText = (file, name) => {
+  const src = readFileSync(file, 'utf8');
+  const at = src.indexOf(`name: '${name}'`);
+  assert.ok(at > 0, `${name} was not found in ${file} — the scanner is wrong, not the code`);
+  const next = src.indexOf("name: '", at + 20);
+  return next === -1 ? src.slice(at) : src.slice(at, next);
+};
+
+const UPSERT_ENTITY = toolText('server/src/mcp/tools/entity.ts', 'upsert_entity');
+const REMEMBER = toolText('server/src/mcp/tools/memory.ts', 'remember');
+
+describe('both write tools explain the refusal shape', () => {
+  for (const [label, text] of [['upsert_entity', UPSERT_ENTITY], ['remember', REMEMBER]]) {
+    it(`${label} names introduced vs preExisting and says which one refuses`, () => {
+      assert.match(text, /introduced/, 'name the half that is the caller\'s fault');
+      assert.match(text, /preExisting/, 'name the half that is not');
+      assert.match(text, /do NOT block|does NOT block|do NOT refuse/i,
+        'say that a pre-existing violation is reported rather than refusing — it changed this release');
+      assert.match(text, /Branch on `introduced`/,
+        'tell the caller which field to branch on, or the distinction is decoration');
+    });
+  }
+});
+
+describe('each says what its write does to what is already there', () => {
+  it('upsert_entity: it merges, and validates the MERGED form', () => {
+    // The reason a partial upsert of a conformant record is accepted when the fragment alone would fail.
+    assert.match(UPSERT_ENTITY, /MERGES/, 'say that an upsert onto an existing record merges');
+    assert.match(UPSERT_ENTITY, /MERGED form/,
+      'and that validation runs on the result, not on the fragment');
+  });
+
+  it('upsert_entity: omitting id always INSERTS, and names deduplicate nothing', () => {
+    assert.match(UPSERT_ENTITY, /Two entities may share a name/,
+      'the obvious wrong assumption is that a name is an identity');
+    assert.match(UPSERT_ENTITY, /find_entities_by_name/, 'point at the tool that answers it');
+  });
+
+  it('remember: always an insert, and duplicates compete with each other', () => {
+    assert.match(REMEMBER, /Always an INSERT/, 'there is no id to update');
+    assert.match(REMEMBER, /compete for the same result slots/,
+      'the cost of a duplicate is not storage, it is recall quality');
+  });
+});
+
+describe('remember says the embedding is asynchronous', () => {
+  it('warns that a recall seconds later can miss the write', () => {
+    // Measurable as a broken feature: write, search, find nothing, conclude search is down.
+    assert.match(REMEMBER, /ASYNCHRONOUS/, 'the write returns before the vector exists');
+    assert.match(REMEMBER, /includeFreshWrites: true/,
+      'name the escape hatch — knowing about the delay without the remedy is half an answer');
+  });
+
+  it('tells the caller to write a self-contained sentence', () => {
+    // An embedding of "he agreed to the change" is unusable, and the failure only appears months later.
+    assert.match(REMEMBER, /carries its own context/,
+      'a memory is retrieved without the conversation it was written in');
+  });
+});


### PR DESCRIPTION
X-2, fifth and sixth tools — and the write tools' version of the gap is worse than the read tools'.

## A refusal is the only thing a caller branches on

The read tools were missing their *response* shape. The write tools were missing their **refusal** shape, and
that is the one a caller has to act on: `introduced` is what this write broke, `preExisting` is what was
already broken. Nothing said so.

**It also changed underneath callers this release.** Until #920 both halves refused the write. Now a violation
the record already carried is reported and does **not** block — so a caller treating any reported violation as
failure will now report a *successful* write as an error. The schema says which field to branch on.

## What the write does to a record that already exists

| tool | what was missing |
|---|---|
| `upsert_entity` | it **merges**, and validates the **merged** form — which is why setting one field of a valid record is accepted when that field alone would fail a required-property rule |
| `upsert_entity` | omitting `id` always **inserts**; two entities may share a name; nothing deduplicates. Now points at `find_entities_by_name` |
| `remember` | always an insert, and a duplicate does not cost storage — it costs **recall quality**, because both copies then compete for the same result slots |

## Embedding is asynchronous, and that one is measurable as a broken feature

`remember` returns as soon as the record is stored; a queued job computes the vector. A probe that writes and
immediately searches finds nothing and concludes search is down. The schema now says it, and names the remedy
— `includeFreshWrites: true` on that recall — because knowing about the delay without the escape hatch is half
an answer.

It also now says to write a **self-contained sentence**: a fact retrieved months later arrives without the
conversation it was written in, and *"he agreed to the change"* is unusable on its own. That failure only
appears long after the write.

7 tests, `npm run preflight` green. ~34 remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
