### PR TITLE
docs(mcp): the file move/delete/mkdir tools describe their cascade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one now points at `excludeFromVectorSearch` first, because "stop this appearing in search" is a different
   request from "destroy this" and only one of them is reversible.
 
+- **The file move, delete and mkdir tools now describe what they do besides the obvious.** Deleting a file is
+  a **cascade**, not an unlink: it also writes a sync tombstone, removes the metadata record, **cancels any
+  queued media or text job** so it cannot outlive the file and retry for ever, removes extracted text and
+  thumbnails, and fires a webhook. It is also **idempotent** — deleting a path that is not there succeeds,
+  which is the opposite of all four brain deletes, so a success is not proof the file existed. Moving
+  tombstones the old path because sync has no rename detection and would otherwise push the original back
+  from a peer, leaving you holding both; a directory move re-roots every child's tags and description; and
+  nothing checks the destination first, so a move onto an existing path is not refused. Creating a directory
+  is mostly unnecessary — writing and moving create their own parents — and an empty directory never reaches
+  a peer, because only files sync. Each claim is pinned to the function that makes it true, so a behaviour
+  that changes fails the description instead of quietly outdating it.
+
 - **The four record-editing tools now say whether a list you send is added to what is stored or replaces it —
   and they do not all do the same thing.** Editing an entity or an edge MERGES tags; editing a memory or a
   chrono entry REPLACES them. So sending one tag adds it in two cases and destroys every other tag in the

--- a/server/src/mcp/tools/file.ts
+++ b/server/src/mcp/tools/file.ts
@@ -156,7 +156,26 @@ export const list_dirTool: ToolHandler = {
 
 export const delete_fileTool: ToolHandler = {
   name: 'delete_file',
-  description: 'Delete a file from the space file store.',
+  description: 'Delete one file from the space file store, and everything the instance derived from it. '
+    + 'IRREVERSIBLE — there is no undelete and no trash.\n\n'
+    + 'IT IS A CASCADE, not just an unlink. The blob goes, a sync tombstone is written, the metadata record is '
+    + 'removed (or flagged deleted when the instance keeps them for audit), any queued media or text job is '
+    + 'CANCELLED so it cannot outlive the file and retry for ever, conversion artifacts such as extracted text '
+    + 'and thumbnails are removed, the space\'s usage figure is invalidated, and a `file.deleted` webhook '
+    + 'fires. Deleting the blob by other means leaves all of that behind.\n\n'
+    + 'IT IS IDEMPOTENT, AND THAT DIFFERS FROM THE BRAIN DELETES. Deleting a path that is not there succeeds '
+    + 'quietly; `delete_memory`, `delete_edge`, `delete_entity` and `delete_chrono` all ERROR on an id that '
+    + 'does not exist. So a success here does not prove a file was there — check `list_dir` first if that '
+    + 'distinction matters to you. The tradeoff is deliberate: a retried delete after a dropped connection '
+    + 'must not report failure for having worked the first time.\n\n'
+    + 'THE TOMBSTONE IS WHY RE-UPLOADING TO THE SAME PATH DOES NOT UNDO THIS cleanly on a synced space — the '
+    + 'tombstone propagates and outranks the old copy on peers. Upload the file again by all means; just do '
+    + 'not expect the deletion to be forgotten.\n\n'
+    + 'PARAMETERS:\n'
+    + '- `path` — the file path relative to the space root, as `list_dir` reports it. One FILE: this is not '
+    + 'the tool for removing a directory tree.\n'
+    + '- `targetSpace` — required when `space` is a proxy: the member space holding the file.\n\n'
+    + 'RESPONSE: one line naming the path that was deleted.',
   mutating: true,
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({
@@ -184,7 +203,19 @@ export const delete_fileTool: ToolHandler = {
 
 export const create_dirTool: ToolHandler = {
   name: 'create_dir',
-  description: 'Create a directory (and any required parents) in the space file store.',
+  description: 'Create a directory in the space file store, including any parent directories that do not yet '
+    + 'exist — the equivalent of `mkdir -p`, so `a/b/c` in one call is fine. Creating a directory that is '
+    + 'already there SUCCEEDS rather than erroring, so this is safe to call without checking first.\n\n'
+    + 'YOU RARELY NEED THIS BEFORE A WRITE. `write_file` and `move_file` both create the parent directories of '
+    + 'their destination on their own, so calling this first is a no-op step in most flows. It is for the case '
+    + 'where the EMPTY directory is the point: laying out a structure a human or another agent will fill.\n\n'
+    + 'A DIRECTORY IS NOT A SYNCED OBJECT. Only files sync between peers, so an empty directory created here '
+    + 'exists on this instance alone and will not appear on a peer until something is written into it. It also '
+    + 'carries no metadata: there is nothing to tag or describe until it holds a file.\n\n'
+    + 'PARAMETERS:\n'
+    + '- `path` — the directory path relative to the space root. Missing parents are created.\n'
+    + '- `targetSpace` — required when `space` is a proxy: the member space to create it in.\n\n'
+    + 'RESPONSE: one line confirming the path.',
   mutating: true,
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({
@@ -210,7 +241,32 @@ export const create_dirTool: ToolHandler = {
 
 export const move_fileTool: ToolHandler = {
   name: 'move_file',
-  description: 'Move or rename a file or directory within the space file store.',
+  description: 'Move or rename a file OR a directory within the space file store. One tool for both: renaming '
+    + 'is moving to a new name in the same place.\n\n'
+    + 'A DIRECTORY MOVE CARRIES EVERY CHILD\'S METADATA WITH IT. Tags, descriptions and custom meta are keyed '
+    + 'by path, so moving `a/` to `b/` re-roots the record of every file underneath. This tool used to rename '
+    + 'only the single record it was given, which orphaned every child record on a directory move — the '
+    + 'metadata still existed, at a path with no file.\n\n'
+    + 'THE OLD PATHS ARE TOMBSTONED, and that is not bookkeeping. Sync has no rename detection: it sees a '
+    + 'file gone from one path and present at another, so without a tombstone the peer\'s manifest pushes the '
+    + 'ORIGINAL back and you end up with both. For a directory move every child path is tombstoned, not just '
+    + 'the directory.\n\n'
+    + 'NOTHING CHECKS THE DESTINATION FIRST. There is no "already exists" refusal here — the move is a '
+    + 'filesystem rename, and a rename onto an existing file replaces it. Read `list_dir` first if that would '
+    + 'lose something. Missing parent directories of `dst` ARE created for you.\n\n'
+    + 'THE FILE IS NOT RE-READ. Moving does not re-extract text, re-run media analysis or re-embed: the '
+    + 'content did not change, only where it lives. A file that failed extraction at the old path is still '
+    + 'failed at the new one — use `retry_embedding` for that, which is a different question from where the '
+    + 'file sits.\n\n'
+    + 'PARAMETERS:\n'
+    + '- `src` — the existing path, relative to the space root, exactly as `list_dir` reports it. A file or a '
+    + 'directory.\n'
+    + '- `dst` — where it should end up, relative to the space root. Its parent directories are created if '
+    + 'missing.\n'
+    + '- `targetSpace` — required when `space` is a proxy: the member space holding the file. This tool moves '
+    + 'WITHIN one space; it cannot move a file between spaces, and naming a different member does not do that '
+    + '— read it and write it instead.\n\n'
+    + 'RESPONSE: one line confirming the move.',
   mutating: true,
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({

--- a/testing/standalone/file-mutation-tools-state-their-cascade.test.js
+++ b/testing/standalone/file-mutation-tools-state-their-cascade.test.js
@@ -1,0 +1,147 @@
+/**
+ * The file-mutation tools say what happens BESIDES the obvious, and each claim is pinned to the code.
+ *
+ * ## What was missing
+ *
+ * Three one-line descriptions — *"Move or rename a file or directory"*, *"Delete a file from the space file
+ * store"*, *"Create a directory (and any required parents)"* — each of which is true and none of which says
+ * the thing a caller gets wrong.
+ *
+ * - **`delete_file` is a CASCADE and it is IDEMPOTENT.** It cancels queued media jobs, removes conversion
+ *   artifacts, writes a sync tombstone and fires a webhook. And deleting a path that is not there SUCCEEDS —
+ *   the opposite of every brain delete, all four of which error on an unknown id. A caller who reads a
+ *   success as proof the file existed is wrong, and nothing said so.
+ * - **`move_file` tombstones the old paths**, because sync has no rename detection: without it the peer's
+ *   manifest pushes the original back and you have both copies. For a directory move that is every child
+ *   path, and every child's metadata is re-rooted too — this tool used to rename only the record it was
+ *   handed, orphaning the rest.
+ * - **`create_dir` is mostly unnecessary.** `write_file` and `move_file` create their destination's parents
+ *   themselves, so the tool is for the case where the EMPTY directory is the point — and an empty directory
+ *   never reaches a peer, because only files sync.
+ *
+ * ## Every claim is checked against source
+ *
+ * Prose about a cascade is worth nothing if the cascade changes underneath it. Each assertion below names the
+ * function that makes its sentence true, so removing the behaviour fails the description rather than quietly
+ * outdating it.
+ *
+ * Run: node --test testing/standalone/file-mutation-tools-state-their-cascade.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripComments } from './_strip-comments.mjs';
+
+const FILE_TOOLS = readFileSync('server/src/mcp/tools/file.ts', 'utf8');
+const CASCADE = stripComments(readFileSync('server/src/files/delete-cascade.ts', 'utf8'));
+const FILES = stripComments(readFileSync('server/src/files/files.ts', 'utf8'));
+const FS_MODES = stripComments(readFileSync('server/src/util/fs-modes.ts', 'utf8'));
+
+const description = (name) => {
+  const s = stripComments(FILE_TOOLS);
+  const at = s.indexOf(`name: '${name}'`);
+  assert.ok(at > 0, `${name} not found — the scanner is wrong, not the code`);
+  const d = s.indexOf('description:', at);
+  const end = s.slice(d).search(/\n {2,}(mutating|spaceRequired|admin|spaceAdmin|inputSchema|async handle):/);
+  assert.ok(end > 0, `could not find the end of ${name}'s description`);
+  return s.slice(d, d + end);
+};
+
+const DELETE = description('delete_file');
+const MOVE = description('move_file');
+const MKDIR = description('create_dir');
+
+describe('delete_file describes the cascade it really performs', () => {
+  it('names the derived things that go with the blob', () => {
+    for (const claim of [/tombstone/i, /job/i, /artifact/i, /webhook/i, /usage/i]) {
+      assert.match(DELETE, claim, 'a caller deleting by other means needs to know what this cleans up');
+    }
+  });
+
+  it('and each of those is really in the cascade', () => {
+    // Pinned to the implementation: prose about a cascade is worthless if the cascade changed underneath it.
+    for (const fn of ['writeFileTombstones', 'cancelMediaJob', 'deleteConversionArtifacts',
+      'invalidateUsageCache', 'emitWebhookEvent']) {
+      assert.match(CASCADE, new RegExp(`${fn}\\(`), `${fn} left the cascade — the description now overclaims`);
+    }
+  });
+
+  it('says it is IDEMPOTENT, and contrasts it with the brain deletes', () => {
+    // The asymmetry that makes a success misleading: this returns fine for a path that was never there,
+    // while delete_memory/edge/entity/chrono all throw on an unknown id.
+    assert.match(DELETE, /IDEMPOTENT/, 'a caller must not read success as proof the file existed');
+    assert.match(DELETE, /delete_memory|brain deletes/i, 'name what behaves differently');
+  });
+
+  it('and that is still true — the handler returns success unconditionally', () => {
+    const handler = FILE_TOOLS.slice(FILE_TOOLS.indexOf("name: 'delete_file'"));
+    const end = handler.indexOf('\nexport const ');
+    const body = stripComments(end === -1 ? handler : handler.slice(0, end));
+    assert.match(body, /await deleteFileCascade\([^)]*\);\s*return \{/,
+      'a not-found check appeared — delete_file is no longer idempotent and the description must change');
+  });
+});
+
+describe('move_file explains the tombstone and the directory case', () => {
+  it('says the OLD paths are tombstoned, and why', () => {
+    assert.match(MOVE, /TOMBSTONED/, 'name it');
+    assert.match(MOVE, /rename detection/i,
+      'the reason is the interesting part: sync cannot tell a move from a delete-plus-create');
+  });
+
+  it('says a directory move carries every child\'s metadata', () => {
+    // The defect that was fixed and would otherwise be invisible: child records orphaned at paths with no
+    // files.
+    assert.match(MOVE, /DIRECTORY MOVE CARRIES EVERY CHILD/,
+      'a caller moving a tree needs to know its tags survive');
+  });
+
+  it('warns that nothing checks the destination', () => {
+    assert.match(MOVE, /NOTHING CHECKS THE DESTINATION FIRST/,
+      'a move onto an existing path is a filesystem rename, and there is no refusal to catch it');
+  });
+
+  it('and that really is the case — moveFile renames with no existence check', () => {
+    const at = FILES.indexOf('export async function moveFile');
+    const body = FILES.slice(at, FILES.indexOf('\nexport ', at + 10));
+    assert.match(body, /fs\.rename\(srcAbs, dstAbs\)/, 'it is a bare rename');
+    assert.doesNotMatch(body, /fileExists|already exists/,
+      'a destination check appeared — delete the warning rather than leaving it wrong');
+  });
+
+  it('says the content is not re-read, so a failed extraction stays failed', () => {
+    assert.match(MOVE, /NOT RE-READ/, 'moving is not a repair, and retry_embedding is the tool that is');
+  });
+});
+
+describe('create_dir says when you do not need it', () => {
+  it('points out that write_file and move_file make their own parents', () => {
+    assert.match(MKDIR, /write_file/, 'most callers should skip this step entirely');
+  });
+
+  it('and they really do', () => {
+    for (const fn of ['writeFile', 'moveFile']) {
+      const at = FILES.indexOf(`export async function ${fn}`);
+      const body = FILES.slice(at, FILES.indexOf('\nexport ', at + 10));
+      assert.match(body, /mkdirPrivate\(path\.dirname\(/, `${fn} no longer creates its parents`);
+    }
+  });
+
+  it('says creating an existing directory succeeds', () => {
+    assert.match(MKDIR, /SUCCEEDS rather than erroring/, 'safe to call blind is worth stating');
+    assert.match(FS_MODES, /mkdir\(dir, \{ recursive: true/, 'which is only true while mkdir is recursive');
+  });
+
+  it('says an empty directory never reaches a peer', () => {
+    assert.match(MKDIR, /NOT A SYNCED OBJECT/, 'only files sync');
+  });
+
+  it('and the sync-facing walk really pushes files only', () => {
+    // `listFilesRecursive` descends into directories but pushes only `isFile()` entries, which is what makes
+    // "an empty directory does not sync" true rather than plausible.
+    const at = FILES.indexOf('export async function listFilesRecursive');
+    const body = FILES.slice(at, FILES.indexOf('\nexport ', at + 10));
+    assert.match(body, /entry\.isDirectory\(\)[\s\S]{0,60}walk\(full\)/, 'it descends');
+    assert.match(body, /entry\.isFile\(\)[\s\S]{0,80}out\.push/, 'but only files are emitted');
+  });
+});


### PR DESCRIPTION
Three one-line descriptions, each true and none saying the thing a caller gets wrong.

## `delete_file` is a cascade, and it is idempotent

*"Delete a file from the space file store"* undersells it. It also writes a sync tombstone, removes the
metadata record (or flags it deleted where the instance keeps them for audit), **cancels any queued media or
text job** so it cannot outlive the file and retry for ever, removes extracted text and thumbnails,
invalidates the usage figure, and fires a `file.deleted` webhook. Removing a blob any other way leaves all of
that behind.

**And deleting a path that is not there succeeds.**

| Tool family | Unknown id / path |
| --- | --- |
| `delete_file` | succeeds quietly |
| `delete_memory` / `delete_edge` / `delete_entity` / `delete_chrono` | **error** |

So a success here is not proof the file existed. The tradeoff is deliberate — a retried delete after a dropped
connection must not report failure for having worked the first time — but it has to be stated, because the two
families disagree and a caller will have used one before the other.

## `move_file` tombstones the old paths, and carries child metadata

Sync has **no rename detection**: it sees a file gone from one path and present at another. Without a
tombstone the peer's manifest pushes the original back and you are holding both copies. For a directory move
that is every child path, not just the directory.

Metadata is keyed by path, so a directory move re-roots every child record too. This tool used to rename only
the record it was handed, orphaning the rest — tags and descriptions living at paths with no file.

Also now stated: **nothing checks the destination first** (it is a filesystem rename; there is no "already
exists" refusal to catch you), missing parents of `dst` *are* created, and the content is not re-read — a file
that failed extraction is still failed at the new path, and `retry_embedding` is the tool for that.

## `create_dir` is mostly unnecessary

`write_file` and `move_file` create their destination's parents themselves, so this is for the case where the
**empty** directory is the point. An empty directory never reaches a peer, because only files sync.

## Every claim is pinned to the code that makes it true

Prose about a cascade is worth nothing if the cascade changes underneath it. The gate asserts from source
that:

- `writeFileTombstones`, `cancelMediaJob`, `deleteConversionArtifacts`, `invalidateUsageCache` and
  `emitWebhookEvent` are really in `delete-cascade.ts`
- `delete_file`'s handler really returns success unconditionally
- `moveFile` really is a bare `fs.rename` with no existence check
- `writeFile` and `moveFile` really `mkdir` their parents, and `mkdirPrivate` really is recursive
- `listFilesRecursive` really descends into directories while pushing only files

**Mutation-tested:** dropping `cancelMediaJob` from the cascade fails; making the sync walk stop naming
`isFile` fails.

Part of **X-2**.
