### PR TITLE
feat(rights): a space administrator gets that space's own settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instance-administrator rights, the create-spaces flag, an all-spaces floor, or any rights on a space they do
   not themselves hold. The second factor is unchanged: if MFA is on, it is on for them too.
 
+- **And that space's own settings, not only its tokens.** The same four-area `admin` rung now opens the
+  space's name, its schema and single types, its schema dry-run, and a rebuild of its own search indexes. The
+  admission is checked against the space in the **URL** — administering Research grants nothing in Finance —
+  which is a stricter question than the token routes ask, and it has to be: a token route's body names its own
+  subject and is filtered afterwards, while a space route's subject is the id being edited, so admitting on
+  "administers something" would have handed over every other space with nothing left to catch it.
+  **`maxGiB` stays with the instance** and answers `403` naming who can change it: it is that space's share of
+  the host's disk rather than a setting of the space. Creating, reordering and **deleting** spaces stay
+  instance-only too — delete is reachable through the same `:id` as everything widened here, and destroying a
+  space is not one of its settings.
+
+  **Both doors, same commit.** `update_space` and `update_space_schema` are the MCP counterparts of those two
+  routes and would otherwise have kept refusing the space administrator that REST now admits — the exact
+  shape of defect the parity rule exists to stop, and it was nearly missed because "no MCP tool mutates space
+  settings" was plausible and wrong. Tools now carry a `spaceAdmin` flag distinct from `admin`, checked at two
+  widths: `tools/list` admits anyone administering *a* space, because no space has been named at listing time,
+  and `tools/call` requires administering *the* space in the call. The stale `if (!isAdmin)` inside each
+  handler is gone — it read the legacy boolean and would have refused, one layer down, exactly the caller the
+  dispatcher had just let in. `create_space`, `wipe_space` and `reindex` stay instance-admin.
+
 ### Breaking
 
 - **A space request body with a key we do not recognise is now refused instead of silently ignored.** Four of

--- a/docs/integration-guide/06-spaces-api.md
+++ b/docs/integration-guide/06-spaces-api.md
@@ -245,6 +245,23 @@ PATCH /api/spaces/:id
 
 Update space properties. Requires an admin token (+ TOTP if MFA is enabled). At least one of `label`, `description`, or `meta` must be provided.
 
+> **A SPACE ADMINISTRATOR reaches this route too, for its own space.** A token holding the `admin` rung on all
+> four areas (`knowledge`, `files`, `schema`, `dataQuality`) of space X administers X, and may change X's
+> settings without being an instance admin. Administering X grants nothing on space Y: the check is against the
+> space id in the URL, not against "administers something".
+>
+> **`maxGiB` is the exception and answers `403`.** It is that space's share of the *host's* disk, so it is the
+> instance's to give. Every other field in the body is accepted. The refusal names who can change it, so the
+> right escalation is obvious rather than guessed.
+>
+> The same admission applies to `PATCH :id/rename`, `PUT :id/schema`, the single-type `PUT`/`DELETE` on
+> `:id/meta/typeSchemas/...`, `POST :id/validate-schema` and `POST :id/rebuild-indexes` — a space's own
+> configuration. It does **not** apply to `POST /api/spaces` (create), `POST /api/spaces/reorder`, or
+> `DELETE /api/spaces/:id`: those are instance-shaped, and destroying a space is not one of its settings.
+>
+> MFA is unchanged. A space administrator is still a human with an authenticator, and exempting one would make
+> the role a way around an instance-wide second factor.
+
 **Optimistic concurrency (`If-Match`).** Meta writes are last-write-wins by default: if two clients read a space, both edit it, and both save, the second save replaces the first in full. To make your write conditional, send the `meta.version` you read as an `If-Match` header:
 
 ```http

--- a/docs/integration-guide/07-tokens-api.md
+++ b/docs/integration-guide/07-tokens-api.md
@@ -244,6 +244,23 @@ the diff.
 
 <!-- markdownlint-disable-next-line MD028 -->
 
+> **The SPACE ADMINISTRATOR, and how it differs from the legacy pair above.** The paragraph above describes an
+> `admin: true` token carrying a `spaces` allowlist. The matrix expresses the same role without the legacy
+> flag: a token holding the `admin` rung on **all four areas** (`knowledge`, `files`, `schema`, `dataQuality`)
+> of space X is X's administrator.
+>
+> All four, not any one — `admin` on Files alone would otherwise mint tokens, which is an escalation rather
+> than a role.
+>
+> Such a token reaches the token routes and is then held to exactly the rules above, scoped to the spaces it
+> administers. It also reaches **its own space's settings** — see
+> [Update a Space](06-spaces-api.md#update-a-space) for which routes and which single field is refused.
+>
+> What it never reaches is anything instance-shaped: creating a space, joining a network, instance settings,
+> the database page. There is no space to scope those to, which is what makes them the instance's.
+
+<!-- markdownlint-disable-next-line MD028 -->
+
 > **Granting `mfa: "exempt"` costs a live TOTP code on the request** whenever MFA is enabled instance-wide —
 > the same rule create has, and for the same reason. Admin authentication here is satisfied by an admin token
 > that is itself exempt, so without it one exemption could grant the next until the instance-wide switch

--- a/docs/integration-guide/16-mcp.md
+++ b/docs/integration-guide/16-mcp.md
@@ -231,10 +231,33 @@ row survives its own tool being built, so the list cannot keep advertising a gap
 | `list_peers` | List all configured peer instances (admin only) |
 | `sync_now` | Trigger immediate sync (all networks or specific peer) (admin only) |
 
-> **Admin-only tools.** `list_peers`, `sync_now`, `update_space`, `update_space_schema`, `create_space`, `reindex`, and `wipe_space` require an `admin`
-> token: the first two are instance-level (they expose the whole peer topology and drive outbound
-> connections to every peer) and have no space scoping. They are hidden from `tools/list` for
-> non-admin tokens and rejected if called directly.
+> **Instance-admin tools.** `list_peers`, `sync_now`, `create_space`, `reindex`, and `wipe_space` require
+> instance-admin rights: they expose the whole peer topology, drive outbound connections to every peer, or
+> destroy data, and none of them is scoped to one space. They are hidden from `tools/list` for other tokens
+> and rejected if called directly.
+
+<!-- markdownlint-disable-next-line MD028 -->
+
+> **`update_space` and `update_space_schema` are SPACE-admin tools**, which is a different requirement.
+> Either instance-admin rights, **or** the `admin` rung on all four areas (`knowledge`, `files`, `schema`,
+> `dataQuality`) of the space named in `space`. These are the MCP counterparts of `PATCH /api/spaces/:id` and
+> `PUT /api/spaces/:id/schema`, and they admit exactly whom those routes admit — see
+> [Update a Space](06-spaces-api.md#update-a-space).
+>
+> **Administering one space does not grant another.** The check happens twice at two widths, and the second
+> is the one that matters:
+>
+> | Where | Question | Why not the other one |
+> | --- | --- | --- |
+> | `tools/list` | do you administer *any* space? | No space has been named yet — the listing is answered per connection |
+> | `tools/call` | do you administer *this* space? | The listing's question would let an administrator of Research reconfigure Finance |
+>
+> So a token that administers one space **sees** both tools and is refused on any space it does not
+> administer, with a message naming the four areas it needs. This mirrors how mutating tools have always been
+> listed on "can write anywhere" and then refused per space.
+>
+> `maxGiB` is not settable from either tool. It is the space's share of the host's disk, so it needs
+> instance-admin rights and the REST route.
 
 ### Example: remember
 

--- a/docs/userguide/04-settings.md
+++ b/docs/userguide/04-settings.md
@@ -172,6 +172,31 @@ shows `none` — both are correct, and the grid is showing you what the token ca
 > upgrading if you see one change; it never restores access from the pre-3.0 `admin` / `read-only` / spaces
 > fields.
 
+#### Setting all four areas to admin makes a space administrator
+
+Give a token **admin** on all four areas of one space and it becomes that space's administrator. It can then do
+two things it could not before:
+
+- **Manage that space's tokens** — create them, edit their rights, rotate and revoke them. It only ever sees
+  and edits tokens whose own reach sits inside the spaces it administers.
+- **Change that space's settings** — its name, its schema and types, and a re-index of its own search
+  indexes.
+
+All four areas, deliberately. Admin on **Files** alone would be enough to mint tokens if any single area
+counted, which is a bigger grant than the cell appears to make.
+
+**Administering one space grants nothing in another.** The check is against the space being edited, so an
+administrator of *Research* who opens *Finance* is refused exactly as before.
+
+**Two things stay with the instance owner**, and both refuse with a message saying so:
+
+| Stays instance-only | Why |
+| --- | --- |
+| **Max size (GiB)** of the space | It is that space's share of the machine's disk, not a setting of the space |
+| Creating, reordering and **deleting** spaces | There is no space to scope those to, and deleting one is not one of its settings |
+
+If MFA is on, a space administrator is prompted for a code like everybody else.
+
 **The second factor is not a token setting.** MFA is instance-wide and lives in **Settings → Preferences**;
 there is nothing about it in the token dialogs, and there is no per-token exemption to grant here.
 

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -2,7 +2,10 @@ import { Router } from 'express';
 import { registerReembedRoute } from './spaces-reembed.js';
 import { registerActivityResetRoute } from './spaces-activity.js';
 import path from 'path';
-import { requireAuth, requireSpaceAuthScoped, requireAdmin, requireAdminMfa, requireAdminMfaScoped } from '../auth/middleware.js';
+import {
+  requireAuth, requireSpaceAuthScoped, requireAdmin, requireAdminMfa, requireAdminMfaScoped,
+  requireAdminOrSpaceAdminMfaScoped,
+} from '../auth/middleware.js';
 import { globalRateLimit } from '../rate-limit/middleware.js';
 import { getConfig, saveConfig, getSecrets, getDataRoot, getSchemaLibrary, getDocumentProcessingConfig, getMediaEmbeddingConfig, getStorageConfig } from '../config/loader.js';
 import { capDocExtractionMode } from '../files/converters/extraction-level.js';
@@ -52,7 +55,7 @@ export const spacesRouter = Router();
 // Deliberately `force`: the caller is here because something is wrong, so the "definition already
 // matches" shortcut is not to be trusted — a stale entry that mongot has not yet collected would make
 // the repair silently do nothing.
-spacesRouter.post('/:id/rebuild-indexes', globalRateLimit, requireAdminMfaScoped('id'), async (req, res) => {
+spacesRouter.post('/:id/rebuild-indexes', globalRateLimit, requireAdminOrSpaceAdminMfaScoped('id'), async (req, res) => {
   const spaceId = req.params['id'] as string;
   if (!getConfig().spaces.some(s => s.id === spaceId)) {
     res.status(404).json({ error: `Space '${spaceId}' not found` });
@@ -74,7 +77,7 @@ registerReembedRoute(spacesRouter);
 registerActivityResetRoute(spacesRouter);
 
 // PATCH /api/spaces/:id/rename
-spacesRouter.patch('/:id/rename', globalRateLimit, requireAdminMfaScoped('id'), async (req, res) => {
+spacesRouter.patch('/:id/rename', globalRateLimit, requireAdminOrSpaceAdminMfaScoped('id'), async (req, res) => {
   const oldId = req.params['id'] as string;
   const parsed = RenameSpaceBody.safeParse(req.body);
   if (!parsed.success) {
@@ -263,10 +266,25 @@ spacesRouter.post('/', globalRateLimit, requireAdminMfa, async (req, res) => {
 //
 // `space-meta-update-contract.test.js` pins the chain the planner now owns, including its ORDER, and it was proven
 // against this handler before the move.
-spacesRouter.patch('/:id', globalRateLimit, requireAdminMfaScoped('id'), async (req, res) => {
+spacesRouter.patch('/:id', globalRateLimit, requireAdminOrSpaceAdminMfaScoped('id'), async (req, res) => {
   const id = req.params['id'] as string;
   const cfg = getConfig();
   const space = cfg.spaces.find(s => s.id === id);
+
+  // `maxGiB` is the one field in this body that spends an INSTANCE resource rather than configuring a space:
+  // it is that space's share of the host's disk. A space administrator setting their own quota could take the
+  // whole volume, which is the instance's to give — so the guard admits them to the route and this refuses the
+  // single field, rather than the route staying shut over one number.
+  //
+  // Checked against `record.admin` for the same reason the guard is: it is the instance-admin bit, and a space
+  // administrator is by construction not it.
+  if (req.body?.maxGiB !== undefined && !req.authToken?.admin) {
+    res.status(403).json({
+      error: 'maxGiB is an instance setting: a space administrator may change this space\'s settings but not '
+        + 'its share of the host\'s storage. Ask an instance administrator to change the quota.',
+    });
+    return;
+  }
 
   const decision = planSpaceMetaUpdate({ spaceId: id, space, body: req.body, ifMatch: req.get('If-Match') });
   if (!decision.ok) {
@@ -294,7 +312,7 @@ spacesRouter.patch('/:id', globalRateLimit, requireAdminMfaScoped('id'), async (
 // Unlike PATCH (which merges types), this completely overwrites `meta.typeSchemas`
 // with the supplied value.  Before applying, the previous schema is written to a
 // timestamped JSON backup file inside the space so it can be recovered or re-imported.
-spacesRouter.put('/:id/schema', globalRateLimit, requireAdminMfaScoped('id'), async (req, res) => {
+spacesRouter.put('/:id/schema', globalRateLimit, requireAdminOrSpaceAdminMfaScoped('id'), async (req, res) => {
   const id = req.params['id'] as string;
   const cfg = getConfig();
   const space = cfg.spaces.find(s => s.id === id);
@@ -475,7 +493,7 @@ spacesRouter.get('/:id/meta/typeSchemas/:knowledgeType/:typeName', globalRateLim
 });
 
 // PUT /api/spaces/:id/meta/typeSchemas/:knowledgeType/:typeName — upsert a single type definition
-spacesRouter.put('/:id/meta/typeSchemas/:knowledgeType/:typeName', globalRateLimit, requireAdminMfaScoped('id'), (req, res) => {
+spacesRouter.put('/:id/meta/typeSchemas/:knowledgeType/:typeName', globalRateLimit, requireAdminOrSpaceAdminMfaScoped('id'), (req, res) => {
   const { id, knowledgeType, typeName } = req.params as { id: string; knowledgeType: string; typeName: string };
 
   if (!VALID_KNOWLEDGE_TYPES.has(knowledgeType)) {
@@ -554,7 +572,7 @@ spacesRouter.put('/:id/meta/typeSchemas/:knowledgeType/:typeName', globalRateLim
 });
 
 // DELETE /api/spaces/:id/meta/typeSchemas/:knowledgeType/:typeName — remove a single type definition
-spacesRouter.delete('/:id/meta/typeSchemas/:knowledgeType/:typeName', globalRateLimit, requireAdminMfaScoped('id'), (req, res) => {
+spacesRouter.delete('/:id/meta/typeSchemas/:knowledgeType/:typeName', globalRateLimit, requireAdminOrSpaceAdminMfaScoped('id'), (req, res) => {
   const { id, knowledgeType, typeName } = req.params as { id: string; knowledgeType: string; typeName: string };
 
   if (!VALID_KNOWLEDGE_TYPES.has(knowledgeType)) {
@@ -615,7 +633,7 @@ spacesRouter.delete('/:id/meta/typeSchemas/:knowledgeType/:typeName', globalRate
 });
 
 // POST /api/spaces/:id/validate-schema — dry-run validation of existing data
-spacesRouter.post('/:id/validate-schema', globalRateLimit, requireAdminMfaScoped('id'), async (req, res) => {
+spacesRouter.post('/:id/validate-schema', globalRateLimit, requireAdminOrSpaceAdminMfaScoped('id'), async (req, res) => {
   const id = req.params['id'] as string;
   const cfg = getConfig();
   const space = cfg.spaces.find(s => s.id === id);

--- a/server/src/auth/middleware.ts
+++ b/server/src/auth/middleware.ts
@@ -5,7 +5,7 @@ import { consumeSseTicket } from './sse-ticket.js';
 import { isMfaEnabled, verifyMfaCode } from './totp.js';
 import { validateOidcJwt, getOidcConfig } from './oidc.js';
 import type { TokenRecord } from '../config/types.js';
-import { spaceAdminSpacesFor } from './editor-scope.js';
+import { spaceAdminSpacesFor, isSpaceAdminFor } from './editor-scope.js';
 import type { OidcTokenRecord } from './oidc.js';
 import { resolveMemberSpaces } from '../spaces/proxy.js';
 import { reachesSpace } from './space-reach.js';
@@ -598,6 +598,58 @@ export function requireAdminMfaScoped(paramName: string) {
     const spaceId = req.params[paramName] as string | undefined;
     if (!enforceSpaceScope(res, record, spaceId)) return;
   if (!enforceAreaRung(res, record, req, spaceTargets(spaceId, record))) return;
+
+    attachToken(req, record, bearer);
+    next();
+  };
+}
+
+/**
+ * As `requireAdminMfaScoped`, and the administrator of THAT SPACE also passes.
+ *
+ * Owner ruling P-8 = B, 2026-08-15, second clause: *"those are INSTANCE admin things. B and includes the rest
+ * of the matrixes rungs for this space."* A space administrator gets their space — its tokens (shipped) and
+ * its own settings (this). Creating a space, reordering the instance's spaces and joining a network stay where
+ * they were, because there is no space to scope them to.
+ *
+ * ## The scope check is the ADMISSION here, not a filter after it
+ *
+ * `requireAdminOrSpaceAdmin` admits any space administrator and lets `refusalsOutsideEditorScope` bound what
+ * they may then write. That works for the token routes, where the body names its own subject. A space route
+ * has no such body: the subject is `req.params[paramName]`, so the space being administered has to BE the
+ * space in the URL or the guard grants nothing it can take back.
+ *
+ * Hence `isSpaceAdminFor(rights, spaceId)` rather than `spaceAdminSpacesFor(...).length > 0`. Administering
+ * space A must not open space B's settings, and the looser predicate would have done exactly that.
+ *
+ * ## The instance-admin path is unchanged
+ *
+ * Byte for byte the old order — MFA, then the legacy allowlist, then the area rungs. A token that passes today
+ * passes identically, which is what keeps this a widening at one named door rather than a rewrite of the
+ * guard every admin route shares.
+ */
+export function requireAdminOrSpaceAdminMfaScoped(paramName: string) {
+  return async function (req: Request, res: Response, next: NextFunction): Promise<void> {
+    const auth = await resolveAuthOrFail(req, res, {});
+    if (!auth) return;
+    const { record, bearer } = auth;
+    const spaceId = req.params[paramName] as string | undefined;
+
+    if (!record.admin) {
+      // Narrowed to the one field the decision reads, for the same reason `enforceAdminOrSpaceAdmin` does it.
+      const withRights = record as { rights?: TokenRights | null };
+      if (!spaceId || !isSpaceAdminFor(withRights.rights, spaceId)) {
+        res.status(403).json({ error: 'Admin token required' });
+        return;
+      }
+    }
+
+    if (!enforceMfa(req, res, bearer, record)) return;
+    // Only meaningful on the instance-admin path: a space administrator was admitted by the space id itself,
+    // so the allowlist has nothing left to narrow. Run unconditionally anyway — a guard that is skipped for
+    // one class of caller is the shape of every "one rule, two implementations" defect in this repo.
+    if (!enforceSpaceScope(res, record, spaceId)) return;
+    if (!enforceAreaRung(res, record, req, spaceTargets(spaceId, record))) return;
 
     attachToken(req, record, bearer);
     next();

--- a/server/src/auth/space-rights.ts
+++ b/server/src/auth/space-rights.ts
@@ -269,6 +269,14 @@ export const TOOL_RIGHTS: readonly ToolRight[] = [
   { tool: 'update_file_meta', area: 'files', needs: 'write' },
   { tool: 'get_space_meta', area: 'schema', needs: 'read' },
   { tool: 'update_space_schema', area: 'schema', needs: 'write' },
+  // Governed by a rung from the moment it stopped being an instance-admin tool. `admin: true` exempts a tool
+  // from this inventory because an instance-level capability has no space to scope to; `spaceAdmin: true` is
+  // the opposite claim — the space IS the subject — so the area check applies like any other space-scoped
+  // tool, on top of the four-area administrator check the dispatcher makes.
+  //
+  // `schema: write` to match `update_space_schema` beside it and the meta half of `PATCH /api/spaces/:id`:
+  // label and purpose are space meta, and meta is the schema area throughout this inventory.
+  { tool: 'update_space', area: 'schema', needs: 'write' },
 ];
 
 export const NOT_AREA_SCOPED: readonly { route: string; why: string }[] = [

--- a/server/src/mcp/router.ts
+++ b/server/src/mcp/router.ts
@@ -11,7 +11,7 @@ import { globalRateLimit } from '../rate-limit/middleware.js';
 import { getConfig } from '../config/loader.js';
 import { log } from '../util/log.js';
 import { reachesSpace } from '../auth/space-reach.js';
-import { toolRightsRefusal } from './tool-rights-guard.js';
+import { toolRightsRefusal, spaceAdminRefusal } from './tool-rights-guard.js';
 import type { TokenRights } from '../config/rights-shape.js';
 import { memberSpacesWithin } from '../spaces/proxy-scoped.js';
 import { ALL_TOOLS, TOOLS_BY_NAME, type ToolSchemas } from './tools/index.js';
@@ -194,7 +194,13 @@ function createGlobalMcpServer(tokenSpaces?: string[], readOnly?: boolean, isAdm
           type: 'text' as const,
           text: tool.admin
             ? `Error: tool '${name}' requires a token with instance-admin rights`
-            : `Error: tool '${name}' mutates, and this token holds no write rung in any space`,
+            // Without its own branch a space-admin tool would be refused as "mutates, and this token holds no
+            // write rung", which names the wrong missing thing — a token can hold write everywhere and still
+            // administer nothing.
+            : tool.spaceAdmin
+              ? `Error: tool '${name}' configures a space, and this token administers none — it needs the admin `
+                + 'rung on all four areas (knowledge, files, schema, dataQuality) of some space, or instance-admin rights'
+              : `Error: tool '${name}' mutates, and this token holds no write rung in any space`,
         }],
         isError: true,
       };
@@ -236,6 +242,15 @@ function createGlobalMcpServer(tokenSpaces?: string[], readOnly?: boolean, isAdm
       const rightsRefusal = toolRightsRefusal(name, rights, rawSpace);
       if (rightsRefusal) {
         return { content: [{ type: 'text' as const, text: rightsRefusal }], isError: true };
+      }
+      // And the space-admin question, for the tools that configure ONE space. `toolIsVisible` admitted anyone
+      // administering *a* space, because `tools/list` runs before a space is named; this is where the space
+      // exists, so this is where "administers THIS one" can be asked. Same two-width split as the REST guard,
+      // and for the same reason: the wider one alone would let the administrator of Research reconfigure
+      // Finance.
+      const adminRefusal = spaceAdminRefusal(tool, rights, rawSpace);
+      if (adminRefusal) {
+        return { content: [{ type: 'text' as const, text: adminRefusal }], isError: true };
       }
     }
     const callSpace = rawSpace;

--- a/server/src/mcp/tool-rights-guard.ts
+++ b/server/src/mcp/tool-rights-guard.ts
@@ -1,6 +1,7 @@
 import { TOOL_RIGHTS } from '../auth/space-rights.js';
 import { effectiveRung } from '../auth/mint-cap.js';
 import { satisfies } from '../auth/required-rung.js';
+import { isSpaceAdminFor } from '../auth/editor-scope.js';
 import type { TokenRights } from '../config/rights-shape.js';
 
 /**
@@ -33,6 +34,33 @@ import type { TokenRights } from '../config/rights-shape.js';
  * grants access to a proxy; narrowing to members happens inside the tools. Checking a member here would let
  * a proxy grant be bypassed by naming the member instead.
  */
+/**
+ * Does this token administer THE space this call names?
+ *
+ * The precise half of the `spaceAdmin` flag, and the MCP mirror of `requireAdminOrSpaceAdminMfaScoped`.
+ * `toolIsVisible` already admitted anyone who administers *a* space, because `tools/list` is answered before
+ * any space is named; this asks the question that actually matters once one is.
+ *
+ * Separate from `toolRightsRefusal` above because it answers a different question against a different input —
+ * that one reads `TOOL_RIGHTS` for an area and a rung, this one asks whether all four areas are at `admin`.
+ * Folding them together would mean one of the two callers passing a flag to say which half it wanted.
+ *
+ * Returns the refusal TEXT or `null`, same contract as its neighbour, and pure for the same reason: a guard
+ * testable only through a transport is one whose test cannot tell live code from dead.
+ */
+export function spaceAdminRefusal(
+  tool: { name?: string; spaceAdmin?: boolean } | undefined,
+  rights: TokenRights | undefined,
+  space: string,
+): string | null {
+  if (!tool?.spaceAdmin) return null;
+  if (rights?.instanceAdmin === true) return null;
+  if (space && isSpaceAdminFor(rights, space)) return null;
+  return `Error: tool '${tool.name ?? 'unknown'}' configures a space, so it needs either instance-admin rights `
+    + `or the admin rung on all four areas (knowledge, files, schema, dataQuality) of space '${space}'. `
+    + 'Administering a different space does not grant this one.';
+}
+
 export function toolRightsRefusal(
   toolName: string,
   rights: TokenRights | undefined,

--- a/server/src/mcp/tool-visibility.ts
+++ b/server/src/mcp/tool-visibility.ts
@@ -1,10 +1,12 @@
 import type { TokenRights } from '../config/rights-shape.js';
 import { canWriteAnywhere } from '../auth/write-anywhere.js';
+import { spaceAdminSpacesFor } from '../auth/editor-scope.js';
 
 /** The shape this needs off a tool — the two flags that decide whether it is reachable at all. */
 export interface VisibilityFlags {
   mutating?: boolean;
   admin?: boolean;
+  spaceAdmin?: boolean;
 }
 
 /**
@@ -36,6 +38,12 @@ export interface VisibilityFlags {
  */
 export function toolIsVisible(tool: VisibilityFlags, rights: TokenRights | undefined): boolean {
   if (tool.admin) return rights?.instanceAdmin === true;
+  // A space-admin tool is LISTED to anyone who administers a space, and refused per call for the space they
+  // did not administer. Coarse here for the reason stated above — `tools/list` is answered before any space is
+  // named, so "administers something" is the only question that can be asked at this point. `spaceAdminRefusal`
+  // asks the real one. Listing a tool the dispatcher may then refuse is the same shape as the mutating case
+  // directly below, which has always been listed on "can write ANYWHERE" and refused per space.
+  if (tool.spaceAdmin) return rights?.instanceAdmin === true || spaceAdminSpacesFor({ rights }).length > 0;
   if (tool.mutating) return canWriteAnywhere(rights);
   return true;
 }

--- a/server/src/mcp/tools/spaces.ts
+++ b/server/src/mcp/tools/spaces.ts
@@ -203,9 +203,14 @@ export const get_space_metaTool: ToolHandler = {
 
 export const update_spaceTool: ToolHandler = {
   name: 'update_space',
-  description: 'Update the label or purpose of the specified space. Requires an admin token. `purpose` is the space-level directive MCP clients receive at handshake. Its `description` alias was removed in 3.0 — sending `description` is now rejected, not silently folded into `purpose`.',
+  description: 'Update the label or purpose of the specified space. Needs EITHER instance-admin rights OR the '
+    + '`admin` rung on all four areas (knowledge, files, schema, dataQuality) of the space named in `space` — '
+    + 'administering a different space does not grant this one. `purpose` is the space-level directive MCP '
+    + 'clients receive at handshake. Its `description` alias was removed in 3.0 — sending `description` is now '
+    + 'rejected, not silently folded into `purpose`. To change the space\'s storage quota you need instance-admin '
+    + 'rights and the REST route: `maxGiB` is the space\'s share of the host disk, so it is not a space setting.',
   mutating: true,
-  admin: true,
+  spaceAdmin: true,
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({
           type: 'object',
@@ -218,13 +223,12 @@ export const update_spaceTool: ToolHandler = {
           additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
-    const { args: a, callSpace, isAdmin } = ctx;
-    if (!isAdmin) {
-      return {
-        content: [{ type: 'text' as const, text: 'Error: update_space requires an admin token' }],
-        isError: true,
-      };
-    }
+    // No second copy of the authorisation rule here. `spaceAdmin: true` is decided in the dispatcher by
+    // `spaceAdminRefusal`, against the rights matrix and the space this call names. The `if (!isAdmin)` that
+    // used to sit here read the LEGACY boolean, which `ToolContext` says outright nothing should read for a
+    // new decision — and left in place it would have refused exactly the space administrator this feature
+    // admits, silently, one layer below the guard that let them in.
+    const { args: a, callSpace } = ctx;
     const newLabel = typeof a['label'] === 'string' ? a['label'].trim() : undefined;
     const newDesc = typeof a['purpose'] === 'string' ? a['purpose'] : undefined;
     if (newLabel === undefined && newDesc === undefined) {
@@ -317,7 +321,9 @@ async function runSpaceMetaUpdate(
  */
 export const update_space_schemaTool: ToolHandler = {
   name: 'update_space_schema',
-  description: 'Write a space\'s type schemas (and its other meta fields). Requires an admin token. '
+  description: 'Write a space\'s type schemas (and its other meta fields). Needs EITHER instance-admin rights OR '
+    + 'the `admin` rung on all four areas (knowledge, files, schema, dataQuality) of the space named in `space` — '
+    + 'administering a different space does not grant this one. '
     + 'MERGES by default: types you do not mention are preserved, so editing one type does not require resending '
     + 'the others. Pass `typeSchemasMode: "replace"` to make the payload authoritative — that is the only way to '
     + 'DELETE a type. Knowledge-type keys are singular: entity, memory, edge, chrono. A `$ref` to a schema-library '
@@ -325,7 +331,7 @@ export const update_space_schemaTool: ToolHandler = {
     + 'network votes on meta changes this opens a vote round instead of writing — the reply says so, and nothing is '
     + 'stored until the round concludes.',
   mutating: true,
-  admin: true,
+  spaceAdmin: true,
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({
     type: 'object',
@@ -356,13 +362,9 @@ export const update_space_schemaTool: ToolHandler = {
     additionalProperties: false,
   }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
-    const { args: a, callSpace, isAdmin } = ctx;
-    if (!isAdmin) {
-      return {
-        content: [{ type: 'text' as const, text: 'Error: update_space_schema requires an admin token' }],
-        isError: true,
-      };
-    }
+    // Authorised by `spaceAdmin: true` in the dispatcher — see the note on `update_space`. The legacy
+    // `isAdmin` check that stood here would have refused a space administrator the guard had just admitted.
+    const { args: a, callSpace } = ctx;
 
     // Everything except `space`/`typeSchemasMode` belongs inside `meta`, which is where the planner's `.strict()`
     // schema expects it. Built by picking the declared names rather than by spreading `args`: a spread would carry

--- a/server/src/mcp/tools/types.ts
+++ b/server/src/mcp/tools/types.ts
@@ -83,6 +83,19 @@ export interface ToolHandler {
   mutating?: boolean;
   /** Requires an admin token (instance-level, no space scoping). */
   admin?: boolean;
+  /**
+   * Requires administering THE SPACE this call names — or the instance.
+   *
+   * The MCP half of `requireAdminOrSpaceAdminMfaScoped`. `admin: true` asks an instance-level question and is
+   * right for a tool with no space to scope to; this one is for a tool that configures ONE space, where
+   * "administers that space" is the honest requirement and demanding the instance is simply the old flag
+   * showing through.
+   *
+   * Checked twice, deliberately and at different widths — see `toolIsVisible` (coarse, per connection, before
+   * any space is named) and `spaceAdminRefusal` (precise, per call). Setting this INSTEAD of `admin`, never
+   * alongside it: two flags for one decision is how the weaker one ends up deciding.
+   */
+  spaceAdmin?: boolean;
   /** Requires a non-empty `space` argument. */
   spaceRequired?: boolean;
   /**

--- a/testing/standalone/space-admin-reaches-its-own-space-settings.test.js
+++ b/testing/standalone/space-admin-reaches-its-own-space-settings.test.js
@@ -1,0 +1,206 @@
+/**
+ * A space administrator reaches THAT SPACE's settings — and nothing the instance owns.
+ *
+ * ## The ruling
+ *
+ * Owner, P-8 = B, 2026-08-15: *"those are INSTANCE admin things. B and includes the rest of the matrixes rungs
+ * for this space."* Tokens shipped first (`space-admin-reaches-its-own-tokens.test.js`); this is the second
+ * clause — the space's own settings.
+ *
+ * ## The two ways this feature could become an escalation
+ *
+ * **1. The wrong predicate.** `spaceAdminSpacesFor(rights).length > 0` asks *"do you administer any space?"*
+ * and is the right question on the token routes, where the body names its own subject and
+ * `refusalsOutsideEditorScope` bounds what may be written. A space route has no such body: the subject is the
+ * space id in the URL. Admitting on "administers something" would let the administrator of space A rewrite
+ * space B's schema, because there is no later filter to catch it. So the scoped guard must call
+ * `isSpaceAdminFor(rights, spaceId)` and the test pins which one it uses.
+ *
+ * **2. The wrong routes.** Creating a space, reordering the instance's spaces and DELETING a space are not
+ * settings. Delete is the sharp one: it is reachable with the same `:id` parameter as everything widened here,
+ * so it would have been swept up by any edit that worked route-by-name rather than route-by-meaning.
+ *
+ * ## And one field inside a widened route
+ *
+ * `maxGiB` is a space's share of the HOST's disk. Everything else in the update body configures the space;
+ * that number spends the instance. The guard admits a space administrator to `PATCH /:id` and the route
+ * refuses the single field, which is better than keeping the whole route shut over one number.
+ *
+ * Run: node --test testing/standalone/space-admin-reaches-its-own-space-settings.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripComments } from './_strip-comments.mjs';
+
+const SPACES = readFileSync('server/src/api/spaces.ts', 'utf8');
+const MIDDLEWARE = readFileSync('server/src/auth/middleware.ts', 'utf8');
+
+/** The guard list of one route, read from source. Comments are stripped so prose about a guard is never it. */
+const guardsFor = (verb, path) => {
+  // Up to the handler's own `(req`, and NOT `[^)]*?` — a guard is written `requireAdminMfaScoped('id')` and a
+  // negated-paren class stops dead at its first `)`, which made every route in this file look unguarded.
+  const re = new RegExp(`spacesRouter\\.${verb}\\('${path.replace(/[/:*]/g, m => '\\' + m)}',([\\s\\S]*?)\\(req`);
+  const m = stripComments(SPACES).match(re);
+  assert.ok(m, `route ${verb.toUpperCase()} ${path} was not found — the scanner is wrong, not the code`);
+  return m[1];
+};
+
+/** Every route a space administrator may reach: this space's own configuration. */
+const WIDENED = [
+  ['patch', '/:id', 'its settings'],
+  ['patch', '/:id/rename', 'its display name'],
+  ['put', '/:id/schema', 'its schema'],
+  ['put', '/:id/meta/typeSchemas/:knowledgeType/:typeName', 'one of its types'],
+  ['delete', '/:id/meta/typeSchemas/:knowledgeType/:typeName', 'removing one of its types'],
+  ['post', '/:id/validate-schema', 'a dry run that writes nothing'],
+  ['post', '/:id/rebuild-indexes', 'its own search indexes'],
+];
+
+/** Instance-shaped, and each for a reason that is not "we ran out of time". */
+const INSTANCE_ONLY = [
+  ['delete', '/:id', 'destroying a space is not one of its settings'],
+  ['post', '/', 'creating a space is instance-shaped — there is no space to scope it to'],
+  ['post', '/reorder', 'the order of the instance\'s spaces belongs to the instance'],
+];
+
+describe('the widened routes are this space\'s own configuration', () => {
+  for (const [verb, path, why] of WIDENED) {
+    it(`${verb.toUpperCase()} ${path} admits the space administrator — ${why}`, () => {
+      assert.match(guardsFor(verb, path), /requireAdminOrSpaceAdminMfaScoped\('id'\)/,
+        'a space administrator must reach this, scoped to the space in the URL');
+    });
+  }
+
+  it('and every one of them is MFA-gated, exactly as it was', () => {
+    // A space administrator is still a human with an authenticator. Dropping the second factor here would make
+    // "space admin" the way around an instance-wide MFA setting.
+    for (const [verb, path] of WIDENED) {
+      assert.match(guardsFor(verb, path), /Mfa/, `${verb.toUpperCase()} ${path} lost its MFA gate`);
+    }
+  });
+});
+
+describe('the instance keeps what is the instance\'s', () => {
+  for (const [verb, path, why] of INSTANCE_ONLY) {
+    it(`${verb.toUpperCase()} ${path} stays instance-admin only — ${why}`, () => {
+      assert.doesNotMatch(guardsFor(verb, path), /requireAdminOrSpaceAdmin/,
+        'this is not a setting of one space and a space administrator must not reach it');
+    });
+  }
+});
+
+describe('the scoped guard admits on THIS space, not on any space', () => {
+  /** The body of `requireAdminOrSpaceAdminMfaScoped`, comments stripped. */
+  const scoped = (() => {
+    const src = stripComments(MIDDLEWARE);
+    const at = src.indexOf('export function requireAdminOrSpaceAdminMfaScoped');
+    assert.ok(at > 0, 'the scoped guard was not found — the scanner is wrong, not the code');
+    const end = src.indexOf('\nexport ', at + 10);
+    return end === -1 ? src.slice(at) : src.slice(at, end);
+  })();
+
+  it('uses the per-space predicate', () => {
+    assert.match(scoped, /isSpaceAdminFor\(/,
+      'admission must be "you administer THE space in the URL"');
+  });
+
+  it('and NOT the any-space one, which would open every other space', () => {
+    // The single assertion this file exists for. `spaceAdminSpacesFor(...).length > 0` is correct on the token
+    // routes and would be an escalation here: administering space A must not reach space B's settings.
+    assert.doesNotMatch(scoped, /spaceAdminSpacesFor/,
+      'the token-route predicate answers "any space", which is the wrong question for a scoped route');
+  });
+
+  it('refuses when the route has no space id at all', () => {
+    // A guard mounted where `req.params[paramName]` is undefined must close, not open.
+    assert.match(scoped, /!spaceId \|\| !isSpaceAdminFor/,
+      'a missing space id must refuse a non-instance-admin rather than fall through');
+  });
+
+  it('leaves the instance-admin path running every check it ran before', () => {
+    for (const check of ['enforceMfa', 'enforceSpaceScope', 'enforceAreaRung']) {
+      assert.match(scoped, new RegExp(`${check}\\(`), `${check} was dropped from the scoped guard`);
+    }
+  });
+});
+
+describe('the MCP door widens with the REST one', () => {
+  // The rule this repo pays most for: one capability, two surfaces, and the difference only found from
+  // outside. `update_space` and `update_space_schema` are the MCP counterparts of `PATCH :id` and
+  // `PUT :id/schema` — leaving them on `admin: true` would have meant a space administrator who can configure
+  // their space through the REST door and is refused through the MCP one.
+  // Stripped, all four: each of these assertions would otherwise fire on the comment EXPLAINING the rule.
+  // The `if (!isAdmin)` check below caught its own note saying that check must not be here.
+  const MCP = stripComments(readFileSync('server/src/mcp/tools/spaces.ts', 'utf8'));
+  const VIS = stripComments(readFileSync('server/src/mcp/tool-visibility.ts', 'utf8'));
+  const GUARD = stripComments(readFileSync('server/src/mcp/tool-rights-guard.ts', 'utf8'));
+  const ROUTER = stripComments(readFileSync('server/src/mcp/router.ts', 'utf8'));
+
+  /** One tool object from the MCP module, `name:` to the next `export const`. */
+  const mcpTool = (name) => {
+    const at = MCP.indexOf(`name: '${name}'`);
+    assert.ok(at > 0, `${name} was not found — the scanner is wrong, not the code`);
+    const end = MCP.indexOf('\nexport const ', at);
+    return end === -1 ? MCP.slice(at) : MCP.slice(at, end);
+  };
+
+  for (const name of ['update_space', 'update_space_schema']) {
+    it(`${name} is spaceAdmin, not instance admin`, () => {
+      const t = mcpTool(name);
+      assert.match(t, /spaceAdmin: true/, 'the MCP counterpart of a widened REST route must widen with it');
+      assert.doesNotMatch(t, /\n {2}admin: true/,
+        'both flags for one decision is how the stricter one silently wins');
+    });
+
+    it(`${name} keeps no second copy of the rule in its handler`, () => {
+      // The one that would have made this a silent no-op: the dispatcher admits the space administrator and
+      // an `if (!isAdmin)` one layer down refuses them, reading the legacy boolean `ToolContext` says nothing
+      // should read for a new decision.
+      assert.doesNotMatch(mcpTool(name), /if \(!isAdmin\)/,
+        'authorisation belongs in the dispatcher, once');
+    });
+  }
+
+  it('the tools that are genuinely instance-shaped did NOT get swept along', () => {
+    // `create_space` has no space to scope to. `wipe_space` destroys data and its REST counterpart was not
+    // widened either. `reindex` likewise. A sweep by flag name would have taken all three.
+    for (const name of ['create_space', 'wipe_space', 'reindex']) {
+      assert.match(mcpTool(name), /\n {2}admin: true/, `${name} must stay instance-admin only`);
+      assert.doesNotMatch(mcpTool(name), /spaceAdmin: true/, `${name} must stay instance-admin only`);
+    }
+  });
+
+  it('visibility admits on ANY space, because tools/list runs before one is named', () => {
+    assert.match(VIS, /tool\.spaceAdmin[\s\S]{0,160}spaceAdminSpacesFor/,
+      'the coarse half must use the any-space predicate — there is no space to check yet');
+  });
+
+  it('and the DISPATCHER asks about the space actually named', () => {
+    // The two-width split, same as REST. Coarse alone would let the administrator of Research reconfigure
+    // Finance; precise alone cannot be evaluated at listing time.
+    assert.match(GUARD, /export function spaceAdminRefusal/, 'the precise half must exist');
+    assert.match(GUARD, /isSpaceAdminFor\(rights, space\)/, 'and ask about the space named in the call');
+    assert.match(ROUTER, /spaceAdminRefusal\(tool, rights, rawSpace\)/,
+      'the dispatcher must actually call it — a guard nobody calls is the failure this repo keeps hitting');
+  });
+
+  it('refusing names what is missing, not "you cannot write"', () => {
+    assert.match(ROUTER, /tool\.spaceAdmin/,
+      'a space-admin tool needs its own refusal text: a token can hold write everywhere and administer nothing');
+  });
+});
+
+describe('maxGiB stays with the instance', () => {
+  it('PATCH /:id refuses it from a token that is not an instance admin', () => {
+    const stripped = stripComments(SPACES);
+    assert.match(stripped, /maxGiB !== undefined && !req\.authToken\?\.admin/,
+      'a space administrator must not set its share of the host disk');
+    assert.match(stripped, /res\.status\(403\)/, 'and the refusal is a 403, not a silent drop');
+  });
+
+  it('and says WHO can change it, so the refusal is actionable', () => {
+    assert.match(SPACES, /Ask an instance administrator to change the quota/,
+      'a refusal that does not name the next step makes the caller guess');
+  });
+});

--- a/testing/standalone/space-admin-reaches-its-own-tokens.test.js
+++ b/testing/standalone/space-admin-reaches-its-own-tokens.test.js
@@ -130,14 +130,20 @@ describe('the guard is applied where a space can be named, and nowhere else', ()
   it('every OTHER admin route still uses the instance-only guard', async () => {
     // The half that must not drift. `enforceAdmin` is one function behind spaces, networks, instance settings
     // and the database page; widening it there would hand a space administrator the instance.
+    //
+    // `spaces.ts` joined `tokens.ts` on the allowlist when the owner's second clause landed — a space
+    // administrator gets that space's own SETTINGS as well as its tokens. Two names in a list is exactly how
+    // this assertion would rot into a formality, so `space-admin-reaches-its-own-space-settings.test.js` pins
+    // WHICH routes in `spaces.ts` may be widened and requires delete/create/reorder to stay shut.
+    const ALLOWED = ['server/src/api/tokens.ts', 'server/src/api/spaces.ts'];
     const { execSync } = await import('node:child_process');
     const { readFileSync } = await import('node:fs');
     const files = execSync('git ls-files "server/src/api/*.ts"', { encoding: 'utf8' })
-      .split('\n').map(s => s.trim()).filter(Boolean).filter(f => !f.endsWith('tokens.ts'));
+      .split('\n').map(s => s.trim()).filter(Boolean).filter(f => !ALLOWED.includes(f));
     // The floor: an empty offender list over an empty enumeration is green and means nothing.
     assert.ok(files.length > 10, `only walked ${files.length} api modules — the enumeration is broken`);
     const widened = files.filter(f => /requireAdminOrSpaceAdmin/.test(readFileSync(f, 'utf8')));
     assert.deepEqual(widened, [],
-      `these are not token routes and must stay instance-admin only: ${widened.join(', ')}`);
+      `neither tokens nor space settings — these must stay instance-admin only: ${widened.join(', ')}`);
   });
 });


### PR DESCRIPTION
Closes the second half of **SA-1**. The owner's P-8 = B ruling had two clauses — *"those are INSTANCE admin
things. B and includes the rest of the matrixes rungs for this space."* Tokens shipped first; this is the
space's own settings.

`admin` on all four areas of space X now opens X's name, its schema and single types, its schema dry-run and a
rebuild of its own search indexes — without the pre-3.0 `admin` flag.

## The admission is a stricter question than the token routes ask

| | Token routes | Space routes (this PR) |
| --- | --- | --- |
| Predicate | `spaceAdminSpacesFor(rights).length > 0` | `isSpaceAdminFor(rights, spaceId)` |
| Question | do you administer **a** space? | do you administer **this** space? |
| Safe because | the body names its subject, and `refusalsOutsideEditorScope` bounds it afterwards | there is no later filter — the subject **is** the id in the URL |

Using the token-route predicate here would have let the administrator of *Research* rewrite *Finance*'s
schema, with nothing downstream to catch it. That single distinction is what the new gate exists to pin.

## Both doors, same commit

`update_space` and `update_space_schema` are the MCP counterparts of `PATCH /api/spaces/:id` and
`PUT /api/spaces/:id/schema`. Left alone they would have gone on refusing the space administrator REST now
admits — the exact defect the parity rule exists to stop, and it was **nearly missed**: "no MCP tool mutates
space settings" was plausible, and wrong.

Tools now carry a `spaceAdmin` flag, distinct from `admin`, checked at two widths for the same reason REST
checks twice:

| Where | Question | Why not the other one |
| --- | --- | --- |
| `tools/list` | administers **any** space? | no space is named yet — the listing is per connection |
| `tools/call` | administers **this** space? | the listing's question would open every other space |

The stale `if (!isAdmin)` inside both handlers is gone. It read the legacy boolean that `ToolContext` says
outright nothing should read for a new decision, and left in place it would have refused — one layer below the
guard that admitted them — exactly the caller this feature is for.

`update_space` also gains a `TOOL_RIGHTS` row. `admin: true` exempted it from that inventory because an
instance capability has no space to scope to; `spaceAdmin: true` is the opposite claim, so the area check
applies like any other space-scoped tool. **The preflight gate caught this**, which is what it is for.

`create_space`, `wipe_space` and `reindex` stay instance-admin: no space to scope to, or destructive with a
REST counterpart that was not widened either.

## What stays with the instance

- **`maxGiB`** — that space's share of the *host's* disk, not a setting of the space. The guard admits, the
  route refuses the single field with a `403` naming who can change it. Better than keeping the whole route
  shut over one number. Neither MCP tool accepts it at all.
- **create, reorder and `DELETE`.** Delete is the sharp one: it hangs off the same `:id` as everything widened
  here, so any edit working route-by-name would have swept it up. Destroying a space is not one of its
  settings.

The instance-admin path through the REST guard is byte-for-byte the old order — MFA, the legacy allowlist,
then the area rungs. MFA is unchanged for a space administrator too: exempting one would make the role a way
around an instance-wide second factor.

## Verification

`testing/standalone/space-admin-reaches-its-own-space-settings.test.js` (25 tests). **Mutation-tested, all six
caught:**

1. the any-space predicate on REST
2. `DELETE /:id` swept up with the rest
3. the `maxGiB` carve-out removed
4. the dispatcher no longer calling the precise MCP guard
5. MCP visibility opening to everyone
6. `update_space` reverting to `admin: true`

The containment test in `space-admin-reaches-its-own-tokens.test.js` grew a second allowed file rather than
being deleted — and the new gate is what stops two names in a list from becoming a formality, by pinning
*which* routes in `spaces.ts` may be widened at all.

## Five places

REST routes · MCP tools · `integration-guide/06-spaces-api.md`, `07-tokens-api.md`, `16-mcp.md` ·
`userguide/04-settings.md` · a `TOOL_RIGHTS` row.
