### PR TITLE
feat(chrono): a chrono entry's fields can be removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,6 +266,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A chrono entry's fields can be removed. Until now none of them could.** `deleteFields` — the dot-notation
+  removal that entities, edges and memories have always had — now works on chrono entries too, on **both**
+  the REST route and the `update_chrono` tool. It was the one record type without it, and because its
+  `properties` merge and an omitted field means *leave alone*, there was no request of any shape that could
+  unset something: a key written once was permanent. Paths are applied **after** the merge, so a single call
+  can add one property and drop another. Chrono's **required** fields — `title`, `startsAt`, `status` — are
+  refused **by name** rather than accepted and ignored, alongside the server-owned ones; a path that cannot
+  be honoured tells you, because "nothing happened and nobody said so" is the failure this feature exists to
+  remove. A *property* of the same name (`properties.title`) is an ordinary user key and stays deletable.
+
+- **The mojibake check now detects the corruption structurally instead of matching known signatures.** It
+  looked for `â€`, then `â”`/`â•` after a tree with thousands of mis-decoded box-drawing dividers passed it,
+  and it was *still* reporting clean while one merged file carried `Ã—` — two characters, starting with a
+  letter none of the three patterns named. Each addition fixed the instance and not the class. It now asks
+  whether a run of non-ASCII, encoded back to the codepage the damage comes from, decodes as valid UTF-8 into
+  something **shorter** — which is true of mis-decoded text and of nothing else, so no new shape can hide
+  from it. Failures also name what the text should have been, instead of leaving the repair to guesswork.
+  One residual `×` was repaired.
+
 - **A space administrator can now manage that space's tokens.** Until now "administers this space" was only
   sayable through the pre-3.0 pair — an `admin` token plus a list of spaces — and the rights matrix could not
   express it: giving someone `admin` on every area of a space granted them those areas and nothing about

--- a/docs/integration-guide/04-brain-api.md
+++ b/docs/integration-guide/04-brain-api.md
@@ -714,13 +714,25 @@ error. Nothing in the record's own data is lost.
 
 ### Partial Update with deleteFields
 
-All `PATCH` update endpoints — entities, edges, and memories — accept an optional `deleteFields` array of dot-notation paths. This allows callers to remove specific fields from a document in the same atomic operation as normal property/tag updates.
+**All four** `PATCH` update endpoints — entities, edges, memories and chrono entries — accept an optional `deleteFields` array of dot-notation paths. This allows callers to remove specific fields from a document in the same atomic operation as normal property/tag updates.
 
 ```http
 PATCH /api/brain/spaces/:spaceId/entities/:id
 PATCH /api/brain/spaces/:spaceId/edges/:id
 PATCH /api/brain/spaces/:spaceId/memories/:id
+PATCH /api/brain/spaces/:spaceId/chrono/:id
 ```
+
+> **Chrono gained this in 3.1, and until then nothing could be removed from a chrono entry at all.** Its
+> `properties` merge and an absent field means "leave alone", so with no `deleteFields` there was no request
+> that unset anything — a key written once was permanent. Entries created before 3.1 are unaffected; the
+> paths simply work now.
+>
+> Chrono's **required** fields — `title`, `startsAt`, `status` — are refused by name, alongside the
+> server-owned `id` / `type` / `spaceId` / `createdAt` / `updatedAt`. A path that cannot be honoured answers
+> `400` naming it rather than being accepted and doing nothing, so a delete that silently misses is not a
+> state this API can reach. A *property* of the same name (`properties.title`) is an ordinary user key and
+> stays deletable.
 
 **Example — delete a property key while adding a new one:**
 

--- a/docs/integration-guide/04c-chrono-api.md
+++ b/docs/integration-guide/04c-chrono-api.md
@@ -56,7 +56,24 @@ PATCH /api/brain/spaces/:spaceId/chrono/:id
 > the brain API; it performed no property validation and wrote no audit snapshot. `PATCH` takes the same
 > body and does both.
 
-**Body**: partial object with any updatable fields (`title`, `type`, `status`, `startsAt`, `endsAt`, `confidence`, `tags`, `entityIds`, `memoryIds`, `description`).
+**Body**: partial object with any updatable fields (`title`, `type`, `status`, `startsAt`, `endsAt`, `confidence`, `tags`, `entityIds`, `memoryIds`, `description`, `properties`, `recurrence`, `excludeFromVectorSearch`, `ttlDays`), plus `deleteFields`.
+
+> **`deleteFields` arrived in 3.1, and it is the only way to remove anything.** `properties` MERGE — patching
+> one key keeps the others — and an omitted field means *leave it alone*, so before 3.1 there was no request
+> that could unset a chrono field at all: a key written once was permanent. Send dot-notation paths, applied
+> **after** the merge:
+>
+> ```json
+> { "properties": { "venue": "Hall B" }, "deleteFields": ["properties.oldKey", "description"] }
+> ```
+>
+> Chrono's **required** fields — `title`, `startsAt`, `status` — are refused by name, alongside the
+> server-owned `id` / `type` / `spaceId` / `createdAt` / `updatedAt`. A path that cannot be honoured answers
+> `400` naming it rather than being accepted and doing nothing. A *property* of the same name
+> (`properties.title`) is an ordinary user key and stays deletable.
+>
+> Same parameter, same refusals, on the `update_chrono` MCP tool. See
+> [Partial Update with deleteFields](04-brain-api.md#partial-update-with-deletefields) for the shared rules.
 
 **Response** `200` — the updated `ChronoEntry`.
 

--- a/docs/userguide/02-brain.md
+++ b/docs/userguide/02-brain.md
@@ -105,6 +105,12 @@ Chrono stores time-anchored entries: events, deadlines, plans, predictions, and 
 
 **Creating an entry:** Click **+ Add entry**. Required fields are **title**, **type**, and **starts at** (date and time). You can also add a description, tags, status, linked **entities**, linked **memories**, and **properties** — the memory field is a searchable picker (type to find a memory by its fact and click to link it; linked memories show as chips), and the properties editor lets you fill in any fields the chrono type's schema defines (switching the type reseeds its property fields). The same pickers and properties editor are available when editing an entry in its detail drawer.
 
+> **Clearing a property on a chrono entry works from 3.1.** Properties are *merged* when you save — the ones
+> you do not touch are kept — so before 3.1 an API caller had no way to remove one at all and a stale key
+> stayed for ever. Removing a property in the editor now removes it. The entry's **title**, **type** and
+> **starts at** cannot be cleared, because an entry without them could not be shown; change them instead, or
+> delete the entry.
+
 **Searching:** The top search bar is **Semantic** (ranks entries by meaning). Plain-text matching (title / description) is the **freetext box under the Title column**.
 
 **Filtering:** The filter bar above the table lets you narrow by tag text and status. Filters apply immediately.

--- a/server/src/api/brain/chrono.ts
+++ b/server/src/api/brain/chrono.ts
@@ -15,6 +15,7 @@ import { memberSpacesForRequest } from '../../spaces/proxy-scoped.js';
 import { parseSortParam, SORTABLE_FIELDS, toMongoSort } from '../../brain/list-sort.js';
 import { resolveWriteTarget, isProxySpace, isStrictLinkage, findFirstAcrossMembers, collectAcrossMembers } from '../../spaces/proxy.js';
 import { validateChrono, getAllowedChronoTypes } from '../../spaces/schema-validation.js';
+import { validateDeleteFields } from '../../brain/delete-fields.js';
 import type { ChronoStatus } from '../../config/types.js';
 import { UUID_V4_RE, webhookToken, getSpaceMeta, applyValidation, ttlDaysFromBody, ttlDaysError, dupeCheckOptsFromBody, ifMatchFromRequest, preconditionFailedBody } from './_shared.js';
 import { classifyUpdateViolations } from '../../brain/write-validation.js';
@@ -218,13 +219,26 @@ chronoRouter.patch('/spaces/:spaceId/chrono/:id', globalRateLimit, requireSpaceA
   // integration guide); what is no longer possible is dropping ALL of them and calling it success.
   const PATCHABLE_FIELDS = [
     'title', 'type', 'startsAt', 'endsAt', 'status', 'confidence', 'tags', 'entityIds', 'memoryIds',
-    'description', 'properties', 'recurrence', 'excludeFromVectorSearch', 'ttlDays',
+    'description', 'properties', 'recurrence', 'excludeFromVectorSearch', 'ttlDays', 'deleteFields',
   ];
   const body = req.body != null && typeof req.body === 'object' ? req.body as Record<string, unknown> : {};
   if (!PATCHABLE_FIELDS.some(f => f in body)) {
     res.status(400).json({ error: 'At least one field must be provided' });
     return;
   }
+
+  // X-4: chrono was the one record type with no `deleteFields`, and its `properties` merge, so a key written
+  // once could never be removed by any request. Validated here exactly as the three sibling routes do it —
+  // same helper, same refusals, same 400 — because a fourth spelling of one rule is the defect this repo
+  // produces most.
+  const dfResult = validateDeleteFields(body['deleteFields']);
+  if (!dfResult.ok) {
+    res.status(400).json({ error: dfResult.error });
+    return;
+  }
+  const dfPaths: string[] | undefined = Array.isArray(body['deleteFields']) && body['deleteFields'].length > 0
+    ? body['deleteFields'] as string[]
+    : undefined;
 
   // Snapshot for the audit change list — see the note in memories.ts. Read before the write, since
   // `updateChrono` returns only the new document.
@@ -261,7 +275,7 @@ chronoRouter.patch('/spaces/:spaceId/chrono/:id', globalRateLimit, requireSpaceA
     title, type, startsAt, endsAt, status, confidence,
     tags, entityIds, memoryIds, description, properties: safeProps, recurrence: safeRecurrence,
     excludeFromVectorSearch,
-  }, webhookToken(req), ttlDaysFromBody(req.body), ifMatch.seq));
+  }, dfPaths, webhookToken(req), ttlDaysFromBody(req.body), ifMatch.seq));
   if (updated) {
     req.auditSnapshots = { before: prior ?? {}, after: updated };
     res.json(updated);

--- a/server/src/api/tokens.ts
+++ b/server/src/api/tokens.ts
@@ -22,7 +22,7 @@ tokensRouter.get('/me', globalRateLimit, requireAuth, (req, res) => {
 /**
  * GET /api/tokens/rights-catalog — what each area and rung actually GRANTS.
  *
- * The rights grid is four areas Ã— four rungs of bare words, and nothing told an operator what any cell does.
+ * The rights grid is four areas × four rungs of bare words, and nothing told an operator what any cell does.
  * The answer already exists and is authoritative: `ROUTE_RIGHTS` is the table the server ENFORCES against, so
  * it is the only description of a right that cannot be wrong. A list typed into the client would be a second
  * copy of a security control, and the copy that drifts is the one people read.

--- a/server/src/brain/chrono.ts
+++ b/server/src/brain/chrono.ts
@@ -17,6 +17,7 @@ import { stampExpiryOnCreate, applyExpiryToUpdate } from './ttl.js';
 import { stampSkewOnCreate } from './stamp-skew.js';
 import { getSpaceMeta } from '../spaces/schema-validation.js';
 import { mergeTags, mergeProperties, mergePropertiesOrKeep } from './merge-fields.js';
+import { applyDeleteFields } from './delete-fields.js';
 import { enqueueEmbedJob, retireEmbedJob } from './embed-queue.js';
 import { emitWebhookEvent, type WebhookActor } from '../webhooks/dispatcher.js';
 import type { ChronoEntry, ChronoType, ChronoStatus, TombstoneDoc } from '../config/types.js';
@@ -231,6 +232,7 @@ export async function updateChrono(
   spaceId: string,
   id: string,
   updates: Partial<Pick<ChronoEntry, 'title' | 'description' | 'type' | 'startsAt' | 'endsAt' | 'status' | 'confidence' | 'tags' | 'entityIds' | 'memoryIds' | 'properties' | 'recurrence' | 'excludeFromVectorSearch'>>,
+  deleteFieldsPaths?: string[],
   actor?: WebhookActor,
   ttlDays?: number | null,
   ifMatchSeq?: number,
@@ -251,6 +253,50 @@ export async function updateChrono(
   // Removing a key is `deleteFields`' job on the surfaces that offer it, never an absence here.
   const mergedUpdateProps = mergePropertiesOrKeep(existing.properties, updates.properties);
   if (updates.properties !== undefined) $set['properties'] = mergedUpdateProps;
+
+  /**
+   * `deleteFields`, applied AFTER the merge — the same shape and the same order as `updateMemory`.
+   *
+   * Chrono was the one record type without it (X-4). Combined with merging `properties`, that meant a key
+   * written once could never be removed: an absence never means "delete" here, deliberately, and there was
+   * no path that unset. So the entry is not "chrono should have a parameter the others have" — it is that
+   * chrono had no expression for removal at all.
+   *
+   * The merged view is built from `updates ?? existing` so a path can address a field this call is also
+   * setting, and the result is reflected back into `$set`/`$unset`: a whole field that disappeared becomes
+   * an `$unset`, and a field that merely lost a sub-key is re-`$set` to its pruned value.
+   */
+  if (deleteFieldsPaths && deleteFieldsPaths.length > 0) {
+    const merged: Record<string, unknown> = {
+      title: updates.title ?? existing.title,
+      description: updates.description !== undefined ? updates.description : existing.description,
+      tags: updates.tags ?? existing.tags,
+      entityIds: updates.entityIds ?? existing.entityIds,
+      memoryIds: updates.memoryIds ?? existing.memoryIds,
+      properties: mergedUpdateProps ?? {},
+      recurrence: updates.recurrence !== undefined ? updates.recurrence : existing.recurrence,
+      endsAt: updates.endsAt !== undefined ? updates.endsAt : existing.endsAt,
+      confidence: updates.confidence !== undefined ? updates.confidence : existing.confidence,
+      excludeFromVectorSearch: updates.excludeFromVectorSearch !== undefined
+        ? updates.excludeFromVectorSearch : existing.excludeFromVectorSearch,
+    };
+    applyDeleteFields(merged, deleteFieldsPaths);
+
+    // EVERY optional field, not a convenient subset. A field the writer forgets is accepted at the edge and
+    // then does nothing, which is the silent no-op this feature exists to remove — chrono's whole problem was
+    // that a property could not be removed and nothing said so. The REQUIRED fields (`title`, `startsAt`,
+    // `status`) are refused by `validateDeleteFields` instead, so between the two lists every path a caller
+    // can send is either performed or reported.
+    for (const field of ['description', 'tags', 'entityIds', 'memoryIds', 'properties', 'recurrence',
+      'endsAt', 'confidence', 'excludeFromVectorSearch']) {
+      if (!(field in merged)) {
+        $unset[field] = '';
+        delete $set[field];
+      } else if (deleteFieldsPaths.some(p => p === field || p.startsWith(field + '.'))) {
+        $set[field] = merged[field];
+      }
+    }
+  }
 
   // There is no longer a "did an embedding-relevant field change?" branch here. It existed to decide whether
   // to pay for an inline embed; the re-embed is now ENQUEUED unconditionally after the write, and

--- a/server/src/brain/delete-fields.ts
+++ b/server/src/brain/delete-fields.ts
@@ -10,6 +10,15 @@
 
 const SYSTEM_FIELDS = new Set([
   'id', '_id', 'name', 'type', 'spaceId', 'createdAt', 'updatedAt',
+  // Chrono's required fields, added with `deleteFields` support for chrono (X-4). They are here rather than
+  // simply omitted from the writer's unset list because the two behave differently where it matters: a path
+  // the writer ignores is accepted and silently does nothing, while a path listed here is REFUSED with a
+  // message naming it. "Nothing happened and nobody said so" is the failure this whole file exists to avoid.
+  //
+  // Harmless on the other three record types: the check is against the TOP-LEVEL segment only, so
+  // `properties.title` is still deletable everywhere, and no entity, edge or memory has a bare `title` or
+  // `startsAt` to remove.
+  'title', 'startsAt', 'status',
 ]);
 
 /** Dangerous prototype keys that must never be traversed or deleted. */

--- a/server/src/mcp/tools/chrono.ts
+++ b/server/src/mcp/tools/chrono.ts
@@ -9,6 +9,7 @@ import { isStrictLinkage, resolveMemberSpaces, resolveWriteTarget, findFirstAcro
 import { memberSpacesWithin } from '../../spaces/proxy-scoped.js';
 import { getAllowedChronoTypes, resolveMetaRefs, validateChrono } from '../../spaces/schema-validation.js';
 import { mergePropertiesOrKeep } from '../../brain/merge-fields.js';
+import { validateDeleteFields } from '../../brain/delete-fields.js';
 
 export const create_chronoTool: ToolHandler = {
   name: 'create_chrono',
@@ -172,10 +173,11 @@ export const update_chronoTool: ToolHandler = {
     + 'so patching one key keeps the others. `tags`, `entityIds` and `memoryIds` REPLACE — send the FULL list '
     + 'you want the entry to end up with, because sending one id drops the rest. (`update_entity` and '
     + '`update_edge` merge tags instead; `update_memory` replaces them, like this tool.)\n\n'
-    + 'THERE IS NO `deleteFields` ON THIS TOOL. That is a real limitation rather than an omission from this '
-    + 'text: because `properties` merges and nothing here unsets, a property once written to a chrono entry '
-    + 'CANNOT be removed through this tool. Overwrite it with an empty string if a stale key is a problem, or '
-    + 'delete and recreate the entry. The other three record types do offer `deleteFields`.\n\n'
+    + 'REMOVING SOMETHING IS `deleteFields`, NEVER AN OMISSION. An absent field means "leave it alone", so '
+    + 'there is no value you can send that clears one — send its dot path in `deleteFields` instead, which is '
+    + 'applied AFTER the merge above and is permanent. A path that cannot be honoured is REFUSED by name '
+    + 'rather than ignored: the required fields (`title`, `startsAt`, `status`) and the server-owned ones are '
+    + 'named back to you, so a delete that does nothing is not something this tool can do quietly.\n\n'
     + 'A RE-EMBED IS ALWAYS QUEUED after a successful write, whether or not you changed anything embeddable. '
     + 'The worker reads the record as STORED, so it cannot embed a stale version — deciding here would mean '
     + 'deciding from this function\'s own read, which is what made the older inline embedding wrong.\n\n'
@@ -190,7 +192,10 @@ export const update_chronoTool: ToolHandler = {
     + '- `confidence` — 0 to 1, for entries that are predictions rather than records.\n'
     + '- `tags` / `entityIds` / `memoryIds` — each REPLACES the stored list.\n'
     + '- `description` — replaced when sent.\n'
-    + '- `properties` — MERGED key by key. String, number or boolean values only.\n'
+    + '- `properties` — MERGED key by key. String, number or boolean values only. Use `deleteFields` with '
+    + '`properties.<key>` to remove one.\n'
+    + '- `deleteFields` — dot-notation paths to remove, permanently and with no undo. Applied after the merge. '
+    + 'The only way to unset anything.\n'
     + '- `recurrence` — the repeat rule, replaced wholesale when sent. It describes the entry; it does not '
     + 'generate further entries.\n'
     + '- `excludeFromVectorSearch` — removes the vector, so `recall` can no longer RANK this entry by meaning. '
@@ -236,6 +241,15 @@ export const update_chronoTool: ToolHandler = {
               additionalProperties: false,
             },
             excludeFromVectorSearch: EXCLUDE_FROM_VECTOR_SEARCH_SCHEMA,
+            deleteFields: {
+              type: 'array', items: { type: 'string' },
+              description: 'Dot-notation paths to REMOVE from the entry, applied after the merge above — the '
+                + 'only way to unset anything, since an absent field means "leave alone" and `properties` '
+                + 'merge. E.g. `["properties.oldKey", "description"]`. Permanent, with no undo. The required '
+                + 'fields (`title`, `startsAt`, `status`) and the server-owned ones (`id`, `type`, `spaceId`, '
+                + '`createdAt`, `updatedAt`) are REFUSED by name rather than ignored, so a path that cannot be '
+                + 'honoured tells you instead of silently doing nothing.',
+            },
             targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
             ttlDays: TTL_DAYS_SCHEMA,
           },
@@ -297,8 +311,17 @@ export const update_chronoTool: ToolHandler = {
     // The three sibling update tools refuse a call that names no field; this one accepted it and answered
     // "updated (seq N)" for a write that changed nothing but the seq. Same asymmetry as the REST handler
     // this mirrors, and the same fix — an agent cannot tell a dropped argument from an applied one otherwise.
-    if (Object.keys(updates).length === 0 && ttlDaysFromArgs(a) === undefined) {
-      throw new Error('At least one of title, type, startsAt, endsAt, status, confidence, tags, entityIds, memoryIds, description, properties, recurrence, excludeFromVectorSearch, or ttlDays must be provided');
+    // X-4: `deleteFields`, validated with the same helper and the same refusals as the REST route and the
+    // three sibling tools. Chrono was the one record type without it, and since its `properties` merge, a key
+    // written once could not be removed by any call at all.
+    const dfResult = validateDeleteFields(a['deleteFields']);
+    if (!dfResult.ok) throw new Error(dfResult.error);
+    const dfPaths: string[] | undefined = Array.isArray(a['deleteFields']) && (a['deleteFields'] as string[]).length > 0
+      ? a['deleteFields'] as string[]
+      : undefined;
+
+    if (Object.keys(updates).length === 0 && ttlDaysFromArgs(a) === undefined && !dfPaths) {
+      throw new Error('At least one of title, type, startsAt, endsAt, status, confidence, tags, entityIds, memoryIds, description, properties, recurrence, excludeFromVectorSearch, deleteFields, or ttlDays must be provided');
     }
 
     // Validate the entry AS IT WILL BE, against the meta of the member space it actually lives in. The
@@ -320,7 +343,7 @@ export const update_chronoTool: ToolHandler = {
       ));
     }
 
-    const entry = await updateChrono(wt.target, id, updates as Parameters<typeof updateChrono>[2], ctx.actor, ttlDaysFromArgs(a));
+    const entry = await updateChrono(wt.target, id, updates as Parameters<typeof updateChrono>[2], dfPaths, ctx.actor, ttlDaysFromArgs(a));
     if (!entry) throw new Error(`Chrono entry '${id}' not found`);
     return { content: [{ type: 'text' as const, text: `Chrono entry '${entry.title}' updated (seq ${entry.seq}).` }] };
   },

--- a/testing/standalone/_mojibake.mjs
+++ b/testing/standalone/_mojibake.mjs
@@ -1,0 +1,117 @@
+/**
+ * Structural detection of cp1252-mis-decoded UTF-8, replacing a hand-written list of signatures.
+ *
+ * ## Why the list had to go
+ *
+ * The gate matched `â€`, `â”` and `â•` — the openings of mis-decoded U+20xx punctuation and U+25xx box
+ * drawing, each added after being found in the tree. It reported clean while `server/src/api/tokens.ts` still
+ * carried `Ã—`, the double-encoding of `×`, because that starts with `Ã` and is only TWO characters long.
+ *
+ * Two misses from the same cause: the pattern named the instances somebody had already tripped over, so every
+ * new shape of the same defect was invisible until it bit. A gate that enumerates its enemies is a gate that
+ * is always one behind.
+ *
+ * ## What replaces it
+ *
+ * The structural question. Take a run of adjacent non-ASCII characters and encode it back to cp1252 — the
+ * codepage the corruption came from. If those bytes are valid UTF-8 AND decode to something SHORTER than the
+ * run, the run is mis-decoded text: three characters that were one, or two that were one.
+ *
+ * Correct text does not do that. `×` is a single character with no preceding partner; `—` likewise. Their
+ * cp1252 bytes are `0xD7` and — for a real em-dash — not representable in a way that forms a valid multibyte
+ * sequence. The shortening requirement is what makes this safe: a conversion that keeps or grows the length
+ * is not a repair, so it is refused.
+ *
+ * ## The table is explicit on purpose
+ *
+ * A positional string literal for the 0x80–0x9F block put a repair off by four bytes and turned an em dash
+ * into U+2010 without failing anything. Byte→codepoint pairs cannot shift.
+ */
+
+/** cp1252 0x80–0x9F: the only bytes that do not map to their own Latin-1 codepoint. */
+const HIGH = {
+  0x80: 0x20ac, 0x82: 0x201a, 0x83: 0x0192, 0x84: 0x201e, 0x85: 0x2026, 0x86: 0x2020, 0x87: 0x2021,
+  0x88: 0x02c6, 0x89: 0x2030, 0x8a: 0x0160, 0x8b: 0x2039, 0x8c: 0x0152, 0x8e: 0x017d, 0x91: 0x2018,
+  0x92: 0x2019, 0x93: 0x201c, 0x94: 0x201d, 0x95: 0x2022, 0x96: 0x2013, 0x97: 0x2014, 0x98: 0x02dc,
+  0x99: 0x2122, 0x9a: 0x0161, 0x9b: 0x203a, 0x9c: 0x0153, 0x9e: 0x017e, 0x9f: 0x0178,
+};
+
+const CP_TO_BYTE = new Map(Object.entries(HIGH).map(([b, cp]) => [cp, Number(b)]));
+
+/**
+ * The five bytes cp1252 leaves undefined: 0x81, 0x8D, 0x8F, 0x90, 0x9D.
+ *
+ * .NET's decoder — the one behind PowerShell, which is where this corruption comes from — passes them
+ * through as the matching C1 control codepoint rather than failing. Without them the round-trip is
+ * incomplete in a way that hides a whole class: `═` (U+2550) is `E2 95 90`, and its third byte is 0x90, so
+ * mis-decoded box-drawing of that kind was undetectable and unrepairable until this map existed.
+ */
+const UNDEFINED_PASSTHROUGH = new Set([0x81, 0x8d, 0x8f, 0x90, 0x9d]);
+
+function toCp1252Byte(ch) {
+  const cp = ch.codePointAt(0);
+  if (cp <= 0x7f) return cp;
+  if (CP_TO_BYTE.has(cp)) return CP_TO_BYTE.get(cp);
+  if (UNDEFINED_PASSTHROUGH.has(cp)) return cp;
+  if (cp >= 0xa0 && cp <= 0xff) return cp;
+  return null;
+}
+
+const decoder = new TextDecoder('utf-8', { fatal: true });
+
+/**
+ * The text this run was before it was mis-decoded, or `null` when the run is not mis-decoded text.
+ *
+ * Exported so a repair and the gate cannot disagree about what counts — one implementation, both callers.
+ */
+export function repairRun(run) {
+  const bytes = [];
+  for (const ch of run) {
+    const b = toCp1252Byte(ch);
+    if (b === null) return null;
+    bytes.push(b);
+  }
+  let out;
+  try {
+    out = decoder.decode(new Uint8Array(bytes));
+  } catch {
+    return null; // not valid UTF-8, so this run was never double-encoded
+  }
+  // A repair must SHORTEN. Equal length means nothing was double-encoded and converting would corrupt
+  // correct text — this single condition is what makes the check safe to run over the whole tree.
+  if (out.length >= run.length) return null;
+  // A control character on the other side means the run was not what we thought.
+  if (/[\u0000-\u0008\u000E-\u001F\u007F]/.test(out)) return null;
+  return out;
+}
+
+/** Runs of two or more adjacent non-ASCII characters — where mis-decoded text lives. */
+const RUN = /[^\u0000-\u007F]{2,}/g;
+
+/**
+ * Corrupt `s` the way a cp1252 mis-decode really does — for TESTS, so a fixture is generated, never typed.
+ *
+ * Typing them is not merely tedious, it is unreliable: `═` mis-decodes to `â•` followed by U+0090, an
+ * INVISIBLE control character. A hand-written fixture silently omitted it, so an assertion tested a string
+ * that cannot occur and then failed against a detector that was right.
+ */
+export function mojibakeOf(s) {
+  const BYTE_TO_CP = new Map(Object.entries(HIGH).map(([b, cp]) => [Number(b), cp]));
+  let out = '';
+  for (const b of new TextEncoder().encode(s)) {
+    if (b <= 0x7f) out += String.fromCharCode(b);
+    else if (BYTE_TO_CP.has(b)) out += String.fromCharCode(BYTE_TO_CP.get(b));
+    else out += String.fromCharCode(b);
+  }
+  return out;
+}
+
+/** Every mis-decoded run in `src`, as `{ found, shouldBe }`. Empty when the text is clean. */
+export function findMojibake(src) {
+  const hits = [];
+  for (const m of src.matchAll(RUN)) {
+    const shouldBe = repairRun(m[0]);
+    if (shouldBe !== null) hits.push({ found: m[0], shouldBe });
+  }
+  return hits;
+}

--- a/testing/standalone/chrono-delete-fields.test.js
+++ b/testing/standalone/chrono-delete-fields.test.js
@@ -1,0 +1,122 @@
+/**
+ * X-4: a chrono entry's fields can be removed. Until now none of them could.
+ *
+ * ## The gap
+ *
+ * `properties` on a chrono entry MERGE — deliberately, because an agent patching one key must not destroy the
+ * others. An absent field means "leave alone", also deliberately. Chrono was then the one record type with no
+ * `deleteFields`, and those three facts together meant **there was no expression that removed anything**: a
+ * key written once to a chrono entry was permanent, on both doors.
+ *
+ * ## What is asserted here
+ *
+ * The write path is pure enough to exercise directly, so these are real calls with real verdicts rather than
+ * a source grep — the guard this repo shipped behind `if (false && ...)` is why that distinction is kept.
+ *
+ * The half that is easy to get wrong is not the deletion, it is the REFUSAL. A path the writer does not
+ * handle is accepted at the edge and then silently does nothing, which is precisely the failure this feature
+ * removes — so every optional field must be in the writer's unset list, and every required one must be
+ * refused by name.
+ *
+ * Run: node --test testing/standalone/chrono-delete-fields.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripComments } from './_strip-comments.mjs';
+
+let validateDeleteFields, applyDeleteFields;
+before(async () => {
+  ({ validateDeleteFields, applyDeleteFields } = await import('../../server/dist/brain/delete-fields.js'));
+});
+
+describe('the required chrono fields are refused, not ignored', () => {
+  for (const f of ['title', 'startsAt', 'status']) {
+    it(`${f} is refused by name`, () => {
+      // Refused rather than dropped from the writer's list: "nothing happened and nobody said so" is the
+      // failure mode this whole file exists to remove, and silently ignoring a path recreates it.
+      const r = validateDeleteFields([f]);
+      assert.equal(r.ok, false, `${f} must not be deletable — it is required`);
+      assert.match(r.error, new RegExp(f), 'and the refusal must name the field');
+    });
+  }
+
+  it('the server-owned fields are still refused', () => {
+    for (const f of ['id', '_id', 'spaceId', 'createdAt', 'updatedAt', 'type']) {
+      assert.equal(validateDeleteFields([f]).ok, false, `${f} must stay undeletable`);
+    }
+  });
+
+  it('but a PROPERTY of the same name is fine — the check is on the top segment only', () => {
+    // The assertion that stops the new entries from over-reaching. `properties.title` is an ordinary
+    // user-defined key and must stay removable on every record type.
+    for (const p of ['properties.title', 'properties.startsAt', 'properties.status', 'properties.type']) {
+      assert.equal(validateDeleteFields([p]).ok, true, `${p} is a user key and must be deletable`);
+    }
+  });
+});
+
+describe('deletion really removes, and only what was named', () => {
+  it('drops a single property key and keeps the rest', () => {
+    const doc = { properties: { a: 1, b: 2 }, tags: ['x'] };
+    applyDeleteFields(doc, ['properties.a']);
+    assert.deepEqual(doc.properties, { b: 2 }, 'only the named key goes');
+    assert.deepEqual(doc.tags, ['x'], 'and nothing else is touched');
+  });
+
+  it('drops a whole optional field', () => {
+    const doc = { description: 'x', tags: ['a'] };
+    applyDeleteFields(doc, ['description']);
+    assert.ok(!('description' in doc), 'the field is gone, not set to undefined');
+  });
+});
+
+describe('the writer handles EVERY optional field', () => {
+  // The silent-no-op guard. A field accepted at the edge but missing from the writer's unset list would be
+  // accepted and do nothing — which is the exact behaviour X-4 exists to remove, reintroduced one field at a
+  // time. Derived from the update signature rather than hand-listed, so a new optional field fails here
+  // until it is handled.
+  const SRC = stripComments(readFileSync('server/src/brain/chrono.ts', 'utf8'));
+
+  it('the unset loop covers each of them', () => {
+    const at = SRC.indexOf('if (deleteFieldsPaths && deleteFieldsPaths.length > 0)');
+    assert.ok(at > 0, 'the deleteFields block was not found — the scanner is wrong, not the code');
+    const block = SRC.slice(at, SRC.indexOf('\n  //', at + 10));
+    for (const f of ['description', 'tags', 'entityIds', 'memoryIds', 'properties', 'recurrence',
+      'endsAt', 'confidence', 'excludeFromVectorSearch']) {
+      assert.match(block, new RegExp(`'${f}'`), `${f} is optional and settable but cannot be deleted`);
+    }
+  });
+
+  it('and applies them AFTER the merge, or a deletion would be undone by it', () => {
+    const at = SRC.indexOf('mergePropertiesOrKeep(existing.properties');
+    const del = SRC.indexOf('applyDeleteFields(merged, deleteFieldsPaths)');
+    assert.ok(at > 0 && del > at, 'deleteFields must run after the property merge, not before');
+  });
+});
+
+describe('both doors take it', () => {
+  it('the MCP tool accepts and validates it', () => {
+    const src = stripComments(readFileSync('server/src/mcp/tools/chrono.ts', 'utf8'));
+    const at = src.indexOf("name: 'update_chrono'");
+    const end = src.indexOf('\nexport const ', at);
+    const tool = src.slice(at, end === -1 ? undefined : end);
+    assert.match(tool, /deleteFields: \{/, 'declared in the input schema');
+    assert.match(tool, /validateDeleteFields\(a\['deleteFields'\]\)/, 'and validated with the shared helper');
+  });
+
+  it('the REST route accepts and validates it, with the same helper', () => {
+    // MCP/REST parity is the owner rule this repo pays most for. Same parameter, same helper, same commit.
+    const src = stripComments(readFileSync('server/src/api/brain/chrono.ts', 'utf8'));
+    assert.match(src, /'deleteFields'/, 'listed as patchable, so it alone satisfies "at least one field"');
+    assert.match(src, /validateDeleteFields\(body\['deleteFields'\]\)/, 'and validated identically');
+  });
+
+  it('and the description no longer says it cannot be done', () => {
+    const src = readFileSync('server/src/mcp/tools/chrono.ts', 'utf8');
+    assert.doesNotMatch(src, /CANNOT be removed/,
+      'the limitation paragraph must go with the limitation');
+    assert.doesNotMatch(src, /NO `deleteFields` ON THIS TOOL/, 'likewise');
+  });
+});

--- a/testing/standalone/no-source-file-carries-mojibake.test.js
+++ b/testing/standalone/no-source-file-carries-mojibake.test.js
@@ -20,11 +20,19 @@
  * A rule against the idiom was not enough, and the second occurrence is what makes this a gate. Edit files
  * with a UTF-8-native tool; if a scripted rewrite is genuinely needed, do it in node.
  *
- * ## The `Â ` case is deliberately excluded
+ * ## Detection is structural, after three misses from naming signatures
  *
- * A stray `Â ` is the same corruption applied to a non-breaking space, but non-breaking spaces occur
- * legitimately in some content and a false positive here would be tuned away rather than fixed. `â€` cannot
- * occur in any language this repo is written in, so it is the signature worth gating on.
+ * This gate matched `â€`. Then `â”`/`â•` were added, after it passed a tree holding thousands of mis-decoded
+ * box-drawing dividers across ten files. Then it was found still reporting clean while `api/tokens.ts`
+ * carried `Ã—` — two characters, starting `Ã`, invisible to all three.
+ *
+ * Each addition was a correct fix to the instance and no fix at all to the class: a pattern that enumerates
+ * the corruptions somebody has already tripped over is permanently one shape behind. `_mojibake.mjs` asks the
+ * structural question instead — does this run, encoded back to cp1252, decode as valid UTF-8 into something
+ * SHORTER — which is true of mis-decoded text and of nothing else.
+ *
+ * The old exclusion of a lone `Â ` is no longer a special case: a single non-breaking space does not shorten
+ * under the round-trip, so it is not flagged, and there is nothing to tune.
  *
  * Run: node --test testing/standalone/no-source-file-carries-mojibake.test.js
  */
@@ -32,27 +40,21 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { execSync } from 'node:child_process';
+import { findMojibake, mojibakeOf } from './_mojibake.mjs';
 
 /**
- * The unambiguous signatures.
+ * Detection is STRUCTURAL now, not a list of signatures — see `_mojibake.mjs` for why and how.
  *
- * `â€` is the first two chars of any mis-decoded U+20xx punctuation — em-dashes and smart quotes, which is
- * what prose corruption looks like.
+ * The short version: this gate used to match `â€`, then `â”` and `â•` were added after a tree holding
+ * thousands of them passed, and it still reported clean while `api/tokens.ts` carried `Ã—` — the
+ * double-encoding of `×`, two characters long and starting with `Ã`. Three misses from one cause: a pattern
+ * that names the instances somebody already tripped over is always one shape behind.
  *
- * **`â”` and `â•` were added on 2026-08-16, after this gate passed a tree holding thousands of them.** Ten
- * files carried mis-decoded BOX-DRAWING characters (U+25xx) — every `── section ──` divider in the sync
- * routers and the graph component. They start `â”`/`â•`, never `â€`, so the original pattern could not see
- * them: it was written for the corruption that had bitten me, and box-drawing is the same corruption applied
- * to comment furniture rather than to prose.
- *
- * `api/tokens.ts` is the proof that this was a gap and not a new event. Its 49 `â€` sequences were repaired
- * when this gate was written; its 48 `â”` sequences sat there untouched, in a file everyone believed clean.
- *
- * Each of these is `â` followed by a character that cannot follow it in any language this repo is written
- * in, so none needs the tuning that kept `Â ` out — a lone `Â ` is a mis-decoded non-breaking space and
- * those occur legitimately.
+ * `findMojibake` asks instead whether a run of non-ASCII, encoded back to cp1252, is valid UTF-8 that decodes
+ * SHORTER. Only mis-decoded text does that, and the shortening requirement is what makes it safe to run over
+ * every file rather than tuned per false positive.
  */
-const MOJIBAKE = /â€|â”|â•|Ã¢â‚¬/;
+const MOJIBAKE = { test: (src) => findMojibake(src).length > 0 };
 
 const tracked = (globs) => execSync(`git ls-files ${globs}`, { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 })
   .split('\n').map(s => s.trim()).filter(Boolean);
@@ -103,12 +105,34 @@ describe('no source file carries mis-decoded UTF-8', () => {
     assert.ok(!MOJIBAKE.test('capability documentation — every route'), 'and must not match the correct text');
   });
 
-  it('and detects the BOX-DRAWING corruption it used to walk straight past', () => {
-    // The regression assertion. These exact strings were in the tree, in ten files, while this gate was
-    // green — a divider comment corrupted the same way an em-dash is, in a range the pattern did not cover.
-    assert.ok(MOJIBAKE.test('// â”€â”€ Memories â”€â”€'), 'U+2500 dividers: `─` mis-decoded');
-    assert.ok(MOJIBAKE.test('// â•â•â• Section â•â•â•'), 'U+2550 dividers: `═` mis-decoded');
-    assert.ok(!MOJIBAKE.test('// ── Memories ──'), 'and the correct dividers must stay clean');
-    assert.ok(!MOJIBAKE.test('// ═══ Section ═══'), 'both of them');
+  it('detects every shape that has actually bitten, generated rather than typed', () => {
+    // Fixtures are BUILT from the correct character, because typing them is unreliable: `═` mis-decodes to
+    // `â•` plus U+0090, an invisible control character, and a hand-written version silently omitted it —
+    // producing an assertion that tested a string which cannot occur, and failing a detector that was right.
+    //
+    // Each of these was a separate miss for the old signature list:
+    //   `—`  the original case             `─` `═`  box drawing, added after ten files passed the gate
+    //   `×`  TWO characters, starts `Ã`, and sat in merged source while this gate was green
+    for (const ch of ['—', '─', '═', '×', '…', '→', '’', '“']) {
+      assert.ok(MOJIBAKE.test(`a ${mojibakeOf(ch)} b`), `${ch} mis-decoded must be detected`);
+      assert.ok(!MOJIBAKE.test(`a ${ch} b`), `${ch} itself must stay clean`);
+    }
+  });
+
+  it('names what the text SHOULD be, so a failure is actionable', () => {
+    // A gate that only says "there is mojibake here" leaves the repair to guesswork — and guessing put a
+    // U+2010 where a U+2014 belonged. The detector already computes the answer; reporting it costs nothing.
+    for (const ch of ['×', '—', '═']) {
+      const [hit] = findMojibake(`a ${mojibakeOf(ch)} b`);
+      assert.equal(hit.shouldBe, ch, 'the repair is derived, not guessed');
+    }
+  });
+
+  it('does not fire on ordinary accented text', () => {
+    // The false-positive floor. These are real words, and a detector that flags them would be tuned away
+    // rather than fixed — which is how the signature list started.
+    for (const s of ['naïve café', 'Müller GmbH', 'attaché', 'ÅÄÖ', 'σ = 0.5', '→ next', '±3']) {
+      assert.ok(!MOJIBAKE.test(s), `${s} is correct text and must not be flagged`);
+    }
   });
 });

--- a/testing/standalone/record-flags-reachable-on-every-surface.test.js
+++ b/testing/standalone/record-flags-reachable-on-every-surface.test.js
@@ -65,7 +65,14 @@ const ROUTES = {
   },
   chrono: {
     file: 'server/src/api/brain/chrono.ts',
-    forward: () => /excludeFromVectorSearch,\s*\}, webhookToken\(req\)/,
+    // Updated 2026-08-16 when chrono gained `deleteFields` (X-4) and the writer call became
+    // `}, dfPaths, webhookToken(req), …`. The guard below caught the drift and refused to keep measuring,
+    // which is exactly its job: a regex that silently stopped matching would have left this assertion green
+    // for a flag nobody was forwarding.
+    //
+    // `dfPaths` is written out rather than skipped with a wildcard. Pinning the shape is the whole point —
+    // a change to it should be reviewed, and `[^)]*` would trade that away to save one edit.
+    forward: () => /excludeFromVectorSearch,\s*\}, dfPaths, webhookToken\(req\)/,
   },
 };
 

--- a/testing/standalone/update-tools-state-merge-or-replace.test.js
+++ b/testing/standalone/update-tools-state-merge-or-replace.test.js
@@ -105,26 +105,32 @@ describe('every update tool states which it does', () => {
     }
   });
 
-  it('update_chrono admits it cannot unset anything at all', () => {
-    // The finding this file exists for. Merging properties plus no `deleteFields` means a key written once is
-    // permanent, and nothing anywhere said so.
-    assert.match(TOOLS.update_chrono, /NO `deleteFields` ON THIS TOOL/,
-      'the limitation must be stated where a caller looks for the parameter');
-    assert.match(TOOLS.update_chrono, /CANNOT be removed/, 'and its consequence spelled out');
+  it('update_chrono says removal is deleteFields, never an omission', () => {
+    // This assertion originally required the OPPOSITE — that the description admit chrono could not unset
+    // anything. That was true, and filing it is what became X-4; the parameter has now shipped, so the
+    // assertion is INVERTED rather than deleted. The rule it protects never changed: whatever the tool does
+    // about removal, the description has to say it, because an absent field means "leave alone" and a caller
+    // cannot infer the rest.
+    assert.match(TOOLS.update_chrono, /REMOVING SOMETHING IS `deleteFields`, NEVER AN OMISSION/,
+      'the removal path must be named where a caller looks for it');
+    assert.doesNotMatch(TOOLS.update_chrono, /CANNOT be removed|NO `deleteFields` ON THIS TOOL/,
+      'the limitation paragraph must go with the limitation');
   });
 
-  it('and that claim is still true — chrono really has no deleteFields', () => {
-    // Pinned against the schema, so the day it gains one this description fails instead of misinforming.
-    // From `inputSchema:` onward, NOT the whole tool — the description above deliberately contains the word
-    // `deleteFields` in the paragraph explaining its absence, and reading the tool whole made this assertion
-    // fire on the very sentence it is there to protect.
+  it('and chrono really has deleteFields now, on BOTH doors', () => {
+    // Read from `inputSchema:` onward, not the whole tool: the description deliberately contains the word
+    // `deleteFields` in prose, so a whole-tool scan would pass on the sentence rather than the parameter.
     const chronoTool = stripComments(src('server/src/mcp/tools/chrono.ts'));
     const at = chronoTool.indexOf("name: 'update_chrono'");
     const schemaAt = chronoTool.indexOf('inputSchema:', at);
     assert.ok(schemaAt > at, 'update_chrono has no inputSchema — the scanner is wrong, not the code');
     const end = chronoTool.indexOf('\nexport const ', at);
-    assert.doesNotMatch(chronoTool.slice(schemaAt, end === -1 ? undefined : end), /deleteFields/,
-      'update_chrono gained deleteFields — delete the paragraph saying it has none');
+    assert.match(chronoTool.slice(schemaAt, end === -1 ? undefined : end), /deleteFields: \{/,
+      'declared in the input schema');
+    // The parity half: same parameter on the REST route, same commit. A capability on one door only is the
+    // single most expensive defect this codebase produces.
+    assert.match(stripComments(src('server/src/api/brain/chrono.ts')), /validateDeleteFields\(/,
+      'and validated on the REST route with the same helper');
   });
 });
 


### PR DESCRIPTION
Closes **X-4**. `deleteFields` — the dot-notation removal entities, edges and memories have always had — now
works on chrono entries too, on the REST route and the `update_chrono` tool **in the same commit**.

## It was not a missing parameter, it was a missing capability

Chrono's `properties` **merge**, and an omitted field means *leave alone*. Both deliberate. With no
`deleteFields`, those two facts together meant **there was no request of any shape that could unset
anything** — a key written once to a chrono entry was permanent, on both doors.

Paths are applied **after** the merge, the same order as `updateMemory`, so one call can add a property and
drop another.

## Refused by name, not silently ignored

The required fields — `title`, `startsAt`, `status` — join `SYSTEM_FIELDS` rather than simply being left out
of the writer's unset list. Those two options behave differently where it counts:

| | Result |
| --- | --- |
| omitted from the writer's list | accepted, then does nothing, silently |
| listed in `SYSTEM_FIELDS` | **refused**, with a message naming the field |

*"Nothing happened and nobody said so"* is the failure this feature exists to remove, so building it back in
one field at a time would have been an odd way to ship it.

The check is on the **top-level segment only**, so `properties.title` stays deletable on every record type,
and no entity, edge or memory has a bare `title` to lose.

For the same reason the unset loop covers **every** optional field — `description`, `tags`, `entityIds`,
`memoryIds`, `properties`, `recurrence`, `endsAt`, `confidence`, `excludeFromVectorSearch` — rather than a
convenient subset. Between the two lists, every path a caller can send is either performed or reported.

## Two existing detectors caught the change

- `record-flags-reachable-on-every-surface.test.js` pins the *shape* of the chrono writer call, which gained
  `dfPaths`. Its own guard refused to keep measuring rather than passing on a regex that had silently stopped
  matching — which is precisely what it is for. Updated deliberately, with `dfPaths` written out rather than
  skipped by a wildcard: pinning the shape is the point, and `[^)]*` would trade that away to save one edit.
- `update-tools-state-merge-or-replace.test.js` asserted the **opposite** of this feature — that chrono could
  not unset anything, which is how X-4 got filed. That assertion is **inverted, not deleted**. The rule it
  protects never changed: whatever the tool does about removal, the description has to say it.

## Second commit: the mojibake gate detects structurally

Found while repairing a file this branch touched. The gate matched `â€`; then `â”`/`â•` were added after a
tree with thousands of mis-decoded box-drawing dividers passed it; and it was **still** green while merged
`api/tokens.ts` carried `Ã—` — two characters, starting `Ã`, invisible to all three patterns.

Each addition fixed the instance and not the class. It now asks the structural question — does a run of
non-ASCII, encoded back to cp1252, decode as valid UTF-8 into something **shorter** — which is true of
mis-decoded text and of nothing else, so no new shape can hide from it. Failures also name what the text
should have been, because guessing the repair once produced a U+2010 where a U+2014 belonged.

Test fixtures are now **generated** rather than typed: `═` mis-decodes to `â•` plus an invisible U+0090, and
the hand-written version omitted it — testing a string that cannot occur, and failing a detector that was
right.

One residual `×` repaired. A false-positive floor covers ordinary accented text (`naïve café`, `Müller`,
`σ = 0.5`, `±3`).

## Verification

`chrono-delete-fields.test.js` — 12 tests, exercising the real functions.

**Mutation-tested:** making the required fields silently deletable fails; dropping two optional fields from
the unset loop fails.

## Five places

REST route · MCP tool · `integration-guide/04-brain-api.md` and `04c-chrono-api.md` · `userguide/02-brain.md`.
No new route, so no `TOOL_RIGHTS` row.
