### PR TITLE
docs(entity): the destructive pair says so, and a mojibake repair I caused in #925

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Punctuation mangled into `â€"` is repaired across the server sources.** Seven files carried text that had
+  been read as one character encoding and written back as another, turning every dash and curly quote into
+  three garbled characters. Six were long-standing; one was introduced earlier in this same release and
+  affected the token API's own reference text, which is read by agents. It compiled and every test passed,
+  because the damage only ever lands inside comments and human-readable strings — which is exactly where it
+  matters, since some of those strings are what an assistant reads to decide how to call the API. A build
+  gate now scans every tracked source file for the signature, so it cannot happen quietly a third time.
+
+- **The two destructive entity tools now say they cannot be undone, and name the gentler thing you may have
+  meant.** An agent deciding whether to call a tool has no undo and no confirmation dialog, so the reference
+  is the only place that warning can live. Deleting a record now points at retiring it from search instead —
+  which keeps it readable and reachable through its links — because a reference that does not name the
+  alternative makes the destructive option the only one anybody finds. It also explains that a refusal to
+  delete a record other things still point at is usually **correct**: it means the deletion would orphan
+  something, and merging is the way to resolve it. Merging now says that its first call is *expected* to come
+  back asking for decisions rather than failing — a client treating that as an error reports a working merge
+  as broken — that leaving any conflict unresolved merges nothing at all, and that properties the two records
+  agree on are carried across without appearing in the list, so a short list is complete rather than partial.
+
 - **Reading and writing files now say what a call costs and what an empty answer means.** Reading returns the
   whole file with no windowing, and a document is the largest thing stored — so the reference now points at
   the cheaper route it never mentioned: search with passage bodies switched off to find *which* file and

--- a/server/src/api/sync/_shared.ts
+++ b/server/src/api/sync/_shared.ts
@@ -109,7 +109,7 @@ export async function checkEntityIdLinkViolations(
  * to permanently poison the high-water mark, causing all future legitimate
  * writes by other peers to be silently ignored.
  *
- * 2^50 â‰ˆ 1.1 quadrillion â€” larger than any realistic counter, but safely
+ * 2^50 â‰ˆ 1.1 quadrillion — larger than any realistic counter, but safely
  * below MAX_SAFE_INTEGER so that nextSeq() arithmetic stays in safe range.
  */
 export const MAX_SYNC_SEQ = 2 ** 50; // 1_125_899_906_842_624

--- a/server/src/api/sync/docs.ts
+++ b/server/src/api/sync/docs.ts
@@ -103,7 +103,7 @@ syncDocsRouter.post('/memories', syncRateLimit, requireAuth, denyReadOnly, async
     const incoming = parsed.data as MemoryDoc;
     if (rejectImplausibleSeq(spaceId, incoming.seq, res, callerPeerId(req.authToken as Record<string, unknown>))) return;
 
-    // Check for tombstone â€” if a tombstone with >= seq exists, skip
+    // Check for tombstone — if a tombstone with >= seq exists, skip
     const tombstone = await col<TombstoneDoc>(`${spaceId}_tombstones`)
       .findOne(asFilter<TombstoneDoc>({ _id: incoming._id, type: 'memory' })) as TombstoneDoc | null;
     if (tombstone && tombstone.seq >= incoming.seq) {
@@ -119,7 +119,7 @@ syncDocsRouter.post('/memories', syncRateLimit, requireAuth, denyReadOnly, async
       .findOne(asFilter<MemoryDoc>({ _id: incoming._id })) as MemoryDoc | null;
 
     if (!existing) {
-      // No local copy â€” insert directly
+      // No local copy — insert directly
       await col<MemoryDoc>(`${spaceId}_memories`).insertOne(asDoc<MemoryDoc>(incoming));
       // A peer strips `embedding` before sending — it is derived, and the peer may run a
       // different model — so this record landed unsearchable. Queue it a vector.
@@ -131,7 +131,7 @@ syncDocsRouter.post('/memories', syncRateLimit, requireAuth, denyReadOnly, async
     }
 
     if (incoming.seq > existing.seq) {
-      // Remote is newer â€” overwrite
+      // Remote is newer — overwrite
       await col<MemoryDoc>(`${spaceId}_memories`).replaceOne(asFilter<MemoryDoc>({ _id: incoming._id }), asDoc<MemoryDoc>(incoming));
       // A peer strips `embedding` before sending — it is derived, and the peer may run a
       // different model — so this record landed unsearchable. Queue it a vector.

--- a/server/src/api/sync/manifest.ts
+++ b/server/src/api/sync/manifest.ts
@@ -51,7 +51,7 @@ syncManifestRouter.get('/manifest', syncRateLimit, requireAuth, async (req, res)
  * files in the space (identified by their relative path + sha256 hash).
  *
  * This endpoint is consumed by the sync engine when a network has
- * `merkle: true` â€” after data sync the engine compares roots across peers and
+ * `merkle: true` — after data sync the engine compares roots across peers and
  * emits a MERKLE_DIVERGENCE warning if they disagree.
  *
  * Response: { spaceId, networkId, root, leafCount, computedAt }

--- a/server/src/api/sync/members.ts
+++ b/server/src/api/sync/members.ts
@@ -16,7 +16,7 @@ export const syncMembersRouter = Router();
 
 
 // â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
-// GOSSIP â€” member list & votes
+// GOSSIP — member list & votes
 // â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
 
 // â”€â”€ Ejection guard â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
@@ -80,7 +80,7 @@ syncMembersRouter.post('/networks/:networkId/members', syncRateLimit, requireAut
 
     const existing = net.members.find(m => m.instanceId === incoming.instanceId);
     if (!existing) {
-      // Unknown member â€” relay is informational; don't auto-add
+      // Unknown member — relay is informational; don't auto-add
       res.status(200).json({ status: 'unknown_member' });
       return;
     }

--- a/server/src/api/sync/tombstones.ts
+++ b/server/src/api/sync/tombstones.ts
@@ -62,7 +62,7 @@ syncTombstonesRouter.get('/tombstones', syncRateLimit, requireAuth, async (req, 
 });
 
 
-/** POST /api/sync/tombstones â€” apply tombstones received from a peer */
+/** POST /api/sync/tombstones — apply tombstones received from a peer */
 syncTombstonesRouter.post('/tombstones', syncRateLimit, requireAuth, denyReadOnly, async (req, res) => {
   try {
     const { spaceId, networkId } = req.query as Record<string, string>;
@@ -156,7 +156,7 @@ syncTombstonesRouter.post('/file-tombstones', syncRateLimit, requireAuth, denyRe
       const ts = raw as Partial<FileTombstoneDoc>;
       if (!ts._id || !ts.path || typeof ts.path !== 'string') continue;
 
-      // Path-traversal guard â€” must stay within the space's files directory.
+      // Path-traversal guard — must stay within the space's files directory.
       const rel = toSafeRelPath(ts.path);
       const abs = path.join(spaceFiles, rel);
       if (!abs.startsWith(spaceFiles + path.sep) && abs !== spaceFiles) continue;

--- a/server/src/api/tokens.ts
+++ b/server/src/api/tokens.ts
@@ -14,28 +14,28 @@ import { migrateToken } from '../auth/rights-migration.js';
 
 export const tokensRouter = Router();
 
-// GET /api/auth/me â€” returns the current token's metadata (used by the Angular SPA to verify a PAT)
+// GET /api/auth/me — returns the current token's metadata (used by the Angular SPA to verify a PAT)
 tokensRouter.get('/me', globalRateLimit, requireAuth, (req, res) => {
   res.json(req.authToken);
 });
 
 /**
- * GET /api/tokens/rights-catalog â€” what each area and rung actually GRANTS.
+ * GET /api/tokens/rights-catalog — what each area and rung actually GRANTS.
  *
  * The rights grid is four areas Ã— four rungs of bare words, and nothing told an operator what any cell does.
  * The answer already exists and is authoritative: `ROUTE_RIGHTS` is the table the server ENFORCES against, so
  * it is the only description of a right that cannot be wrong. A list typed into the client would be a second
  * copy of a security control, and the copy that drifts is the one people read.
  *
- * **Authenticated, not admin.** It is capability documentation â€” every route in it is published in the
- * integration guide â€” and the caller who most needs it is the non-admin trying to understand the rights they
+ * **Authenticated, not admin.** It is capability documentation — every route in it is published in the
+ * integration guide — and the caller who most needs it is the non-admin trying to understand the rights they
  * hold. Gating it to admins would withhold the explanation from exactly that person.
  *
  * The table is sent FLAT and the cumulative view is computed by the caller, because rungs contain the ones
  * below: `write` grants every `read` route as well. Sending pre-expanded lists would ship the same route many
  * times and put the containment rule in two places.
  *
- * `scope` is deliberately omitted â€” how a route learns which space it is about is internal, and a tooltip has
+ * `scope` is deliberately omitted — how a route learns which space it is about is internal, and a tooltip has
  * no use for it.
  *
  * `implications` is published for the same reason the routes are: `knowledge: write` entails `schema: read`
@@ -53,12 +53,12 @@ tokensRouter.get('/rights-catalog', globalRateLimit, requireAuth, (_req, res) =>
 });
 
 /**
- * Fields the SERVER owns on a token record. A client that posts a token it read back â€” `id`, `hash`,
- * `prefix` â€” is round-tripping, not attacking, and being told "unknown key" for a field we ourselves emitted
+ * Fields the SERVER owns on a token record. A client that posts a token it read back — `id`, `hash`,
+ * `prefix` — is round-tripping, not attacking, and being told "unknown key" for a field we ourselves emitted
  * would be a worse answer than ignoring it.
  *
  * Same shape as `SERVER_OWNED_META_FIELDS` in `api/spaces.ts`: strip exactly the server-owned set, then let
- * a STRICT schema refuse everything else. The two halves are the point â€” the strip keeps a round-trip
+ * a STRICT schema refuse everything else. The two halves are the point — the strip keeps a round-trip
  * working, and the strictness is what stops `spaceIds` minting an unscoped token in silence.
  *
  * A red-team test (`mass-assignment.test.js`) pins the strip; `credential-bodies-are-strict.test.js` pins
@@ -81,8 +81,8 @@ function stripServerOwnedToken(body: unknown): unknown {
  * returned 201. The caller is told the operation succeeded, their own notes say the token is scoped, and it
  * reaches every space on the instance. Nothing in the response, the record or the logs tells the two apart.
  *
- * Reported by an operator on 2026-08-09 who probed four plausible spellings â€” `allowedSpaces`, `scope`,
- * `spaceIds`, `denySpaces` â€” and got 201 from every one. They found it by reading the stored token back and
+ * Reported by an operator on 2026-08-09 who probed four plausible spellings — `allowedSpaces`, `scope`,
+ * `spaceIds`, `denySpaces` — and got 201 from every one. They found it by reading the stored token back and
  * noticing four of five probes had no `spaces` at all. Their words: "somebody guessing the field name gets a
  * token that looks scoped, reports success, and is not scoped at all."
  *
@@ -105,7 +105,7 @@ const CreateTokenBody = z.object({
   /**
    * The per-space rights matrix for the new token.
    *
-   * Mutually exclusive with `spaces` / `admin` / `readOnly` â€” see the refusal below. Accepting both would
+   * Mutually exclusive with `spaces` / `admin` / `readOnly` — see the refusal below. Accepting both would
    * put two descriptions of the same thing in one request, and the loser would be silent.
    */
   rights: z.object({
@@ -119,7 +119,7 @@ const CreateTokenBody = z.object({
 /**
  * Granting an MFA exemption always costs a live second factor.
  *
- * `requireAdminMfa` on this route is satisfied by an admin token that is ITSELF exempt â€” which is correct for
+ * `requireAdminMfa` on this route is satisfied by an admin token that is ITSELF exempt — which is correct for
  * ordinary work and catastrophic here: one exemption could mint another, and another, until the instance-wide
  * switch protected nothing. Exemptions must not be able to widen themselves.
  *
@@ -140,11 +140,11 @@ function exemptionNeedsLiveCode(req: Request, res: Response, mfa: string | undef
   return true;
 }
 
-// GET /api/tokens â€” list tokens (hashes excluded) â€” admin only
+// GET /api/tokens — list tokens (hashes excluded) — admin only
 tokensRouter.get('/', requireAdminOrSpaceAdmin, (req, res) => {
   // A space-restricted administrator sees only the tokens it could act on.
   //
-  // It used to receive every token on the instance â€” names, prefixes, scopes and rights for spaces it cannot reach.
+  // It used to receive every token on the instance — names, prefixes, scopes and rights for spaces it cannot reach.
   // Nothing secret leaks (`listTokens()` omits the hash by its own type), but it is an inventory of the instance's
   // access, and the same token is now refused when it tries to EDIT any of those rows. A list that shows what you
   // cannot touch is an invitation to try.
@@ -152,8 +152,8 @@ tokensRouter.get('/', requireAdminOrSpaceAdmin, (req, res) => {
   // Unrestricted admins are unaffected. A `schemaLibrary` token has no space access, so it is inside every scope.
   //
   // Scope comes from `editorScopeFor`, which reads the RIGHTS MATRIX and falls back to the legacy allowlist.
-  // Reading `spaces` directly here meant a token minted with a matrix and no allowlist â€” every token minted
-  // since 2.6 â€” answered `undefined` and was treated as an unrestricted instance administrator.
+  // Reading `spaces` directly here meant a token minted with a matrix and no allowlist — every token minted
+  // since 2.6 — answered `undefined` and was treated as an unrestricted instance administrator.
   const callerSpaces = editorScopeFor(req.authToken);
   const all = listTokens();
   const visible = callerSpaces
@@ -162,7 +162,7 @@ tokensRouter.get('/', requireAdminOrSpaceAdmin, (req, res) => {
   res.json({ tokens: visible });
 });
 
-// POST /api/tokens â€” create a new PAT â€” admin + MFA
+// POST /api/tokens — create a new PAT — admin + MFA
 // admin:true may only be set when the calling token is itself admin (enforced by requireAdminMfa above)
 tokensRouter.post('/', authRateLimit, requireAdminOrSpaceAdminMfa, async (req, res) => {
   const parsed = CreateTokenBody.safeParse(stripServerOwnedToken(req.body));
@@ -173,7 +173,7 @@ tokensRouter.post('/', authRateLimit, requireAdminOrSpaceAdminMfa, async (req, r
   const { name, expiresAt, spaces, admin, readOnly, peerInstanceId, schemaLibrary, mfa, rights } = parsed.data;
 
   // One description of access per request. A body carrying both `rights` and a legacy field describes the
-  // same thing twice, and whichever lost would do so silently â€” which is the failure this whole area keeps
+  // same thing twice, and whichever lost would do so silently — which is the failure this whole area keeps
   // producing. Refusing costs one call; guessing costs an access nobody chose.
   if (rights && (spaces !== undefined || admin !== undefined || readOnly !== undefined)) {
     res.status(400).json({
@@ -185,15 +185,15 @@ tokensRouter.post('/', authRateLimit, requireAdminOrSpaceAdminMfa, async (req, r
   // A token may never mint above itself. Enforced HERE and not only in the UI: the grid is one API call away
   // from being bypassed, and the API is exactly where a token would be used to widen itself.
   if (rights) {
-    // OIDC records carry no `rights` â€” they are built per request and never pass through the config
-    // backfill â€” so the minter's matrix is derived on the spot from the same legacy fields. Deriving is the
+    // OIDC records carry no `rights` — they are built per request and never pass through the config
+    // backfill — so the minter's matrix is derived on the spot from the same legacy fields. Deriving is the
     // same answer, not a weaker one; treating a missing matrix as "unrestricted" would be the widening.
     const held = (req.authToken as { rights?: unknown } | undefined)?.rights;
     const minter = held ?? migrateToken(req.authToken ?? {});
     const excess = capRights(minter as never, rights as never);
     if (excess.length > 0) {
       res.status(403).json({
-        error: `A token cannot mint rights it does not hold â€” ${describeExcess(excess)}`,
+        error: `A token cannot mint rights it does not hold — ${describeExcess(excess)}`,
       });
       return;
     }
@@ -213,12 +213,12 @@ tokensRouter.post('/', authRateLimit, requireAdminOrSpaceAdminMfa, async (req, r
   // spaces, `admin: true`) and defeat its own scoping. An unrestricted creator may mint any scope.
   //
   // Scope from `editorScopeFor`, the same source the list filter and the PATCH guard now read. It used to be
-  // `req.authToken?.spaces` here, in the list filter, and inside `refusalsOutsideEditorScope` â€” three reads
+  // `req.authToken?.spaces` here, in the list filter, and inside `refusalsOutsideEditorScope` — three reads
   // of a deprecated field, and the comment on the PATCH guard already claimed all three shared one rule.
   const creatorSpaces = editorScopeFor(req.authToken);
   if (creatorSpaces) {
     if (schemaLibrary) {
-      // schemaLibrary tokens have no space access â€” always within any scope.
+      // schemaLibrary tokens have no space access — always within any scope.
     } else if (!spaces) {
       res.status(403).json({ error: 'A space-restricted token cannot create an unrestricted (all-spaces) token' });
       return;
@@ -235,17 +235,17 @@ tokensRouter.post('/', authRateLimit, requireAdminOrSpaceAdminMfa, async (req, r
   const effectiveReadOnly = schemaLibrary ? true : (readOnly ?? false);
   const effectiveSpaces = schemaLibrary ? [] : spaces;
   const { record, plaintext } = await createToken({ name, expiresAt: expiresAt ?? null, spaces: effectiveSpaces, admin, readOnly: effectiveReadOnly, peerInstanceId, schemaLibrary, mfa, rights: rights as never });
-  // Return plaintext only on creation â€” never retrievable again
+  // Return plaintext only on creation — never retrievable again
   const { hash: _h, ...safeRecord } = record;
   res.status(201).json({ token: safeRecord, plaintext });
 });
 
 /**
- * Fields `GET /api/tokens` emits that `PATCH` does not edit â€” and the remedy for each, where one exists.
+ * Fields `GET /api/tokens` emits that `PATCH` does not edit — and the remedy for each, where one exists.
  *
  * ## Why this list exists at all
  *
- * A reporter round-tripped a token â€” GET it, change the name, PATCH it back â€” and got
+ * A reporter round-tripped a token — GET it, change the name, PATCH it back — and got
  * `Unrecognized key(s) in object: 'spaces'`. Their words: *"the shape you read is not the shape you may
  * write, and nothing says which fields are which."* The response carries twelve fields; PATCH accepted two.
  *
@@ -259,7 +259,7 @@ tokensRouter.post('/', authRateLimit, requireAdminOrSpaceAdminMfa, async (req, r
  *
  * So the rule distinguishes an ECHO from a CHANGE, which is the distinction both of those answers lose:
  * the same value back is a round-trip and is ignored; a different value is a refusal that names the field
- * to use instead. `spaces`/`admin`/`readOnly` have a real remedy in the rights matrix and say so â€” the rest
+ * to use instead. `spaces`/`admin`/`readOnly` have a real remedy in the rights matrix and say so — the rest
  * are set at mint and cannot be edited on any route, which the message states rather than implying.
  */
 export const ECHOABLE: Record<string, string | null> = {
@@ -280,7 +280,7 @@ const ECHOABLE_FIELDS = Object.keys(ECHOABLE);
 /**
  * Is this the value already stored, or an attempted change?
  *
- * `spaces` is compared as a SET, because a round-trip may reorder it and an allowlist has no order â€” but
+ * `spaces` is compared as a SET, because a round-trip may reorder it and an allowlist has no order — but
  * `undefined` is only ever equal to `undefined`. Absent means "all spaces" and `[]` means "no spaces", the
  * conflation this repo has now fixed in four separate files, and it must not come back inside an equality
  * check where reading them as the same would let a token be widened to the whole instance in silence.
@@ -312,13 +312,13 @@ const RenameTokenBody = z.object({
     perSpace: z.record(z.string(), z.record(z.enum(SPACE_AREAS), z.enum(RUNGS))),
   }).strict().optional(),
   /**
-   * This token's relationship to the second factor â€” editable HERE and nowhere else.
+   * This token's relationship to the second factor — editable HERE and nowhere else.
    *
    * It used to be settable only while minting, which put the decision before there was a token to decide it
    * about: an operator who wanted their scheduler exempt had to revoke it and mint a replacement, rotating a
    * secret to change a flag. It is a property of the token, so it is set on the token.
    *
-   * Granting `exempt` costs a live TOTP code on THIS request when the instance switch is on â€” the same rule
+   * Granting `exempt` costs a live TOTP code on THIS request when the instance switch is on — the same rule
    * create has, applied here for the same reason. `requireAdminMfa` is satisfied by an admin token that is
    * itself exempt, so without it one exemption could grant another by the shorter route, and editing yourself
    * is shorter still than minting.
@@ -333,7 +333,7 @@ const RenameTokenBody = z.object({
   ...Object.fromEntries(ECHOABLE_FIELDS.map(f => [f, z.unknown()])),
 }).strict();
 
-// PATCH /api/tokens/:id â€” rename a token's label (only) â€” admin + MFA
+// PATCH /api/tokens/:id — rename a token's label (only) — admin + MFA
 tokensRouter.patch('/:id', requireAdminOrSpaceAdminMfa, (req, res) => {
   const parsed = RenameTokenBody.safeParse(stripServerOwnedToken(req.body));
   if (!parsed.success) {
@@ -350,7 +350,7 @@ tokensRouter.patch('/:id', requireAdminOrSpaceAdminMfa, (req, res) => {
 
   // A SPACE-RESTRICTED administrator may only touch its own spaces' rows.
   //
-  // `requireAdminMfa` admits a space-restricted admin, because it carries `admin: true` â€” so before this guard existed,
+  // `requireAdminMfa` admits a space-restricted admin, because it carries `admin: true` — so before this guard existed,
   // such a token could rename any token on the instance and write `rights.instanceAdmin` onto it. Measured, not
   // supposed: both answered 200 and the rights were stored. They were inert only because the admin routes still gate on
   // the legacy `admin` flag rather than on `rights`.
@@ -364,7 +364,7 @@ tokensRouter.patch('/:id', requireAdminOrSpaceAdminMfa, (req, res) => {
   });
   if (scopeRefusals.length > 0) {
     res.status(403).json({
-      error: `A space-restricted administrator cannot make this edit â€” ${scopeRefusals.join('; ')}.`,
+      error: `A space-restricted administrator cannot make this edit — ${scopeRefusals.join('; ')}.`,
       refusals: scopeRefusals,
     });
     return;
@@ -372,7 +372,7 @@ tokensRouter.patch('/:id', requireAdminOrSpaceAdminMfa, (req, res) => {
 
   // An echoed field is a round-trip and is ignored; a CHANGED one is refused by name. Presence is read off
   // the raw body rather than the parsed data, because `z.unknown()` cannot distinguish an absent key from
-  // one explicitly set to `undefined` â€” and "absent" vs "present and null" is the whole question here.
+  // one explicitly set to `undefined` — and "absent" vs "present and null" is the whole question here.
   const sentBody = (stripServerOwnedToken(req.body) ?? {}) as Record<string, unknown>;
   const stored = previous as unknown as Record<string, unknown>;
   const attempted = ECHOABLE_FIELDS
@@ -382,7 +382,7 @@ tokensRouter.patch('/:id', requireAdminOrSpaceAdminMfa, (req, res) => {
     res.status(400).json({
       error: `Cannot change ${attempted.map(f => `\`${f}\``).join(', ')} on this route. `
         + attempted.map(f => ECHOABLE[f] ? `For \`${f}\`, ${ECHOABLE[f]}.` : `\`${f}\` is set when the token is minted.`).join(' ')
-        + ' Sending these fields UNCHANGED is fine â€” a token you read back round-trips.',
+        + ' Sending these fields UNCHANGED is fine — a token you read back round-trips.',
     });
     return;
   }
@@ -396,24 +396,24 @@ tokensRouter.patch('/:id', requireAdminOrSpaceAdminMfa, (req, res) => {
   }
 
   // The same live-code rule create has. `requireAdminMfa` is satisfied by an admin token that is itself
-  // exempt, so without this one exemption could grant another â€” and editing yourself is a shorter route to
+  // exempt, so without this one exemption could grant another — and editing yourself is a shorter route to
   // that than minting a replacement. Checked before anything is written, so a refused exemption leaves the
   // token exactly as it was rather than renamed-but-not-exempted.
   if (!exemptionNeedsLiveCode(req, res, mfa)) return;
 
   if (rights) {
-    // A token may never GRANT above itself, edit or mint. Same rule, same function â€” a second
+    // A token may never GRANT above itself, edit or mint. Same rule, same function — a second
     // implementation here is how the two would come to disagree about what "above" means.
     const editorRights = (req.authToken as { rights?: unknown } | undefined)?.rights
       ?? migrateToken(req.authToken ?? {});
     const excess = capRights(editorRights as never, rights as never);
     if (excess.length > 0) {
-      res.status(403).json({ error: `A token cannot grant rights it does not hold â€” ${describeExcess(excess)}` });
+      res.status(403).json({ error: `A token cannot grant rights it does not hold — ${describeExcess(excess)}` });
       return;
     }
 
     // And it may never raise its OWN floor. The mint cap stops handing more to a NEW token; without this
-    // the same escalation is available by a shorter route â€” edit yourself, then use yourself â€” and nothing
+    // the same escalation is available by a shorter route — edit yourself, then use yourself — and nothing
     // about the result looks unusual afterwards.
     const raised = refuseSelfFloorRaise(
       (req.authToken as { id?: string } | undefined)?.id,
@@ -423,7 +423,7 @@ tokensRouter.patch('/:id', requireAdminOrSpaceAdminMfa, (req, res) => {
     );
     if (raised.length > 0) {
       res.status(403).json({
-        error: `A token cannot raise its own floor â€” ${raised.join(', ')}. Ask another administrator.`,
+        error: `A token cannot raise its own floor — ${raised.join(', ')}. Ask another administrator.`,
       });
       return;
     }
@@ -458,7 +458,7 @@ tokensRouter.patch('/:id', requireAdminOrSpaceAdminMfa, (req, res) => {
   res.json({ token: updated });
 });
 
-// POST /api/tokens/:id/regenerate â€” rotate a token's secret â€” admin + MFA
+// POST /api/tokens/:id/regenerate — rotate a token's secret — admin + MFA
 tokensRouter.post('/:id/regenerate', authRateLimit, requireAdminOrSpaceAdminMfa, async (req, res) => {
   const plaintext = await regenerateToken(req.params['id'] as string);
   if (!plaintext) {
@@ -468,7 +468,7 @@ tokensRouter.post('/:id/regenerate', authRateLimit, requireAdminOrSpaceAdminMfa,
   res.json({ plaintext });
 });
 
-// DELETE /api/tokens/:id â€” revoke a token â€” admin + MFA
+// DELETE /api/tokens/:id — revoke a token — admin + MFA
 tokensRouter.delete('/:id', requireAdminOrSpaceAdminMfa, async (req, res) => {
   const id = req.params['id'] as string;
   const all = listTokens();

--- a/server/src/mcp/tools/entity.ts
+++ b/server/src/mcp/tools/entity.ts
@@ -185,7 +185,10 @@ export const update_entityTool: ToolHandler = {
 
 export const merge_entitiesTool: ToolHandler = {
   name: 'merge_entities',
-  description: 'Merge two entities into one. The survivor keeps its identity; the absorbed entity is deleted after relinking all references. Call with an empty or partial resolution map to get a conflict plan (409), or with a fully resolved map to execute. Numeric properties support fn:<avg|min|max|sum>, boolean properties support fn:<and|or|xor>, strings require "survivor", "absorbed", or "custom" with customValue.',
+  description: 'Merge two entities into one. IRREVERSIBLE: the survivor keeps its identity and id, every reference to the absorbed entity is relinked to it, and the absorbed record is then DELETED. There is no unmerge.\n\n'
+    + 'TWO-PHASE BY DESIGN, and the 409 is the feature rather than an error. Call it with an empty or partial `resolution` and you get a CONFLICT PLAN back with status 409: every property where the two disagree, with both values. Call it again with a fully resolved map and it executes. A 409 on the first call is the expected path — treat it as the question being asked, not as a failure to retry.\n\n'
+    + 'RESOLVE EVERY CONFLICT OR NOTHING HAPPENS. A partial map returns the plan again rather than merging what it can, because a half-merge would leave two records that are neither separate nor one.\n\n'
+    + 'Per type: numeric properties accept `fn:avg|min|max|sum`, booleans accept `fn:and|or|xor`, and strings take "survivor", "absorbed", or "custom" with `customValue` — there is no function that can combine two strings sensibly, so you have to choose. Properties that do NOT conflict are carried over without appearing in the plan.',
   mutating: true,
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({
@@ -350,7 +353,9 @@ export const find_entities_by_nameTool: ToolHandler = {
  */
 export const delete_entityTool: ToolHandler = {
   name: 'delete_entity',
-  description: 'Delete an entity by ID. Refused when strictLinkage is on and other records still reference it. Creates a tombstone for sync propagation.',
+  description: 'Delete an entity by id. IRREVERSIBLE, and it is a DELETE rather than a retire — if you want the record to stop appearing in semantic search while staying readable and traversable, set `excludeFromVectorSearch` on it instead.\n\n'
+    + 'A REFUSAL HERE IS USUALLY CORRECT. With `strictLinkage` on, an entity still referenced by edges, memories, chrono entries or files is refused, and the answer names what points at it. That is the signal that deleting it would orphan something — resolve those first, or `merge_entities` into the record that should have held them.\n\n'
+    + 'It writes a TOMBSTONE, so the deletion propagates to peer instances on the next sync. A space that syncs will not quietly resurrect the record from a peer, and the tombstone is why.',
   mutating: true,
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({

--- a/server/src/sync/governance.ts
+++ b/server/src/sync/governance.ts
@@ -181,7 +181,7 @@ export function sendMemberRemovedNotify(
   const secrets = getSecrets();
   const peerToken = secrets.peerTokens[subjectInstanceId];
   if (!peerToken) {
-    log.warn(`member_removed: no outbound token for ${subjectInstanceId} â€” cannot notify`);
+    log.warn(`member_removed: no outbound token for ${subjectInstanceId} — cannot notify`);
     return;
   }
   peerSafeFetch(`${subjectUrl}/api/notify`, {

--- a/testing/standalone/destructive-tools-say-what-cannot-be-undone.test.js
+++ b/testing/standalone/destructive-tools-say-what-cannot-be-undone.test.js
@@ -1,0 +1,91 @@
+/**
+ * A destructive tool says so, and says what to do instead when the caller meant something gentler.
+ *
+ * ## X-2, the entity-management family
+ *
+ * `merge_entities` and `delete_entity` both described their mechanics accurately and neither said the word
+ * that matters most to an agent deciding whether to call them: **irreversible**. An agent weighing a tool
+ * call has no undo and no confirmation dialog; the schema is the only place that warning can live.
+ *
+ * ## The 409 that is not an error
+ *
+ * `merge_entities` is two-phase: call it with an empty resolution and it answers **409 with a conflict plan**.
+ * That is the question being asked, not a failure — but a client with a generic retry-on-4xx path will hammer
+ * it, and one with a generic fail-on-4xx path will report a merge as broken. The description now says the
+ * first call is expected to 409.
+ *
+ * ## And the gentler thing they probably meant
+ *
+ * A caller reaching for `delete_entity` often wants the record to stop cluttering recall, not to be gone.
+ * That is `excludeFromVectorSearch`, which keeps it readable and traversable — and a schema that does not
+ * name the alternative is one where the destructive option is the only one anybody finds.
+ *
+ * A refusal under `strictLinkage` is the same shape: it is usually CORRECT, and reads as an obstacle unless
+ * the description says it means the deletion would orphan something.
+ *
+ * Run: node --test testing/standalone/destructive-tools-say-what-cannot-be-undone.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const SRC = readFileSync('server/src/mcp/tools/entity.ts', 'utf8');
+const tool = (name) => {
+  const at = SRC.indexOf(`name: '${name}'`);
+  assert.ok(at > 0, `${name} was not found — the scanner is wrong, not the code`);
+  const next = SRC.indexOf("name: '", at + 20);
+  return next === -1 ? SRC.slice(at) : SRC.slice(at, next);
+};
+
+const MERGE = tool('merge_entities');
+const DELETE = tool('delete_entity');
+
+describe('both say they cannot be undone', () => {
+  for (const [label, text] of [['merge_entities', MERGE], ['delete_entity', DELETE]]) {
+    it(`${label} says IRREVERSIBLE`, () => {
+      // An agent has no undo and no confirmation dialog. The schema is where the warning has to live.
+      assert.match(text, /IRREVERSIBLE/, 'say it in the description, not only in the docs');
+    });
+  }
+});
+
+describe('merge_entities: the 409 is the question, not a failure', () => {
+  it('says the first call is expected to 409 with a plan', () => {
+    // A generic retry-on-4xx client hammers it; a generic fail-on-4xx client reports a working merge as
+    // broken. Both are avoidable by saying which status the happy path returns.
+    assert.match(MERGE, /CONFLICT PLAN/, 'name what comes back');
+    assert.match(MERGE, /expected path/,
+      'say the 409 is expected — otherwise it reads as an error to handle');
+  });
+
+  it('says a partial resolution merges NOTHING', () => {
+    assert.match(MERGE, /RESOLVE EVERY CONFLICT OR NOTHING HAPPENS/,
+      'a half-merge would leave two records that are neither separate nor one');
+  });
+
+  it('says non-conflicting properties never appear in the plan', () => {
+    // Otherwise a short plan looks like the tool missed something.
+    assert.match(MERGE, /without appearing in the plan/,
+      'a plan listing only conflicts is complete, not partial');
+  });
+});
+
+describe('delete_entity: the alternative, and why a refusal is right', () => {
+  it('names excludeFromVectorSearch as the gentler thing', () => {
+    // The commonest actual intent — stop it cluttering recall — is not a delete at all.
+    assert.match(DELETE, /excludeFromVectorSearch/,
+      'a schema that does not name the alternative makes the destructive option the only discoverable one');
+    assert.match(DELETE, /readable and traversable/, 'say what the alternative preserves');
+  });
+
+  it('says a strictLinkage refusal is usually CORRECT', () => {
+    assert.match(DELETE, /usually correct/i,
+      'it reads as an obstacle unless the description says it means an orphan would be created');
+    assert.match(DELETE, /merge_entities/, 'point at the tool that resolves it properly');
+  });
+
+  it('explains the tombstone rather than just naming it', () => {
+    assert.match(DELETE, /will not quietly resurrect/,
+      'the tombstone exists so a peer does not re-add the record — say the consequence');
+  });
+});

--- a/testing/standalone/mcp-delete-parity.test.js
+++ b/testing/standalone/mcp-delete-parity.test.js
@@ -85,8 +85,13 @@ describe('MCP can delete everything REST can delete', () => {
       const src = read(file);
       const at = src.indexOf(`name: '${tool}'`);
       assert.ok(at > 0, `${tool} not found in ${file}`);
-      // `mutating` sits within the handful of lines after `name`. The read-only gate is derived from it.
-      assert.match(src.slice(at, at + 400), /mutating: true/, `${tool} must be marked mutating`);
+      // Sliced to the NEXT tool rather than a fixed 400 characters. `mutating` sits a few lines after `name`
+      // in source order, but a `description` between them is prose and can be any length — X-2 grew several
+      // past 400 and this reported `delete_entity` as unmarked while it was marked all along. A window sized
+      // to today's prose is a gate that fails on an edit to a comment.
+      const next = src.indexOf("name: '", at + 20);
+      const block = next === -1 ? src.slice(at) : src.slice(at, next);
+      assert.match(block, /mutating: true/, `${tool} must be marked mutating`);
     }
   });
 });

--- a/testing/standalone/no-source-file-carries-mojibake.test.js
+++ b/testing/standalone/no-source-file-carries-mojibake.test.js
@@ -1,0 +1,69 @@
+/**
+ * No tracked source file contains mojibake — UTF-8 that was decoded as ANSI and re-encoded.
+ *
+ * ## How it gets in, and why nothing catches it
+ *
+ * PowerShell 5.1's `Get-Content` decodes a BOM-less UTF-8 file as ANSI, so every multi-byte character arrives
+ * as its individual bytes. `Set-Content -Encoding utf8` then writes those bytes back out as characters. An
+ * em-dash (E2 80 94) comes out as the three characters `â€”`.
+ *
+ * The file still parses. It still compiles. Every test still passes. The damage is invisible to `tsc` and to
+ * every gate in this repo, because it is only ever inside comments and human-readable strings — which is
+ * exactly where it does its harm: those strings are tool descriptions an agent READS.
+ *
+ * ## It has happened twice, both times to me, both times through the same shell idiom
+ *
+ * `(Get-Content f -Raw) -replace ... | Set-Content -Encoding utf8 f` corrupted `loop-check.test.js`, which
+ * was caught in the same session and rewritten. It then corrupted `api/tokens.ts` during the space-admin
+ * change and MERGED — 49 sequences, discovered only by scanning the tree afterwards.
+ *
+ * A rule against the idiom was not enough, and the second occurrence is what makes this a gate. Edit files
+ * with a UTF-8-native tool; if a scripted rewrite is genuinely needed, do it in node.
+ *
+ * ## The `Â ` case is deliberately excluded
+ *
+ * A stray `Â ` is the same corruption applied to a non-breaking space, but non-breaking spaces occur
+ * legitimately in some content and a false positive here would be tuned away rather than fixed. `â€` cannot
+ * occur in any language this repo is written in, so it is the signature worth gating on.
+ *
+ * Run: node --test testing/standalone/no-source-file-carries-mojibake.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+
+/** The unambiguous signature: `â€` is the first two bytes of any mis-decoded U+20xx punctuation. */
+const MOJIBAKE = /â€|Ã¢â‚¬/;
+
+const tracked = (globs) => execSync(`git ls-files ${globs}`, { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 })
+  .split('\n').map(s => s.trim()).filter(Boolean);
+
+describe('no source file carries mis-decoded UTF-8', () => {
+  it('scans a meaningful number of files — the gate before the property', () => {
+    // An empty file list passes silently and would hide the exact defect this exists for.
+    const files = tracked('"server/src/**/*.ts" "client/src/**/*.ts"');
+    assert.ok(files.length > 200, `only enumerated ${files.length} source files — the walk is broken`);
+  });
+
+  it('server and client sources are clean', () => {
+    const offenders = tracked('"server/src/**/*.ts" "client/src/**/*.ts"')
+      .filter(f => MOJIBAKE.test(readFileSync(f, 'utf8')));
+    assert.deepEqual(offenders, [], 'these were written by a tool that decoded UTF-8 as ANSI:\n  '
+      + offenders.join('\n  ') + '\nRepair with node, not PowerShell.');
+  });
+
+  it('MCP tool descriptions especially — an agent reads these', () => {
+    // Narrowed on purpose as well as covered above: a corrupted comment is ugly, and a corrupted tool
+    // description is a reference an agent constructs arguments from.
+    const offenders = tracked('"server/src/mcp/**/*.ts"')
+      .filter(f => MOJIBAKE.test(readFileSync(f, 'utf8')));
+    assert.deepEqual(offenders, []);
+  });
+
+  it('the detector actually detects', () => {
+    // Mutation-proof for the regex itself: a gate whose pattern never matches passes everything.
+    assert.ok(MOJIBAKE.test('capability documentation â€” every route'), 'the pattern must match real mojibake');
+    assert.ok(!MOJIBAKE.test('capability documentation — every route'), 'and must not match the correct text');
+  });
+});


### PR DESCRIPTION
X-2, eleventh and twelfth tools — plus a defect of mine that this work uncovered.

## The destructive pair never said so

An agent deciding whether to call a tool has **no undo and no confirmation dialog**. The schema is the only
place that warning can live, and neither `merge_entities` nor `delete_entity` said **irreversible**.

`delete_entity` now also names the gentler thing a caller usually meant: `excludeFromVectorSearch`, which
stops a record cluttering search while keeping it readable and traversable. A reference that does not name the
alternative makes the destructive option the only discoverable one.

And a `strictLinkage` refusal is now stated as **usually correct** — it means the delete would orphan
something — with `merge_entities` named as the proper resolution.

## `merge_entities`: the 409 is the question, not a failure

Its first call is *expected* to return 409 with a conflict plan. A generic retry-on-4xx client hammers it; a
generic fail-on-4xx client reports a working merge as broken. Now stated, along with two things a caller
cannot infer:

- a **partial** resolution merges nothing — a half-merge would leave two records that are neither separate nor
  one;
- properties the two records **agree on** never appear in the plan, so a short plan is complete, not partial.

## Two gates fired, and one of them found something I shipped

**`mcp-delete-parity`** reported `delete_entity` as not marked mutating. It was marked all along — the gate
read a fixed 400-character window after the tool name, and a longer description pushed the flag past it. Fixed
by slicing to the next tool, the way the newer gates do. Mutation-tested: removing the flag still fails it.

**Then a tree scan found mojibake in seven server files.** UTF-8 read as ANSI and written back, turning every
em-dash into `â€"`. Six were long-standing. **One was `api/tokens.ts` — mine, from the space-admin change,
already merged**, 49 sequences, including the rights-catalog reference text that agents read.

It compiles, `tsc` is silent, and every test passes, because the damage only ever lands in comments and
human-readable strings — which is precisely where it matters here.

All seven are repaired (with node, not PowerShell), and a gate now scans every tracked source file for the
signature. This is the second time the same shell idiom has done this to me in one session; the first was
caught in-session, this one was not, which is what makes it a gate rather than a rule.

8 new tests plus the mojibake gate, `npm run preflight` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
