### PR TITLE
docs(mcp): the delete tools say what they do NOT delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The four delete tools now say what they do *not* delete, and which of them can refuse.** Three of them
+  read *"Delete an X by ID. Creates a tombstone for sync propagation"* and nothing else, which left a caller
+  to discover the interesting parts by doing it. Deleting an **entity** is refused while something still
+  points at it, on a space with strict linkage — that guard exists only for entities, so deleting a memory,
+  edge or chrono entry is never refused and can leave a reference dangling on a space configured to forbid
+  exactly that. Each description now says which side it is on. They also say that deleting an edge leaves both
+  entities and every other edge between them untouched; that a chrono entry's links are references rather than
+  contents; that a recurrence rule creates no series, so there is no "and all future occurrences" to worry
+  about; and that the tombstone is why re-creating a record with the same id does **not** undo the delete. Each
+  one now points at `excludeFromVectorSearch` first, because "stop this appearing in search" is a different
+  request from "destroy this" and only one of them is reversible.
+
 - **The four record-editing tools now say whether a list you send is added to what is stored or replaces it —
   and they do not all do the same thing.** Editing an entity or an edge MERGES tags; editing a memory or a
   chrono entry REPLACES them. So sending one tag adds it in two cases and destroys every other tag in the

--- a/server/src/mcp/tools/chrono.ts
+++ b/server/src/mcp/tools/chrono.ts
@@ -384,7 +384,26 @@ export const list_chronoTool: ToolHandler = {
 /** Delete one chrono entry. Mirrors `DELETE /api/brain/spaces/:spaceId/chrono/:id`. */
 export const delete_chronoTool: ToolHandler = {
   name: 'delete_chrono',
-  description: 'Delete a chrono entry by ID. Creates a tombstone for sync propagation.',
+  description: 'Delete one chrono entry by its ID. IRREVERSIBLE — there is no undelete and no trash.\n\n'
+    + 'A PAST OR CANCELLED ENTRY IS USUALLY NOT A DELETE. Nothing recomputes `status` from the clock, so an '
+    + 'entry that has happened simply keeps whatever status it was given; set `status: "completed"` or '
+    + '`"cancelled"` with `update_chrono` and the entry stays as the record that it happened. Deleting is for '
+    + 'entries that should never have existed. If you only want it out of meaning-ranking, set '
+    + '`excludeFromVectorSearch` — it stays listable by `list_chrono` and reachable by traversal.\n\n'
+    + 'THE ENTITIES AND MEMORIES IT LINKS ARE NOT TOUCHED. `entityIds` and `memoryIds` are references; '
+    + 'deleting the entry drops the references and leaves every referenced record in place.\n\n'
+    + 'IT IS NEVER REFUSED FOR BEING REFERENCED. Strict linkage guards ENTITY deletion only.\n\n'
+    + 'A RECURRENCE RULE DOES NOT SPREAD THE DELETE, because it never created anything to delete. '
+    + '`recurrence` describes one entry as repeating; it does not generate further entries, so there is no '
+    + 'series here and no "this and all future occurrences" to choose between.\n\n'
+    + 'A TOMBSTONE IS WRITTEN, so the deletion propagates to peer instances on the next sync and the entry is '
+    + 'not quietly resurrected from a peer that still has it. That is also why re-creating it with the same '
+    + 'id does not undo this — the tombstone outranks it.\n\n'
+    + 'PARAMETERS:\n'
+    + '- `id` — the entry\'s `_id`, as `list_chrono` and `query` report it. Required. An id that does not '
+    + 'exist is an ERROR, not a silent success.\n'
+    + '- `targetSpace` — required when `space` is a proxy: the member space holding the entry.\n\n'
+    + 'RESPONSE: one line confirming the id that was deleted.',
   mutating: true,
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({

--- a/server/src/mcp/tools/edge.ts
+++ b/server/src/mcp/tools/edge.ts
@@ -289,7 +289,26 @@ export const traverseTool: ToolHandler = {
  */
 export const delete_edgeTool: ToolHandler = {
   name: 'delete_edge',
-  description: 'Delete an edge by ID. Creates a tombstone for sync propagation.',
+  description: 'Delete one edge by its ID. IRREVERSIBLE — there is no undelete and no trash.\n\n'
+    + 'THE ENTITIES AT EITHER END ARE NOT TOUCHED. Deleting an edge removes the RELATIONSHIP and nothing '
+    + 'else: both endpoints stay exactly as they were, and every other edge between them survives. This is '
+    + 'the tool for "these two are not related after all", not for removing a record.\n\n'
+    + 'IT IS ALSO HOW YOU REPOINT AN EDGE. `update_edge` deliberately has no `from`/`to` — an edge whose end '
+    + 'changed is a different relationship — so the sequence is delete this one, then `upsert_edge` the new '
+    + 'one.\n\n'
+    + 'IF YOU WANT IT OUT OF SEARCH RATHER THAN GONE, set `excludeFromVectorSearch` with `update_edge` '
+    + 'instead. Edges are searchable records and compete with knowledge for a recall `topK`; excluding one '
+    + 'stops it being ranked while `traverse` still walks it and recall still expands through it. Deleting it '
+    + 'removes it from the graph as well, which is a much larger change than "it was crowding my results".\n\n'
+    + 'IT IS NEVER REFUSED FOR BEING REFERENCED. Strict linkage guards ENTITY deletion only.\n\n'
+    + 'A TOMBSTONE IS WRITTEN, so the deletion propagates to peer instances on the next sync and the edge is '
+    + 'not quietly resurrected from a peer that still has it. That is also why re-creating it with the same '
+    + 'id does not undo this — the tombstone outranks it. Use a new id.\n\n'
+    + 'PARAMETERS:\n'
+    + '- `id` — the edge\'s `_id`, as `traverse`, `query` and recall\'s `_graph` report it. Required. An id '
+    + 'that does not exist is an ERROR, not a silent success.\n'
+    + '- `targetSpace` — required when `space` is a proxy: the member space holding the edge.\n\n'
+    + 'RESPONSE: one line confirming the id that was deleted.',
   mutating: true,
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({

--- a/server/src/mcp/tools/memory.ts
+++ b/server/src/mcp/tools/memory.ts
@@ -279,7 +279,23 @@ export const update_memoryTool: ToolHandler = {
 
 export const delete_memoryTool: ToolHandler = {
   name: 'delete_memory',
-  description: 'Delete a memory by ID. Creates a tombstone for sync propagation.',
+  description: 'Delete one memory by its ID. IRREVERSIBLE — there is no undelete and no trash.\n\n'
+    + 'IF YOU WANT IT OUT OF SEARCH RATHER THAN GONE, this is the wrong tool. Set '
+    + '`excludeFromVectorSearch` with `update_memory` instead: the record stays readable, listable and '
+    + 'traversable, and only stops being ranked by meaning. Deleting is for records that should not exist.\n\n'
+    + 'IT IS NEVER REFUSED FOR BEING REFERENCED, and that differs from `delete_entity`. A chrono entry '
+    + 'listing this memory in `memoryIds` keeps the id after the memory is gone, and nothing reports it — '
+    + 'strict linkage guards ENTITY deletion only. Check `query` for referrers first if a dangling id would '
+    + 'matter to you.\n\n'
+    + 'A TOMBSTONE IS WRITTEN, so the deletion propagates to peer instances on the next sync and the record '
+    + 'is not quietly resurrected from a peer that still has it. That is also why this cannot be undone by '
+    + 'writing the record back with the same id — the tombstone outranks it.\n\n'
+    + 'PARAMETERS:\n'
+    + '- `id` — the memory\'s `_id`. Required. An id that does not exist is an ERROR, not a silent success, '
+    + 'so a successful reply means a record really was deleted.\n'
+    + '- `targetSpace` — required when `space` is a proxy: the member space holding the memory. Without it '
+    + 'the call is refused rather than guessing which member you meant.\n\n'
+    + 'RESPONSE: one line confirming the id that was deleted.',
   mutating: true,
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({

--- a/testing/standalone/delete-tools-state-what-survives.test.js
+++ b/testing/standalone/delete-tools-state-what-survives.test.js
@@ -1,0 +1,120 @@
+/**
+ * Every `delete_*` tool says what it does NOT delete, and which of them can refuse.
+ *
+ * ## The asymmetry a caller cannot guess
+ *
+ * `delete_entity` consults `findEntityBacklinks` and, under strict linkage, refuses while anything still
+ * points at the record. The other three delete unconditionally — strict linkage does not guard them at all.
+ * So a chrono entry's `memoryIds` can be left holding the id of a memory that no longer exists, silently,
+ * on a space configured to forbid exactly that shape.
+ *
+ * That is defensible (an edge IS the link; entity references are the structural ones) but it is not
+ * inferable, and the four descriptions read identically before this change: *"Delete an X by ID. Creates a
+ * tombstone for sync propagation."*
+ *
+ * ## The other three things a delete has to say
+ *
+ * - **Retire vs delete.** `excludeFromVectorSearch` is what "stop it appearing in search" actually means;
+ *   deleting is a much larger change and there is no undo. A caller who wanted the first and used the second
+ *   cannot get the record back.
+ * - **The tombstone is why re-creating with the same id does not undo it.** The deletion propagates, and the
+ *   tombstone outranks a later write of that id — which is the surprising half.
+ * - **What survives.** Deleting an edge leaves both endpoints; deleting a chrono entry leaves everything it
+ *   linked. Stated because "delete the relationship" and "delete the things" are one keystroke apart.
+ *
+ * Run: node --test testing/standalone/delete-tools-state-what-survives.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripComments } from './_strip-comments.mjs';
+
+const description = (file, name) => {
+  const s = stripComments(readFileSync(file, 'utf8'));
+  const at = s.indexOf(`name: '${name}'`);
+  assert.ok(at > 0, `${name} not found in ${file} — the scanner is wrong, not the code`);
+  const d = s.indexOf('description:', at);
+  const end = s.slice(d).search(/\n {2,}(mutating|spaceRequired|admin|spaceAdmin|inputSchema|async handle):/);
+  assert.ok(end > 0, `could not find the end of ${name}'s description`);
+  return s.slice(d, d + end);
+};
+
+const TOOLS = {
+  delete_entity: description('server/src/mcp/tools/entity.ts', 'delete_entity'),
+  delete_edge: description('server/src/mcp/tools/edge.ts', 'delete_edge'),
+  delete_memory: description('server/src/mcp/tools/memory.ts', 'delete_memory'),
+  delete_chrono: description('server/src/mcp/tools/chrono.ts', 'delete_chrono'),
+};
+
+describe('every delete says it cannot be undone, and what to use instead', () => {
+  for (const [name, d] of Object.entries(TOOLS)) {
+    it(`${name} says IRREVERSIBLE`, () => {
+      assert.match(d, /IRREVERSIBLE/, 'a destructive tool must lead with that');
+    });
+
+    it(`${name} points at the retire alternative`, () => {
+      // The mistake this pre-empts: wanting a record out of search results and reaching for delete.
+      assert.match(d, /excludeFromVectorSearch/,
+        'a caller who wanted "stop showing this" must be told the non-destructive option exists');
+    });
+
+    it(`${name} explains the tombstone, not just that there is one`, () => {
+      // "Creates a tombstone for sync propagation" was the whole of three of these descriptions and told a
+      // caller nothing they could act on. The actionable half is that it outranks a later write of that id.
+      assert.match(d, /tombstone/i, 'name it');
+      assert.match(d, /peer/i, 'and say it propagates');
+    });
+  }
+});
+
+describe('the refusal asymmetry is stated on all four', () => {
+  it('delete_entity says it CAN be refused, and that a refusal is usually correct', () => {
+    assert.match(TOOLS.delete_entity, /REFUSAL HERE IS USUALLY CORRECT/,
+      'a caller who reads a refusal as an obstacle will work around it');
+    assert.match(TOOLS.delete_entity, /strictLinkage/, 'and say what turns the guard on');
+  });
+
+  for (const name of ['delete_edge', 'delete_memory', 'delete_chrono']) {
+    it(`${name} says it is NEVER refused for being referenced`, () => {
+      // Pinned because it is the surprising direction: on a space with strict linkage a caller reasonably
+      // expects the same protection the entity delete gives, and does not get it.
+      assert.match(TOOLS[name], /NEVER REFUSED FOR BEING REFERENCED/,
+        'the asymmetry with delete_entity has to be stated where the caller is');
+      assert.match(TOOLS[name], /ENTITY deletion only/, 'and say where the guard does apply');
+    });
+  }
+
+  it('and that claim is true — only the entity delete consults backlinks', () => {
+    // Read from source, so the day a backlink guard is added to another delete this fails instead of
+    // misinforming. `findEntityBacklinks` is the only such check in the tools.
+    const entity = stripComments(readFileSync('server/src/mcp/tools/entity.ts', 'utf8'));
+    assert.match(entity, /findEntityBacklinks\(/, 'delete_entity really does check');
+    for (const f of ['server/src/mcp/tools/edge.ts', 'server/src/mcp/tools/memory.ts',
+      'server/src/mcp/tools/chrono.ts']) {
+      assert.doesNotMatch(stripComments(readFileSync(f, 'utf8')), /findEntityBacklinks|Backlinks\(/,
+        `${f} gained a backlink guard — the "never refused" paragraph is now wrong`);
+    }
+  });
+});
+
+describe('what survives a delete is named', () => {
+  it('delete_edge says both endpoints stay', () => {
+    assert.match(TOOLS.delete_edge, /ENTITIES AT EITHER END ARE NOT TOUCHED/,
+      '"delete the relationship" and "delete the things" are one keystroke apart');
+  });
+
+  it('and that it is how an edge gets repointed, since update_edge cannot', () => {
+    assert.match(TOOLS.delete_edge, /upsert_edge/, 'name the second half of the sequence');
+  });
+
+  it('delete_chrono says its links are references, not contents', () => {
+    assert.match(TOOLS.delete_chrono, /NOT TOUCHED/, 'entityIds and memoryIds are references');
+  });
+
+  it('delete_chrono says a recurrence rule does not spread the delete', () => {
+    // Pre-empts the calendar assumption: there is no series, so there is no "this and all future
+    // occurrences" question to answer.
+    assert.match(TOOLS.delete_chrono, /DOES NOT SPREAD THE DELETE/,
+      'a caller from any calendar API will assume a series exists');
+  });
+});


### PR DESCRIPTION
Three of the four delete tools read, in full:

> *"Delete an X by ID. Creates a tombstone for sync propagation."*

That leaves everything interesting to be discovered by doing it — on tools that cannot be undone.

## The asymmetry a caller cannot guess

`delete_entity` consults `findEntityBacklinks` and, under **strict linkage**, refuses while an edge, memory,
chrono entry or file still points at the record. **That guard exists for entities only.**

| Tool | Refused when referenced? |
| --- | --- |
| `delete_entity` | yes, under strict linkage — and the refusal names what points at it |
| `delete_edge` | never |
| `delete_memory` | never |
| `delete_chrono` | never |

So a chrono entry's `memoryIds` can be left holding the id of a memory that no longer exists — silently, on a
space explicitly configured to forbid exactly that shape.

It is defensible (an edge *is* the link; entity references are the structural ones) but it is not inferable,
and the four descriptions were identical. Each now says which side it is on.

## The rest of what a delete has to say

- **Retire vs delete.** Each now points at `excludeFromVectorSearch` **first**. "Stop this appearing in
  search" is a different request from "destroy this", and only one of them is reversible. A caller who wanted
  the first and reached for the second cannot get the record back.
- **The tombstone is why re-creating the record with the same id does not undo the delete** — it outranks a
  later write of that id. That is the surprising half, and *"creates a tombstone for sync propagation"* did
  not say it.
- **What survives.** Deleting an edge leaves both endpoints and every other edge between them; deleting a
  chrono entry leaves everything it linked. "Delete the relationship" and "delete the things" are one
  keystroke apart.
- **`delete_edge` is also how an edge gets repointed**, since `update_edge` deliberately has no `from`/`to` —
  an edge whose end changed is a different relationship. Delete, then `upsert_edge`.
- **A recurrence rule creates no series**, so there is no "this and all future occurrences" question. Stated
  because every calendar API a caller has used *does* have one.

## The gate

`delete-tools-state-what-survives.test.js` reads the backlink claim from **source**, so the day a backlink
guard is added to another delete, the "never refused" paragraph fails instead of quietly misinforming.

**Mutation-tested:** dropping the asymmetry note from `delete_edge` fails; adding a backlink guard to
`delete_memory` fails.

Part of **X-2**.
