### PR TITLE
docs(mcp): the embed-job tools say WHICH QUEUE they act on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The embedding-queue tools now say which queue they act on — one of them is not the queue its name
+  suggests.** `retry_failed_embeddings` sits directly beside the tool that lists pending and failed record
+  embeddings, and re-queues the **media** pipeline instead: image captioning, transcription, document
+  extraction. So the obvious sequence — list the failures, then retry them — quietly acted on a different
+  queue and reported a count unrelated to what was listed. Both references now say which queue is which and
+  name the right tool for a single record, and a build check pins that description against the code it calls
+  so the two cannot drift. Renaming it properly is a breaking change and is filed separately. The job listing
+  also now explains its two counters, one of which is new in this release: attempts spent on failures a retry
+  cannot fix, versus times the embedder simply did not answer. A job with many of the second and none of the
+  first is an outage waiting itself out and needs nothing from an operator; a failed job that used up the
+  first is a record whose content needs fixing. It also notes that failed jobs are retried once automatically
+  after a version upgrade, so there is no need to sweep them by hand.
+
 - **Listing spaces and reading their counts now orient an assistant that has just connected.** Listing spaces
   is the first call anything makes in an unfamiliar instance — every other tool needs a space id, and the ids
   are not guessable from the labels — and the reference never said so. It also now says that a space's stated

--- a/server/src/mcp/tools/embed.ts
+++ b/server/src/mcp/tools/embed.ts
@@ -33,7 +33,19 @@ export const list_embed_jobsTool: ToolHandler = {
   description: 'List brain records whose embedding is pending, in progress, or has failed, with the attempt count and '
     + 'last error for each. A record with an unfinished job is STORED but not yet findable by recall or query — this is '
     + 'how you tell "the record is missing" from "the record has no vector yet". Filter with `status`; omit it for the '
-    + 'whole backlog. Counts are returned either way.',
+    + 'whole backlog. Counts are returned either way.\n\n'
+    + 'READING `attempts` AND `transientFailures`: they answer different questions and a job can climb one without the '
+    + 'other. `attempts` is the PERMANENT-failure budget and is spent only on errors a retry cannot fix — a malformed '
+    + 'input, a rejection from a reachable embedder. `transientFailures` counts the times the embedder simply did not '
+    + 'answer (connection refused, DNS, a timeout, a 429 or 5xx); those hand the attempt back and back off instead, up '
+    + 'to half-hourly, and NEVER go terminal. So a high `transientFailures` with `attempts` at zero is an outage waiting '
+    + 'itself out and needs nothing from you; a `failed` job with `attempts` at its maximum is a record that cannot be '
+    + 'embedded and needs the content fixed. `lastError` tells you which.\n\n'
+    + 'A terminal `failed` job is also revived once per server VERSION at startup, so an upgrade retries everything that '
+    + 'died under the old one without anybody asking.\n\n'
+    + 'This tool only REPORTS. The per-record retry lives on its own mutating tool, and a read-only token is '
+    + 'deliberately not shown one — `help()` lists what your token can actually reach, so if no retry appears there, '
+    + 'the answer is that this token cannot retry rather than that no such tool exists.',
   mutating: false,
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({
@@ -149,8 +161,13 @@ export const retry_record_embeddingTool: ToolHandler = {
  */
 export const retry_failed_embeddingsTool: ToolHandler = {
   name: 'retry_failed_embeddings',
-  description: 'Re-queue EVERY failed media job in a space at once, so the worker picks them all up again — the '
-    + 'recovery path after an embedder or model outage. Returns how many jobs were reset. Use this instead of '
+  description: 'THE MEDIA QUEUE, NOT THE BRAIN ONE — read this before reaching for it. Despite the name, and '
+    + 'despite sitting beside `list_embed_jobs`, this re-queues failed MEDIA jobs: image captioning, audio and '
+    + 'video transcription, document extraction. It does NOT touch the brain embed jobs that `list_embed_jobs` '
+    + 'reports; for one of those use `retry_record_embedding`, and note that a brain job that failed against an '
+    + 'unreachable embedder is already retried on its own and needs no intervention at all.\n\n'
+    + 'Re-queues EVERY failed media job in a space at once, so the worker picks them all up again — the '
+    + 'recovery path after an extractor or model outage. Returns how many jobs were reset. Use this instead of '
     + 'calling retry_embedding once per file; use retry_embedding when you want one specific file. Jobs the '
     + 'worker currently holds are left alone rather than interrupted. On a proxy space every member is retried, '
     + 'because that is what asking the proxy means.',

--- a/testing/standalone/embed-job-tools-say-which-queue.test.js
+++ b/testing/standalone/embed-job-tools-say-which-queue.test.js
@@ -1,0 +1,119 @@
+/**
+ * The embed-job tools say which QUEUE they act on, and how to read a job's two counters.
+ *
+ * ## The trap in the names
+ *
+ * `list_embed_jobs` reports BRAIN embed jobs. `retry_failed_embeddings` sits in the same module, next to it,
+ * with a name that reads as its remedy — and re-queues the MEDIA queue instead: captioning, transcription,
+ * document extraction. It imports `files/media/job-queue.js`, which is a fact about the code rather than a
+ * suspicion.
+ *
+ * So the obvious sequence — list the failed embed jobs, then retry the failed embeddings — silently acts on a
+ * different queue and reports a count that has nothing to do with what was listed. Nothing in either
+ * description said so. The tool for a brain record is `retry_record_embedding`.
+ *
+ * Renaming is the real fix and is a breaking change to a tool name; until then, each description says which
+ * queue it is, which is the half that can ship today.
+ *
+ * ## Two counters that answer different questions
+ *
+ * As of the transient-failure change, a job carries `attempts` (the permanent-failure budget) and
+ * `transientFailures` (the embedder did not answer). A high `transientFailures` with `attempts` at zero is an
+ * outage waiting itself out and needs nothing; a `failed` job with `attempts` at its maximum is a record that
+ * cannot be embedded and needs its content fixed. Reading one without the other gives the wrong answer in
+ * both directions, and the field is new this release so nobody has prior knowledge of it.
+ *
+ * Run: node --test testing/standalone/embed-job-tools-say-which-queue.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const SRC = readFileSync('server/src/mcp/tools/embed.ts', 'utf8');
+/**
+ * The tool's DESCRIPTION only — from `description:` to the next sibling key.
+ *
+ * Slicing "to the next `name: '`" reads too far: the next tool's doc comment sits above its object, so the
+ * slice swallows it and a `doesNotMatch` assertion fails on a tool name that appears in the NEIGHBOUR's
+ * prose. That is a false positive in the test, and it looked exactly like a real one.
+ */
+const at = (name) => {
+  const i = SRC.indexOf(`name: '${name}'`);
+  assert.ok(i > 0, `${name} was not found — the scanner is wrong, not the code`);
+  return i;
+};
+
+const tool = (name) => {
+  const start = at(name);
+  const desc = SRC.indexOf('description:', start);
+  assert.ok(desc > start, `${name} has no description`);
+  const end = SRC.slice(desc).search(/\n {2}(mutating|spaceRequired|inputSchema|async handle):/);
+  assert.ok(end > 0, `could not find the end of ${name}'s description`);
+  return SRC.slice(desc, desc + end);
+};
+
+/** The whole tool object, handler included — for pinning prose against what the code actually imports. */
+const body = (name) => {
+  const start = at(name);
+  const end = SRC.indexOf('\nexport const ', start);
+  return end === -1 ? SRC.slice(start) : SRC.slice(start, end);
+};
+
+const LIST = tool('list_embed_jobs');
+const RETRY_ALL = tool('retry_failed_embeddings');
+const RETRY_ALL_BODY = body('retry_failed_embeddings');
+
+describe('the queue each tool acts on is stated', () => {
+  it('retry_failed_embeddings says up front that it is the MEDIA queue', () => {
+    // It is the first thing in the description on purpose: a caller who reads one line must not act on the
+    // wrong queue, and the name actively misleads.
+    assert.match(RETRY_ALL, /THE MEDIA QUEUE, NOT THE BRAIN ONE/,
+      'the correction has to come before the description, not after it');
+    assert.match(RETRY_ALL, /retry_record_embedding/, 'name the tool that does the brain-side job');
+  });
+
+  it('and that it really is the media queue, not a stale comment', () => {
+    // Pinned against the import rather than trusting the prose either way — this is the assertion that makes
+    // the description checkable rather than plausible.
+    // Reads the whole tool object, not just the description — the import is in the handler, and the point of
+    // this assertion is precisely that the two must agree.
+    assert.match(RETRY_ALL_BODY, /files\/media\/job-queue\.js/,
+      'if this ever switches to the brain queue, the description above becomes a lie and must change with it');
+  });
+
+  it('list_embed_jobs does NOT name a mutating tool, and says why', () => {
+    // `mcp-help.test.js` refused the first draft: help() for a read-only token must not mention a tool that
+    // token cannot reach, and this description named two. The warning about the confusing name therefore
+    // lives on the mutating tool itself, where only a caller who can act on it sees it.
+    //
+    // What replaces it is the more useful fact anyway: an absent retry in help() means THIS TOKEN cannot
+    // retry, not that no such tool exists — which is the wrong conclusion a read-only caller would otherwise
+    // draw and report.
+    assert.doesNotMatch(LIST, /retry_record_embedding|retry_failed_embeddings/,
+      'a read-only tool must not advertise a mutating one');
+    assert.match(LIST, /only REPORTS/, 'say what this tool does and does not do');
+    assert.match(LIST, /cannot retry rather than that no such tool exists/,
+      'pre-empt the wrong conclusion from an absent tool');
+  });
+});
+
+describe('the two counters are explained', () => {
+  it('says attempts is the permanent-failure budget', () => {
+    assert.match(LIST, /PERMANENT-failure budget/, 'attempts is spent on what a retry cannot fix');
+  });
+
+  it('says transientFailures never goes terminal', () => {
+    assert.match(LIST, /NEVER go terminal/,
+      'an outage backs off instead of giving up — that is the whole point of the second counter');
+  });
+
+  it('gives the reading for each combination, which is the actionable half', () => {
+    assert.match(LIST, /needs nothing from you/, 'high transientFailures, zero attempts: wait');
+    assert.match(LIST, /needs the content fixed/, 'failed at max attempts: the record is the problem');
+  });
+
+  it('mentions the per-version revive, so an operator does not retry by hand after an upgrade', () => {
+    assert.match(LIST, /once per server VERSION/,
+      'an upgrade already retries everything that died under the old version');
+  });
+});


### PR DESCRIPTION
## The trap

`retry_failed_embeddings` sits in `mcp/tools/embed.ts` **directly beside** `list_embed_jobs`, and re-queues a
different queue. It imports `files/media/job-queue.js` — image captioning, audio/video transcription, document
extraction — while `list_embed_jobs` reports BRAIN embed jobs.

So the obvious sequence:

> list the failed embed jobs → retry the failed embeddings

silently acts on another queue and returns a count that has nothing to do with what was just listed. Nothing in
either description said so. The brain-side tool is `retry_record_embedding`.

Found while writing the schema description for X-2, and confirmed **from the import** rather than from the prose.

## What this changes

**`retry_failed_embeddings`** opens with the correction — `THE MEDIA QUEUE, NOT THE BRAIN ONE` — before anything
else, because a caller who reads one line must not act on the wrong queue when the name actively misleads.

**`list_embed_jobs`** gains the two-counter reading, which is the actionable half and is new information:

| Reading | Means | Do |
|---|---|---|
| high `transientFailures`, `attempts` 0 | an outage waiting itself out | nothing |
| `failed`, `attempts` at max | the record cannot be embedded | fix its content |

`attempts` is the PERMANENT-failure budget, spent only on what a retry cannot fix. `transientFailures` is new
this release, counts an embedder that did not answer, backs off up to half-hourly and **never goes terminal**.
Reading one without the other gives the wrong answer in both directions. It also states the per-version revive,
so nobody retries by hand after an upgrade that already did it.

It does **not** name the mutating retry tools, and says why instead: `help()` lists what your token can actually
reach, so an absent retry means *this token cannot retry*, not *no such tool exists* — the wrong conclusion a
read-only caller would otherwise draw and report. `mcp-help.test.js` refused the first draft for exactly this.

## The gate

`testing/standalone/embed-job-tools-say-which-queue.test.js` (7 tests) pins the media description against the
**import**, so if the tool ever switches queues the description cannot silently become a lie. Mutation-tested:
putting a mutating tool name back into the read-only description fails the gate.

## Not fixed here

The real fix is a **rename**, which breaks a tool name. Filed as **X-3** with the owner call it needs (alias for
a release, or cut it) and the four places that must move together. This is the half that ships without breaking
anybody.

Part of **X-2** — every MCP tool schema to the owner recall standard.