### PR TITLE
docs(mcp): bulk_write says where it loses data quietly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   already-empty space succeeds with zeroes rather than erroring. Whether wiping *should* propagate is a real
   question with three defensible answers, so it is filed rather than decided.
 
+- **`bulk_write` now says where it loses data quietly.** Anything past **500 entries per collection is
+  discarded before validation** — it appears in neither the inserted counts nor the error list, so a 600-item
+  import stores 500 and the reply says nothing about the other 100. The cap was previously mentioned only
+  inside one parameter's own text, where a caller reading the tool summary would never meet it, and nothing
+  said the loss went unreported. The description now leads with it, and with the related trap: because this
+  tool reports bad items rather than failing, **a call that returns normally may have written nothing**, so
+  the inserted counts and the error list both have to be read. It also states an asymmetry with the
+  single-record tools — bulk checks that a reference is a well-formed id but never that it exists, so it can
+  store a dangling link that `remember` or `update_memory` would have refused under strict linkage. That is
+  deliberate, since a batch may legitimately reference an entity created later in the same payload, and the
+  description now says so, so nobody "fixes" it into rejecting valid forward references.
+
 - **The four delete tools now say what they do *not* delete, and which of them can refuse.** Three of them
   read *"Delete an X by ID. Creates a tombstone for sync propagation"* and nothing else, which left a caller
   to discover the interesting parts by doing it. Deleting an **entity** is refused while something still

--- a/server/src/mcp/tools/bulk.ts
+++ b/server/src/mcp/tools/bulk.ts
@@ -15,7 +15,32 @@ import { emitWebhookEvent } from '../../webhooks/dispatcher.js';
 
 export const bulk_writeTool: ToolHandler = {
   name: 'bulk_write',
-  description: 'Batch upsert memories, entities, edges, and/or chrono entries in a single call. Processing order: memories → entities → edges → chrono, so edges referencing newly created entities within the same batch resolve correctly. Each array is optional and capped at 500 entries. Per-item validation errors are reported in `errors` without aborting the rest of the batch.',
+  description: 'Write memories, entities, edges and chrono entries in one call. Every array is optional; send '
+    + 'any combination.\n\n'
+    + 'A SUCCESSFUL CALL MAY HAVE WRITTEN NOTHING. This is partial-success by design: a bad item is reported '
+    + 'in `errors` and the rest of the batch proceeds, so there is no failure status to check. ALWAYS read '
+    + '`inserted` and `errors` from the response — `inserted` counts what landed, per collection, and `errors` '
+    + 'names each rejection by `type` and by its INDEX in the array you sent. Treating a returned result as '
+    + 'proof of success is the mistake this tool most invites.\n\n'
+    + 'ANYTHING BEYOND 500 PER COLLECTION IS SILENTLY DROPPED. Not an error, not a warning, and not counted in '
+    + '`errors` — items 501 and beyond are discarded before validation, so `inserted` plus `errors` can be far '
+    + 'short of what you sent and nothing in the reply says so. The cap is per collection, so 500 memories AND '
+    + '500 entities in one call is fine. Split larger imports yourself and check the counts add up.\n\n'
+    + 'REFERENCES ARE CHECKED FOR SHAPE, NEVER FOR EXISTENCE — and that differs from the single-record tools. '
+    + 'In a space with strict linkage `remember` and `update_memory` refuse an `entityIds` value that does not '
+    + 'resolve; here a well-formed UUID that points at nothing is accepted and stored. That is deliberate: a '
+    + 'batch may legitimately reference an entity created LATER in the same payload, and an existence check '
+    + 'would reject valid forward references. The cost is that bulk can write a dangling link the single-record '
+    + 'path would have refused, so verify with `traverse` after a large import if linkage matters.\n\n'
+    + 'ORDER IS memories → entities → edges → chrono, which is why an edge may name an entity created in the '
+    + 'same batch. It also means a MEMORY cannot resolve an entity from the same batch at read time even '
+    + 'though its ids are accepted — the entity exists by the end of the call, so this only matters if you '
+    + 'read between calls.\n\n'
+    + 'PARAMETERS: each collection takes the same fields as its single-record tool — `memories` as `remember`, '
+    + '`entities` as `upsert_entity`, `edges` as `upsert_edge`, `chrono` as `create_chrono` — including '
+    + '`ttlDays` per item. `targetSpace` is required when `space` is a proxy.\n\n'
+    + 'RESPONSE: `inserted` (a count per collection) and `errors` (one entry per rejected item, with its '
+    + 'collection and index). Neither tells you about items dropped by the 500 cap; only your own count does.',
   mutating: true,
   spaceRequired: true,
   // Partial-success contract: invalid items are reported per-item in `errors`, not rejected up front.

--- a/testing/standalone/bulk-write-states-its-silent-losses.test.js
+++ b/testing/standalone/bulk-write-states-its-silent-losses.test.js
@@ -1,0 +1,121 @@
+/**
+ * `bulk_write` says where it loses data quietly, and each claim is pinned to the code.
+ *
+ * ## Two silent losses and one asymmetry
+ *
+ * **1. Items past 500 per collection vanish.** `slice(v, 0, BULK_MAX_PER_TYPE)` runs before validation, so
+ * entry 501 is not rejected — it is never seen. It appears in neither `inserted` nor `errors`, and nothing in
+ * the reply hints that the payload was truncated. The old description mentioned the cap inside one
+ * parameter's own text ("excess entries are dropped") where a caller reading the tool summary would not meet
+ * it, and never said the loss was unreported.
+ *
+ * **2. A successful call may have written nothing.** Partial success is the contract, so there is no failure
+ * status: every rejection lands in `errors` and the call still returns normally. A caller who treats the
+ * result as proof of success is wrong, and this tool invites exactly that.
+ *
+ * **3. References are checked for SHAPE, never existence** — unlike `remember` and `update_memory`, which
+ * call `assertRefsResolve` under strict linkage and refuse a link that points at nothing. Bulk deliberately
+ * does not, because a payload may reference an entity created later in the same call and an existence check
+ * would reject valid forward references. The cost is real and worth stating: bulk can store a dangling link
+ * the single-record path would have refused.
+ *
+ * Run: node --test testing/standalone/bulk-write-states-its-silent-losses.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripComments } from './_strip-comments.mjs';
+
+const TOOL = stripComments(readFileSync('server/src/mcp/tools/bulk.ts', 'utf8'));
+const CORE = stripComments(readFileSync('server/src/brain/bulk.ts', 'utf8'));
+const MEMORY_TOOL = stripComments(readFileSync('server/src/mcp/tools/memory.ts', 'utf8'));
+
+const DESC = (() => {
+  const at = TOOL.indexOf("name: 'bulk_write'");
+  assert.ok(at > 0, 'bulk_write not found — the scanner is wrong, not the code');
+  const d = TOOL.indexOf('description:', at);
+  const end = TOOL.slice(d).search(/\n {2,}(mutating|spaceRequired|skipSchemaValidation|inputSchema|async handle):/);
+  assert.ok(end > 0, 'could not find the end of bulk_write\'s description');
+  return TOOL.slice(d, d + end);
+})();
+
+describe('the 500 cap is described as the silent loss it is', () => {
+  it('says it is SILENT, not merely that a cap exists', () => {
+    assert.match(DESC, /SILENTLY DROPPED/,
+      'a cap a caller can see in `errors` is survivable; one they cannot is not');
+  });
+
+  it('says the drop appears in neither counter', () => {
+    assert.match(DESC, /not counted in\s*'?\s*\+?\s*'?`errors`|not counted in `errors`/,
+      'the reply gives no way to detect the truncation, which is the actionable half');
+  });
+
+  it('says the cap is PER COLLECTION, so a caller does not split unnecessarily', () => {
+    assert.match(DESC, /per collection/i, '500 memories and 500 entities in one call is fine');
+  });
+
+  it('and the truncation really happens before validation', () => {
+    // Pinned to the implementation: if the slice ever moved after validation, or started reporting, this
+    // description would be overstating the danger.
+    assert.match(CORE, /export const BULK_MAX_PER_TYPE = 500/, 'the cap');
+    assert.match(CORE, /v\.slice\(0, BULK_MAX_PER_TYPE\)/, 'applied by a plain slice');
+    assert.doesNotMatch(CORE, /truncated|droppedCount/,
+      'a truncation report appeared — say so in the description instead of calling it silent');
+  });
+});
+
+describe('partial success is stated as the trap it is', () => {
+  it('leads with "may have written nothing"', () => {
+    assert.match(DESC, /MAY HAVE WRITTEN NOTHING/,
+      'there is no failure status, so the caller has to be told to look');
+  });
+
+  it('names both response fields the caller must read', () => {
+    assert.match(DESC, /`inserted`/, 'what landed');
+    assert.match(DESC, /`errors`/, 'and what did not');
+  });
+
+  it('and says errors are indexed, so a caller can map them back', () => {
+    assert.match(DESC, /INDEX/, 'an error without a position is not actionable on a 500-item batch');
+    assert.match(CORE, /errors\.push\(\{ type: 'memory', index: i/, 'and they really are');
+  });
+});
+
+describe('the reference-checking asymmetry is stated', () => {
+  it('says shape is checked and existence is not', () => {
+    assert.match(DESC, /SHAPE, NEVER FOR EXISTENCE/, 'the difference from the single-record tools');
+  });
+
+  it('says WHY, so nobody "fixes" it into rejecting forward references', () => {
+    assert.match(DESC, /forward reference/i,
+      'the reason is the design constraint — an existence check would break valid batches');
+  });
+
+  it('and the asymmetry is real: bulk checks format, the single-record path checks resolution', () => {
+    assert.match(CORE, /UUID_V4_RE\.test\(id\)/, 'bulk checks the shape');
+    assert.doesNotMatch(CORE, /assertRefsResolve/,
+      'bulk gained an existence check — the description now misdescribes it');
+    assert.match(MEMORY_TOOL, /assertRefsResolve\(/,
+      'and the single-record path still resolves, which is what makes this a contrast');
+  });
+});
+
+describe('the processing order is stated with its consequence', () => {
+  it('names the order', () => {
+    assert.match(DESC, /memories → entities → edges → chrono/, 'the order itself');
+  });
+
+  it('and says what it buys — an edge naming an entity from the same batch', () => {
+    assert.match(DESC, /edge may name an entity created in the\s*'?\s*\+?\s*'?same batch|same batch/,
+      'the order is only interesting because of what it makes possible');
+  });
+
+  it('and the code really runs in that order', () => {
+    const iMem = CORE.indexOf('const memories = slice(input.memories)');
+    const iEnt = CORE.indexOf('const entities = slice(input.entities)');
+    const iEdge = CORE.indexOf('const edges = slice(input.edges)');
+    const iChrono = CORE.indexOf('const chrono = slice(input.chrono)');
+    assert.ok(iMem > 0 && iEnt > iMem && iEdge > iEnt && iChrono > iEdge,
+      `order changed: memories=${iMem} entities=${iEnt} edges=${iEdge} chrono=${iChrono}`);
+  });
+});


### PR DESCRIPTION
Three things a caller could only learn by losing something.

## 1. Items past 500 per collection vanish

`slice(0, BULK_MAX_PER_TYPE)` runs **before** validation, so entry 501 is not rejected — it is never seen.

| | |
| --- | --- |
| in `inserted`? | no |
| in `errors`? | no |
| any hint in the reply? | none |

A 600-item import stores 500 and reports success.

The cap *was* documented — inside the `memories` parameter's own text (*"excess entries are dropped"*), where
a caller reading the tool summary never meets it, and with nothing saying the loss goes unreported. It now
leads the description, along with the fact that the cap is **per collection**, so nobody splits a
500-memories-plus-500-entities call that would always have worked.

## 2. A call that returns normally may have written nothing

Partial success is the contract: bad items are reported and the batch continues, so there is no failure status
to check. The description now says to read `inserted` **and** `errors` every time, and that errors carry the
**index** of the offending item — without which an error is not actionable on a 500-item batch.

## 3. References are checked for shape, never existence

`remember` and `update_memory` call `assertRefsResolve` under strict linkage and refuse a link that points at
nothing. Bulk checks UUID *format* only, so a well-formed id pointing nowhere is stored.

**That is deliberate** — a payload may reference an entity created later in the same call, and an existence
check would reject valid forward references. The description says so, so nobody "fixes" it into rejecting
them. The cost is stated too: bulk can write a dangling link the single-record path would have refused.

## Not changed here

`create_space` and `reindex` were checked and are already at the standard — `reindex` since 7fe259f, and
`create_space` already states its create-only field and its 409/422 refusals. The branch was renamed rather
than padded with tools that needed nothing.

## The gate

Every claim is pinned to the code that makes it true: the slice, the *absence* of any truncation report, the
indexed errors, the UUID format check, the absence of `assertRefsResolve` here against its presence in the
memory tool, and the `memories → entities → edges → chrono` ordering read from source positions rather than
from the comment that asserts it.

**Mutation-tested:** removing the 500 slice fails; adding an existence check to bulk fails.

Part of **X-2**.
