### PR TITLE
docs(spaces): the first call an agent makes, and what a count does not mean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Listing spaces and reading their counts now orient an assistant that has just connected.** Listing spaces
+  is the first call anything makes in an unfamiliar instance — every other tool needs a space id, and the ids
+  are not guessable from the labels — and the reference never said so. It also now says that a space's stated
+  **purpose** is the owner telling the assistant what belongs there and how to behave in it, rather than one
+  more descriptive string: a purpose exists because somebody needed it followed. The counts are framed as a
+  planning aid, since an empty space is not worth searching and a very large one needs a filter rather than a
+  broad question. Record counts now say what they do **not** mean: they are totals, and they include records
+  retired from search and records whose indexing has not finished, so a count larger than a search result is
+  normal rather than a sign of a broken index — with the tool that answers the indexing question named. Both
+  also now say that a space grouping other spaces reports their totals combined, so four spaces are not
+  mistaken for one large one.
+
 - **Punctuation mangled into `â€"` is repaired across the server sources.** Seven files carried text that had
   been read as one character encoding and written back as another, turning every dash and curly quote into
   three garbled characters. Six were long-standing; one was introduced earlier in this same release and

--- a/server/src/mcp/tools/spaces.ts
+++ b/server/src/mcp/tools/spaces.ts
@@ -9,7 +9,10 @@ import { SPACE_PURPOSE_MAX, needsReindex } from '../../spaces/_shared.js';
 
 export const list_spacesTool: ToolHandler = {
   name: 'list_spaces',
-  description: 'List all accessible spaces with their IDs, labels, purposes, and entry counts (memories, entities, edges, chrono). Use counts to decide which spaces are populated and worth querying.',
+  description: 'List every space this token can reach, with ids, labels, purposes and entry counts. CALL THIS FIRST in an unfamiliar instance: every other tool takes a space id, and the ids are not guessable from the labels.\n\n'
+    + 'READ THE `purpose`. It is the space owner telling you what belongs there and how to behave in it — conventions, what to write, what not to. A space with a purpose has one because somebody needed you to follow it.\n\n'
+    + 'The counts are what make this a planning tool rather than a directory: an empty space is not worth a recall, and a space with 40 000 records needs a filter rather than a broad query. A PROXY space reports its members\' totals combined and is marked as a proxy — writes to one need `targetSpace`.\n\n'
+    + 'Accessibility is per TOKEN. A space absent here is not a space that does not exist; it is one this token holds no rung in.',
   inputSchema: (_s: ToolSchemas) => ({ type: 'object', properties: {}, required: [], additionalProperties: false }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
     const { accessibleSpaces , accessibleSpaceIds } = ctx;
@@ -53,7 +56,9 @@ export const list_spacesTool: ToolHandler = {
 
 export const get_statsTool: ToolHandler = {
   name: 'get_stats',
-  description: 'Return counts of memories, entities, edges, and chrono entries for the current space.',
+  description: 'Return counts of memories, entities, edges, chrono entries and files for one space — the cheapest call there is, and the right way to check whether a space holds anything before spending a recall on it.\n\n'
+    + 'These are TOTALS, not search coverage. A record retired from semantic ranking is counted here and cannot be reached by `recall`, and a record written seconds ago is counted before its embedding exists. So a count that exceeds what a search returns is normal and is not evidence of a broken index — `list_embed_jobs` is what answers "is anything still queued or failed".\n\n'
+    + 'On a PROXY space the numbers are the members\' totals combined, so a per-member breakdown means asking each member by id.',
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({
           type: 'object',

--- a/testing/standalone/space-info-tools-orient-a-caller.test.js
+++ b/testing/standalone/space-info-tools-orient-a-caller.test.js
@@ -1,0 +1,91 @@
+/**
+ * The space-information tools orient a caller who has just connected.
+ *
+ * ## X-2, the space family
+ *
+ * `list_spaces` is the FIRST call an agent makes in an unfamiliar instance — every other tool takes a space
+ * id, and the ids are not guessable from the labels. Its description listed the fields it returns and never
+ * said that, nor that the `purpose` field is the space owner telling the agent how to behave there.
+ *
+ * A purpose exists because somebody needed it followed. A tool reference that presents it as one more string
+ * among ids and counts is why it gets skipped.
+ *
+ * ## Counts are not search coverage
+ *
+ * `get_stats` returns totals. A record retired from semantic ranking is counted and cannot be recalled; a
+ * record written seconds ago is counted before its embedding exists. So `count > what a search returned` is
+ * NORMAL — and without being told, it reads as a broken index. This is the same family of misreading as an
+ * empty `find_similar`: the number is right and the inference from it is wrong.
+ *
+ * ## Proxy spaces aggregate
+ *
+ * Both tools report a proxy's members combined. A caller who does not know that will read one large space
+ * where there are four, and will write to it without the `targetSpace` a proxy write requires.
+ *
+ * Run: node --test testing/standalone/space-info-tools-orient-a-caller.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const SRC = readFileSync('server/src/mcp/tools/spaces.ts', 'utf8');
+const tool = (name) => {
+  const at = SRC.indexOf(`name: '${name}'`);
+  assert.ok(at > 0, `${name} was not found — the scanner is wrong, not the code`);
+  const next = SRC.indexOf("name: '", at + 20);
+  return next === -1 ? SRC.slice(at) : SRC.slice(at, next);
+};
+
+const LIST = tool('list_spaces');
+const STATS = tool('get_stats');
+
+describe('list_spaces orients a new caller', () => {
+  it('says to call it first, and why', () => {
+    assert.match(LIST, /CALL THIS FIRST/, 'every other tool needs a space id');
+    assert.match(LIST, /not guessable from the labels/,
+      'say why guessing does not work, or a caller will guess');
+  });
+
+  it('tells the agent that `purpose` is instructions for it', () => {
+    // The field most likely to be skipped, and the one a space owner wrote FOR the agent.
+    assert.match(LIST, /what belongs there and how to behave/,
+      'purpose is not a description, it is direction');
+    assert.match(LIST, /somebody needed you to follow it/, 'say why it is there');
+  });
+
+  it('says the counts are for planning, not decoration', () => {
+    assert.match(LIST, /planning tool rather than a directory/,
+      'an empty space is not worth a recall; a huge one needs a filter');
+  });
+
+  it('says an absent space may simply be unreachable by this token', () => {
+    assert.match(LIST, /holds no rung in/,
+      'absent is not non-existent — otherwise a caller reports a space as missing');
+  });
+});
+
+describe('get_stats says what its numbers do NOT mean', () => {
+  it('warns that totals exceed search coverage, and that this is normal', () => {
+    // Without it, a count larger than a search result reads as a broken index.
+    assert.match(STATS, /TOTALS, not search coverage/, 'name the distinction plainly');
+    assert.match(STATS, /is normal and is not evidence of a broken index/,
+      'pre-empt the wrong inference, which is the whole point of saying it');
+  });
+
+  it('names the tool that answers the indexing question instead', () => {
+    assert.match(STATS, /list_embed_jobs/,
+      'a warning with no remedy sends the caller looking; name the tool');
+  });
+});
+
+describe('both say a proxy aggregates', () => {
+  for (const [label, text] of [['list_spaces', LIST], ['get_stats', STATS]]) {
+    it(`${label} says a proxy reports its members combined`, () => {
+      assert.match(text, /PROXY|proxy/, 'a proxy is not one space and the numbers are not one space\'s');
+      // Matched without the apostrophe: it is escaped as \' inside the single-quoted TS string, so a regex
+      // written against the rendered text does not match the source.
+      assert.match(text, /totals combined/,
+        'say that the figure is a sum, or four spaces read as one large one');
+    });
+  }
+});


### PR DESCRIPTION
X-2, thirteenth and fourteenth tools — the two an agent reaches for **before it knows anything**.

## `list_spaces` is the first call, and never said so

Every other tool takes a space id, and the ids are not guessable from the labels. The description listed the
fields it returns and left the caller to work that out.

**It also never said what `purpose` is for.** That field is the space owner telling the agent what belongs
there and how to behave in it — conventions, what to write, what not to. A reference that presents it as one
more string among ids and counts is precisely why it gets skipped. A purpose exists because somebody needed it
followed.

The counts are now framed as a **planning** aid rather than a directory listing: an empty space is not worth a
recall, and one with 40 000 records needs a filter rather than a broad query.

And an absent space is not a non-existent one — it is one this token holds no rung in, which is a different
thing to report.

## `get_stats` needed to say what its numbers do NOT mean

They are **totals**, not search coverage. A record retired from semantic ranking is counted and cannot be
recalled; a record written seconds ago is counted before its embedding exists.

So a count larger than what a search returned is **normal** — and without being told, it reads as a broken
index. Same family of misreading as an empty `find_similar`: the number is right and the inference from it is
wrong. `list_embed_jobs` is named as the tool that actually answers *"is anything still queued or failed"*,
because a warning with no remedy just sends the caller looking.

## Both: a proxy aggregates

A space grouping others reports their totals combined. A caller who does not know reads one large space where
there are four — and writes to it without the `targetSpace` a proxy write requires.

## A note on the test

One assertion had to drop an apostrophe: the source escapes it as `\'` inside a single-quoted TypeScript
string, so a regex written against the *rendered* text does not match the *source*. Noted in the test rather
than silently loosened.

8 tests, `npm run preflight` green. ~26 remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
