### PR TITLE
docs(files): say what a read costs, what an empty read means, and that a write replaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Reading and writing files now say what a call costs and what an empty answer means.** Reading returns the
+  whole file with no windowing, and a document is the largest thing stored — so the reference now points at
+  the cheaper route it never mentioned: search with passage bodies switched off to find *which* file and
+  *which* passage, then read only if the rest is needed. It also separates the three things that all look
+  like a blank document: a file still being extracted, a file whose type yields no text, and one that really
+  is empty — the first of those is a wait, not a fact. Writing now says plainly that it **replaces** the whole
+  file: there is no append and no patch, and writing over an existing path is silent. It also explains that a
+  file is stored as chunks embedded separately, which is why a search returns a passage rather than a
+  document, and that structuring text with headings is what makes a hit locatable — and that indexing is
+  asynchronous here too, so a search moments later may not see it.
+
 - **Storing a relationship now says that the two endpoints and the label ARE its identity.** There is no id
   anywhere in the call, so repeating the same from/to/label pair updates the existing relationship rather
   than adding a second one — and nothing in the arguments hints at that. Direction is part of the meaning

--- a/server/src/mcp/tools/file.ts
+++ b/server/src/mcp/tools/file.ts
@@ -15,7 +15,9 @@ import { log } from '../../util/log.js';
 
 export const read_fileTool: ToolHandler = {
   name: 'read_file',
-  description: 'Read the text contents of a file in the space file store.',
+  description: 'Read the text contents of a file in the space file store. Whole file, no paging — a large document arrives entire and is paid for in tokens, so prefer `recall` with `includeContent: false` to find WHICH file and WHICH passage first, then read only if you need the rest.\n\n'
+    + 'It reads the STORED TEXT, which for an uploaded PDF or image is the extracted text rather than the original bytes. A file whose extraction has not finished, or whose type yields no text, reads as empty — that is a pending or unextractable document, not an empty file. `list_dir` shows what is present, and `list_embed_jobs` shows whether its indexing is still queued or failed.\n\n'
+    + 'This is a path lookup, not a search: an unknown path is an error, not an empty result.',
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({
           type: 'object',
@@ -42,7 +44,10 @@ export const read_fileTool: ToolHandler = {
 
 export const write_fileTool: ToolHandler = {
   name: 'write_file',
-  description: 'Write text content to a file in the space file store.',
+  description: 'Write text content to a file in the space file store.\n\n'
+    + 'IT REPLACES THE WHOLE FILE. There is no append and no patch: whatever you send becomes the entire content, so read first if you meant to add to it. Writing a path that already exists overwrites it without asking.\n\n'
+    + 'The file is CHUNKED and each chunk is embedded separately, which is why `recall` returns a passage rather than a document and why `includeContent: false` is worth using — one long chunk can crowd out several one-line records. Structure the text with headings: a chunk that begins under a heading carries it, and that is what makes a recall hit locatable.\n\n'
+    + 'Embedding is ASYNCHRONOUS, as with `remember`: the write returns once the bytes are stored and a queued job computes the vectors afterwards, so a `recall` seconds later may not see it — pass `includeFreshWrites: true` on that recall. Rewriting a file resets its embedding: new content is new content, and a previous failure to embed it is not carried forward.',
   mutating: true,
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({

--- a/testing/standalone/file-tools-say-what-they-cost.test.js
+++ b/testing/standalone/file-tools-say-what-they-cost.test.js
@@ -1,0 +1,85 @@
+/**
+ * The file tools say what a call COSTS and what an empty answer means.
+ *
+ * ## X-2, the file family
+ *
+ * `read_file` said *"Read the text contents of a file in the space file store."* and `write_file` the
+ * matching one line. Both are accurate and neither tells a caller the two things that decide how to use them.
+ *
+ * ## Cost, because a file is the largest thing stored
+ *
+ * A read is the whole file — no paging — and a passage body is by far the biggest field any result carries.
+ * The cheap flow is `recall` with `includeContent: false` to find WHICH file and WHICH passage, then read
+ * only if the rest is needed. That flow already exists and `recall`'s own schema describes it; the file tool
+ * never pointed at it, so a caller reaching for a file first pays for a document to answer a sentence.
+ *
+ * ## Empty means several different things
+ *
+ * A file whose extraction has not finished reads as empty. So does one whose type yields no text. So does an
+ * actually-empty file. Without being told, all three look like "the document is blank" — and the first is a
+ * wait, not a fact.
+ *
+ * ## And a write is a REPLACE
+ *
+ * There is no append and no patch. Writing an existing path overwrites it silently, which is the destructive
+ * default a caller should be told about before discovering it.
+ *
+ * Run: node --test testing/standalone/file-tools-say-what-they-cost.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const SRC = readFileSync('server/src/mcp/tools/file.ts', 'utf8');
+const tool = (name) => {
+  const at = SRC.indexOf(`name: '${name}'`);
+  assert.ok(at > 0, `${name} was not found — the scanner is wrong, not the code`);
+  const next = SRC.indexOf("name: '", at + 20);
+  return next === -1 ? SRC.slice(at) : SRC.slice(at, next);
+};
+
+const READ = tool('read_file');
+const WRITE = tool('write_file');
+
+describe('read_file states the cost and points at the cheaper flow', () => {
+  it('says it is the whole file with no paging', () => {
+    assert.match(READ, /Whole file, no paging/,
+      'a caller sizing a request needs to know there is no window');
+  });
+
+  it('names the two-phase alternative rather than just warning', () => {
+    assert.match(READ, /includeContent: false/,
+      'point at the flow that answers the question cheaply — a warning with no remedy is half an answer');
+  });
+
+  it('distinguishes pending extraction from an empty document', () => {
+    // Three different things read as empty, and one of them is a wait.
+    assert.match(READ, /pending or unextractable/,
+      'an empty read is not evidence the document is blank');
+  });
+
+  it('says an unknown path is an error, not an empty result', () => {
+    assert.match(READ, /not a search/, 'a path lookup and a search fail differently');
+  });
+});
+
+describe('write_file states that it replaces', () => {
+  it('says there is no append and no patch', () => {
+    assert.match(WRITE, /REPLACES THE WHOLE FILE/, 'the destructive default must be stated, not discovered');
+    assert.match(WRITE, /overwrites it without asking/, 'and that an existing path is taken silently');
+  });
+
+  it('explains chunking, because it is why recall returns passages', () => {
+    assert.match(WRITE, /CHUNKED/, 'a file is stored as chunks and each is embedded separately');
+    assert.match(WRITE, /Structure the text with headings/,
+      'the actionable half: a chunk under a heading carries it, which is what makes a hit locatable');
+  });
+
+  it('warns that embedding is asynchronous here too', () => {
+    // Same trap as `remember`, and a caller who learned it there should find it confirmed here rather than
+    // having to assume it generalises.
+    assert.match(WRITE, /ASYNCHRONOUS/, 'the write returns before the chunks are searchable');
+    assert.match(WRITE, /Rewriting a file resets its embedding/,
+      'new content is new content — a previous embedding failure is not carried forward');
+  });
+});


### PR DESCRIPTION
X-2, ninth and tenth tools. `read_file` said *"Read the text contents of a file in the space file store."* and
`write_file` the matching one line. Both accurate; neither told a caller the two things that decide how to use
them.

## Cost, because a file is the largest thing stored

A read is the **whole file, no windowing**. The cheap flow is `recall` with `includeContent: false` to find
*which* file and *which* passage, then read only if the rest is needed — a flow that already exists and that
`recall`'s own schema describes. The file tool never pointed at it, so a caller reaching for a file first pays
for a document to answer a sentence.

## Empty means three different things

A file still being extracted reads as empty. So does one whose type yields no text. So does an actually-empty
file. Without being told, all three look like *"the document is blank"* — and the first is a **wait**, not a
fact. Now separated, with `list_embed_jobs` named as where the indexing state lives.

## A write REPLACES

No append, no patch, and an existing path is overwritten silently — the destructive default a caller should
be told about rather than discover.

It also explains **chunking**: a file is stored as chunks embedded separately, which is *why* a search returns
a passage rather than a document, and structuring text with headings is what makes a hit locatable. And
indexing is asynchronous here as it is for facts, with `includeFreshWrites` named as the remedy.

## An existing gate caught two things, one of them mine

`tool-descriptions-name-reachable-things.test.js` refused the first draft: a tool description must not send an
MCP caller to a REST route, because a pure-MCP client cannot follow it.

- **A real pointer**: `read_file` said extraction state lives in "the file API". Replaced with
  `list_embed_jobs`, which is a tool.
- **A false positive of my own making**: "a queued job does the **rest**" matched the gate's case-insensitive
  search for REST. Reworded rather than loosening the gate — the phrasing was loose prose anyway, and a gate
  that fires on a near-miss is cheaper than one tuned until it misses the real thing.

7 new tests, 55 across the two suites, `npm run preflight` green. ~30 remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
