### PR TITLE
docs(mcp): the six shortest tool descriptions say where their answer is narrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   retired record stops competing on meaning, it does not disappear from the graph. **No behaviour changed**;
   this is what it always did.
 
+- **The six shortest tool descriptions now say where their answer is narrower than it looks.** Each was
+  accurate as far as it went, and each left out the same shape of thing. `list_chrono`'s `after` and `before`
+  filter **when an entry was written, not when it happens** — so "what is scheduled next quarter" was quietly
+  answering "what did we write down last quarter", on a tool whose whole subject is dates; it also now says
+  that nothing recomputes `status` from the clock, so `upcoming` means "nobody has updated this" rather than
+  "still in the future". `list_dir` merges a proxy's members **by filename**, so two members holding the same
+  name collapse to one entry with nothing saying which won; it is also not recursive and returns names rather
+  than paths. `find_entities_by_name` is exact and case-sensitive, several results usually means a duplicate
+  worth merging rather than a fact about the world, and an empty list does **not** mean the thing is absent.
+  `list_peers` returns one row per peer **per network**, not per machine. `sync_now` returns when the cycle
+  *starts*, and a peer that is unreachable does not make it fail — that surfaces as a climbing failure count
+  on the peer. `list_tokens` still lists **expired** tokens, because expiry is enforced when a token is used,
+  so appearing there is not proof of access.
+
 ### Added
 
 - **A space administrator can now manage that space's tokens.** Until now "administers this space" was only

--- a/server/src/mcp/tools/chrono.ts
+++ b/server/src/mcp/tools/chrono.ts
@@ -328,7 +328,31 @@ export const update_chronoTool: ToolHandler = {
 
 export const list_chronoTool: ToolHandler = {
   name: 'list_chrono',
-  description: 'List chronological entries, optionally filtered by status, type, tags, date range, or a text search. Omit space to list across all accessible spaces.',
+  description: 'List chrono entries — the time-anchored records: events, deadlines, plans, predictions and '
+    + 'milestones. Every filter is optional and they AND together; no filters at all returns the most recent '
+    + '20.\n\n'
+    + '`after` AND `before` FILTER WHEN THE ENTRY WAS WRITTEN, NOT WHEN IT HAPPENS. This is the one that '
+    + 'catches people. An entry has `startsAt`/`endsAt` — the time it is ABOUT — and a `createdAt`, the time '
+    + 'someone recorded it. These two parameters read `createdAt`. To ask "what is scheduled next quarter" you '
+    + 'want `query` with a predicate on `startsAt`; `after`/`before` here answer "what did we write down last '
+    + 'week", which is a different question and usually not the one being asked.\n\n'
+    + 'NOTHING RECOMPUTES `status` FROM THE CLOCK. An entry stays `upcoming` after its date has passed until '
+    + 'something sets it otherwise, so `status: "upcoming"` means "nobody has updated this", not "still in the '
+    + 'future", and `status: "overdue"` only finds entries somebody marked overdue. Filter on the dates if you '
+    + 'want the truth about time.\n\n'
+    + 'OMIT `space` TO SEARCH EVERY SPACE THE TOKEN REACHES. That is unusual — most tools require one — and it '
+    + 'is what makes this the tool for "when did we ever say we would do this". Results carry their space.\n\n'
+    + 'PARAMETERS:\n'
+    + '- `status` — `upcoming`, `active`, `completed`, `overdue`, `cancelled`. See the warning above.\n'
+    + '- `type` — `event`, `deadline`, `plan`, `prediction`, `milestone`, or any custom type the space schema '
+    + 'defines.\n'
+    + '- `tags` — entries carrying ALL of these. `tagsAny` — entries carrying ANY. Send both and both apply.\n'
+    + '- `after` / `before` — ISO 8601, against `createdAt`. See the warning above.\n'
+    + '- `search` — case-insensitive SUBSTRING match on title and description. Not meaning-ranked and not '
+    + 'tokenised: it will not find a synonym, and it WILL match inside a longer word. Use `recall` for meaning.\n'
+    + '- `limit` — 1 to 100, default 20. `skip` — for paging; combine with a stable `limit`.\n\n'
+    + 'RESPONSE: the matching entries, newest first, each with its id, title, type, status, dates and space. '
+    + 'An empty list means nothing matched, which is not an error.',
   inputSchema: (s: ToolSchemas) => ({
           type: 'object',
           properties: {

--- a/server/src/mcp/tools/entity.ts
+++ b/server/src/mcp/tools/entity.ts
@@ -344,7 +344,24 @@ export const merge_entitiesTool: ToolHandler = {
 
 export const find_entities_by_nameTool: ToolHandler = {
   name: 'find_entities_by_name',
-  description: 'Find all entities in the space that match the given name (exact, case-sensitive). Returns a list — multiple entities may share a name. Prefer this over querying by name + type to avoid missing entities with unexpected types.',
+  description: 'Look up entities by their EXACT name. Case-sensitive, whole-string: "Acme" does not find '
+    + '"acme", "Acme Corp" or " Acme". If you are not certain of the exact stored spelling, this is the wrong '
+    + 'tool — use `recall` for meaning, or `query` with a `$regex` filter for a pattern.\n\n'
+    + 'IT RETURNS A LIST, AND THE LIST IS THE POINT. Names are not unique in a space: the same name can exist '
+    + 'as several entities, often with different types, and that is usually a duplicate somebody should merge '
+    + 'rather than a fact about the world. Getting more than one back is the signal to look, not a result to '
+    + 'index into: taking `[0]` and moving on is how the second copy survives and goes on accumulating edges. '
+    + 'A token that may write will find a merge tool in `help()`; one that may not will not, because `help()` '
+    + 'lists only what your token can reach.\n\n'
+    + 'PREFER IT OVER FILTERING BY NAME AND TYPE TOGETHER. A name/type predicate silently misses the copy '
+    + 'stored under an unexpected type, which is exactly the copy you were looking for when you asked this '
+    + 'question. Look up by name, then read the types you get back.\n\n'
+    + 'PARAMETERS:\n'
+    + '- `name` — the exact stored name. Not trimmed for you and not case-folded.\n'
+    + '- `space` — required. This tool does not search across spaces; `recall` with `space` omitted does.\n\n'
+    + 'RESPONSE: every matching entity with its id, name, type, tags and properties. An empty list means no '
+    + 'entity carries that exact name — it is not an error, and it does NOT mean the thing is absent from the '
+    + 'space. It may be there under a different spelling, which is the case `recall` is for.',
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({
           type: 'object',

--- a/server/src/mcp/tools/file.ts
+++ b/server/src/mcp/tools/file.ts
@@ -115,7 +115,24 @@ export const write_fileTool: ToolHandler = {
 
 export const list_dirTool: ToolHandler = {
   name: 'list_dir',
-  description: 'List files and directories at a path in the space file store.',
+  description: 'List one directory in the space file store. NOT recursive: it returns the immediate children '
+    + 'of `path` and nothing below them, so walking a tree means calling it per directory.\n\n'
+    + 'IT IS THE SOURCE OF THE PATHS EVERY OTHER FILE TOOL WANTS. `read_file` and every write-side file tool '
+    + 'your token can reach take a path relative to the space root, exactly as it is reported here. '
+    + 'Constructing one by hand is where the mistakes come from.\n\n'
+    + 'ON A PROXY SPACE THE MEMBERS ARE MERGED, AND A COLLISION IS RESOLVED SILENTLY. Every member the token '
+    + 'reaches is listed and the results are combined by NAME — so if two members both hold `notes.md`, you '
+    + 'see one entry and the other is dropped, with nothing saying which member won or that a second existed. '
+    + 'A member that has no such directory is skipped rather than erroring. When that ambiguity matters, list '
+    + 'the member space directly instead of the proxy.\n\n'
+    + 'A MISSING DIRECTORY IS AN EMPTY LISTING, not an error. So an empty result means "nothing here OR no '
+    + 'such path" and the two are indistinguishable — check the parent if you expected content.\n\n'
+    + 'PARAMETERS:\n'
+    + '- `path` — relative to the space root. OMIT IT (or send `""`) for the root itself, which is the usual '
+    + 'starting point.\n\n'
+    + 'RESPONSE: one entry per child with its `name`, its `type` (`file` or `dir`) and, for a file, its `size` '
+    + 'in bytes. Names only — not full paths — so join them onto `path` yourself when descending. There is no '
+    + 'limit or paging here: a very large directory returns in full.',
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({
           type: 'object',

--- a/server/src/mcp/tools/spaces.ts
+++ b/server/src/mcp/tools/spaces.ts
@@ -662,10 +662,25 @@ export const wipe_spaceTool: ToolHandler = {
  */
 export const list_tokensTool: ToolHandler = {
   name: 'list_tokens',
-  description: 'List this instance\'s API tokens with their names, prefixes, expiry and rights matrix. Admin '
-    + 'only. Secrets are never included — a token\'s value exists only at the moment it is minted, and the '
-    + 'stored hash is not returned by this or any other surface. Use it to audit which tokens can reach which '
-    + 'spaces and at what level.',
+  description: 'List this instance\'s API tokens — names, prefixes, expiry and rights matrix. Requires '
+    + 'instance-admin rights. Read-only.\n\n'
+    + 'SECRETS ARE NEVER INCLUDED, and there is no parameter that changes that. A token\'s value exists only '
+    + 'at the moment it is minted; what is stored is a hash, and the hash is not returned by this or any other '
+    + 'surface. If a token\'s value is lost the answer is to rotate it, never to look it up.\n\n'
+    + 'THE `prefix` IS HOW YOU IDENTIFY A TOKEN FROM A LOG. Audit entries and error reports carry the prefix '
+    + 'rather than the secret, so matching one to a row here is how you find out who did something.\n\n'
+    + 'READ `rights`, NOT THE LEGACY FLAGS. `rights` is the matrix that actually governs access: a `floor` '
+    + 'applying to every space including ones created later, a `perSpace` row per space, and `instanceAdmin` / '
+    + '`createSpaces`. The older `admin` and `readOnly` booleans still appear on records that predate the '
+    + 'matrix and are on their way out — a token showing `legacy scope` has no matrix and is governed by its '
+    + '`spaces` allowlist instead. That distinction matters for an audit: the two are not different spellings '
+    + 'of the same thing.\n\n'
+    + 'An expired token is still LISTED. Expiry is enforced when the token is used, not by removing the row, '
+    + 'so seeing it here does not mean it works — check `expiresAt` before concluding anything about who has '
+    + 'access.\n\n'
+    + 'RESPONSE: one row per token with its id, name, prefix, expiry, whether it carries a rights matrix or '
+    + 'legacy scope, and the matrix itself. Use it to answer "which tokens reach this space, and at what '
+    + 'level" — the question the rights editor answers one token at a time.',
   admin: true,
   inputSchema: () => ({
     type: 'object',

--- a/server/src/mcp/tools/sync.ts
+++ b/server/src/mcp/tools/sync.ts
@@ -3,7 +3,23 @@ import { getConfig } from '../../config/loader.js';
 
 export const list_peersTool: ToolHandler = {
   name: 'list_peers',
-  description: 'List all configured peer ythril instances (for Brain Networks).',
+  description: 'List every peer instance this brain is connected to, flattened across all of its networks. '
+    + 'Requires instance-admin rights. Read-only — it configures nothing and triggers nothing.\n\n'
+    + 'ONE PEER APPEARS ONCE PER NETWORK IT BELONGS TO, not once overall. The same instance in two networks '
+    + 'gives two rows with the same `instanceId` and different `network`/`networkId`. Deduplicate on '
+    + '`instanceId` if you want distinct machines; keep the rows as they are if you care about which network a '
+    + 'link belongs to, because the direction and the sync state are per network.\n\n'
+    + 'IT IS THE SOURCE OF THE `instanceId` VALUES the sync-triggering tool wants — that one takes an exact '
+    + 'instanceId and never a URL or a label, so copy it from here rather than typing it.\n\n'
+    + 'NO CREDENTIALS ARE EVER RETURNED. Token hashes and invite-key hashes are stripped before the reply is '
+    + 'built; there is no parameter that includes them and no other surface that exposes them.\n\n'
+    + 'RESPONSE, per row: `instanceId` and `label` (who), `url` (where), `direction` (whether this link '
+    + 'pushes, pulls or both), `network`/`networkId`/`networkType` (which network this row is about), '
+    + '`lastSyncAt` (null if this pair has never synced), `consecutiveFailures` (0 when healthy — a climbing '
+    + 'number is the signal that a peer is unreachable, and it is the field to check before blaming missing '
+    + 'records on anything else), and `skipTlsVerify` (true means certificate checking is off for this peer, '
+    + 'which is worth noticing on an audit).\n\n'
+    + 'An empty list means this instance is in no network, not that syncing failed.',
   admin: true,
   inputSchema: (_s: ToolSchemas) => ({ type: 'object', properties: {}, required: [], additionalProperties: false }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
@@ -40,10 +56,22 @@ export const list_peersTool: ToolHandler = {
 export const sync_nowTool: ToolHandler = {
   name: 'sync_now',
   description:
-        'Trigger an immediate sync cycle. ' +
-        'If peerId is supplied, syncs only that one peer (across all networks it belongs to). ' +
-        'If omitted, runs a full cycle for every network. ' +
-        'peerId must be an exact instanceId from the member list — it is never used as a URL.',
+        'Run a sync cycle now instead of waiting for the schedule. Requires instance-admin rights.\n\n'
+        + 'IT DOES NOT WAIT FOR THE DATA. The cycle is started and the reply comes back; records arrive '
+        + 'afterwards, and how long that takes depends on how far behind the peers are. So a successful reply '
+        + 'means "a cycle was started", never "everything is now in step" — read `list_peers` and its '
+        + '`lastSyncAt` / `consecutiveFailures` to see whether it landed.\n\n'
+        + 'SYNC IS ALREADY AUTOMATIC. Every network has a schedule, so this is for closing a gap you do not '
+        + 'want to wait out: after fixing a peer that was unreachable, or before reading a space you have just '
+        + 'been told was changed elsewhere. It is not something to call in a loop — a cycle that overlaps the '
+        + 'scheduled one does no more work, it competes with it.\n\n'
+        + 'PARAMETERS:\n'
+        + '- `peerId` — an EXACT `instanceId` from `list_peers`. Never a URL and never a label. That one peer '
+        + 'is synced across every network it belongs to. Omit it to run a full cycle for every network, which '
+        + 'is the usual call.\n\n'
+        + 'RESPONSE: confirmation that the cycle started, and what it covers. A peer that is unreachable does '
+        + 'NOT make this return an error — that surfaces as a climbing `consecutiveFailures` on the peer, so '
+        + 'this call succeeding is not evidence any peer answered.',
   mutating: true,
   admin: true,
   inputSchema: (s: ToolSchemas) => ({

--- a/testing/standalone/read-tools-state-their-blind-spots.test.js
+++ b/testing/standalone/read-tools-state-their-blind-spots.test.js
@@ -1,0 +1,169 @@
+/**
+ * The listing and lookup tools say where their answer is narrower than it looks.
+ *
+ * These five were the shortest descriptions in the fleet — between 78 and 368 characters — and each was
+ * accurate as far as it went. What they left out is the same shape every time: a filter that answers a
+ * slightly different question from the one being asked, or an empty result that means two different things.
+ *
+ * | Tool | The gap |
+ * | --- | --- |
+ * | `list_chrono` | `after`/`before` filter `createdAt` — when it was WRITTEN, not when it HAPPENS |
+ * | `list_dir` | on a proxy, two members holding the same filename collapse to one entry, silently |
+ * | `find_entities_by_name` | exact and case-sensitive, and an empty list does not mean the thing is absent |
+ * | `list_peers` | one row per peer PER NETWORK, not per machine |
+ * | `sync_now` | returns when the cycle STARTS; an unreachable peer does not make it fail |
+ * | `list_tokens` | an expired token is still listed, and `rights` is not the legacy `admin` flag |
+ *
+ * The `list_chrono` one is the sharpest: "list entries between two dates" is the obvious reading, the
+ * parameters are named `after` and `before`, and they filter the wrong field for that question. Confirmed
+ * from `brain/chrono.ts`, where the range is assigned to `query['createdAt']`.
+ *
+ * Run: node --test testing/standalone/read-tools-state-their-blind-spots.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripComments } from './_strip-comments.mjs';
+
+const src = (p) => stripComments(readFileSync(p, 'utf8'));
+
+const description = (file, name) => {
+  const s = src(file);
+  const at = s.indexOf(`name: '${name}'`);
+  assert.ok(at > 0, `${name} not found in ${file} — the scanner is wrong, not the code`);
+  const d = s.indexOf('description:', at);
+  const end = s.slice(d).search(/\n {2,}(mutating|spaceRequired|admin|spaceAdmin|skipSchemaValidation|inputSchema|async handle):/);
+  assert.ok(end > 0, `could not find the end of ${name}'s description`);
+  return s.slice(d, d + end);
+};
+
+const CHRONO = description('server/src/mcp/tools/chrono.ts', 'list_chrono');
+const DIR = description('server/src/mcp/tools/file.ts', 'list_dir');
+const BYNAME = description('server/src/mcp/tools/entity.ts', 'find_entities_by_name');
+const PEERS = description('server/src/mcp/tools/sync.ts', 'list_peers');
+const SYNCNOW = description('server/src/mcp/tools/sync.ts', 'sync_now');
+const TOKENS = description('server/src/mcp/tools/spaces.ts', 'list_tokens');
+
+describe('list_chrono: the date filter answers a different question', () => {
+  it('says after/before filter when the entry was WRITTEN', () => {
+    assert.match(CHRONO, /NOT WHEN IT HAPPENS/,
+      'the parameters are named after/before on a tool full of dates — this has to be unmissable');
+  });
+
+  it('and points at what to use for the scheduling question', () => {
+    assert.match(CHRONO, /startsAt/, 'name the field the caller actually meant');
+  });
+
+  it('and that is what the code does', () => {
+    // Pinned: the range really is assigned to createdAt. The old description said "created after", which was
+    // correct and easy to read past.
+    assert.match(src('server/src/brain/chrono.ts'), /query\['createdAt'\] = range/,
+      'the range moved off createdAt — rewrite the warning rather than leaving it wrong');
+  });
+
+  it('says status is not recomputed from the clock', () => {
+    assert.match(CHRONO, /NOTHING RECOMPUTES `status` FROM THE CLOCK/,
+      'filtering status: upcoming to find future entries is the natural mistake');
+  });
+
+  it('and the default order really is newest-written first', () => {
+    assert.match(CHRONO, /newest first/, 'stated');
+    assert.match(src('server/src/brain/chrono.ts'), /\{ createdAt: -1 \}/, 'and true');
+  });
+});
+
+describe('list_dir: the proxy merge loses a duplicate name', () => {
+  it('says collisions are resolved silently', () => {
+    assert.match(DIR, /COLLISION IS RESOLVED SILENTLY/,
+      'two members with the same filename yield one entry and no warning');
+  });
+
+  it('and the merge really is by name with first-wins', () => {
+    const s = src('server/src/mcp/tools/file.ts');
+    assert.match(s, /if \(!seen\.has\(e\.name\)\)/,
+      'dedupe is on the bare name — if that changes, so must the warning');
+  });
+
+  it('says it is not recursive, and that names are not paths', () => {
+    assert.match(DIR, /NOT recursive/, 'a caller expecting a tree gets one level');
+    assert.match(DIR, /Names only/, 'and must join them onto `path` themselves');
+  });
+
+  it('says a missing directory reads as empty', () => {
+    assert.match(DIR, /MISSING DIRECTORY IS AN EMPTY LISTING/,
+      'empty means "nothing here OR no such path" and the two are indistinguishable');
+  });
+});
+
+describe('find_entities_by_name: exact, and an empty list proves nothing', () => {
+  it('says exact and case-sensitive', () => {
+    assert.match(BYNAME, /EXACT name/, 'and not a search');
+    assert.match(BYNAME, /[Cc]ase-sensitive/, 'which is the half that surprises');
+  });
+
+  it('says several results usually means a duplicate to merge', () => {
+    assert.match(BYNAME, /duplicate somebody should merge/,
+      'taking [0] is how the second copy survives and keeps accumulating edges');
+  });
+
+  it('without NAMING the mutating merge tool — this is a read-only tool', () => {
+    // `mcp-help.test.js` refused the first draft, for the second time this session: read-only help must not
+    // advertise a tool a read-only token cannot call. The useful fact survives without the name — help()
+    // lists what your token can reach, so its absence means "not you", not "does not exist".
+    assert.doesNotMatch(BYNAME, /merge_entities/,
+      'a read-only tool must not advertise a mutating one');
+    assert.match(BYNAME, /help\(\)/, 'point at where a writing token would find it instead');
+  });
+
+  it('says an empty list does NOT mean the thing is absent', () => {
+    assert.match(BYNAME, /does NOT mean/, 'it may be stored under another spelling');
+    assert.match(BYNAME, /recall/, 'and name the tool for that case');
+  });
+});
+
+describe('the sync tools say what their answers do not cover', () => {
+  it('list_peers: one row per peer PER NETWORK', () => {
+    assert.match(PEERS, /ONCE PER NETWORK/, 'counting rows is not counting machines');
+  });
+
+  it('list_peers: no credentials, ever', () => {
+    assert.match(PEERS, /NO CREDENTIALS/, 'say it, because it is the first thing an auditor asks');
+    // The guarantee is by CONSTRUCTION, not by deleting named fields: the reply lists its fields one by one
+    // off the member record. A spread would carry `tokenHash` and `inviteKeyHash` along the moment either is
+    // added upstream, which is the failure this assertion exists to prevent — so pin the shape, not a name.
+    // (The first version of this test grepped for `tokenHash` and matched only the comment explaining it.)
+    const sync = src('server/src/mcp/tools/sync.ts');
+    const at = sync.indexOf('net.members.map');
+    assert.ok(at > 0, 'the peer mapping was not found — the scanner is wrong, not the code');
+    const mapping = sync.slice(at, sync.indexOf('}))', at) + 3);
+    assert.match(mapping, /instanceId: m\.instanceId/, 'fields are named individually');
+    assert.doesNotMatch(mapping, /\.\.\.m\b/,
+      'a spread here would leak every field the member record ever gains, credentials included');
+  });
+
+  it('sync_now: returns when the cycle STARTS', () => {
+    assert.match(SYNCNOW, /DOES NOT WAIT FOR THE DATA/,
+      'a success here is not evidence anything is in step');
+  });
+
+  it('sync_now: an unreachable peer does not make it fail', () => {
+    assert.match(SYNCNOW, /consecutiveFailures/,
+      'name where the failure actually surfaces, or a caller concludes the peers are fine');
+  });
+});
+
+describe('list_tokens: what an audit would get wrong', () => {
+  it('says an expired token is still listed', () => {
+    assert.match(TOKENS, /still LISTED/,
+      'expiry is enforced at use, so presence in this list is not proof of access');
+  });
+
+  it('says to read `rights`, not the legacy flags', () => {
+    assert.match(TOKENS, /legacy/i, 'the two are not different spellings of one thing');
+    assert.match(TOKENS, /instanceAdmin/, 'and name what actually governs');
+  });
+
+  it('says the prefix is the identifier that appears in logs', () => {
+    assert.match(TOKENS, /prefix/, 'it is how a row is matched to an audit entry');
+  });
+});


### PR DESCRIPTION
The six shortest descriptions in the fleet — 78 to 368 characters. Each was accurate as far as it went, and
each left out the same shape of thing: a filter that answers a slightly different question from the one being
asked, or an empty result that means two different things.

| Tool | What it did not say |
| --- | --- |
| `list_chrono` | `after`/`before` filter `createdAt` — when it was **written**, not when it happens |
| `list_dir` | on a proxy, two members holding the same filename collapse to one entry, silently |
| `find_entities_by_name` | exact and case-sensitive; an empty list does **not** mean the thing is absent |
| `list_peers` | one row per peer **per network**, not per machine |
| `sync_now` | returns when the cycle **starts**; an unreachable peer does not make it fail |
| `list_tokens` | an **expired** token is still listed, because expiry is enforced at use |

## The sharpest one

`list_chrono` is a tool whose entire subject is time. It has `startsAt`/`endsAt` — when an entry is *about* —
and `createdAt`, when someone wrote it down. The parameters are named `after` and `before`.

They filter `createdAt`. So *"what is scheduled next quarter"* was quietly answering *"what did we write down
next quarter"*. Confirmed from `brain/chrono.ts`, where the range is assigned to `query['createdAt']`.

It also now says that **nothing recomputes `status` from the clock**: an entry stays `upcoming` after its date
passes until something sets it, so `status: "upcoming"` means "nobody has updated this", not "still in the
future".

## `list_dir` on a proxy

Members are merged **by filename**, first wins. Two members holding `notes.md` give one entry, with nothing
saying which won or that a second existed. Also now stated: not recursive, returns names rather than paths,
and a missing directory reads as an empty listing — so empty means "nothing here *or* no such path".

## Caught twice by an existing gate

`mcp-help.test.js` refused two drafts for naming a mutating tool from a **read-only** description —
`merge_entities` from `find_entities_by_name`, and four file tools from `list_dir`. That is the second and
third time this session, and the rule is right: read-only help must not advertise what a read-only token
cannot call.

The useful fact survives without the name — `help()` lists what your token can reach, so an absent tool means
*"not you"*, not *"does not exist"*. Both descriptions now say that instead.

## Verification

`read-tools-state-their-blind-spots.test.js`, 20 tests, each claim pinned to source.

**Mutation-tested:** moving the chrono range to `startsAt` fails; removing `list_dir`'s dedupe fails; spreading
the member record in `list_peers` fails.

One assertion was rewritten during review: it grepped for `tokenHash` to prove credentials are scrubbed and
matched only the *comment* saying so. It now pins the real guarantee — the reply names its fields individually
and must never spread the member record, which would leak every field that record later gains.

## Also in this PR

A **W-2 recurrence, recorded honestly.** The preflight client gate failed once and passed on re-run with the
same tree; the failing tail was lost because every preflight this session was piped through a filter that
discarded it. The tracker now says to redirect to a file first, which is how this PR's own final preflight was
run.

Part of **X-2** — 44 tools, and after this one every remaining description is at or above the medium band.
