### PR TITLE
fix(scope): two more checks read the dead allowlist and answered 'unrestricted'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -345,6 +345,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Two more scope checks were reading the pre-3.0 allowlist, and so answered "unrestricted" for every token
+  minted since the rights matrix.** Same cause as the sync-route entry below: `spaces` is `undefined` on a
+  modern token, so any check shaped `if (token.spaces)` or `!tokenSpaces` silently means *no restriction*.
+
+  **A cross-space `recall` searched the whole instance.** With `space` omitted, the set of spaces to search
+  was filtered by the allowlist, which matched nothing to filter — so a token scoped to one space ranked
+  records from every space on the instance. It now builds that set from the matrix, at `knowledge: read`, so
+  a token holding files-only in a space does not have that space's records ranked either.
+
+  **Signing-key rotation accepted a space-restricted administrator.** The route means to require an
+  unrestricted admin token and tested the allowlist for truthiness; a matrix-scoped administrator passed. The
+  instance signing key is the credential every peer pins, and continuity proofs are signed with it. It now
+  asks the matrix whether the token is genuinely unrestricted.
+
+  Both use helpers that already existed and already made the distinction the hand-written checks lost: an
+  **absent** allowlist is every space, an **empty** one is none, and reading empty as absent turns the
+  narrowest token into the widest.
+
 - **The sync read routes enforced space scope only for tokens that still carried the pre-3.0 allowlist —
   which no token minted today does.** The check that confined a caller to its own spaces was written
   `if (tokenSpaces && ...)`, and `tokenSpaces` was the deprecated `spaces` array. The rights editor writes the

--- a/server/src/api/brain/search.ts
+++ b/server/src/api/brain/search.ts
@@ -5,6 +5,8 @@
  */
 import { Router } from 'express';
 import { requireSpaceAuth, denyReadOnly } from '../../auth/middleware.js';
+import { spacesWhereTokenMay } from '../../auth/reachable-spaces.js';
+import type { TokenRights } from '../../config/rights-shape.js';
 import { summariseActivity } from '../../metrics/space-activity-store.js';
 import { globalRateLimit } from '../../rate-limit/middleware.js';
 import { parseSortParam, toMongoSort, SORTABLE_FIELDS } from '../../brain/list-sort.js';
@@ -628,10 +630,22 @@ searchRouter.post('/spaces/:spaceId/find-similar', globalRateLimit, requireSpace
   // Determine cross-space search scope
   let crossSpaceIds: string[] | undefined;
   if (crossSpace) {
-    const tokenSpaces = req.authToken?.spaces;
-    crossSpaceIds = cfg.spaces
-      .filter(s => !tokenSpaces || tokenSpaces.includes(s.id))
-      .map(s => s.id);
+    // The MATRIX decides the cross-space set, with the legacy allowlist only as a fallback.
+    //
+    // This read the allowlist alone, and `spaces` is `undefined` on every token minted since the matrix —
+    // the rights editor writes `rights.perSpace` and nothing writes that array. So `!tokenSpaces` was true
+    // for a modern token and the filter kept EVERY space: a cross-space recall from a token scoped to one
+    // space searched the whole instance. Same shape as the sync-scope hole, one route over, and the same
+    // fix — `spacesWhereTokenMay` makes the absent/empty distinction explicitly instead of by truthiness.
+    //
+    // `knowledge: read` because that is what a recall is. A token holding files-only in a space has no
+    // business having its records ranked here.
+    crossSpaceIds = spacesWhereTokenMay(
+      (req.authToken as { rights?: TokenRights } | undefined)?.rights,
+      req.authToken?.spaces,
+      'knowledge',
+      'read',
+    );
   }
 
   try {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -14,6 +14,7 @@ import { conflictsRouter } from './api/conflicts.js';
 import { duplicatesRouter } from './api/duplicates.js';
 import { contradictionsRouter } from './api/contradictions.js';
 import { syncRouter } from './api/sync/index.js';
+import { editorScopeFor } from './auth/editor-scope.js';
 import { networksRouter } from './api/networks/index.js';
 import { notifyRouter } from './api/notify.js';
 import { inviteRouter } from './api/invite.js';
@@ -563,7 +564,13 @@ export function createApp() {
   // gossip; the new public key propagates on the next sync cycle. Requires an
   // unrestricted admin token (+ TOTP when MFA is enabled).
   app.post('/api/admin/rotate-signing-key', globalRateLimit, requireAdminMfa, async (req, res) => {
-    if (req.authToken?.spaces) {
+    // "Unrestricted" from the MATRIX, with the legacy allowlist only as a fallback — `editorScopeFor`
+    // returns `undefined` for a token that reaches everything and a list for one that does not.
+    //
+    // This tested `req.authToken?.spaces` for truthiness, and that array is `undefined` on every token
+    // minted since the matrix. So a space-restricted administrator whose scope lives in `rights` read as
+    // unrestricted here and could rotate the INSTANCE signing key — the credential every peer pins.
+    if (editorScopeFor(req.authToken) !== undefined) {
       res.status(403).json({ error: 'Signing-key rotation requires an unrestricted admin token' });
       return;
     }

--- a/testing/standalone/cross-space-and-unrestricted-read-the-matrix.test.js
+++ b/testing/standalone/cross-space-and-unrestricted-read-the-matrix.test.js
@@ -1,0 +1,113 @@
+/**
+ * Two more scoping decisions that read the DEAD allowlist, and so answered "unrestricted" for every modern
+ * token.
+ *
+ * ## The class, third and fourth instances
+ *
+ * `spaces` is `undefined` on every token minted since the rights matrix — the editor writes
+ * `rights.perSpace`, the mint body has `spaces` optional, `createToken` stores it verbatim, and the mint
+ * route's own refusal map tells a caller to use `rights.perSpace` instead. So any check shaped
+ * `!tokenSpaces` or `if (token.spaces)` silently means "no restriction" on a token that is in fact scoped.
+ *
+ * The sync routes had it (19 copies of one line). These two are the same defect on different surfaces:
+ *
+ * | Site | Read as | Actually |
+ * | --- | --- | --- |
+ * | cross-space `recall` | search every space | search only what the token reaches |
+ * | signing-key rotation | unrestricted admin | a space-restricted admin was let through |
+ *
+ * The second is the sharper one: the instance signing key is the credential every peer pins, and continuity
+ * proofs are signed with it.
+ *
+ * ## Why these use two different helpers
+ *
+ * They ask different questions. Cross-space recall wants the SET of spaces to search, at `knowledge: read` —
+ * `spacesWhereTokenMay`. Rotation wants a yes/no about being unrestricted — `editorScopeFor`, which returns
+ * `undefined` for a token that reaches everything and a list for one that does not. Using the set-builder for
+ * the boolean would have meant comparing lengths against the config, making the answer depend on how many
+ * spaces happen to exist.
+ *
+ * Run: node --test testing/standalone/cross-space-and-unrestricted-read-the-matrix.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripComments } from './_strip-comments.mjs';
+
+let editorScopeFor;
+before(async () => {
+  ({ editorScopeFor } = await import('../../server/dist/auth/editor-scope.js'));
+});
+
+const ALL = (r) => ({ knowledge: r, files: r, schema: r, dataQuality: r });
+const rights = (over = {}) => ({ instanceAdmin: false, createSpaces: false, floor: null, perSpace: {}, ...over });
+
+describe('"unrestricted" is answered from the matrix', () => {
+  it('a matrix-scoped token is NOT unrestricted', () => {
+    // The bug: this token has no `spaces` array, so `if (token.spaces)` was false and it read as
+    // unrestricted — with the instance signing key behind that check.
+    const scope = editorScopeFor({ rights: rights({ perSpace: { qa: ALL('admin') } }) });
+    assert.notEqual(scope, undefined, 'a token scoped to one space must not read as unrestricted');
+    assert.deepEqual([...scope], ['qa']);
+  });
+
+  it('a floor that grants something IS unrestricted', () => {
+    // The floor applies to every space including ones created later, which is what unrestricted means here.
+    assert.equal(editorScopeFor({ rights: rights({ floor: ALL('read') }) }), undefined);
+  });
+
+  it('a legacy token with no allowlist is unrestricted, exactly as before', () => {
+    assert.equal(editorScopeFor({}), undefined);
+    assert.equal(editorScopeFor(undefined), undefined);
+  });
+
+  it('a legacy token WITH an allowlist is not', () => {
+    assert.deepEqual(editorScopeFor({ spaces: ['qa'] }), ['qa']);
+  });
+
+  it('and the rotation route really asks it that way', () => {
+    const src = stripComments(readFileSync('server/src/app.ts', 'utf8'));
+    assert.match(src, /editorScopeFor\(req\.authToken\) !== undefined/,
+      'signing-key rotation must not test the dead allowlist for truthiness');
+    assert.doesNotMatch(src, /if \(req\.authToken\?\.spaces\)/,
+      'the old truthiness check must be gone, not merely joined');
+  });
+});
+
+describe('cross-space recall searches only what the token reaches', () => {
+  it('the route builds its set from the matrix helper', () => {
+    const src = stripComments(readFileSync('server/src/api/brain/search.ts', 'utf8'));
+    assert.match(src, /spacesWhereTokenMay\(/, 'not a hand-rolled filter over cfg.spaces');
+    assert.doesNotMatch(src, /!tokenSpaces \|\| tokenSpaces\.includes/,
+      'the truthiness filter must be gone — it kept every space for a modern token');
+  });
+
+  it('and asks for knowledge:read, which is what a recall is', () => {
+    const src = stripComments(readFileSync('server/src/api/brain/search.ts', 'utf8'));
+    assert.match(src, /'knowledge',\s*'read',/,
+      'a token holding files-only in a space should not have its records ranked here');
+  });
+
+  it('the helper it uses still makes the absent/empty distinction', () => {
+    // The trap this whole class rests on: an ABSENT allowlist is every space, an EMPTY one is none, and
+    // reading empty as absent turns the narrowest token into the widest.
+    const src = stripComments(readFileSync('server/src/auth/reachable-spaces.ts', 'utf8'));
+    assert.match(src, /legacySpaces === undefined/, 'absent is checked explicitly');
+    assert.doesNotMatch(src, /legacySpaces\.length === 0/, 'and never by length-as-truthiness');
+  });
+});
+
+describe('the legacy reads that remain are deliberate', () => {
+  it('they are matrix-first with the allowlist only as a fallback', () => {
+    // Not every `record.spaces` is a defect. The middleware and `editorScopeFor` read it only when there is
+    // no matrix, which keeps a pre-matrix token working; those go with the field itself in D-8d. What must
+    // not exist is a read that consults the allowlist FIRST, or instead.
+    for (const f of ['server/src/auth/middleware.ts', 'server/src/auth/editor-scope.ts']) {
+      const src = stripComments(readFileSync(f, 'utf8'));
+      assert.match(src, /rights/, `${f} must consult the matrix`);
+      assert.doesNotMatch(src, /const \w+ = record\.spaces;\s*if \(/,
+        `${f} must not branch on the allowlist before the matrix`);
+    }
+  });
+});


### PR DESCRIPTION
Same cause as the sync-route fix two PRs ago: **`spaces` is `undefined` on every token minted since the
rights matrix**, so any check shaped `if (token.spaces)` or `!tokenSpaces` silently means *no restriction* on
a token that is in fact scoped.

| Site | Read as | Actually |
| --- | --- | --- |
| cross-space `recall` | search every space | search only what the token reaches |
| signing-key rotation | unrestricted admin | a space-restricted admin was let through |

## A cross-space recall searched the whole instance

With `space` omitted, `api/brain/search.ts` built the set of spaces to search by filtering `cfg.spaces`
through the allowlist. There was nothing to filter with — so a token scoped to one space had records from
**every** space on the instance ranked and returned.

It builds that set from `spacesWhereTokenMay` now, at `knowledge: read`. That also expresses something the
old filter could not: a token holding *files-only* in a space does not get that space's records ranked
either.

## Signing-key rotation accepted a space-restricted administrator

The route means to require an unrestricted admin token, and tested `req.authToken?.spaces` for truthiness. A
matrix-scoped administrator passed.

**The instance signing key is the credential every peer pins**, and continuity proofs are signed with it. It
now asks `editorScopeFor`, which returns `undefined` for a token that reaches everything and a list for one
that does not.

## Two helpers, because they are two questions

`spacesWhereTokenMay` builds a **set** for an area and a rung. `editorScopeFor` answers a **yes/no** about
being unrestricted. Using the set-builder for the boolean would have meant comparing lengths against the
config — making the answer depend on how many spaces happen to exist rather than on what the token says.

Both already existed, and both already made the distinction the hand-written checks had lost: an **absent**
allowlist is every space, an **empty** one is none, and reading empty as absent turns the narrowest token
into the widest.

## Not every legacy read is a defect

The remaining ones — `auth/middleware.ts` and `editor-scope.ts` — consult the matrix **first** and fall back
to the allowlist only when there is no matrix, which is what keeps a pre-matrix token working. Those go with
the field itself.

The gate asserts that *shape* rather than the absence of the field name, so it cannot be satisfied by
deleting a fallback that is load-bearing.

## Verification

**Mutation-tested:** reverting rotation to the truthiness check fails; making `editorScopeFor` stop scoping a
legacy token fails.

Part of **D-8d**.
