### PR TITLE
docs(edge,chrono): the triplet is the identity, and a dated fact is not a memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Storing a relationship now says that the two endpoints and the label ARE its identity.** There is no id
+  anywhere in the call, so repeating the same from/to/label pair updates the existing relationship rather
+  than adding a second one — and nothing in the arguments hints at that. Direction is part of the meaning
+  too: *depends on* reversed is a different claim, and a walk follows the two directions separately, so a
+  backwards relationship is not merely untidy, it is unreachable from the side that should have found it.
+  It also now says that relationships are searchable records in their own right and compete for slots in a
+  search, which is why searching has a type filter.
+
+- **Storing a dated entry now says what belongs there rather than in a plain fact.** Anything with a date —
+  an event, a deadline, a plan — carries start and end times and a status, so it can be listed by date and
+  *closed*, where the same thing written as a fact can only ever be contradicted later. It also warns that a
+  space defining its own dated-entry types **replaces** the built-in list rather than adding to it, so a
+  space with a custom schema will refuse `event`; and that linking the entry to the entities it concerns is
+  what makes it reachable from them, since those links are not relationships in the graph sense.
+
 - **The two most-used write tools now explain what a validation refusal means, and what the write does to a
   record that already exists.** A refusal is the only response a caller has to branch on, and it has two
   halves: what *this* write broke, and what was already broken before it. Only the first refuses — that

--- a/server/src/mcp/tools/chrono.ts
+++ b/server/src/mcp/tools/chrono.ts
@@ -12,7 +12,10 @@ import { mergePropertiesOrKeep } from '../../brain/merge-fields.js';
 
 export const create_chronoTool: ToolHandler = {
   name: 'create_chrono',
-  description: 'Create a chronological entry in the knowledge graph. The default types are event, deadline, plan, prediction, and milestone; spaces with a custom typeSchemas.chrono accept their own type names instead.',
+  description: 'Create a chronological entry — something that happened, or is meant to. Default types are event, deadline, plan, prediction and milestone; a space with its own `typeSchemas.chrono` accepts ITS names INSTEAD, not in addition, so a custom schema that omits `event` refuses `event`.\n\n'
+    + 'THIS IS THE RECORD FOR ANYTHING DATED, and the reason the distinction matters: a memory saying "the migration is planned for March" is a fact whose truth expires, while a chrono entry carries `startsAt`/`endsAt` and a `status`, so it can be listed by date, found by `list_chrono` in a window, and closed rather than contradicted. If it has a date, it belongs here.\n\n'
+    + 'Link it with `entityIds` — that is what lets `traverse` reach it from the entity it is about (with `includeChrono`, on by default). Those references are NOT edges, so a chrono entry left unlinked is reachable only by search or by date, never from the thing it concerns.\n\n'
+    + 'Always an INSERT; use `update_chrono` to change one, including to move its `status`. IF THE SPACE VALIDATES: `introduced` are violations this write caused and are what refuses it; `preExisting` were already stored, are reported, and do NOT block. Branch on `introduced`.',
   mutating: true,
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({

--- a/server/src/mcp/tools/edge.ts
+++ b/server/src/mcp/tools/edge.ts
@@ -13,7 +13,11 @@ import { mergePropertiesOrKeep } from '../../brain/merge-fields.js';
 
 export const upsert_edgeTool: ToolHandler = {
   name: 'upsert_edge',
-  description: 'Create or update a directed relationship edge between two entities.',
+  description: 'Create or update a directed relationship between two entities.\n\n'
+    + 'IDENTITY IS THE TRIPLET `(from, to, label)` — there is no id anywhere in the call, so EVERY repeat of the same triplet is an update of the existing edge and nothing in the arguments suggests it. Properties merge over what is stored; an absent `properties` means "leave them alone", not "clear them". Change the label and you have a second, different edge rather than a renamed one.\n\n'
+    + 'DIRECTION IS PART OF THE MEANING. `from`/`to` are not interchangeable, and `depends_on` reversed is a different claim about the world. A traversal follows them separately (`direction: outbound|inbound|both`), so a reversed edge is not merely untidy — it is unreachable from the side that should have found it.\n\n'
+    + 'Both endpoints must be entity ids that exist when the space uses strict linkage; that is a refusal, not a dangling edge. And an edge IS a searchable record: it carries its own embedding and competes with knowledge for a recall\'s result slots, which is why `recall` has a `types` filter.\n\n'
+    + 'IF THE SPACE VALIDATES: `introduced` are violations this write caused and are what refuses it; `preExisting` were already stored, are reported, and do NOT block. Branch on `introduced`.',
   mutating: true,
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({

--- a/testing/standalone/write-tools-say-what-a-refusal-means.test.js
+++ b/testing/standalone/write-tools-say-what-a-refusal-means.test.js
@@ -38,9 +38,16 @@ const toolText = (file, name) => {
 
 const UPSERT_ENTITY = toolText('server/src/mcp/tools/entity.ts', 'upsert_entity');
 const REMEMBER = toolText('server/src/mcp/tools/memory.ts', 'remember');
+const UPSERT_EDGE = toolText('server/src/mcp/tools/edge.ts', 'upsert_edge');
+const CREATE_CHRONO = toolText('server/src/mcp/tools/chrono.ts', 'create_chrono');
 
-describe('both write tools explain the refusal shape', () => {
-  for (const [label, text] of [['upsert_entity', UPSERT_ENTITY], ['remember', REMEMBER]]) {
+describe('every write tool explains the refusal shape', () => {
+  // Applied across the family rather than per tool: the refusal shape is identical on all four, so one of
+  // them documenting it and three not is the drift this loop exists to prevent.
+  for (const [label, text] of [
+    ['upsert_entity', UPSERT_ENTITY], ['remember', REMEMBER],
+    ['upsert_edge', UPSERT_EDGE], ['create_chrono', CREATE_CHRONO],
+  ]) {
     it(`${label} names introduced vs preExisting and says which one refuses`, () => {
       assert.match(text, /introduced/, 'name the half that is the caller\'s fault');
       assert.match(text, /preExisting/, 'name the half that is not');
@@ -70,6 +77,49 @@ describe('each says what its write does to what is already there', () => {
     assert.match(REMEMBER, /Always an INSERT/, 'there is no id to update');
     assert.match(REMEMBER, /compete for the same result slots/,
       'the cost of a duplicate is not storage, it is recall quality');
+  });
+});
+
+describe('upsert_edge: identity is the triplet, and direction is meaning', () => {
+  it('says every repeat of the same triplet is an UPDATE', () => {
+    // There is no id in the call, so nothing in the arguments hints that a repeat merges. This is the same
+    // shape that made a partial upsert fail validation before the merged form was validated.
+    assert.match(UPSERT_EDGE, /IDENTITY IS THE TRIPLET/, 'the triplet IS the id');
+    assert.match(UPSERT_EDGE, /nothing in the arguments suggests it/,
+      'say that the call gives no hint — that is why it surprises people');
+  });
+
+  it('says direction is not interchangeable', () => {
+    assert.match(UPSERT_EDGE, /not interchangeable/, 'from/to reversed is a different claim');
+    assert.match(UPSERT_EDGE, /unreachable from the side that should have found it/,
+      'a reversed edge is not untidy, it is missing from a traversal');
+  });
+
+  it('warns that an edge is a searchable record', () => {
+    assert.match(UPSERT_EDGE, /competes with knowledge/,
+      'edges take result slots in recall, which is why recall has a types filter');
+  });
+});
+
+describe('create_chrono: what belongs here rather than in a memory', () => {
+  it('says a custom chrono schema REPLACES the defaults', () => {
+    // The trap: a space that declares its own chrono types stops accepting `event`, and the refusal reads
+    // like a bug unless you know the list is a replacement rather than an extension.
+    assert.match(CREATE_CHRONO, /INSTEAD, not in addition/,
+      'a custom schema replaces the default type names, it does not add to them');
+  });
+
+  it('says what makes something a chrono entry rather than a memory', () => {
+    assert.match(CREATE_CHRONO, /whose truth expires/,
+      'a dated fact stored as a memory cannot be closed, only contradicted');
+    assert.match(CREATE_CHRONO, /If it has a date, it belongs here/, 'give the caller the rule, not a hint');
+  });
+
+  it('says entityIds are what make it reachable from the entity', () => {
+    assert.match(CREATE_CHRONO, /NOT edges/,
+      'the reference is not an edge, which is why only the traverse TOOL reaches it');
+    assert.match(CREATE_CHRONO, /never from the thing it concerns/,
+      'an unlinked chrono entry is findable by search and date only — say the cost of forgetting');
   });
 });
 


### PR DESCRIPTION
X-2, seventh and eighth tools. That completes the brain write family, so the refusal-shape assertion now runs
across **all four** rather than the two it started on — one tool documenting it and three not is exactly the
drift this sweep exists to stop.

## `upsert_edge` — the triplet is the identity

There is **no id anywhere in the call**. `(from, to, label)` is it, so every repeat of the same triplet is an
update of the existing edge, properties merge over what is stored, and *nothing in the arguments suggests
that*. It is the same shape that made partial upserts fail validation before the merged form was the thing
validated.

**Direction is part of the meaning.** `depends_on` reversed is a different claim about the world, and a
traversal follows the two directions separately — so a backwards edge is not untidy, it is **unreachable from
the side that should have found it**.

It also now says an edge is a searchable record in its own right: it carries an embedding and competes with
knowledge for a recall's result slots, which is *why* `recall` has a `types` filter.

## `create_chrono` — what belongs here rather than in a memory

A custom `typeSchemas.chrono` **replaces** the default type names rather than extending them, so a space with
its own schema refuses `event`. That refusal reads like a bug unless you know the list is a replacement.

The rule it was missing: **if it has a date, it belongs here.** A memory saying *"the migration is planned for
March"* is a fact whose truth expires and can only ever be contradicted; a chrono entry carries
`startsAt`/`endsAt` and a `status`, so it can be listed by date and **closed**.

And `entityIds` is what makes it reachable from the entity it concerns — those references are not edges, so
an unlinked chrono entry is findable by search or by date and **never from the thing it is about**.

## Verification

The gate is 15 assertions and the refusal-shape check is now parameterised over all four write tools.
`npm run preflight` green. ~32 remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
