### PR TITLE
docs(mcp): wipe_space says it does not reach sync peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`wipe_space` now warns that it does not reach sync peers, which is the most consequential thing about
+  it.** Every per-record delete writes a tombstone, because a tombstone is the only thing that tells a peer a
+  record is gone. Wiping does the opposite: it deletes the data and then deletes the **tombstones** too,
+  writing none. On a space that belongs to a sync network that leaves an empty space with no record of any
+  deletion, facing a peer that still offers everything it holds — so the next round puts much of it back. The
+  old description said the space and its configuration are preserved and nothing about sync, which reads as
+  though the data is gone for good. It now says the wipe is local, and names the three ways to actually empty
+  a networked space. It also says that omitting `types` wipes **all five** collections rather than none, that
+  the duplicate and contradiction queues are cleared along with the records they point at, and that wiping an
+  already-empty space succeeds with zeroes rather than erroring. Whether wiping *should* propagate is a real
+  question with three defensible answers, so it is filed rather than decided.
+
 - **The four delete tools now say what they do *not* delete, and which of them can refuse.** Three of them
   read *"Delete an X by ID. Creates a tombstone for sync propagation"* and nothing else, which left a caller
   to discover the interesting parts by doing it. Deleting an **entity** is refused while something still

--- a/server/src/mcp/tools/spaces.ts
+++ b/server/src/mcp/tools/spaces.ts
@@ -578,7 +578,30 @@ export const reindexTool: ToolHandler = {
 
 export const wipe_spaceTool: ToolHandler = {
   name: 'wipe_space',
-  description: 'Wipe data from the specified space. By default wipes all collections (memories, entities, edges, chrono, files). Pass `types` to wipe only specific collections. The space itself and its configuration are preserved. Requires an admin token. Idempotent — wiping an empty space returns zero counts.',
+  description: 'Empty a space of its DATA while keeping the space itself — its id, label, purpose, schema, '
+    + 'rights and network membership all survive. Requires instance-admin rights. IRREVERSIBLE: there is no '
+    + 'undo, no trash, and no confirmation step, so the call that arrives is the call that runs.\n\n'
+    + 'IT IS A LOCAL WIPE, AND ON A NETWORKED SPACE THAT IS PROBABLY NOT WHAT YOU WANT. Unlike every '
+    + '`delete_*` tool, this writes NO tombstones — it deletes the existing ones as well. Tombstones are the '
+    + 'only thing that tells a peer a record is gone; without them a peer\'s manifest still offers everything '
+    + 'it holds and this instance, now empty and with no record of any deletion, has no reason to refuse it. '
+    + 'So on a space that belongs to a sync network, expect the next round to put much of it back. Wipe every '
+    + 'peer, or leave the network first, or use the per-record `delete_*` tools — those do tombstone.\n\n'
+    + 'On a space in no network there is nothing to bring it back and the wipe is simply final.\n\n'
+    + 'IT IS IDEMPOTENT. Wiping an empty space succeeds and returns zeroes rather than erroring, so a retry '
+    + 'after a dropped connection is safe.\n\n'
+    + 'WHAT ELSE GOES WITH IT: the review queues are cleared for whatever you wiped — duplicate and '
+    + 'contradiction findings are claims ABOUT two records, so once those records are gone the finding is not '
+    + 'merely stale, it is unopenable. Wiping `files` also deletes the space\'s file directory on disk and '
+    + 'recreates it empty.\n\n'
+    + 'PARAMETERS:\n'
+    + '- `types` — a subset of `memories`, `entities`, `edges`, `chrono`, `files`. OMIT IT TO WIPE ALL FIVE; '
+    + 'an omitted `types` is not a safe default. A partial wipe clears only the tombstones and review findings '
+    + 'belonging to the types you named.\n'
+    + '- `space` — the space to empty. On a proxy this is the proxy\'s own id and there is no `targetSpace` '
+    + 'here, so do not reach for this tool to empty one member.\n\n'
+    + 'RESPONSE: a per-collection count of what was deleted. Zeroes mean the space was already empty, not '
+    + 'that anything refused.',
   mutating: true,
   admin: true,
   spaceRequired: true,

--- a/testing/standalone/wipe-space-says-it-is-local.test.js
+++ b/testing/standalone/wipe-space-says-it-is-local.test.js
@@ -1,0 +1,101 @@
+/**
+ * `wipe_space` says it does not propagate — and the claim is pinned to the code that makes it true.
+ *
+ * ## The finding
+ *
+ * Every `delete_*` tool writes a tombstone, because a tombstone is the only thing that tells a peer a record
+ * is gone. `wipeSpace` does the opposite: it deletes the documents and then deletes the **tombstones** as
+ * well — `${spaceId}_tombstones` wholesale on a full wipe, filtered by type on a partial one, and
+ * `${spaceId}_file_tombstones` when files are included. It writes none.
+ *
+ * So on a space in a sync network the result is an empty space with no record of any deletion, facing a peer
+ * that still offers everything it holds. This codebase states the consequence in three separate places —
+ * `delete-cascade.ts`: *"Propagate the deletion to sync peers, else the peer's manifest re-pushes the file"* —
+ * so the outcome is its own documented mechanism, not a guess.
+ *
+ * The old description said *"The space itself and its configuration are preserved"* and nothing about sync,
+ * which reads as though the data is gone for good.
+ *
+ * Filed as **X-5**: the real fix is an owner call between propagating the wipe, refusing on a networked space
+ * without a flag, and leaving it documented. Saying so is the half that ships without choosing for them.
+ *
+ * Run: node --test testing/standalone/wipe-space-says-it-is-local.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripComments } from './_strip-comments.mjs';
+
+const TOOLS = readFileSync('server/src/mcp/tools/spaces.ts', 'utf8');
+const LIFECYCLE = stripComments(readFileSync('server/src/spaces/lifecycle.ts', 'utf8'));
+
+const WIPE = (() => {
+  const s = stripComments(TOOLS);
+  const at = s.indexOf("name: 'wipe_space'");
+  assert.ok(at > 0, 'wipe_space not found — the scanner is wrong, not the code');
+  const d = s.indexOf('description:', at);
+  const end = s.slice(d).search(/\n {2,}(mutating|spaceRequired|admin|spaceAdmin|inputSchema|async handle):/);
+  assert.ok(end > 0, 'could not find the end of wipe_space\'s description');
+  return s.slice(d, d + end);
+})();
+
+describe('wipe_space warns that it does not reach peers', () => {
+  it('says it is LOCAL', () => {
+    assert.match(WIPE, /LOCAL WIPE/, 'the single most consequential fact about this tool');
+  });
+
+  it('says it writes NO tombstones and removes the existing ones', () => {
+    assert.match(WIPE, /NO tombstones/, 'name the mechanism, not just the outcome');
+    assert.match(WIPE, /deletes the existing ones/,
+      'clearing them is worse than not writing them and has to be said separately');
+  });
+
+  it('says what to do instead, so the warning is actionable', () => {
+    // A warning with no alternative gets ignored by the caller who still has to empty the space.
+    assert.match(WIPE, /leave the network|Wipe every peer/,
+      'name at least one way to actually empty a networked space');
+    assert.match(WIPE, /delete_\*|delete_/, 'and point at the tools that DO tombstone');
+  });
+
+  it('and does not overstate it for a space in no network', () => {
+    // Accuracy in the other direction: on an unnetworked space the wipe is simply final, and a caller who
+    // reads this as "wipe never works" would go looking for a tool that does not exist.
+    assert.match(WIPE, /no network/, 'the unnetworked case must be stated too');
+  });
+});
+
+describe('the claim matches the implementation', () => {
+  it('wipeSpace really deletes tombstones rather than writing them', () => {
+    // The assertion that keeps the description honest. If a future change starts WRITING tombstones here,
+    // this fails and the warning above must come out.
+    assert.match(LIFECYCLE, /col\(`\$\{spaceId\}_tombstones`\)\.deleteMany/,
+      'brain tombstones are cleared');
+    assert.match(LIFECYCLE, /col\(`\$\{spaceId\}_file_tombstones`\)\.deleteMany/,
+      'file tombstones are cleared');
+    const at = LIFECYCLE.indexOf('export async function wipeSpace');
+    const body = LIFECYCLE.slice(at, LIFECYCLE.indexOf('\nexport ', at + 10));
+    assert.doesNotMatch(body, /writeFileTombstones|writeTombstone/,
+      'wipeSpace started writing tombstones — it now propagates, so delete the warning');
+  });
+
+  it('and the per-record deletes really do write them, which is the contrast drawn', () => {
+    const cascade = stripComments(readFileSync('server/src/files/delete-cascade.ts', 'utf8'));
+    assert.match(cascade, /writeFileTombstones\(/,
+      'if the delete tools stop tombstoning too, the contrast in this description is wrong');
+  });
+
+  it('the review queues really are cleared with the data', () => {
+    // Stated in the description because a finding is a claim about two records: once they are gone the
+    // Review tab lists something that cannot be opened.
+    assert.match(WIPE, /review queues/i, 'say it');
+    assert.match(LIFECYCLE, /_dupe_candidates`\)\.deleteMany/, 'duplicates');
+    assert.match(LIFECYCLE, /_contradiction_candidates`\)\.deleteMany/, 'and contradictions');
+  });
+
+  it('omitting `types` really wipes everything', () => {
+    // The parameter where a wrong assumption is destructive: an omitted filter is not a safe default.
+    assert.match(WIPE, /OMIT IT TO WIPE ALL FIVE/, 'a caller must not read absence as "nothing"');
+    assert.match(LIFECYCLE, /types && types\.length > 0 \? types : WIPE_COLLECTION_TYPES/,
+      'and that is what the code does');
+  });
+});


### PR DESCRIPTION
## The finding

Every `delete_*` tool writes a tombstone, because a tombstone is the only thing that tells a peer a record is
gone. **`wipeSpace` does the opposite:** it deletes the documents and then deletes the *tombstones* as well —
`${spaceId}_tombstones` wholesale on a full wipe, filtered by type on a partial one, and
`${spaceId}_file_tombstones` when files are included. It writes none.

On a space in a sync network that leaves an empty space with **no record of any deletion**, facing a peer that
still offers everything it holds and nothing to refuse it with.

That consequence is this codebase's own documented mechanism, not an inference about behaviour I have not
observed. `delete-cascade.ts`: *"Propagate the deletion to sync peers, else the peer's manifest re-pushes the
file."* The `move_file` handler: *"sync has no rename detection, so the source would otherwise resurrect from a
peer's manifest."*

The old description said *"The space itself and its configuration are preserved"* and nothing about sync,
which reads as though the data is gone for good.

## What the description says now

It leads with the wipe being **local**, and names the three ways to actually empty a networked space: wipe
every peer, leave the network first, or use the per-record `delete_*` tools — which do tombstone. It also
states the unnetworked case plainly, so nobody concludes the tool never works.

Three other things it did not say:

| | |
| --- | --- |
| **Omitting `types` wipes all five collections** | An omitted filter is not a safe default, and this is the parameter where that assumption is destructive |
| The duplicate and contradiction queues are cleared with the records | A finding is a claim about two records; once they are gone it is not stale, it is *unopenable* |
| Wiping an empty space returns zeroes | Idempotent, so a retry after a dropped connection is safe |

## Filed, not decided — X-5

Whether a wipe *should* propagate is an owner call, because there are three defensible answers that behave
very differently:

1. **Write tombstones for everything wiped** — the wipe empties the network. Correct if "wipe" means "this
   data should not exist"; catastrophic if someone wipes a local copy expecting to re-pull.
2. **Refuse on a networked space without an explicit flag** — safest, and consistent with how the destructive
   REST routes ask for confirmation.
3. **Leave it and document it** — what this PR does.

It is not obviously (1): a wipe that silently empties every peer is a much bigger gun than the name suggests.

## Verification

`wipe-space-says-it-is-local.test.js` pins the description against the tombstone-clearing code, so if
`wipeSpace` ever starts *writing* tombstones the warning fails instead of quietly becoming wrong. The
`OMIT IT TO WIPE ALL FIVE` claim is pinned to
`types && types.length > 0 ? types : WIPE_COLLECTION_TYPES`, and the review-queue claim to both
`deleteMany` calls.

**Mutation-tested both directions:** stopping the tombstone clear fails; softening the LOCAL warning fails.

Part of **X-2**.
