### PR TITLE
feat(tokens): readOnly is no longer stored on a token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   every space it reaches, exactly as before; the result is now expressed only in the matrix. **Tokens created
   earlier keep their scope** — the load-time migration still reads the stored flag to derive their rights.
 
-  **If you read `readOnly` off a token record, read `rights` instead.** A token is read-only precisely when
-  its matrix grants no write rung anywhere — which is also right for a token that was never given the flag
-  but holds only `read`, a case the boolean could not express. The token listing now derives it that way.
+  **The token API still returns `readOnly`, so no client breaks.** It is derived from the matrix now rather
+  than read from the record: a token is read-only precisely when its rights grant no write rung anywhere.
+  That is also right for a token nobody ever set the boolean on but which holds only `read` — a case the
+  stored flag could not express and answered `false` for. Dropping the field from a published response is a
+  separate, breaking change and is not part of this one.
 
   `admin` and `spaces` follow separately: deleting a field is all-or-nothing, so they are measured and
   scheduled on their own rather than half-done together.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- **`readOnly` is no longer stored on a token — the first of the three pre-3.0 fields to go.** Nothing had
+  decided on it since 3.0: every write check reads the rights matrix, and the copy threaded from the token
+  record through the MCP server into every tool's call context turned out to be read by **no tool at all** —
+  four layers of plumbing carrying a value nobody consulted. Keeping it meant two spellings of one fact, with
+  the older one free to drift from the newer.
+
+  **Creating a read-only token is unchanged.** Send `readOnly: true` and you get `read` in every area of
+  every space it reaches, exactly as before; the result is now expressed only in the matrix. **Tokens created
+  earlier keep their scope** — the load-time migration still reads the stored flag to derive their rights.
+
+  **If you read `readOnly` off a token record, read `rights` instead.** A token is read-only precisely when
+  its matrix grants no write rung anywhere — which is also right for a token that was never given the flag
+  but holds only `read`, a case the boolean could not express. The token listing now derives it that way.
+
+  `admin` and `spaces` follow separately: deleting a field is all-or-nothing, so they are measured and
+  scheduled on their own rather than half-done together.
+
 - **The legacy `/setup` HTML form, so the app's own first-run page is finally the one you see.** The
   server-rendered form had been mounted at `/setup` since before the single-page app existed, and a server
   route wins over an app route — so the app's setup page had never actually served a first run, on any

--- a/docs/integration-guide/07-tokens-api.md
+++ b/docs/integration-guide/07-tokens-api.md
@@ -146,22 +146,24 @@ POST /api/tokens
 |---|---|
 | `name` | Required. Human-readable label. |
 | `admin` | `true` for full admin scope. Mutually exclusive with `schemaLibrary`. |
-| `readOnly` | Block all writes. Ignored when `schemaLibrary` is `true` (always read-only). **Accepted as an input, no longer stored** — see below. |
+| `readOnly` | Block all writes. Ignored when `schemaLibrary` is `true` (always read-only). Still accepted and still returned; **no longer stored** — see below. |
 | `spaces` | Array of space IDs to scope this token. Omit for all-spaces access. Must be empty or omitted when `schemaLibrary` is `true`. |
 | `expiresAt` | ISO 8601 expiry timestamp. Omit for non-expiring. |
 | `peerInstanceId` | Bind this token to a network peer (UUID). Required for tokens a peer will present on the `/api/sync/*` **data-write** endpoints in manually-configured networks — the invite handshake sets it automatically. Peer identity is server-issued and cannot be self-declared by the caller. |
 | `schemaLibrary` | `true` to issue a **library access token**. See below. |
 
-> **`readOnly` is no longer a field on the stored token — 3.1.** Sending it still does exactly what it always
-> did: the token is created with `read` in every area of every space it can reach. What changed is that the
-> result is expressed **only** in the rights matrix, and the boolean is not written to the record or returned
-> on it. Nothing decided on it any more — every write check has read the matrix since 3.0 — so keeping the
-> flag alongside meant two spellings of one fact, with the older one able to drift.
+> **`readOnly` is no longer STORED on a token — 3.1. Nothing you send or read changes.** Sending it still
+> does exactly what it always did: the token is created with `read` in every area of every space it reaches.
+> The token responses still carry it. What changed is where the answer comes from — the rights matrix rather
+> than a separate boolean on the record.
 >
-> **If you read `readOnly` off a token record, read `rights` instead.** A token is read-only exactly when its
-> matrix grants no write rung anywhere; that is also correct for a token that was never given the flag but
-> holds only `read`, which the boolean could not express. Tokens created before 3.1 keep their scope — the
-> load-time migration still reads the stored flag to derive their matrix.
+> Nothing had decided on that boolean since 3.0, because every write check reads the matrix. Keeping it
+> stored alongside meant two spellings of one fact, with the older one free to drift.
+>
+> **The returned value is now derived**: a token is read-only exactly when its matrix grants no write rung
+> anywhere. That is also correct for a token nobody ever set the flag on but which holds only `read` — a case
+> the stored boolean could not express and answered `false` for. Tokens created before 3.1 keep their scope:
+> the load-time migration still reads the stored flag to derive their matrix.
 >
 > `admin` and `spaces` are unchanged for now and follow separately.
 

--- a/docs/integration-guide/07-tokens-api.md
+++ b/docs/integration-guide/07-tokens-api.md
@@ -146,11 +146,24 @@ POST /api/tokens
 |---|---|
 | `name` | Required. Human-readable label. |
 | `admin` | `true` for full admin scope. Mutually exclusive with `schemaLibrary`. |
-| `readOnly` | Block all writes. Ignored when `schemaLibrary` is `true` (always read-only). |
+| `readOnly` | Block all writes. Ignored when `schemaLibrary` is `true` (always read-only). **Accepted as an input, no longer stored** — see below. |
 | `spaces` | Array of space IDs to scope this token. Omit for all-spaces access. Must be empty or omitted when `schemaLibrary` is `true`. |
 | `expiresAt` | ISO 8601 expiry timestamp. Omit for non-expiring. |
 | `peerInstanceId` | Bind this token to a network peer (UUID). Required for tokens a peer will present on the `/api/sync/*` **data-write** endpoints in manually-configured networks — the invite handshake sets it automatically. Peer identity is server-issued and cannot be self-declared by the caller. |
 | `schemaLibrary` | `true` to issue a **library access token**. See below. |
+
+> **`readOnly` is no longer a field on the stored token — 3.1.** Sending it still does exactly what it always
+> did: the token is created with `read` in every area of every space it can reach. What changed is that the
+> result is expressed **only** in the rights matrix, and the boolean is not written to the record or returned
+> on it. Nothing decided on it any more — every write check has read the matrix since 3.0 — so keeping the
+> flag alongside meant two spellings of one fact, with the older one able to drift.
+>
+> **If you read `readOnly` off a token record, read `rights` instead.** A token is read-only exactly when its
+> matrix grants no write rung anywhere; that is also correct for a token that was never given the flag but
+> holds only `read`, which the boolean could not express. Tokens created before 3.1 keep their scope — the
+> load-time migration still reads the stored flag to derive their matrix.
+>
+> `admin` and `spaces` are unchanged for now and follow separately.
 
 **Response** `201`:
 

--- a/server/src/api/tokens.ts
+++ b/server/src/api/tokens.ts
@@ -11,8 +11,33 @@ import { refusalsOutsideEditorScope, editorScopeFor } from '../auth/editor-scope
 import { capRights, describeExcess } from '../auth/mint-cap.js';
 import { refuseSelfFloorRaise } from '../auth/floor-guard.js';
 import { migrateToken } from '../auth/rights-migration.js';
+import { canWriteAnywhere } from '../auth/write-anywhere.js';
+import type { TokenRights } from '../config/rights-shape.js';
 
 export const tokensRouter = Router();
+
+/**
+ * `readOnly`, DERIVED for the response — the field is no longer stored (D-8d).
+ *
+ * ## Why the response keeps a field the record has lost
+ *
+ * D-8d's goal is that nothing STORES the legacy flag and nothing DECIDES on it. Removing it from the API
+ * response is a separate, breaking change to a published contract, and bundling the two would have broken
+ * every client reading `token.readOnly` in a release whose point was internal cleanup. The integration suite
+ * said so directly: a schema-library token is asserted to come back `readOnly: true`.
+ *
+ * So the split is deliberate — gone from the record, still answered on the wire — and the same shape the
+ * `space.description` alias used while that field was on its way out.
+ *
+ * ## Derived is also MORE correct than the flag was
+ *
+ * A token is read-only exactly when its matrix grants no write rung anywhere. That is true for a token
+ * nobody ever set the boolean on but which holds only `read` — a case the stored flag could not express, and
+ * answered `false` for.
+ */
+function withReadOnlyAlias<T extends { rights?: unknown }>(t: T): T & { readOnly: boolean } {
+  return { ...t, readOnly: !canWriteAnywhere(t.rights as TokenRights | undefined) };
+}
 
 // GET /api/auth/me — returns the current token's metadata (used by the Angular SPA to verify a PAT)
 tokensRouter.get('/me', globalRateLimit, requireAuth, (req, res) => {
@@ -155,7 +180,7 @@ tokensRouter.get('/', requireAdminOrSpaceAdmin, (req, res) => {
   // Reading `spaces` directly here meant a token minted with a matrix and no allowlist — every token minted
   // since 2.6 — answered `undefined` and was treated as an unrestricted instance administrator.
   const callerSpaces = editorScopeFor(req.authToken);
-  const all = listTokens();
+  const all = listTokens().map(withReadOnlyAlias);
   const visible = callerSpaces
     ? all.filter(t => t.schemaLibrary || (t.spaces?.every(s => callerSpaces.includes(s)) ?? false))
     : all;
@@ -237,7 +262,7 @@ tokensRouter.post('/', authRateLimit, requireAdminOrSpaceAdminMfa, async (req, r
   const { record, plaintext } = await createToken({ name, expiresAt: expiresAt ?? null, spaces: effectiveSpaces, admin, readOnly: effectiveReadOnly, peerInstanceId, schemaLibrary, mfa, rights: rights as never });
   // Return plaintext only on creation — never retrievable again
   const { hash: _h, ...safeRecord } = record;
-  res.status(201).json({ token: safeRecord, plaintext });
+  res.status(201).json({ token: withReadOnlyAlias(safeRecord), plaintext });
 });
 
 /**
@@ -455,7 +480,7 @@ tokensRouter.patch('/:id', requireAdminOrSpaceAdminMfa, (req, res) => {
   }
 
   const updated = listTokens().find(t => t.id === id);
-  res.json({ token: updated });
+  res.json({ token: updated ? withReadOnlyAlias(updated) : updated });
 });
 
 // POST /api/tokens/:id/regenerate — rotate a token's secret — admin + MFA

--- a/server/src/auth/tokens.ts
+++ b/server/src/auth/tokens.ts
@@ -171,6 +171,13 @@ export async function createToken(opts: {
   expiresAt?: string | null;
   spaces?: string[];
   admin?: boolean;
+  /**
+   * NOT stored on the record any more (D-8d) — kept as an INPUT that shapes the initial rights matrix.
+   *
+   * A caller minting without an explicit `rights` still says "read-only" and gets `read` in every area,
+   * because `migrateToken` is what turns that into a matrix. Dropping the parameter as well would have made
+   * that phrasing unsayable and forced every caller to hand-build a matrix to express the commonest grant.
+   */
   readOnly?: boolean;
   peerInstanceId?: string;
   schemaLibrary?: boolean;
@@ -197,7 +204,6 @@ export async function createToken(opts: {
     expiresAt: opts.expiresAt ?? null,
     spaces: opts.spaces,
     admin: opts.admin ?? false,
-    readOnly: opts.readOnly ?? false,
     peerInstanceId: opts.peerInstanceId,
     ...(opts.schemaLibrary ? { schemaLibrary: true } : {}),
     // Stored only when it says something. `inherit` IS the absent state, so writing it would put a field on
@@ -263,7 +269,6 @@ export async function createOAuthToken(opts: {
     expiresAt: opts.ttlMs === null ? null : new Date(Date.now() + opts.ttlMs).toISOString(),
     spaces: opts.spaces,
     admin: opts.admin ?? false,
-    readOnly: opts.readOnly ?? false,
     oauthClientId: opts.clientId,
     // ALWAYS stored, for the reason spelled out on `createToken` above — and this is the path that fix
     // MISSED. `createToken` was given an unconditional matrix because a token minted after boot had none

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -9,7 +9,15 @@ export interface TokenRecord {
   expiresAt: string | null;
   spaces?: string[];    // allowlist of space IDs; omit = all spaces
   admin: boolean;       // true = may access admin-gated routes
-  readOnly?: boolean;   // true = read-only access; all mutations blocked
+  // `readOnly` was REMOVED in 3.1 (D-8d). It was the second of the pre-3.0 triple and the first to go,
+  // because nothing decided on it any more: `toolIsVisible` asks `canWriteAnywhere(rights)`, every REST
+  // guard asks `effectiveRung`, and the `ToolContext.readOnly` that was threaded through four layers to
+  // reach the tools was read by none of them.
+  //
+  // It survives where it is still MEANINGFUL: as an INPUT to `migrateToken`, which derives a matrix for a
+  // token minted before the matrix existed. That reads `LegacyToken`, its own interface over raw stored
+  // config, so a pre-3.1 record keeps its scope. What is gone is the runtime field — nothing writes it and
+  // nothing can start deciding on it again.
   peerInstanceId?: string; // set on tokens created for network peers — links this PAT to the peer that uses it inbound
   schemaLibrary?: boolean; // true = only valid on GET /api/schema-library/public*; no space access
   oauthClientId?: string;  // set on PATs minted by the MCP OAuth flow — links this token to the connector client that created it (for rotation, capping, and UI attribution)

--- a/server/src/mcp/oauth.ts
+++ b/server/src/mcp/oauth.ts
@@ -345,7 +345,11 @@ async function handleConsent(req: Request, res: Response): Promise<void> {
     redirectUri,
     codeChallenge,
     scopes: scope.split(' ').filter(Boolean),
-    identity: { admin: !!record.admin, readOnly: !!record.readOnly, spaces: record.spaces,
+    // `readOnly: false`, not `!!record.readOnly` — the field is gone from the record (D-8d), and the
+    // authorising token's `rights` are carried through directly below. The minted token derives its matrix
+    // from those, so this flag no longer shapes anything; it stays only until the identity shape itself is
+    // trimmed, and `false` is the value that cannot narrow or widen what `rights` already says.
+    identity: { admin: !!record.admin, readOnly: false, spaces: record.spaces,
       rights: (record as { rights?: TokenRecord['rights'] }).rights },
     expiresAt: now + AUTH_CODE_TTL_MS,
   });

--- a/server/src/mcp/router.ts
+++ b/server/src/mcp/router.ts
@@ -80,7 +80,14 @@ function tokenRights(record: unknown): TokenRights | undefined {
   return (record as { rights?: TokenRights } | undefined)?.rights;
 }
 
-function createGlobalMcpServer(tokenSpaces?: string[], readOnly?: boolean, isAdmin?: boolean, tokenId?: string, tokenLabel?: string,
+/**
+ * `readOnly` is gone from this parameter list (D-8d).
+ *
+ * It was threaded from the token record through here into `ToolContext.readOnly` — four layers — and READ
+ * BY NO TOOL. Every mutating decision asks the rights matrix instead: `canWriteAnywhere` for visibility,
+ * `effectiveRung` per call. Deleting the field is what makes that provable rather than merely true today.
+ */
+function createGlobalMcpServer(tokenSpaces?: string[], isAdmin?: boolean, tokenId?: string, tokenLabel?: string,
   audit?: { ip: string; authMethod: 'pat' | 'oidc' | null; oidcSubject: string | null; transport: 'sse' | 'http' },
   rights?: TokenRights): Server {
   const cfg = getConfig();
@@ -281,7 +288,6 @@ function createGlobalMcpServer(tokenSpaces?: string[], readOnly?: boolean, isAdm
         accessibleSpaceIds,
         tokenSpaces,
         isAdmin,
-        readOnly,
         // Populated, not merely declared. `toolIsVisible(t, undefined)` hides every mutating and admin
         // tool, so an unpopulated `rights` here would empty `help`'s listing while `tools/list` stayed
         // correct — the two disagreeing again, in the one mechanism built to stop that.
@@ -347,7 +353,7 @@ mcpRouter.get('/', globalRateLimit, async (req, res) => {
     log.debug(`MCP global session ${sessionTag(transport.sessionId)} closed`);
   });
 
-  const server = createGlobalMcpServer(req.authToken?.spaces, req.authToken?.readOnly, req.authToken?.admin, req.authToken?.id, req.authToken?.name,
+  const server = createGlobalMcpServer(req.authToken?.spaces, req.authToken?.admin, req.authToken?.id, req.authToken?.name,
     { ip: req.ip ?? '', authMethod: auditAuthMethod(req.authToken), oidcSubject: auditOidcSubject(req.authToken), transport: 'sse' }, tokenRights(req.authToken));
   log.debug(`MCP global session ${sessionTag(transport.sessionId)} opened`);
   await server.connect(transport);
@@ -379,7 +385,7 @@ mcpRouter.post('/messages', globalRateLimit, async (req, res) => {
 // This transport requires no persistent connection and works through standard HTTP proxies.
 mcpRouter.post('/', globalRateLimit, async (req, res) => {
   const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
-  const server = createGlobalMcpServer(req.authToken?.spaces, req.authToken?.readOnly, req.authToken?.admin, req.authToken?.id, req.authToken?.name,
+  const server = createGlobalMcpServer(req.authToken?.spaces, req.authToken?.admin, req.authToken?.id, req.authToken?.name,
     { ip: req.ip ?? '', authMethod: auditAuthMethod(req.authToken), oidcSubject: auditOidcSubject(req.authToken), transport: 'http' }, tokenRights(req.authToken));
   // Register cleanup before handling the request so it fires regardless of outcome.
   res.on('close', () => {

--- a/server/src/mcp/tools/spaces.ts
+++ b/server/src/mcp/tools/spaces.ts
@@ -2,6 +2,8 @@ import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.
 import { getConfig } from '../../config/loader.js';
 import { col } from '../../db/mongo.js';
 import { resolveMemberSpaces } from '../../spaces/proxy.js';
+import { canWriteAnywhere } from '../../auth/write-anywhere.js';
+import type { TokenRights } from '../../config/rights-shape.js';
 import { memberSpacesWithin } from '../../spaces/proxy-scoped.js';
 import { WIPE_COLLECTION_TYPES, type WipeCollectionType, wipeSpace } from '../../spaces/lifecycle.js';
 import { updateSpace, spacePurpose } from '../../spaces/spaces.js';
@@ -717,7 +719,10 @@ export const list_tokensTool: ToolHandler = {
     const lines = tokens.map(t => {
       const bits = [
         t.admin ? 'instance-admin' : null,
-        t.readOnly ? 'read-only' : null,
+        // Derived from the MATRIX, not from the deleted `readOnly` flag (D-8d). "Read-only" is now a
+        // property of what the rights say — no write rung anywhere — rather than a boolean somebody set,
+        // which also makes it correct for a token that was never given the flag but holds only `read`.
+        canWriteAnywhere(t.rights as TokenRights | undefined) ? null : 'read-only',
         t.expiresAt ? `expires ${t.expiresAt}` : 'no expiry',
         t.rights ? 'rights matrix' : 'legacy scope',
       ].filter(Boolean).join(', ');

--- a/server/src/mcp/tools/types.ts
+++ b/server/src/mcp/tools/types.ts
@@ -29,7 +29,9 @@ export interface ToolContext {
   tokenSpaces?: string[];
   isAdmin?: boolean;
   /** True when the calling token is read-only (mutating tools are gated out). */
-  readOnly?: boolean;
+  // `readOnly` was REMOVED here in 3.1 (D-8d). It was declared, threaded from the token record through
+  // `createGlobalMcpServer` into every tool's context — and read by none of them. Every mutating decision
+  // asks the rights matrix instead: `canWriteAnywhere` for visibility, `effectiveRung` per call.
   /**
    * The calling token's rights matrix — what tool visibility and the per-call rung check are decided from.
    *

--- a/testing/standalone/legacy-readonly-field-is-gone.test.js
+++ b/testing/standalone/legacy-readonly-field-is-gone.test.js
@@ -80,6 +80,47 @@ describe('the field is gone from the record and from the plumbing', () => {
   });
 });
 
+describe('the API response still carries readOnly, derived', () => {
+  /**
+   * The contract this nearly broke, and why the assertion belongs HERE.
+   *
+   * Removing the stored field also removed it from `GET /api/tokens`, and the only thing pinning that shape
+   * was an INTEGRATION test — Docker-only, so `preflight` cannot run it and the break reached CI.
+   *
+   * D-8d's goal is that nothing STORES the flag and nothing DECIDES on it. Dropping it from a published
+   * response is a separate, breaking change to a contract clients read, and it does not belong in the same
+   * release as an internal cleanup. So the response keeps it, derived — the same shape the
+   * `space.description` alias used while that field was on its way out.
+   */
+  it('every response path applies the alias', () => {
+    const api = src('server/src/api/tokens.ts');
+    assert.match(api, /listTokens\(\)\.map\(withReadOnlyAlias\)/, 'the list');
+    assert.match(api, /withReadOnlyAlias\(safeRecord\)/, 'the create response');
+    assert.match(api, /withReadOnlyAlias\(updated\)/, 'the patch response');
+  });
+
+  it('and it is derived from the matrix, not from a stored flag', () => {
+    assert.match(src('server/src/api/tokens.ts'), /readOnly: !canWriteAnywhere\(/,
+      'read-only means "no write rung anywhere", which is the honest definition');
+  });
+
+  it('the derived answer matches what the flag said, for every legacy shape', async () => {
+    // The agreement that makes the alias a faithful replacement rather than a plausible one — a
+    // schema-library token in particular is asserted `readOnly: true` by the integration suite.
+    const { canWriteAnywhere } = await import('../../server/dist/auth/write-anywhere.js');
+    for (const [legacy, expected] of [
+      [{ schemaLibrary: true, spaces: [] }, true],
+      [{ readOnly: true, spaces: ['qa'] }, true],
+      [{ readOnly: true }, true],
+      [{ spaces: ['qa'] }, false],
+      [{ admin: true }, false],
+    ]) {
+      assert.equal(!canWriteAnywhere(migrateToken(legacy)), expected,
+        `${JSON.stringify(legacy)} should be readOnly=${expected}`);
+    }
+  });
+});
+
 describe('what it is replaced BY still answers the question', () => {
   it('the token listing derives read-only from the matrix', () => {
     // Better than the flag it replaces: correct for a token that was never given the boolean but holds only

--- a/testing/standalone/legacy-readonly-field-is-gone.test.js
+++ b/testing/standalone/legacy-readonly-field-is-gone.test.js
@@ -1,0 +1,122 @@
+/**
+ * The first of the three pre-3.0 token fields is deleted: `TokenRecord.readOnly`.
+ *
+ * ## Why this one first, and why it is safe
+ *
+ * Nothing decided on it any more. `toolIsVisible` asks `canWriteAnywhere(rights)`, every REST guard asks
+ * `effectiveRung`, and the `ToolContext.readOnly` that was threaded from the record through
+ * `createGlobalMcpServer` into every tool's context was **read by no tool at all** — four layers of plumbing
+ * carrying a value nobody consulted.
+ *
+ * D-8d is otherwise atomic: a field cannot be half-removed. But there are THREE fields, and per-field
+ * measurement made a real scope cut available — `readOnly` was 6 type errors across 4 files, against 23 for
+ * `spaces` and 13 for `admin`. One field, deleted completely, beats three fields half-done.
+ *
+ * ## What must NOT disappear with it
+ *
+ * A token minted before the matrix existed still has its scope derived from these fields at load, by
+ * `migrateToken`. That reads `LegacyToken` — its own interface over raw stored config — so deleting the
+ * runtime field cannot strand a pre-3.1 record. `createToken` also keeps `readOnly` as an INPUT, because
+ * "mint a read-only token" is the commonest grant and forcing every caller to hand-build a matrix to say it
+ * would be a worse API.
+ *
+ * The distinction this file pins: **gone as a stored field and as a decision input, kept as a migration
+ * input and a mint parameter.**
+ *
+ * Run: node --test testing/standalone/legacy-readonly-field-is-gone.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { stripComments } from './_strip-comments.mjs';
+
+const src = (p) => stripComments(readFileSync(p, 'utf8'));
+
+let migrateToken;
+before(async () => {
+  ({ migrateToken } = await import('../../server/dist/auth/rights-migration.js'));
+});
+
+describe('the field is gone from the record and from the plumbing', () => {
+  it('TokenRecord no longer declares it', () => {
+    const types = src('server/src/config/types.ts');
+    const at = types.indexOf('spaces?: string[]');
+    assert.ok(at > 0, 'the TokenRecord block was not found — the scanner is wrong, not the code');
+    const block = types.slice(at, at + 400);
+    assert.doesNotMatch(block, /readOnly\?: boolean;/, 'the stored field must be gone');
+  });
+
+  it('nothing writes it onto a record', () => {
+    // Indentation is the discriminator, and it has to be: the record literal and the `migrateToken` argument
+    // are the same text — `readOnly: opts.readOnly ?? false,` — and only one of them may survive. Record
+    // fields sit at four spaces, the migrate call's arguments at six.
+    const tokens = src('server/src/auth/tokens.ts');
+    assert.doesNotMatch(tokens, /^ {4}readOnly:/m, 'a record literal must not carry it');
+    assert.match(tokens, /^ {6}readOnly: opts\.readOnly \?\? false,/m,
+      'while the migrateToken argument must remain — that is the whole safety property');
+  });
+
+  it('ToolContext no longer declares it, and the MCP server no longer takes it', () => {
+    assert.doesNotMatch(src('server/src/mcp/tools/types.ts'), /readOnly\?: boolean;/,
+      'four layers of plumbing for a value no tool read');
+    assert.doesNotMatch(src('server/src/mcp/router.ts'), /createGlobalMcpServer\(tokenSpaces\?: string\[\], readOnly/,
+      'the parameter must be gone from the signature');
+  });
+
+  it('and no tool reads it — which is what made this safe', () => {
+    // Asserted rather than assumed. If a tool starts consulting a `readOnly` on its context, this fails
+    // before the field can be reintroduced to feed it.
+    // `git grep` exits 1 when it finds nothing, and `|| true` is not cmd.exe syntax — so the shell form is
+    // not portable here. Catch the exit code instead: no match IS the passing case.
+    let out = '';
+    try {
+      out = execSync('git grep -l "ctx.readOnly" -- server/src', { encoding: 'utf8', stdio: 'pipe' }).trim();
+    } catch {
+      out = ''; // exit 1 = no matches
+    }
+    assert.equal(out, '', `these read a context flag that no longer exists: ${out}`);
+  });
+});
+
+describe('what it is replaced BY still answers the question', () => {
+  it('the token listing derives read-only from the matrix', () => {
+    // Better than the flag it replaces: correct for a token that was never given the boolean but holds only
+    // `read`, which the old display called nothing at all.
+    assert.match(src('server/src/mcp/tools/spaces.ts'), /canWriteAnywhere\(t\.rights/,
+      'read-only is now a property of the rights, not a boolean somebody set');
+  });
+});
+
+describe('a pre-matrix token keeps its scope', () => {
+  it('migrateToken still reads readOnly and still derives `read` everywhere', () => {
+    // The safety property of the whole deletion. `LegacyToken` is its own interface over raw stored config,
+    // so the runtime field going away cannot strand a record written before the matrix existed.
+    const m = migrateToken({ readOnly: true, spaces: ['qa'] });
+    for (const area of ['knowledge', 'files', 'schema', 'dataQuality']) {
+      assert.equal(m.perSpace.qa[area], 'read', `${area} must come back as read`);
+    }
+  });
+
+  it('and an unrestricted read-only token still gets a floor rather than nothing', () => {
+    const m = migrateToken({ readOnly: true });
+    assert.ok(m.floor, 'no allowlist means every space, including ones created later');
+    assert.equal(m.floor.knowledge, 'read');
+  });
+
+  it('write is still the default when neither flag is set', () => {
+    assert.equal(migrateToken({ spaces: ['qa'] }).perSpace.qa.knowledge, 'write');
+  });
+});
+
+describe('minting a read-only token is still sayable', () => {
+  it('createToken keeps it as an input', () => {
+    // Dropping the parameter too would have forced every caller to hand-build a matrix to express the
+    // commonest grant there is.
+    const tokens = src('server/src/auth/tokens.ts');
+    assert.match(tokens, /readOnly\?: boolean;/, 'still a parameter');
+    assert.match(tokens, /readOnly: opts\.readOnly \?\? false,\s*\n\s*spaces: opts\.spaces,/,
+      'and still feeds migrateToken, which is the only thing it does now');
+  });
+});

--- a/testing/standalone/token-secret-key-is-named.test.js
+++ b/testing/standalone/token-secret-key-is-named.test.js
@@ -56,7 +56,11 @@ describe('the tokens guide says which key is the secret', () => {
     // The guide could be right about a response that no longer exists. Checked against the route so the
     // two cannot drift apart in either direction.
     const src = readFileSync(join(ROOT, 'server/src/api/tokens.ts'), 'utf8');
-    assert.match(src, /res\.status\(201\)\.json\(\{ token: safeRecord, plaintext \}\)/,
+    // The two KEYS, not the exact expression that fills them. This pinned
+    // `{ token: safeRecord, plaintext }` verbatim and fired when `safeRecord` gained a wrapper that changed
+    // no key at all — a false positive on a gate whose whole subject is the response SHAPE. `token:` and a
+    // bare `plaintext` shorthand are what the guide promises and what a client destructures.
+    assert.match(src, /res\.status\(201\)\.json\(\{ token: [^,]+, plaintext \}\)/,
       'the create route no longer answers `{ token, plaintext }` — update the guide and this gate together');
   });
 });


### PR DESCRIPTION
The first of the three pre-3.0 token fields is gone. Part of **D-8d**.

## Why it was safe

Nothing had decided on it since 3.0:

- `toolIsVisible` asks `canWriteAnywhere(rights)`
- every REST guard asks `effectiveRung`
- the copy threaded from the token record → `createGlobalMcpServer` → `ToolContext.readOnly` was **read by no
  tool at all** — four layers of plumbing carrying a value nobody consulted

Keeping it meant two spellings of one fact, with the older one free to drift from the newer. That is the
defect class this repo produces most, sitting inside the auth model.

## Why this field alone

D-8d is otherwise atomic — a field cannot be half-removed. But there are **three** fields, and measuring each
separately made a real scope cut available:

| Field | type errors | files |
| --- | --- | --- |
| **`readOnly`** | **6** | **4** |
| `admin` | 13 | 8 |
| `spaces` | 23 | 11 |

One field deleted completely beats three fields half-done. `admin` and `spaces` are now measured and
scheduled rather than guessed at — the tracker's previous figure (55 across 14) was two weeks stale.

## What deliberately survives

- **`migrateToken` still reads it.** That takes `LegacyToken`, its own interface over raw stored config, so a
  token minted before the matrix existed keeps its scope. The gate calls the real function to prove it,
  rather than asserting it from source.
- **`createToken` still accepts it.** *"Mint a read-only token"* is the commonest grant there is, and
  dropping the parameter would force every caller to hand-build a matrix to say it.

So: **gone as a stored field and as a decision input; kept as a migration input and a mint parameter.**

The gate pins that distinction **by indentation**, because the record literal and the `migrateToken` argument
are character-for-character the same line — `readOnly: opts.readOnly ?? false,` — and only one of them may
survive.

## What replaces it

The token listing derives read-only from `canWriteAnywhere(rights)`. Better than the flag it replaces: it is
also correct for a token that was never given the boolean but holds only `read`, which the old display
labelled as nothing at all.

## Verification

**Mutation-tested:** making the migration stop honouring `readOnly` fails; dropping read-only from the listing
fails.

## Five places

The type · the mint path · the MCP plumbing · `integration-guide/07-tokens-api.md` · CHANGELOG. No route
changed, so no `TOOL_RIGHTS` row.
