### PR TITLE
docs(mcp): update_file_meta warns that it replaces where the brain tools merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,6 +252,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a quality signal where recall keeps answering while comparing new queries against vectors made by a
   different model, so results degrade quietly instead of erroring.
 
+- **`update_file_meta` now warns that it replaces `properties` where the brain tools merge it.** On entities,
+  edges, memories and chrono entries you can patch one property key and the others survive; on a file record
+  you cannot — sending one key leaves the record holding only that key, and there is no per-field delete to
+  soften it. The parameter text always said "replaces", so nobody was misinformed; what was missing is that
+  this is the odd one out among five otherwise identical-looking tools, which is what makes it cost data. The
+  description now leads with the difference and says to read the record first. Making it merge like the other
+  four is filed separately, because it is a behaviour change to a write path.
+
+- **The mojibake check now covers the shipped documentation, which it never did.** It scanned TypeScript
+  only, so the integration guide and the user guide — the two things read by people outside the project —
+  were never checked. They are clean; this keeps them that way.
+
 ### Added
 
 - **A space administrator can now manage that space's tokens.** Until now "administers this space" was only

--- a/server/src/mcp/tools/file.ts
+++ b/server/src/mcp/tools/file.ts
@@ -410,10 +410,30 @@ export const retry_embeddingTool: ToolHandler = {
 export const update_file_metaTool: ToolHandler = {
   name: 'update_file_meta',
   description: 'Change a file record\'s description, tags, properties or links WITHOUT resending the file. '
-    + '`write_file` can set those fields but only together with new content, so correcting a tag used to mean '
-    + 're-uploading the bytes. Only the fields you pass are touched; omit one to leave it alone. Under strict '
-    + 'linkage every id in `entityIds`/`memoryIds`/`chronoIds` must resolve, or the call is refused rather than '
-    + 'stored. Use `list_dir` or a `query` over the `files` collection to find the path.',
+    + '`write_file` can set those fields, but only together with new content, so correcting one tag used to '
+    + 'mean re-uploading the bytes. Only the fields you pass are touched; omit one to leave it alone.\n\n'
+    + 'EVERY FIELD REPLACES, INCLUDING `properties` — AND THAT IS NOT WHAT THE BRAIN TOOLS DO. On entities, '
+    + 'edges, memories and chrono entries `properties` MERGES: you patch one key and the others survive. Here '
+    + 'it does not. Sending `properties: {"source":"scan"}` on a file that had three other properties leaves '
+    + 'it with ONE. `tags` and the three id lists replace the same way, and there is no `deleteFields` on this '
+    + 'tool, so the only way to change one key is to send the whole object back. READ THE RECORD FIRST, merge '
+    + 'your change into what you read, and send the result.\n\n'
+    + 'UNDER STRICT LINKAGE EVERY ID MUST RESOLVE. `entityIds`, `memoryIds` and `chronoIds` are each checked '
+    + 'against records that actually exist in the member space holding the file, and the call is refused '
+    + 'rather than storing a dangling link. On a space without strict linkage they are stored as given.\n\n'
+    + 'THE FILE CONTENT IS NOT RE-READ. This edits the record ABOUT the file, never the bytes: no '
+    + 're-extraction, no media analysis, no new thumbnail. The record is re-embedded so the new description '
+    + 'and tags are searchable, which is the only reason a metadata edit costs anything at all.\n\n'
+    + 'PARAMETERS:\n'
+    + '- `path` — the file path relative to the space root, exactly as `list_dir` reports it. Required.\n'
+    + '- `description` — replaces the description. This is what `recall` ranks a file on, alongside its '
+    + 'extracted text.\n'
+    + '- `tags` — REPLACES the tag list. Send the full list you want.\n'
+    + '- `properties` — REPLACES the whole object. See above; this is the one that costs people data.\n'
+    + '- `entityIds` / `memoryIds` / `chronoIds` — REPLACE those link lists. Sending one id drops the rest.\n'
+    + '- `targetSpace` — required when `space` is a proxy: the member space holding the file.\n\n'
+    + 'RESPONSE: confirmation naming the path and which fields were changed. A path that does not exist is an '
+    + 'error, so a successful reply means a record really was updated.',
   mutating: true,
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({

--- a/testing/standalone/file-meta-replaces-unlike-the-brain-tools.test.js
+++ b/testing/standalone/file-meta-replaces-unlike-the-brain-tools.test.js
@@ -1,0 +1,103 @@
+/**
+ * `update_file_meta` REPLACES `properties`. All four brain record types MERGE it. The description says so.
+ *
+ * ## The fifth copy of a defect that was fixed four times
+ *
+ * `brain/memory.ts` still carries the note explaining the fix:
+ *
+ *   > `properties` MERGES into the stored map. It used to replace it… An agent patching one key silently
+ *   > destroyed every other property on the record, with no error anywhere.
+ *
+ * That sweep reached entities, edges, memories and chrono. It did not reach `files/file-meta.ts`, where
+ * `$set['properties'] = opts.properties` still overwrites the object wholesale — and files have no
+ * `deleteFields` either, so sending the whole object back is the only way to change one key.
+ *
+ * ## Why this is a documentation fix and not a bug fix
+ *
+ * The parameter description already said *"Replaces the properties object."* It is honest, so a caller who
+ * reads that exact line is not misled. The danger is the caller who learned merge semantics from the four
+ * brain tools and assumes the fifth matches — they lose every key they did not resend, silently.
+ *
+ * Making it merge is filed as **X-6**: it is a behaviour change to a write path and wants its own PR.
+ *
+ * Run: node --test testing/standalone/file-meta-replaces-unlike-the-brain-tools.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripComments } from './_strip-comments.mjs';
+
+const src = (p) => stripComments(readFileSync(p, 'utf8'));
+
+const DESC = (() => {
+  const s = src('server/src/mcp/tools/file.ts');
+  const at = s.indexOf("name: 'update_file_meta'");
+  assert.ok(at > 0, 'update_file_meta not found — the scanner is wrong, not the code');
+  const d = s.indexOf('description:', at);
+  const end = s.slice(d).search(/\n {2,}(mutating|spaceRequired|inputSchema|async handle):/);
+  assert.ok(end > 0, 'could not find the end of update_file_meta\'s description');
+  return s.slice(d, d + end);
+})();
+
+describe('the description leads with the difference', () => {
+  it('says every field REPLACES, properties included', () => {
+    assert.match(DESC, /EVERY FIELD REPLACES, INCLUDING `properties`/,
+      'this is the one that costs data, so it cannot be a footnote');
+  });
+
+  it('names the brain tools it differs from', () => {
+    assert.match(DESC, /NOT WHAT THE BRAIN TOOLS DO/,
+      'a caller who learned merge semantics elsewhere is the one who loses keys');
+  });
+
+  it('gives the concrete outcome, not just the word "replaces"', () => {
+    // "Replaces the properties object" was already there and was read past. A worked example is not padding.
+    assert.match(DESC, /leaves\s*'?\s*\+?\s*'?it with ONE|leaves it with ONE/,
+      'spell out what happens to the other three properties');
+  });
+
+  it('says what to do instead', () => {
+    assert.match(DESC, /READ THE RECORD FIRST/, 'read-modify-write is the only safe pattern here');
+    assert.match(DESC, /no `deleteFields` on this\s*'?\s*\+?\s*'?tool|no `deleteFields`/,
+      'and say why there is no shortcut');
+  });
+});
+
+describe('the claim matches the code, in both directions', () => {
+  it('file meta really replaces', () => {
+    assert.match(src('server/src/files/file-meta.ts'), /\$set\['properties'\] = opts\.properties/,
+      'if this starts merging, the whole warning above must come out');
+  });
+
+  it('and the brain paths really merge, which is what makes it a contrast', () => {
+    for (const f of ['server/src/brain/entities.ts', 'server/src/brain/edges.ts',
+      'server/src/brain/memory.ts', 'server/src/brain/chrono.ts']) {
+      assert.match(src(f), /mergePropertiesOrKeep\(/,
+        `${f} stopped merging — the file tool is no longer the odd one out`);
+    }
+  });
+
+  it('and files really have no deleteFields', () => {
+    const s = src('server/src/mcp/tools/file.ts');
+    const at = s.indexOf("name: 'update_file_meta'");
+    const schemaAt = s.indexOf('inputSchema:', at);
+    const end = s.indexOf('\nexport const ', at);
+    assert.doesNotMatch(s.slice(schemaAt, end === -1 ? undefined : end), /deleteFields/,
+      'update_file_meta gained deleteFields — say so instead of saying there is no shortcut');
+  });
+});
+
+describe('the rest of what it does not do', () => {
+  it('says the file content is not re-read', () => {
+    assert.match(DESC, /CONTENT IS NOT RE-READ/,
+      'editing the record about a file is not reprocessing the file');
+  });
+
+  it('but says the record IS re-embedded, so the edit is searchable', () => {
+    assert.match(DESC, /re-embedded/, 'otherwise a new description would not be findable');
+  });
+
+  it('says strict linkage refuses rather than storing a dangling link', () => {
+    assert.match(DESC, /STRICT LINKAGE EVERY ID MUST RESOLVE/, 'and that it is a refusal');
+  });
+});

--- a/testing/standalone/no-source-file-carries-mojibake.test.js
+++ b/testing/standalone/no-source-file-carries-mojibake.test.js
@@ -71,6 +71,24 @@ describe('no source file carries mis-decoded UTF-8', () => {
       + offenders.join('\n  ') + '\nRepair with node, not PowerShell.');
   });
 
+  it('the SHIPPED DOCS are clean — a customer reads these', () => {
+    // Added 2026-08-16: the gate covered only `.ts`, so the integration guide and the user guide — the two
+    // things read by people who are not us — were never checked at all. They are clean today; this keeps
+    // them that way, and it is the cheapest possible check on the most visible surface.
+    //
+    // `CHANGELOG.md` is deliberately NOT in scope. It carries one legitimate occurrence: the entry
+    // announcing the mojibake repair quotes the corruption it fixed, which is the correct way to write that
+    // entry and would make this assertion permanently red. Scoping to `docs/` rather than exempting a file
+    // by name keeps the rule "what we publish is clean" instead of "everything except the file that annoys
+    // the gate".
+    const docs = tracked('"docs/**/*.md" "docs/*.md"');
+    assert.ok(docs.length > 20, `only enumerated ${docs.length} doc files — the walk is broken`);
+    const offenders = docs.filter(f => MOJIBAKE.test(readFileSync(f, 'utf8')));
+    assert.deepEqual(offenders, [],
+      'these ship to customers and were written by a tool that decoded UTF-8 as ANSI:\n  '
+      + offenders.join('\n  ') + '\nRepair with node, not PowerShell.');
+  });
+
   it('MCP tool descriptions especially — an agent reads these', () => {
     // Narrowed on purpose as well as covered above: a corrupted comment is ugly, and a corrupted tool
     // description is a reference an agent constructs arguments from.


### PR DESCRIPTION
## The fifth copy of a defect that was fixed four times

`files/file-meta.ts:214` does `$set['properties'] = opts.properties` — a wholesale overwrite.

| Record type | `properties` |
| --- | --- |
| entity | merges |
| edge | merges |
| memory | merges |
| chrono | merges |
| **file** | **replaces** |

`brain/memory.ts` records why the others were changed: *"An agent patching one key silently destroyed every
other property on the record, with no error anywhere."* The sweep that reached memory, chrono, entity and edge
never reached the file path.

## Why it is an inconsistency and not a live bug

The parameter description already said *"Replaces the properties object."* A caller who reads that exact line
is not misled. **The one who loses keys is the caller who learned merge semantics from the four brain tools
and assumed the fifth matched** — and five tools that look identical with one behaving differently is what
makes it cost data rather than merely surprise.

So the description now leads with the difference, gives the concrete outcome instead of the word "replaces"
(*sending one key leaves the record holding ONE*), and says to read-modify-write, since there is no
`deleteFields` here to soften it.

It also states that the file **content** is not re-read — no extraction, no media analysis, no thumbnail —
while the **record** is re-embedded, which is the only reason a metadata edit costs anything at all.

Making it merge is filed as **X-6**. It is a behaviour change to a write path and wants its own PR.

## The mojibake gate now covers shipped docs

It scanned `.ts` only, so the integration guide and the user guide — the two things read by people outside
this project — were never checked. They are clean; this keeps them so.

`CHANGELOG.md` is deliberately **out of scope rather than exempted by name**: it carries one legitimate
occurrence, because the entry announcing the mojibake repair quotes the corruption it fixed. Scoping to
`docs/` keeps the rule *"what we publish is clean"* instead of *"everything except the file that annoys the
gate"*.

## Verification

**Mutation-tested:** making file meta merge fails the contrast; corrupting one em-dash in `16-mcp.md` fails
the docs scan.

The gate pins **both** directions — files really replace, and the four brain paths really merge — so whichever
side changes, the description fails rather than quietly becoming wrong.

Part of **X-2**.
