### PR TITLE
docs(mcp): the update tools say whether a list is merged or replaced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The four record-editing tools now say whether a list you send is added to what is stored or replaces it —
+  and they do not all do the same thing.** Editing an entity or an edge MERGES tags; editing a memory or a
+  chrono entry REPLACES them. So sending one tag adds it in two cases and destroys every other tag in the
+  other two, with no error either way, and nothing in the tool descriptions said which you were doing. The
+  split is deliberate and long-standing, so it is now stated in capitals on the tools that replace, rather than
+  quietly unified. Properties merge on all four, as they always should have. Each description also answers a
+  question that had no written answer anywhere: excluding a record from vector search removes its **ranking**,
+  not the record — traversal, listing and direct reads all still reach it, and an excluded record linked to an
+  embedded one still appears in that neighbour's graph. A build check pins each claim against the store it
+  describes, so unifying the behaviour later fails the prose instead of silently outdating it.
+
+  This surfaced one real gap, filed rather than fixed here because it is a capability change: **a property
+  written to a chrono entry cannot be removed at all.** Chrono is the one record type with no `deleteFields`,
+  its properties merge, and an absence never means "delete" — so there is no expression that unsets a key. The
+  description now says so where a caller looks for the parameter, and names the two workarounds.
+
 - **The embedding-queue tools now say which queue they act on — one of them is not the queue its name
   suggests.** `retry_failed_embeddings` sits directly beside the tool that lists pending and failed record
   embeddings, and re-queues the **media** pipeline instead: image captioning, transcription, document

--- a/server/src/mcp/tools/chrono.ts
+++ b/server/src/mcp/tools/chrono.ts
@@ -166,7 +166,42 @@ function chronoTypeGate(spaceId: string): { meta: ReturnType<typeof resolveMetaR
 
 export const update_chronoTool: ToolHandler = {
   name: 'update_chrono',
-  description: 'Update an existing chronological entry.',
+  description: 'Update one chrono entry by its ID. Every field except `id` is optional; a field you omit is '
+    + 'left exactly as it was.\n\n'
+    + 'ONE FIELD MERGES AND THE REST REPLACE, and the split is not guessable. `properties` MERGES key by key, '
+    + 'so patching one key keeps the others. `tags`, `entityIds` and `memoryIds` REPLACE — send the FULL list '
+    + 'you want the entry to end up with, because sending one id drops the rest. (`update_entity` and '
+    + '`update_edge` merge tags instead; `update_memory` replaces them, like this tool.)\n\n'
+    + 'THERE IS NO `deleteFields` ON THIS TOOL. That is a real limitation rather than an omission from this '
+    + 'text: because `properties` merges and nothing here unsets, a property once written to a chrono entry '
+    + 'CANNOT be removed through this tool. Overwrite it with an empty string if a stale key is a problem, or '
+    + 'delete and recreate the entry. The other three record types do offer `deleteFields`.\n\n'
+    + 'A RE-EMBED IS ALWAYS QUEUED after a successful write, whether or not you changed anything embeddable. '
+    + 'The worker reads the record as STORED, so it cannot embed a stale version — deciding here would mean '
+    + 'deciding from this function\'s own read, which is what made the older inline embedding wrong.\n\n'
+    + 'PARAMETERS:\n'
+    + '- `id` — the entry\'s `_id`, as `list_chrono` and `query` report it. Required.\n'
+    + '- `title` — replaced when sent.\n'
+    + '- `type` — `event`, `deadline`, `plan`, `prediction`, `milestone`, or any custom type the space schema '
+    + 'defines. Re-validated against the allowlist.\n'
+    + '- `startsAt` / `endsAt` — ISO 8601. `endsAt` before `startsAt` is refused.\n'
+    + '- `status` — `upcoming`, `active`, `completed`, `overdue`, `cancelled`. Nothing recomputes this from '
+    + 'the clock, so an entry stays `upcoming` after its date passes until something sets it.\n'
+    + '- `confidence` — 0 to 1, for entries that are predictions rather than records.\n'
+    + '- `tags` / `entityIds` / `memoryIds` — each REPLACES the stored list.\n'
+    + '- `description` — replaced when sent.\n'
+    + '- `properties` — MERGED key by key. String, number or boolean values only.\n'
+    + '- `recurrence` — the repeat rule, replaced wholesale when sent. It describes the entry; it does not '
+    + 'generate further entries.\n'
+    + '- `excludeFromVectorSearch` — removes the vector, so `recall` can no longer RANK this entry by meaning. '
+    + '`list_chrono`, `query`, `get` and recall\'s `traverse` expansion all still reach it — excluding an entry '
+    + 'never hides it from the graph or from a time-ordered listing.\n'
+    + '- `ttlDays` — this entry\'s own expiry, the MOST specific of three tiers: it beats the type\'s retention '
+    + 'window, which beats the space-wide one.\n'
+    + '- `targetSpace` — required when `space` is a proxy: the member space holding the entry.\n\n'
+    + 'RESPONSE: one line with the entry\'s id and its new `seq` — the sync sequence number, which increments '
+    + 'on every write and is how a peer knows this version is newer. An id that does not exist is an error, not '
+    + 'a silent no-op.',
   mutating: true,
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({

--- a/server/src/mcp/tools/edge.ts
+++ b/server/src/mcp/tools/edge.ts
@@ -105,7 +105,39 @@ export const upsert_edgeTool: ToolHandler = {
 
 export const update_edgeTool: ToolHandler = {
   name: 'update_edge',
-  description: 'Update an existing edge by its ID. All fields are optional — only supplied fields are changed.',
+  description: 'Update one edge by its ID. Every field except `id` is optional; a field you omit is left '
+    + 'exactly as it was.\n\n'
+    + 'IT CANNOT REPOINT AN EDGE. There is no `from`/`to` here, deliberately: an edge that changes either end '
+    + 'is a different relationship, not an edited one, and rewriting it in place would silently invalidate '
+    + 'anything already traversed through it. Delete this edge and `upsert_edge` the new one.\n\n'
+    + 'MERGE, NOT REPLACE, for `tags` and `properties`. Sending `tags: ["b"]` on an edge tagged `["a"]` leaves '
+    + 'it tagged `["a","b"]`. Note that `update_memory` REPLACES tags instead — one word of difference between '
+    + 'tools that otherwise take the same arguments. To remove a tag or a property here, use `deleteFields` '
+    + 'with its dot path; there is no way to shrink either by sending a smaller value.\n\n'
+    + 'EDGES ARE SEARCHABLE RECORDS, which is why `excludeFromVectorSearch` exists on this tool at all: an edge '
+    + 'carries a label and a description, they get embedded, and they compete with knowledge records for a '
+    + 'recall `topK`. Excluding a busy structural edge is how you stop it crowding out the records it '
+    + 'connects.\n\n'
+    + 'PARAMETERS:\n'
+    + '- `id` — the edge\'s `_id`, as `traverse`, `query` and `recall`\'s `_graph` report it. Required.\n'
+    + '- `label` — the relationship\'s name, replaced when sent. Re-embeds.\n'
+    + '- `type` — replaced when sent, and re-validated against the space\'s edge-type allowlist.\n'
+    + '- `weight` — 0 to 1. Ranking uses it; traversal does not filter on it.\n'
+    + '- `description` — replaced when sent.\n'
+    + '- `tags` — MERGED into the existing tags, never replacing them.\n'
+    + '- `properties` — MERGED key by key. String, number or boolean values only.\n'
+    + '- `deleteFields` — dot-notation paths to remove, permanently and with no undo. System fields are '
+    + 'refused. This is the ONLY way to unset anything, and it runs AFTER the merge above.\n'
+    + '- `excludeFromVectorSearch` — see its own description. It removes the vector, so `recall` can no longer '
+    + 'RANK this edge by meaning. It does NOT remove the edge from the graph: `traverse` still walks it, and a '
+    + 'recall on either endpoint still expands through it into `_graph`. Excluding an edge hides it from '
+    + 'ranking, never from traversal.\n'
+    + '- `ttlDays` — this edge\'s own expiry, the MOST specific of three tiers: it beats the type\'s retention '
+    + 'window, which beats the space-wide one.\n'
+    + '- `targetSpace` — required when `space` is a proxy: the member space holding the edge.\n\n'
+    + 'RESPONSE: one line with the edge\'s id and its new `seq` — the sync sequence number, which increments on '
+    + 'every write and is how a peer knows this version is newer. An id that does not exist is an error, not a '
+    + 'silent no-op.',
   mutating: true,
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({

--- a/server/src/mcp/tools/entity.ts
+++ b/server/src/mcp/tools/entity.ts
@@ -104,7 +104,41 @@ export const upsert_entityTool: ToolHandler = {
 
 export const update_entityTool: ToolHandler = {
   name: 'update_entity',
-  description: 'Update an existing entity by its ID. All fields are optional — only supplied fields are changed.',
+  description: 'Update one entity by its ID. Every field except `id` is optional; a field you omit is left '
+    + 'exactly as it was.\n\n'
+    + 'MERGE, NOT REPLACE, for `tags` and `properties` — this is the trap. Sending `tags: ["b"]` on an entity '
+    + 'tagged `["a"]` leaves it tagged `["a","b"]`, and sending `properties: {"colour":"red"}` keeps every '
+    + 'other property. There is no way to shrink either by sending a smaller value; to REMOVE something use '
+    + '`deleteFields` with its dot path (`properties.colour`, or `tags` for all of them). Scalar fields — '
+    + '`name`, `type`, `description` — do replace, because there is nothing to merge.\n\n'
+    + 'VALIDATION IS OF THE RESULT, and it refuses only what your edit BREAKS. The record as it will be — your '
+    + 'fields plus the ones already stored — is checked against the space schema. A record that was already '
+    + 'invalid before you touched it (written before the schema was tightened, imported, or synced from a peer) '
+    + 'is REPORTED and still saved: the problem is already stored, so refusing your edit would not fix it, only '
+    + 'stop you maintaining the record. Before 3.1 it did refuse, which quietly froze every record that no '
+    + 'longer fitted a tightened schema. Violations your change introduces are refused as before, in a '
+    + '`strict` space.\n\n'
+    + 'PARAMETERS:\n'
+    + '- `id` — the entity\'s `_id`, as `query`, `recall` and `find_entities_by_name` report it. Required.\n'
+    + '- `name` / `type` / `description` — replaced when sent. Changing `type` is re-validated against the '
+    + 'space\'s type allowlist, so it cannot be moved somewhere `upsert_entity` would have refused.\n'
+    + '- `tags` — MERGED into the existing tags, never replacing them.\n'
+    + '- `properties` — MERGED key by key. Values must be string, number or boolean; nested objects are not '
+    + 'stored.\n'
+    + '- `deleteFields` — dot-notation paths to remove, permanently and with no undo. The system fields (`id`, '
+    + '`name`, `type`, `spaceId`, `createdAt`, `updatedAt`) are refused. This is the ONLY way to unset '
+    + 'anything.\n'
+    + '- `excludeFromVectorSearch` — see its own description. In short: it removes the vector, so `recall` can '
+    + 'no longer RANK this record by meaning, but `query`, `list`, `get` and recall\'s own `traverse` expansion '
+    + 'all still reach it. An excluded entity linked to an embedded one still appears in that neighbour\'s '
+    + '`_graph`.\n'
+    + '- `ttlDays` — this record\'s own expiry, and the MOST specific of three tiers: it beats the type\'s '
+    + 'retention window, which beats the space-wide one.\n'
+    + '- `targetSpace` — required when `space` is a proxy: the member space holding the record. Without it the '
+    + 'call is refused rather than guessing which member you meant.\n\n'
+    + 'RESPONSE: one line naming the entity, its type, its id and its new `seq` — the sync sequence number, '
+    + 'which increments on every write and is how a peer knows this version is newer. An id that does not exist '
+    + 'is an error, not a silent no-op, so a successful reply means a record really changed.',
   mutating: true,
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({

--- a/server/src/mcp/tools/memory.ts
+++ b/server/src/mcp/tools/memory.ts
@@ -155,7 +155,43 @@ export const rememberTool: ToolHandler = {
 
 export const update_memoryTool: ToolHandler = {
   name: 'update_memory',
-  description: 'Update an existing memory\'s fact, tags, entity links, description, or properties, or retire it from semantic search with excludeFromVectorSearch. Re-embeds automatically if any content field changes.',
+  description: 'Update one memory by its ID. Every field except `id` is optional; a field you omit is left '
+    + 'exactly as it was. Changing content re-embeds the record automatically — you never queue that '
+    + 'yourself.\n\n'
+    + 'TAGS REPLACE HERE. THEY MERGE ON `update_entity` AND `update_edge`. Read that twice: it is one word of '
+    + 'difference between three tools that otherwise take the same arguments. Sending `tags: ["b"]` on a memory '
+    + 'tagged `["a"]` leaves it tagged `["b"]` — `"a"` is gone. The same call on an entity would leave it '
+    + 'tagged `["a","b"]`. The difference is deliberate and pinned by a test rather than an accident waiting to '
+    + 'be unified, so do not expect it to change: send the FULL tag list you want this memory to end up with. '
+    + '`entityIds` replaces the same way.\n\n'
+    + '`properties` MERGES, on this tool and on the other two. Keys you do not name are kept, so patching one '
+    + 'key is safe. It used to replace, which silently destroyed every other property on the record; removing a '
+    + 'key is `deleteFields`\' job, and an absence never means "delete".\n\n'
+    + 'VALIDATION IS OF THE RESULT, and it refuses only what your edit BREAKS. The memory as it will be — your '
+    + 'fields plus the stored ones — is checked against the space schema. A record that was ALREADY invalid '
+    + 'before you touched it is reported and still saved, because refusing your edit would not fix a problem '
+    + 'that is already stored, it would only stop you maintaining the record. Violations your change introduces '
+    + 'are refused as before, in a `strict` space.\n\n'
+    + 'PARAMETERS:\n'
+    + '- `id` — the memory\'s `_id`, as `recall` and `query` report it. Required.\n'
+    + '- `fact` — the memory\'s text, replaced when sent. Re-embeds. Must not be empty.\n'
+    + '- `tags` — REPLACES the stored list. See above.\n'
+    + '- `entityIds` — REPLACES the stored links. UUID v4 each, and in a space with strict linkage every one '
+    + 'must resolve to an entity that exists in the member space this write lands in. Before 3.0 this path '
+    + 'checked nothing and wrote any string through as a link.\n'
+    + '- `description` — replaced when sent.\n'
+    + '- `properties` — MERGED key by key. String, number or boolean values only.\n'
+    + '- `deleteFields` — dot-notation paths to remove, permanently and with no undo. System fields are '
+    + 'refused. This is the ONLY way to unset a property; applied AFTER the merge above.\n'
+    + '- `excludeFromVectorSearch` — see its own description. In short: it removes the vector, so `recall` can '
+    + 'no longer RANK this memory by meaning, but `query`, `list`, `get` and recall\'s `traverse` expansion all '
+    + 'still reach it. Excluding a record does not hide it from the graph.\n'
+    + '- `ttlDays` — this record\'s own expiry, the MOST specific of three tiers: it beats the type\'s '
+    + 'retention window, which beats the space-wide one.\n'
+    + '- `targetSpace` — required when `space` is a proxy: the member space holding the record.\n\n'
+    + 'RESPONSE: one line with the memory\'s id and its new `seq` — the sync sequence number, which increments '
+    + 'on every write and is how a peer knows this version is newer. An id that does not exist is an error, not '
+    + 'a silent no-op.',
   mutating: true,
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({

--- a/testing/standalone/update-tools-state-merge-or-replace.test.js
+++ b/testing/standalone/update-tools-state-merge-or-replace.test.js
@@ -1,0 +1,143 @@
+/**
+ * Each `update_*` tool says whether its list fields MERGE or REPLACE — and says the same thing the store does.
+ *
+ * ## The trap
+ *
+ * Four tools take the same-looking arguments and do not agree:
+ *
+ * | Tool | `tags` | `properties` | can unset? |
+ * | --- | --- | --- | --- |
+ * | `update_entity` | merge | merge | `deleteFields` |
+ * | `update_edge` | merge | merge | `deleteFields` |
+ * | `update_memory` | **replace** | merge | `deleteFields` |
+ * | `update_chrono` | **replace** | merge | **no way at all** |
+ *
+ * The memory/chrono split is deliberate and `brain/memory.ts` says so in as many words — both halves were
+ * documented, so both were kept and pinned rather than silently unified. That makes it permanent, which makes
+ * it something a caller has to be TOLD: sending `tags: ["b"]` adds a tag on an entity and destroys the other
+ * tags on a memory, with no error either way.
+ *
+ * `update_chrono` having no `deleteFields` is the sharper one. Its `properties` merge, so a key written once
+ * cannot be removed through the tool at all — there is no absence that means "delete" and no path that unsets.
+ *
+ * ## Why the assertions read the STORE
+ *
+ * A test that only checked the descriptions would pass on four confident sentences that had drifted from the
+ * code together. `mergeTagsOrKeep` in the store is the fact; the description is the claim. This pins the claim
+ * to the fact, in the direction that matters — if someone unifies the behaviour, the prose fails until it is
+ * rewritten.
+ *
+ * Run: node --test testing/standalone/update-tools-state-merge-or-replace.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripComments } from './_strip-comments.mjs';
+
+const src = (p) => readFileSync(p, 'utf8');
+
+/** One tool object's description, `name:` to the next sibling key. Comments stripped. */
+const description = (file, name) => {
+  const s = stripComments(src(file));
+  const at = s.indexOf(`name: '${name}'`);
+  assert.ok(at > 0, `${name} not found in ${file} — the scanner is wrong, not the code`);
+  const d = s.indexOf('description:', at);
+  const end = s.slice(d).search(/\n {2}(mutating|spaceRequired|admin|spaceAdmin|inputSchema|async handle):/);
+  assert.ok(end > 0, `could not find the end of ${name}'s description`);
+  return s.slice(d, d + end);
+};
+
+const TOOLS = {
+  update_entity: description('server/src/mcp/tools/entity.ts', 'update_entity'),
+  update_edge: description('server/src/mcp/tools/edge.ts', 'update_edge'),
+  update_memory: description('server/src/mcp/tools/memory.ts', 'update_memory'),
+  update_chrono: description('server/src/mcp/tools/chrono.ts', 'update_chrono'),
+};
+
+describe('the store still behaves the way the descriptions claim', () => {
+  it('entity and edge updates MERGE tags', () => {
+    // If this stops being true, the two descriptions below become wrong and their assertions must change with
+    // it — which is the whole point of asserting on the store rather than only on the prose.
+    for (const f of ['server/src/brain/entities.ts', 'server/src/brain/edges.ts']) {
+      assert.match(stripComments(src(f)), /mergeTagsOrKeep\(existing\.tags, updates\.tags\)/,
+        `${f} no longer merges tags — the update tool description is now a lie`);
+    }
+  });
+
+  it('memory and chrono updates REPLACE tags', () => {
+    assert.match(stripComments(src('server/src/brain/memory.ts')),
+      /\$set\['tags'\] = updates\.tags/, 'memory tags are a straight overwrite');
+    // Chrono writes every supplied field through a generic loop, and only `properties` is pulled out of it.
+    const chrono = stripComments(src('server/src/brain/chrono.ts'));
+    assert.match(chrono, /for \(const \[k, v\] of Object\.entries\(updates\)\)/, 'the generic overwrite loop');
+    assert.match(chrono, /\$set\['properties'\] = mergedUpdateProps/, 'with properties lifted out to merge');
+  });
+
+  it('all four MERGE properties', () => {
+    for (const f of ['server/src/brain/entities.ts', 'server/src/brain/edges.ts',
+      'server/src/brain/memory.ts', 'server/src/brain/chrono.ts']) {
+      assert.match(stripComments(src(f)), /mergePropertiesOrKeep\(/,
+        `${f} must merge properties — replacing them destroys keys the caller never named`);
+    }
+  });
+});
+
+describe('every update tool states which it does', () => {
+  for (const [name, d] of Object.entries(TOOLS)) {
+    it(`${name} names the behaviour of BOTH tags and properties`, () => {
+      assert.match(d, /MERGE|REPLACE|MERGED|REPLACES/,
+        'a caller constructing arguments cannot infer this from the type');
+      assert.match(d, /properties/i, 'properties must be described, not just listed');
+      assert.match(d, /tags/i, 'tags must be described, not just listed');
+    });
+  }
+
+  it('the two that REPLACE tags say so in capitals, because it destroys data', () => {
+    assert.match(TOOLS.update_memory, /TAGS REPLACE HERE/, 'the difference has to be unmissable');
+    assert.match(TOOLS.update_chrono, /REPLACE/, 'chrono replaces tags, entityIds and memoryIds');
+  });
+
+  it('the two that MERGE tags say how to remove one', () => {
+    // A merge with no stated removal path reads as "there is no way to remove a tag", which is wrong and
+    // would send a caller to delete-and-recreate.
+    for (const name of ['update_entity', 'update_edge']) {
+      assert.match(TOOLS[name], /deleteFields/, `${name} must point at the only way to unset`);
+    }
+  });
+
+  it('update_chrono admits it cannot unset anything at all', () => {
+    // The finding this file exists for. Merging properties plus no `deleteFields` means a key written once is
+    // permanent, and nothing anywhere said so.
+    assert.match(TOOLS.update_chrono, /NO `deleteFields` ON THIS TOOL/,
+      'the limitation must be stated where a caller looks for the parameter');
+    assert.match(TOOLS.update_chrono, /CANNOT be removed/, 'and its consequence spelled out');
+  });
+
+  it('and that claim is still true — chrono really has no deleteFields', () => {
+    // Pinned against the schema, so the day it gains one this description fails instead of misinforming.
+    // From `inputSchema:` onward, NOT the whole tool — the description above deliberately contains the word
+    // `deleteFields` in the paragraph explaining its absence, and reading the tool whole made this assertion
+    // fire on the very sentence it is there to protect.
+    const chronoTool = stripComments(src('server/src/mcp/tools/chrono.ts'));
+    const at = chronoTool.indexOf("name: 'update_chrono'");
+    const schemaAt = chronoTool.indexOf('inputSchema:', at);
+    assert.ok(schemaAt > at, 'update_chrono has no inputSchema — the scanner is wrong, not the code');
+    const end = chronoTool.indexOf('\nexport const ', at);
+    assert.doesNotMatch(chronoTool.slice(schemaAt, end === -1 ? undefined : end), /deleteFields/,
+      'update_chrono gained deleteFields — delete the paragraph saying it has none');
+  });
+});
+
+describe('the excludeFromVectorSearch answer is stated on every tool that offers it', () => {
+  // Owner, 2026-08-15: *"excludefromvector does also exclude from recalls traversal? ambigous and i want
+  // entries to be findable via traversal even if they are not embedded themselves."* The behaviour was
+  // already right; the sentence saying so existed nowhere, which is why the question had to be asked at all.
+  for (const [name, d] of Object.entries(TOOLS)) {
+    it(`${name} says traversal still reaches an excluded record`, () => {
+      assert.match(d, /traverse|_graph|graph/i,
+        'the owner asked this exact question — the answer belongs where the parameter is described');
+      assert.match(d, /RANK/,
+        'excluded means "cannot be ranked by meaning", not "removed from search"');
+    });
+  }
+});


### PR DESCRIPTION
Four tools take the same-looking arguments and do not agree with each other:

| Tool | `tags` | `properties` | can unset? |
| --- | --- | --- | --- |
| `update_entity` | **merge** | merge | `deleteFields` |
| `update_edge` | **merge** | merge | `deleteFields` |
| `update_memory` | **replace** | merge | `deleteFields` |
| `update_chrono` | **replace** | merge | **nothing** |

So `tags: ["b"]` adds a tag on an entity and destroys every other tag on a memory. No error either way, and
neither description said which you were doing — *"All fields are optional, only supplied fields are changed"*
reads as replace-per-field, which is correct for exactly half of them.

**The split is deliberate.** `brain/memory.ts` says so in as many words: both behaviours were documented, so
both were kept and pinned by a test rather than silently unified. That makes it permanent, which makes it
something a caller has to be *told* rather than left to discover from a destroyed tag list.

## The excludeFromVectorSearch question, answered where it is asked

Owner, 2026-08-15: *"excludefromvector does also exclude from recalls traversal? ambigous and i want entries to
be findable via traversal even if they are not embedded themselves."*

The behaviour was already what he wanted. The sentence saying so existed **nowhere**, which is why the question
had to be asked at all. Every one of these four tools now states it: excluding a record removes its **ranking**,
not the record. `query`, `list`, `get` and recall's own `traverse` expansion all still reach it, and an excluded
record linked to an embedded one still appears in that neighbour's `_graph`.

## X-4, found while writing `update_chrono`

Chrono is the one record type with **no `deleteFields`**. Its `properties` merge — `brain/chrono.ts:252` lifts
them out of the generic overwrite loop on purpose — and an absence never means "delete". Those two facts
together mean there is no expression at all that removes a key: **a property written once to a chrono entry is
permanent.**

Filed as **X-4** rather than fixed here — it is a capability change and this batch was descriptions. The
description states the limitation where a caller looks for the parameter and names the two workarounds
(overwrite with an empty string, or delete and recreate). The gate pins the claim against the schema, so the
day `deleteFields` is added the prose fails instead of misinforming.

## The gate reads the store, not just the prose

A test that only checked descriptions would pass on four confident sentences that had drifted from the code
together. `mergeTagsOrKeep` in the store is the fact; the description is the claim, and
`update-tools-state-merge-or-replace.test.js` pins one to the other in the direction that matters.

**Mutation-tested both ways:** memory silently starting to merge tags, and chrono gaining `deleteFields`. Both
caught.

Part of **X-2** — every MCP tool schema to the owner's `recall` standard.
