### PR TITLE
docs(mcp): help says its own tool list is filtered to your token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on the peer. `list_tokens` still lists **expired** tokens, because expiry is enforced when a token is used,
   so appearing there is not proof of access.
 
+- **`help` now says that the tool list it returns is filtered to your token — which was the one thing it most
+  needed to say.** A read-only token is shown no mutating tools and a token without instance-admin rights is
+  shown no admin tools, correctly and deliberately. What nobody was told is the consequence: a tool missing
+  from that reply means *this token cannot invoke it*, never that the instance lacks the capability. The
+  unsupportable conclusion — "there is no way to do X here" — is exactly the one that gets reported outward as
+  a missing feature, and it had to be written into three individual tool descriptions this release because the
+  one place it belonged did not carry it. `help` also now states that each tool's own schema description is
+  the authoritative reference, and that adding words to `query` narrows the answer rather than broadening it.
+
+- **`get_space_meta` now distinguishes what a space DECLARES from what it actually holds.** It returns the
+  types somebody defined; `er_model` returns the types that have records. A space can declare twenty types and
+  hold three, so a declaration read as an inventory produces plans against empty types. It also explains what
+  each validation mode does to a write, pre-empts the reasonable "strict validation on a space that accepts
+  everything must be a bug" (a space with no type schemas has nothing to violate), notes that strict refuses
+  what your change *breaks* rather than what was already broken, and describes `needsReindex` as what it is —
+  a quality signal where recall keeps answering while comparing new queries against vectors made by a
+  different model, so results degrade quietly instead of erroring.
+
 ### Added
 
 - **A space administrator can now manage that space's tokens.** Until now "administers this space" was only

--- a/server/src/mcp/tools/help.ts
+++ b/server/src/mcp/tools/help.ts
@@ -24,12 +24,28 @@ import { helpSections, renderHelp, renderHelpIndex, renderSection, searchHelp } 
 export const helpTool: ToolHandler = {
   name: 'help',
   description:
-    'Explain this Ythril instance: the tools available to your token, the knowledge model '
-    + '(spaces, memories, entities, edges, chrono, files), how to choose between query / recall / '
-    + 'filtered recall, schema authoring, and the REST API map. Call this first when unsure. '
-    + 'Pass `query` to get only the matching sections instead of the whole guide — matching is plain '
-    + 'keyword (all words must appear), never semantic, so it works when the embedder does not. A query '
-    + 'that matches nothing returns the section index rather than an empty answer.',
+    'Explain this Ythril instance: the tools available to your token, the knowledge model (spaces, '
+    + 'memories, entities, edges, chrono, files), how to choose between query / recall / filtered recall, '
+    + 'schema authoring, and the REST API map. Call this first when unsure.\n\n'
+    + 'THE TOOL LIST IS FILTERED TO WHAT YOUR TOKEN CAN REACH, and that is the most important thing to know '
+    + 'about this answer. A tool missing from it does NOT mean the instance lacks that capability — it means '
+    + 'THIS TOKEN cannot invoke it. A read-only token is shown no mutating tools; a token without '
+    + 'instance-admin rights is shown no admin tools. So "there is no way to do X here" is a conclusion you '
+    + 'cannot draw from this reply, and reporting it as a missing feature is the mistake this paragraph '
+    + 'exists to prevent. The supportable conclusion is "this token cannot do X", and the remedy is a token '
+    + 'holding the rung for it.\n\n'
+    + 'THE TOOL SCHEMAS ARE THE AUTHORITATIVE REFERENCE. Each tool\'s own `inputSchema` description is what '
+    + 'to read while constructing arguments: it carries the per-parameter behaviour, the traps and the '
+    + 'response shape in more detail than this guide does. Where this guide and a tool schema disagree, the '
+    + 'schema is the one maintained against the code.\n\n'
+    + 'PARAMETERS:\n'
+    + '- `query` — keywords. Returns only the sections containing ALL of them, so extra words NARROW the '
+    + 'answer rather than broadening it. Matching is plain keyword, never semantic: it works when the '
+    + 'embedder is down or absent, and it will not find a synonym. A tool name returns just that tool\'s '
+    + 'line. Omit it for the complete guide.\n\n'
+    + 'RESPONSE: the matching sections, or the whole guide when `query` is omitted. A query matching NOTHING '
+    + 'returns the section index rather than an empty answer — so a reply that is a list of section names '
+    + 'means your keywords missed, and the fix is fewer words or a tool name.',
   // Deliberately not mutating, not admin, not spaceRequired: read-only and instance-global.
   inputSchema: (_s: ToolSchemas) => ({
     type: 'object',

--- a/server/src/mcp/tools/spaces.ts
+++ b/server/src/mcp/tools/spaces.ts
@@ -144,10 +144,31 @@ export const get_space_metaTool: ToolHandler = {
         // Deliberately NOT the words "reindex state": `mcp-help.test.js` holds that a read-only token is never told
         // the name of a tool it cannot call, and `reindex` is one. Naming the STATE rather than the repair is also
         // the more useful sentence for a reader who cannot perform the repair — `needsReindex` still names the field.
-        'Returns the schema, purpose, usage notes, validation mode, entry counts and whether the stored '
-        + 'embeddings are stale (`needsReindex`) for this space. ' +
-        'Call this before writing to an unfamiliar space to learn what entity types, edge labels, ' +
-        'required properties, and naming patterns are expected.',
+        'What this space DECLARES: its purpose, usage notes, per-type schemas, validation posture and entry '
+        + 'counts. Call it before writing to an unfamiliar space, so the write is shaped to what the space '
+        + 'expects instead of being refused by it.\n\n'
+        + 'DECLARED, NOT ACTUAL — and the difference matters. This returns what MAY exist: the types somebody '
+        + 'defined, with their naming patterns and required properties. `er_model` returns what DOES exist: '
+        + 'the types that actually hold records, and which edge labels really connect which types. A space '
+        + 'can declare twenty types and hold three, or hold records of a type nobody declared. Read this to '
+        + 'learn the rules, `er_model` to learn the shape.\n\n'
+        + 'WHAT `validationMode` MEANS FOR YOUR WRITE: `off` accepts anything; `warn` accepts the write and '
+        + 'reports violations; `strict` REFUSES a write that breaks a schema. With `strictLinkage` on, a '
+        + 'reference that does not resolve is refused too. A space with no `typeSchemas` yet accepts every '
+        + 'type even on `strict`, because there is nothing to violate — so `strict` plus an empty schema is '
+        + 'not a contradiction.\n\n'
+        + 'AND A SUBTLETY ON `strict`: it refuses what your change BREAKS, not what was already broken. '
+        + 'Editing a record that was invalid before you touched it reports the pre-existing violation and '
+        + 'still saves, because refusing would not fix a problem that is already stored.\n\n'
+        + '`needsReindex` IS TRUE WHEN THE STORED VECTORS WERE MADE BY A DIFFERENT EMBEDDING MODEL from the '
+        + 'one configured now. Recall still answers while it is true, but it compares new queries against old '
+        + 'vectors, so results degrade quietly rather than erroring. Treat a true value as the explanation '
+        + 'for poor ranking, and as something for whoever administers the instance — not a reason to stop '
+        + 'reading.\n\n'
+        + 'RESPONSE: `purpose` and `usageNotes` (prose written for whoever reads this space), `typeSchemas` '
+        + 'per knowledge type, `validationMode`, `strictLinkage`, the entry counts, `needsReindex`, and '
+        + '`version` — which increments on every meta write and is what a conditional update is checked '
+        + 'against.',
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({
           type: 'object',

--- a/testing/standalone/orientation-tools-say-what-they-do-not-cover.test.js
+++ b/testing/standalone/orientation-tools-say-what-they-do-not-cover.test.js
@@ -1,0 +1,116 @@
+/**
+ * The two orientation tools say what their answer is NOT.
+ *
+ * These are the tools an agent calls before it knows anything, so a gap here becomes a wrong conclusion that
+ * gets reported outward as a missing feature.
+ *
+ * ## `help` — the tool list is filtered, and nothing said so
+ *
+ * `toolIsVisible` filters `tools/list` and `help()` alike: a read-only token sees no mutating tools, a
+ * non-admin sees no admin tools. That is correct and deliberate. What was missing is the consequence — a tool
+ * absent from the reply means THIS TOKEN cannot invoke it, never that the instance lacks the capability.
+ *
+ * This is not hypothetical. `mcp-help.test.js` refused three of this session's own drafts for naming a
+ * mutating tool in a read-only description, and the reason it exists at all is that advertising an
+ * unreachable tool produces exactly the wrong bug report. The same sentence had to be written into
+ * `list_embed_jobs`, `find_entities_by_name` and `list_dir` one at a time, because the one place it really
+ * belonged — `help` itself — did not carry it.
+ *
+ * ## `get_space_meta` — declared, not actual
+ *
+ * It returns what MAY exist. `er_model` returns what DOES. A space can declare twenty types and hold three,
+ * and a caller who reads the declaration as an inventory plans against types with no records in them.
+ *
+ * Run: node --test testing/standalone/orientation-tools-say-what-they-do-not-cover.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripComments } from './_strip-comments.mjs';
+
+const src = (p) => stripComments(readFileSync(p, 'utf8'));
+
+const description = (file, name) => {
+  const s = src(file);
+  const at = s.indexOf(`name: '${name}'`);
+  assert.ok(at > 0, `${name} not found in ${file} — the scanner is wrong, not the code`);
+  const d = s.indexOf('description:', at);
+  const end = s.slice(d).search(/\n {2,}(mutating|spaceRequired|admin|spaceAdmin|skipSchemaValidation|inputSchema|async handle):/);
+  assert.ok(end > 0, `could not find the end of ${name}'s description`);
+  return s.slice(d, d + end);
+};
+
+const HELP = description('server/src/mcp/tools/help.ts', 'help');
+const META = description('server/src/mcp/tools/spaces.ts', 'get_space_meta');
+
+describe('help says its own tool list is filtered', () => {
+  it('says the list is scoped to the calling token', () => {
+    assert.match(HELP, /FILTERED TO WHAT YOUR TOKEN CAN REACH/,
+      'the most important property of this answer, and it was unstated');
+  });
+
+  it('spells out the wrong conclusion so it is not drawn', () => {
+    // The whole point. "There is no way to do X here" is unsupportable from a filtered list, and it is
+    // exactly what gets reported outward.
+    assert.match(HELP, /does NOT mean the instance lacks/, 'name the false inference');
+    assert.match(HELP, /THIS TOKEN cannot invoke it/, 'and the true one');
+  });
+
+  it('and the filtering really is per token', () => {
+    assert.match(src('server/src/mcp/tool-visibility.ts'), /export function toolIsVisible/,
+      'the predicate this paragraph describes');
+    assert.match(src('server/src/mcp/tool-visibility.ts'), /if \(tool\.mutating\) return canWriteAnywhere/,
+      'read-only tokens really are shown fewer tools');
+  });
+
+  it('points at the tool schemas as the authoritative reference', () => {
+    // CLAUDE.md: a stale sentence in a schema is invisible, because nobody reports a capability they were
+    // told they did not have. help() saying the schemas are authoritative is what makes them get read.
+    assert.match(HELP, /AUTHORITATIVE REFERENCE/, 'say which source wins');
+    assert.match(HELP, /inputSchema/, 'and name it precisely');
+  });
+
+  it('says query narrows rather than broadens', () => {
+    assert.match(HELP, /NARROW/, 'ALL words must appear, so more words find less');
+  });
+});
+
+describe('get_space_meta distinguishes declared from actual', () => {
+  it('says DECLARED, NOT ACTUAL', () => {
+    assert.match(META, /DECLARED, NOT ACTUAL/,
+      'a declaration read as an inventory produces plans against empty types');
+  });
+
+  it('names er_model as the other half', () => {
+    assert.match(META, /er_model/, 'the caller needs to know where the actual shape lives');
+  });
+
+  it('explains what each validation mode does to a WRITE', () => {
+    for (const mode of ['off', 'warn', 'strict']) {
+      assert.match(META, new RegExp('`' + mode + '`'), `${mode} must be explained, not just listed`);
+    }
+    assert.match(META, /strictLinkage/, 'and the linkage flag beside it');
+  });
+
+  it('pre-empts "strict plus an empty schema must be a bug"', () => {
+    assert.match(META, /not a contradiction/,
+      'a new space is strict AND accepts everything, which reads as broken until explained');
+  });
+
+  it('says strict refuses what your change breaks, not what was already broken', () => {
+    // Shipped in this release (#920), so nobody has prior knowledge of it.
+    assert.match(META, /BREAKS, not what was already broken/, 'the P-6 behaviour');
+  });
+
+  it('explains needsReindex as a QUALITY signal, not an outage', () => {
+    assert.match(META, /degrade quietly rather than erroring/,
+      'recall still answers, which is why nobody notices');
+  });
+
+  it('and still does not name the repair tool, which a read-only token cannot call', () => {
+    // The constraint the original comment recorded, kept through the rewrite: naming the STATE is both
+    // allowed and more useful to a reader who cannot perform the repair.
+    assert.doesNotMatch(META, /\breindex\b/, 'read-only help must not advertise a mutating tool');
+    assert.match(META, /needsReindex/, 'the field name is not the tool name and stays');
+  });
+});


### PR DESCRIPTION
The two tools an agent calls before it knows anything. A gap in either becomes a wrong conclusion that gets
reported outward.

## `help` — the tool list is filtered, and nothing said so

`toolIsVisible` filters `tools/list` and `help()` alike: a read-only token sees no mutating tools, a token
without instance-admin rights sees no admin tools. Correct and deliberate.

**What nobody was told is the consequence.** A tool absent from that reply means *this token cannot invoke
it* — never that the instance lacks the capability. The unsupportable conclusion, *"there is no way to do X
here"*, is exactly the one that gets filed as a missing feature.

That is not hypothetical. The same sentence had to be written into `list_embed_jobs`,
`find_entities_by_name` and `list_dir` individually this release — because the one place it really belonged,
`help` itself, did not carry it. Three drafts were refused by `mcp-help.test.js` along the way, which is the
gate that exists precisely because advertising an unreachable tool produces the wrong bug report.

`help` now also states:

- **each tool's own `inputSchema` description is the authoritative reference** — which is what makes those
  descriptions get read at all, and where this guide and a schema disagree, the schema is the one maintained
  against the code
- **`query` narrows rather than broadens** — all words must appear, so adding one finds less

## `get_space_meta` — declared, not actual

It returns the types somebody **defined**. `er_model` returns the types that actually **have records**. A
space can declare twenty and hold three, or hold records of a type nobody declared, so a declaration read as
an inventory produces plans against empty types.

Also now stated:

| | |
| --- | --- |
| what each `validationMode` does to a *write* | `off` accepts, `warn` accepts and reports, `strict` refuses |
| why `strict` + empty schema is not a bug | a space with no `typeSchemas` has nothing to violate |
| `strict` refuses what your change **breaks** | not what was already broken — #920, new this release |
| `needsReindex` is a quality signal, not an outage | recall keeps answering while comparing new queries against vectors from a different model, so results degrade quietly instead of erroring |

The original comment on this tool recorded that it must not name the repair tool, because a read-only token
cannot call it. **That constraint survives the rewrite and is now asserted** rather than left to a comment —
the field name `needsReindex` stays, the tool name does not.

## Verification

`orientation-tools-say-what-they-do-not-cover.test.js`, 12 tests.

**Mutation-tested:** making `toolIsVisible` stop filtering mutating tools fails; dropping the declared/actual
warning fails.

Part of **X-2**.
