### PR TITLE
feat(api)!: name the media half of the embedding queue, on both doors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -345,6 +345,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
+- **The media half of the embedding queue is named, on both doors. No alias — update both paths.** The
+  namespace always had two halves: `/embedding-queue/records` for brain records, and the **bare**
+  `/embedding-queue` for media. Only one of them said which it was, so *"no qualifier means files"* was true
+  and knowable only from a paragraph in the integration guide. On MCP it was worse, because a tool name has
+  no namespace to sit in: `retry_failed_embeddings` sat directly beside `list_embed_jobs`, read as its
+  remedy, and acted on a different queue — so the obvious sequence *list the failed embed jobs, then retry
+  the failed embeddings* quietly did something else and returned a count unrelated to what was listed.
+
+  | was | is |
+  | --- | --- |
+  | `GET /api/brain/spaces/:spaceId/embedding-queue` | `GET …/embedding-queue/media` |
+  | `POST /api/brain/spaces/:spaceId/embedding-queue/retry-failed` | `POST …/embedding-queue/media/retry-failed` |
+  | MCP `retry_failed_embeddings` | MCP `retry_failed_media_embeddings` |
+
+  Responses, parameters and rights are unchanged — only the names. `/embedding-queue/records` and the two
+  record tools are untouched. **No alias, deliberately:** an alias on one door and a rename on the other is
+  the two-surfaces drift this project pays most for, and keeping both names would mean documenting both
+  until 4.0.
+
 - **A space request body with a key we do not recognise is now refused instead of silently ignored.** Four of
   the ten schemas already refused one and six did not, and the split fell across a nesting level, so the same
   misspelling got two answers: `PATCH {"meta":{"validationMdoe":"strict"}}` returned 400, while

--- a/client/src/app/core/brain-api.service.ts
+++ b/client/src/app/core/brain-api.service.ts
@@ -49,12 +49,12 @@ export class BrainApi {
 
   /** Embedding-job backlog for a space (F9 Overview embedding-queue panel). */
   getEmbeddingQueue(spaceId: string): Observable<EmbeddingQueue> {
-    return this.http.get<EmbeddingQueue>(`/api/brain/spaces/${spaceId}/embedding-queue`);
+    return this.http.get<EmbeddingQueue>(`/api/brain/spaces/${spaceId}/embedding-queue/media`);
   }
 
   /** Re-queue every failed media job in a space (F9 Overview "retry all failed"). Returns the count reset. */
   retryFailedEmbeddings(spaceId: string): Observable<{ retried: number }> {
-    return this.http.post<{ retried: number }>(`/api/brain/spaces/${spaceId}/embedding-queue/retry-failed`, {});
+    return this.http.post<{ retried: number }>(`/api/brain/spaces/${spaceId}/embedding-queue/media/retry-failed`, {});
   }
 
   /** Which tokens can reach a space and at what level (F9 Overview matrix). ADMIN-only — 403 for others. */

--- a/docs/integration-guide/04d-brain-ops-api.md
+++ b/docs/integration-guide/04d-brain-ops-api.md
@@ -247,12 +247,19 @@ appear.
 ### Media embedding queue for a space
 
 ```http
-GET /api/brain/spaces/:spaceId/embedding-queue
+GET /api/brain/spaces/:spaceId/embedding-queue/media
 ```
 
 The **media** half of the queue — file chunks produced by the conversion pipeline. For brain records (memories, entities,
 edges, chrono) see [Vectorless records](#vectorless-records--the-embed-queue-for-brain-records), which is a separate
 collection with a separate worker.
+
+> **The `/media` segment is new in 3.1, and this path was `/embedding-queue` with nothing after it.** The
+> namespace always had two halves — `/records` for brain records, and the bare path for media — but only one
+> of them said which it was, so "no qualifier means files" was true and knowable only from this paragraph.
+> Both halves are named now.
+>
+> **This is a breaking change with no alias.** Update the path; the response is unchanged.
 
 **Response** `200`:
 
@@ -271,7 +278,7 @@ proxy's grouping describes its members rather than whichever one was read first.
 ### Retry every failed media job in a space
 
 ```http
-POST /api/brain/spaces/:spaceId/embedding-queue/retry-failed
+POST /api/brain/spaces/:spaceId/embedding-queue/media/retry-failed
 ```
 
 Re-queues **all** failed media jobs in the space (and across members for a proxy). Requires `files: write`.

--- a/docs/integration-guide/16-mcp.md
+++ b/docs/integration-guide/16-mcp.md
@@ -54,7 +54,7 @@ On connect, the server sends global instructions listing all available space IDs
 
 ### Read-Only Tokens
 
-When connecting with a `readOnly` token, mutating tools (`remember`, `update_memory`, `delete_memory`, `upsert_entity`, `update_entity`, `delete_entity`, `merge_entities`, `upsert_edge`, `update_edge`, `delete_edge`, `create_chrono`, `update_chrono`, `delete_chrono`, `bulk_write`, `write_file`, `delete_file`, `create_dir`, `move_file`, `retry_embedding`, `retry_record_embedding`, `retry_failed_embeddings`, `update_file_meta`, `sync_now`, `update_space`, `update_space_schema`, `create_space`, `reindex`, `wipe_space`) are **hidden** from `tools/list` and rejected with an error if called directly. Read-only tools (`help`, `recall`, `find_similar`, `query`, `get_stats`, `get_space_meta`, `list_spaces`, `find_entities_by_name`, `list_chrono`, `read_file`, `list_dir`, `traverse`, `list_embed_jobs`) work normally. `list_tokens` is read-only but **admin-gated**, like `list_peers`. `list_peers` is read-only but **admin-gated** — see the admin-only note below.
+When connecting with a `readOnly` token, mutating tools (`remember`, `update_memory`, `delete_memory`, `upsert_entity`, `update_entity`, `delete_entity`, `merge_entities`, `upsert_edge`, `update_edge`, `delete_edge`, `create_chrono`, `update_chrono`, `delete_chrono`, `bulk_write`, `write_file`, `delete_file`, `create_dir`, `move_file`, `retry_embedding`, `retry_record_embedding`, `retry_failed_media_embeddings`, `update_file_meta`, `sync_now`, `update_space`, `update_space_schema`, `create_space`, `reindex`, `wipe_space`) are **hidden** from `tools/list` and rejected with an error if called directly. Read-only tools (`help`, `recall`, `find_similar`, `query`, `get_stats`, `get_space_meta`, `list_spaces`, `find_entities_by_name`, `list_chrono`, `read_file`, `list_dir`, `traverse`, `list_embed_jobs`) work normally. `list_tokens` is read-only but **admin-gated**, like `list_peers`. `list_peers` is read-only but **admin-gated** — see the admin-only note below.
 
 ### Connecting
 
@@ -219,7 +219,7 @@ row survives its own tool being built, so the list cannot keep advertising a gap
 | `retry_embedding` | Re-queue a file whose media embedding failed or was skipped. Returns `processing` unchanged when the worker already holds it |
 | `list_embed_jobs` | List brain records whose embedding is pending, processing or **failed**, with `attempts` and `lastError` for each, plus counts. This is how you tell *"the record is missing"* from *"the record has no vector yet"*: a record with an unfinished job is stored but not yet findable by `recall`/`query`. Filter with `status`; omit it for the whole backlog. Read-only, so a `readOnly` token can still diagnose a stalled queue |
 | `update_file_meta` | Change a file record's description, tags, properties or links **without resending the file**. `write_file` can set those fields but only alongside new content. Only the fields you pass are touched; under strict linkage every id must resolve. Same as [`PATCH /api/brain/spaces/:spaceId/files`](04d-brain-ops-api.md) |
-| `retry_failed_embeddings` | Re-queue **every** failed media job in the space at once — the recovery path after an embedder outage. Returns the count reset. Sums across a proxy's members. Same as [`POST /embedding-queue/retry-failed`](04d-brain-ops-api.md) |
+| `retry_failed_media_embeddings` | Re-queue **every** failed media job in the space at once — the recovery path after an embedder outage. Returns the count reset. Sums across a proxy's members. Same as [`POST /embedding-queue/media/retry-failed`](04d-brain-ops-api.md) |
 | `retry_record_embedding` | Re-queue ONE brain record whose embedding failed, by `recordType` + `recordId` from `list_embed_jobs`. Resets the job to pending and clears its attempt count and last error. Returns `processing` unchanged when the worker already holds it. For files use `retry_embedding` — that re-runs the media pipeline, this only re-embeds |
 | `create_dir` | Create a directory |
 | `move_file` | Move or rename a file/directory |
@@ -515,7 +515,7 @@ composes what REST exposes as one DELETE per collection.
 | | `reindex` | `POST /api/brain/spaces/:spaceId/reindex` | admin `schema` |
 | | `list_embed_jobs` | `GET /api/brain/spaces/:spaceId/embedding-queue/records` | read `knowledge` |
 | | `retry_record_embedding` | `POST /api/brain/spaces/:spaceId/embedding-queue/records/retry` | write `knowledge` |
-| | `retry_failed_embeddings` | `POST /api/brain/spaces/:spaceId/embedding-queue/retry-failed` | write `files` |
+| | `retry_failed_media_embeddings` | `POST /api/brain/spaces/:spaceId/embedding-queue/media/retry-failed` | write `files` |
 | **Files** | | | |
 | | `read_file` | `GET /api/files/:spaceId` | read `files` |
 | | `write_file` | `POST /api/files/:spaceId` | write `files` |

--- a/server/src/api/brain/embed-jobs.ts
+++ b/server/src/api/brain/embed-jobs.ts
@@ -15,9 +15,13 @@
  *
  * ## Why it nests under `embedding-queue` instead of a name of its own
  *
- * `GET /spaces/:spaceId/embedding-queue` already existed and answers for MEDIA jobs only — file chunks, not brain
- * records. Two sibling top-level names (`embedding-queue` and, say, `embed-jobs`) would have left a caller guessing
- * which half of the same subsystem each one meant. Nesting says it in the URL: the queue, the records in it.
+ * Two sibling top-level names (`embedding-queue` and, say, `embed-jobs`) would have left a caller guessing which
+ * half of the same subsystem each one meant. Nesting says it in the URL: the queue, and which half of it.
+ *
+ * **Both halves are named as of 3.1 — `/embedding-queue/media` and `/embedding-queue/records`.** The media half
+ * used to be the BARE `/embedding-queue`, so "the queue with no qualifier means files, not records" was true and
+ * knowable only from this comment and the integration guide. That is the half of X-3 that lived on REST; the MCP
+ * half was a flat tool name with no namespace to sit in at all.
  *
  * The media half stays where it is, in file-meta.ts next to the file records it reports on.
  */

--- a/server/src/api/brain/file-meta.ts
+++ b/server/src/api/brain/file-meta.ts
@@ -276,9 +276,11 @@ fileMetaRouter.get('/spaces/:spaceId/files/extract', globalRateLimit, requireSpa
   });
 });
 
-// GET /api/brain/spaces/:spaceId/embedding-queue — this space's embedding-job backlog by status (F9 Overview).
+// GET /api/brain/spaces/:spaceId/embedding-queue/media — this space's MEDIA job backlog by status (F9
+// Overview). The `/media` segment is new in 3.1: this path used to be the bare `/embedding-queue`, where
+// being the media half was knowable only from the docs (X-3).
 // Read-only summary; sums across member spaces for a proxy space (resolveMemberSpaces → [spaceId] otherwise).
-fileMetaRouter.get('/spaces/:spaceId/embedding-queue', globalRateLimit, requireSpaceAuth, async (req, res) => {
+fileMetaRouter.get('/spaces/:spaceId/embedding-queue/media', globalRateLimit, requireSpaceAuth, async (req, res) => {
   const spaceId = req.params['spaceId'] as string;
   const cfg = getConfig();
   if (!cfg.spaces.some(s => s.id === spaceId)) {
@@ -305,9 +307,9 @@ fileMetaRouter.get('/spaces/:spaceId/embedding-queue', globalRateLimit, requireS
   res.json(total);
 });
 
-// POST /api/brain/spaces/:spaceId/embedding-queue/retry-failed — re-queue every failed media job in
+// POST /api/brain/spaces/:spaceId/embedding-queue/media/retry-failed — re-queue every failed media job in
 // this space (F9 Overview "retry all failed"). Sums across member spaces like the GET above.
-fileMetaRouter.post('/spaces/:spaceId/embedding-queue/retry-failed', globalRateLimit, requireSpaceAuth, denyReadOnly, async (req, res) => {
+fileMetaRouter.post('/spaces/:spaceId/embedding-queue/media/retry-failed', globalRateLimit, requireSpaceAuth, denyReadOnly, async (req, res) => {
   const spaceId = req.params['spaceId'] as string;
   const cfg = getConfig();
   if (!cfg.spaces.some(s => s.id === spaceId)) {

--- a/server/src/audit/middleware.ts
+++ b/server/src/audit/middleware.ts
@@ -78,7 +78,7 @@ const ROUTE_RULES: RouteRule[] = [
   { method: 'DELETE', pattern: /^\/api\/brain\/(?:spaces\/)?([^/]+)\/files$/,      operation: 'file.meta.delete', spaceGroup: 1 },
   { method: 'PATCH',  pattern: /^\/api\/brain\/(?:spaces\/)?([^/]+)\/files$/,      operation: 'file.meta.update', spaceGroup: 1 },
   { method: 'POST',   pattern: /^\/api\/brain\/(?:spaces\/)?([^/]+)\/reindex$/,    operation: 'space.reindex',  spaceGroup: 1 },
-  { method: 'POST',   pattern: /^\/api\/brain\/spaces\/([^/]+)\/embedding-queue\/retry-failed$/, operation: 'file.retry_embedding_all', spaceGroup: 1 },
+  { method: 'POST',   pattern: /^\/api\/brain\/spaces\/([^/]+)\/embedding-queue\/media\/retry-failed$/, operation: 'file.retry_embedding_all', spaceGroup: 1 },
   // A record retry is audited because it is the operator saying "embed this again" about a record that already gave
   // up, and the snapshot is the only place the failure it was retried FROM survives: a successful retry clears
   // `lastError`, so without this row the reason the job failed is gone the moment someone fixes it.

--- a/server/src/auth/space-rights.ts
+++ b/server/src/auth/space-rights.ts
@@ -136,8 +136,8 @@ export const ROUTE_RIGHTS: readonly RouteRight[] = [
   { route: '/api/files/:spaceId/upload-status', method: 'GET', area: 'files', needs: 'read', scope: 'path' },
   { route: '/api/brain/spaces/:spaceId/files', method: 'GET', area: 'files', needs: 'read', scope: 'path' },
   { route: '/api/brain/spaces/:spaceId/files/extract', method: 'GET', area: 'files', needs: 'read', scope: 'path' },
-  { route: '/api/brain/spaces/:spaceId/embedding-queue', method: 'GET', area: 'files', needs: 'read', scope: 'path' },
-  { route: '/api/brain/spaces/:spaceId/embedding-queue/retry-failed', method: 'POST', area: 'files', needs: 'write', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/embedding-queue/media', method: 'GET', area: 'files', needs: 'read', scope: 'path' },
+  { route: '/api/brain/spaces/:spaceId/embedding-queue/media/retry-failed', method: 'POST', area: 'files', needs: 'write', scope: 'path' },
   // The RECORD half of the queue is `knowledge`, not `files`: it reports on memories, entities, edges and chrono.
   // A files-only token can read the media queue and must not read a listing of knowledge record ids.
   { route: '/api/brain/spaces/:spaceId/embedding-queue/records', method: 'GET', area: 'knowledge', needs: 'read', scope: 'path' },
@@ -258,7 +258,7 @@ export const TOOL_RIGHTS: readonly ToolRight[] = [
   { tool: 'reindex', area: 'schema', needs: 'admin' },
   { tool: 'list_embed_jobs', area: 'knowledge', needs: 'read' },
   { tool: 'retry_record_embedding', area: 'knowledge', needs: 'write' },
-  { tool: 'retry_failed_embeddings', area: 'files', needs: 'write' },
+  { tool: 'retry_failed_media_embeddings', area: 'files', needs: 'write' },
   { tool: 'read_file', area: 'files', needs: 'read' },
   { tool: 'write_file', area: 'files', needs: 'write' },
   { tool: 'delete_file', area: 'files', needs: 'write' },

--- a/server/src/mcp/audit-map.ts
+++ b/server/src/mcp/audit-map.ts
@@ -64,7 +64,7 @@ export const MCP_TOOL_OPERATIONS: Record<string, string | null> = {
   // Same operation as the REST route it mirrors: one capability, one audit name.
   // The route's own operation: one capability, one audit name, whichever door it came through.
   update_file_meta: 'file.meta.update',
-  retry_failed_embeddings: 'file.retry_embedding_all',
+  retry_failed_media_embeddings: 'file.retry_embedding_all',
   retry_record_embedding: 'brain.retry_embedding',
   create_dir: 'file.mkdir',
   // The tool registry flags this `mutating: true`, and it is right: a sync cycle pulls records from

--- a/server/src/mcp/tools/embed.ts
+++ b/server/src/mcp/tools/embed.ts
@@ -149,7 +149,7 @@ export const retry_record_embeddingTool: ToolHandler = {
 /**
  * Re-queue EVERY failed media job in a space — the bulk counterpart to `retry_embedding`.
  *
- * `POST /api/brain/spaces/:spaceId/embedding-queue/retry-failed` was REST-only, so an agent recovering a space
+ * `POST /api/brain/spaces/:spaceId/embedding-queue/media/retry-failed` was REST-only, so an agent recovering a space
  * after an embedder outage had to enumerate the failures and call the single-file tool once per file. That is the
  * shape of the reindex-by-curl-loop that motivated the `reindex` tool in the first place: a customer did fourteen
  * spaces by hand because the agent that planned their work could not do it.
@@ -159,18 +159,24 @@ export const retry_record_embeddingTool: ToolHandler = {
  * **Sums across member spaces**, exactly as the route does: on a proxy the failures live in the members, and a
  * caller who asked the proxy to retry means all of them.
  */
-export const retry_failed_embeddingsTool: ToolHandler = {
-  name: 'retry_failed_embeddings',
-  description: 'THE MEDIA QUEUE, NOT THE BRAIN ONE — read this before reaching for it. Despite the name, and '
-    + 'despite sitting beside `list_embed_jobs`, this re-queues failed MEDIA jobs: image captioning, audio and '
-    + 'video transcription, document extraction. It does NOT touch the brain embed jobs that `list_embed_jobs` '
-    + 'reports; for one of those use `retry_record_embedding`, and note that a brain job that failed against an '
-    + 'unreachable embedder is already retried on its own and needs no intervention at all.\n\n'
-    + 'Re-queues EVERY failed media job in a space at once, so the worker picks them all up again — the '
-    + 'recovery path after an extractor or model outage. Returns how many jobs were reset. Use this instead of '
-    + 'calling retry_embedding once per file; use retry_embedding when you want one specific file. Jobs the '
-    + 'worker currently holds are left alone rather than interrupted. On a proxy space every member is retried, '
-    + 'because that is what asking the proxy means.',
+export const retry_failed_media_embeddingsTool: ToolHandler = {
+  name: 'retry_failed_media_embeddings',
+  description: 'Re-queue EVERY failed MEDIA job in a space at once — image captioning, audio and video '
+    + 'transcription, document extraction — so the worker picks them all up again. The recovery path after an '
+    + 'extractor or model outage.\n\n'
+    + 'MEDIA, NOT THE BRAIN QUEUE, and the name now says so. It was `retry_failed_embeddings` until 3.1, which '
+    + 'sat beside `list_embed_jobs` and read as its remedy while acting on a different queue entirely. It does '
+    + 'NOT touch the brain embed jobs that `list_embed_jobs` reports; for one of those use '
+    + '`retry_record_embedding`. And usually you need neither: a brain job that failed against an unreachable '
+    + 'embedder is retried on its own, backing off, and needs no intervention at all.\n\n'
+    + 'ONE FILE OR ALL OF THEM. Use `retry_embedding` for one specific file; use this instead of calling it in '
+    + 'a loop. Jobs the worker currently holds are left alone rather than interrupted, so a retry during a run '
+    + 'cannot take work away from it.\n\n'
+    + 'PARAMETERS:\n'
+    + '- `space` — the space to sweep. On a PROXY every member is retried, because that is what asking the '
+    + 'proxy means; the count returned is the total across them.\n\n'
+    + 'RESPONSE: how many jobs were reset. Zero means nothing was failed — not that the call did nothing '
+    + 'wrong. Check `list_embed_jobs` for the brain queue, which this does not touch.',
   mutating: true,
   spaceRequired: true,
   inputSchema: (s: ToolSchemas) => ({

--- a/server/src/mcp/tools/index.ts
+++ b/server/src/mcp/tools/index.ts
@@ -9,7 +9,7 @@ import { create_chronoTool, update_chronoTool, list_chronoTool, delete_chronoToo
 import { read_fileTool, write_fileTool, update_file_metaTool, list_dirTool, delete_fileTool, create_dirTool, move_fileTool, retry_embeddingTool } from './file.js';
 import { list_peersTool, sync_nowTool } from './sync.js';
 import { helpTool } from './help.js';
-import { list_embed_jobsTool, retry_record_embeddingTool, retry_failed_embeddingsTool } from './embed.js';
+import { list_embed_jobsTool, retry_record_embeddingTool, retry_failed_media_embeddingsTool } from './embed.js';
 
 export type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.js';
 
@@ -66,7 +66,7 @@ export const ALL_TOOLS: ToolHandler[] = [
   sync_nowTool,
   list_embed_jobsTool,
   retry_record_embeddingTool,
-  retry_failed_embeddingsTool,
+  retry_failed_media_embeddingsTool,
 ];
 
 export const TOOLS_BY_NAME: ReadonlyMap<string, ToolHandler> =

--- a/testing/integration/brain-embed-jobs-both-surfaces.test.js
+++ b/testing/integration/brain-embed-jobs-both-surfaces.test.js
@@ -112,10 +112,10 @@ describe('REST: the record half of the embedding queue', () => {
   });
 
   it('does not collide with the MEDIA queue endpoint it nests under', async () => {
-    // `/embedding-queue` and `/embedding-queue/records` are different answers about different halves of the same
+    // `/embedding-queue/media` and `/embedding-queue/records` are different answers about different halves of the same
     // subsystem. If the nested path ever shadowed its parent, the F9 Overview panel would silently start reading brain
     // counts as media counts — the two shapes are similar enough that nothing would throw.
-    const media = await get(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/embedding-queue`);
+    const media = await get(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/embedding-queue/media`);
     assert.equal(media.status, 200, JSON.stringify(media.body));
     assert.ok('complete' in media.body, 'the media summary has a `complete` counter; the record listing does not');
     assert.ok(!('jobs' in media.body), 'and it does not carry a jobs array');

--- a/testing/integration/files.test.js
+++ b/testing/integration/files.test.js
@@ -84,10 +84,10 @@ describe('File upload & download', () => {
     assert.equal(r.body.embeddingStatus, 'pending', 'Text document uploads must return embeddingStatus=pending');
   });
 
-  it('GET embedding-queue returns per-space job counts by status (F9 Overview panel)', async () => {
+  it('GET embedding-queue/media returns per-space job counts by status (F9 Overview panel)', async () => {
     // Seed a job by uploading a document, then read the queue summary.
     await uploadFile(tokenA, 'general', 'queue-probe.txt', 'embedding queue probe');
-    const r = await get(INSTANCES.a, tokenA, '/api/brain/spaces/general/embedding-queue');
+    const r = await get(INSTANCES.a, tokenA, '/api/brain/spaces/general/embedding-queue/media');
     assert.equal(r.status, 200, JSON.stringify(r.body));
     // Shape (not exact counts — a job races through pending→processing→complete): the four status
     // counts are non-negative integers, failedSample is an array, and at least one job now exists.

--- a/testing/integration/recall-traverse.test.js
+++ b/testing/integration/recall-traverse.test.js
@@ -436,7 +436,7 @@ describe('Recall traverse — the complete graph is downloadable when it does no
 
     // Not embedded: embedding a read's own output would let the next recall match the JSON dump of an
     // earlier one, and would spend model time doing it.
-    const queue = await get(INSTANCES.a, token(), `/api/brain/spaces/${SPACE_DENSE}/embedding-queue`);
+    const queue = await get(INSTANCES.a, token(), `/api/brain/spaces/${SPACE_DENSE}/embedding-queue/media`);
     assert.equal(queue.status, 200, JSON.stringify(queue.body));
     const jobs = JSON.stringify(queue.body);
     assert.ok(!jobs.includes('_tmp/'), `no spill may be queued: ${jobs.slice(0, 300)}`);

--- a/testing/integration/retry-failed-embeddings-both-doors.test.js
+++ b/testing/integration/retry-failed-embeddings-both-doors.test.js
@@ -3,7 +3,7 @@
  *
  * ## Why the tool exists
  *
- * `POST /api/brain/spaces/:spaceId/embedding-queue/retry-failed` was REST-only. An agent recovering a space
+ * `POST /api/brain/spaces/:spaceId/embedding-queue/media/retry-failed` was REST-only. An agent recovering a space
  * after an embedder outage had to list the failures and call the single-file `retry_embedding` once per file —
  * the shape of the reindex-by-curl-loop that motivated the `reindex` tool, where a customer did fourteen spaces
  * by hand because the agent planning their work could not do it.
@@ -52,9 +52,9 @@ after(async () => {
   }).catch(() => {});
 });
 
-describe('retry_failed_embeddings answers the same as its route', () => {
+describe('retry_failed_media_embeddings answers the same as its route', () => {
   it('REST reports a count, and zero is an answer rather than an error', async () => {
-    const r = await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/embedding-queue/retry-failed`, {});
+    const r = await post(INSTANCES.a, token(), `/api/brain/spaces/${SPACE}/embedding-queue/media/retry-failed`, {});
     assert.equal(r.status, 202, JSON.stringify(r.body));
     assert.equal(typeof r.body.retried, 'number', `a count, not a message: ${JSON.stringify(r.body)}`);
     assert.equal(r.body.retried, 0, 'a fresh space has no failed jobs');
@@ -68,7 +68,7 @@ describe('retry_failed_embeddings answers the same as its route', () => {
       return t.skip(`MCP session unavailable: ${e.message}`);
     }
     try {
-      const res = await session.callTool('retry_failed_embeddings', { space: SPACE });
+      const res = await session.callTool('retry_failed_media_embeddings', { space: SPACE });
       const text = JSON.stringify(res ?? {});
       // The tool must EXIST — against a stale image this is where an "Unknown tool" answer would hide.
       assert.doesNotMatch(text, /Unknown tool/i, 'the tool is missing — rebuild the test image');
@@ -99,7 +99,7 @@ describe('retry_failed_embeddings answers the same as its route', () => {
     let session;
     try {
       session = await openMcpSession(roToken);
-      const res = await session.callTool('retry_failed_embeddings', { space: SPACE });
+      const res = await session.callTool('retry_failed_media_embeddings', { space: SPACE });
       const text = JSON.stringify(res ?? {});
       // The refusal names the missing GRANT now rather than a flag: mutating tools are gated on holding a
       // write rung somewhere. `Unknown tool` stays in the alternation because a hidden tool can legitimately
@@ -109,7 +109,7 @@ describe('retry_failed_embeddings answers the same as its route', () => {
 
       // And it must not even be OFFERED: a tool a token cannot call should not appear in its listing.
       const listed = await session.listTools();
-      assert.ok(!listed.some(x => x.name === 'retry_failed_embeddings'),
+      assert.ok(!listed.some(x => x.name === 'retry_failed_media_embeddings'),
         'a mutating tool must be hidden from a read-only token, not merely refused on call');
     } finally {
       session?.close();

--- a/testing/standalone/embed-job-tools-say-which-queue.test.js
+++ b/testing/standalone/embed-job-tools-say-which-queue.test.js
@@ -3,7 +3,7 @@
  *
  * ## The trap in the names
  *
- * `list_embed_jobs` reports BRAIN embed jobs. `retry_failed_embeddings` sits in the same module, next to it,
+ * `list_embed_jobs` reports BRAIN embed jobs. `retry_failed_media_embeddings` sits in the same module, next to it,
  * with a name that reads as its remedy — and re-queues the MEDIA queue instead: captioning, transcription,
  * document extraction. It imports `files/media/job-queue.js`, which is a fact about the code rather than a
  * suspicion.
@@ -60,15 +60,20 @@ const body = (name) => {
 };
 
 const LIST = tool('list_embed_jobs');
-const RETRY_ALL = tool('retry_failed_embeddings');
-const RETRY_ALL_BODY = body('retry_failed_embeddings');
+const RETRY_ALL = tool('retry_failed_media_embeddings');
+const RETRY_ALL_BODY = body('retry_failed_media_embeddings');
 
 describe('the queue each tool acts on is stated', () => {
-  it('retry_failed_embeddings says up front that it is the MEDIA queue', () => {
-    // It is the first thing in the description on purpose: a caller who reads one line must not act on the
-    // wrong queue, and the name actively misleads.
-    assert.match(RETRY_ALL, /THE MEDIA QUEUE, NOT THE BRAIN ONE/,
-      'the correction has to come before the description, not after it');
+  it('the NAME says media now, so the description need not open with a correction', () => {
+    // This required the description to LEAD with `THE MEDIA QUEUE, NOT THE BRAIN ONE`, because the tool was
+    // called `retry_failed_embeddings` and a caller reading one line had to be stopped before acting. X-3
+    // renamed it, so the correction stops being the first sentence and becomes history.
+    //
+    // Inverted rather than deleted: the rule never changed. Something must say which queue this acts on,
+    // unmissably — only which of the name and the prose carries it has moved.
+    assert.match(RETRY_ALL, /MEDIA, NOT THE BRAIN QUEUE/, 'still stated, just no longer as an apology');
+    assert.match(RETRY_ALL, /`retry_failed_embeddings` until 3\.1/,
+      'and the OLD name is named, so an integrator hitting an unknown-tool error can find out why');
     assert.match(RETRY_ALL, /retry_record_embedding/, 'name the tool that does the brain-side job');
   });
 
@@ -89,7 +94,7 @@ describe('the queue each tool acts on is stated', () => {
     // What replaces it is the more useful fact anyway: an absent retry in help() means THIS TOKEN cannot
     // retry, not that no such tool exists — which is the wrong conclusion a read-only caller would otherwise
     // draw and report.
-    assert.doesNotMatch(LIST, /retry_record_embedding|retry_failed_embeddings/,
+    assert.doesNotMatch(LIST, /retry_record_embedding|retry_failed_media_embeddings/,
       'a read-only tool must not advertise a mutating one');
     assert.match(LIST, /only REPORTS/, 'say what this tool does and does not do');
     assert.match(LIST, /cannot retry rather than that no such tool exists/,

--- a/testing/standalone/mcp-tool-schemas.test.js
+++ b/testing/standalone/mcp-tool-schemas.test.js
@@ -39,7 +39,7 @@ describe('MCP tool schemas — universal invariants', () => {
     // 41 -> 42: `er_model`. Prerequisites done — `audit-map.ts` maps it to `brain.er_model` (and the REST
     // route is now audited too, which it was not while `stats` was), it is read-only and deliberately
     // visible to a readOnly token, and `16-mcp.md` carries its row.
-    // 42 -> 43: `retry_failed_embeddings`, the bulk counterpart to `retry_embedding`. Prerequisites done —
+    // 42 -> 43: `retry_failed_media_embeddings`, the bulk counterpart to `retry_embedding`. Prerequisites done —
     // `audit-map.ts` maps it to `file.retry_embedding_all` like the route it mirrors, it is `mutating: true` and listed among
     // the tools a readOnly token cannot see, and `16-mcp.md` carries its row.
     // 43 -> 44: `update_file_meta`. Prerequisites done — `audit-map.ts` maps it to `file.meta.update` like

--- a/testing/standalone/proxy-fanout-inventory.test.js
+++ b/testing/standalone/proxy-fanout-inventory.test.js
@@ -132,7 +132,7 @@ const RECLASSIFIED = 1;
  * cannot exist, since an edge cannot cross a space.
  */
 /**
- * 39 -> 40: the `retry_failed_embeddings` MCP tool.
+ * 39 -> 40: the `retry_failed_media_embeddings` MCP tool.
  *
  * The REST route it mirrors has always summed across members with `memberSpacesForRequest`; the tool narrows
  * with `memberSpacesWithin` and retries every member, because asking a proxy to retry means all of them.


### PR DESCRIPTION
Closes **X-3**. Owner ruled **B** — rename both surfaces, no alias: *"since rest and mcp must be in sync"*.

## The defect was narrower than first reported

The REST path is **not** simply wrong. `/embedding-queue` is a deliberate namespace with two halves,
documented at [embed-jobs.ts:16](server/src/api/brain/embed-jobs.ts#L16): `/records` for brain records, and
the bare path for media. Two sibling top-level names would have left a caller guessing which half each meant.

**What was wrong is that only one half said which it was.** *"No qualifier means files"* was true, and
knowable only from a paragraph in the integration guide.

On MCP it was worse, because a tool name has no namespace to sit in. `retry_failed_embeddings` sat directly
beside `list_embed_jobs`, read as its remedy, and acted on a different queue — so the obvious sequence *list
the failed embed jobs, then retry the failed embeddings* quietly did something else and returned a count
unrelated to what was listed.

## What moved

| was | is |
| --- | --- |
| `GET /api/brain/spaces/:spaceId/embedding-queue` | `GET …/embedding-queue/media` |
| `POST /api/brain/spaces/:spaceId/embedding-queue/retry-failed` | `POST …/embedding-queue/media/retry-failed` |
| MCP `retry_failed_embeddings` | MCP `retry_failed_media_embeddings` |

Responses, parameters and rights are unchanged — only the names. `/embedding-queue/records` and the two
record tools are **untouched**.

**No alias, deliberately**, and that is the owner's reason: an alias on one door and a rename on the other
*is* the two-surfaces drift this project pays most for, and keeping both names would mean documenting both
until 4.0.

## Everything that registers a route moved with it

The audit pattern, both rights rows, the audit-map key, the client's two call sites, and the tool export.
Each of those is somebody's authoritative source, and the one that is wrong is invisible to whoever reads it.

## The Docker-only suites were checked by hand before pushing

`preflight` cannot run them — and one PR ago that is exactly how a contract break reached CI. Four
integration files still called the old paths: `files.test.js`, `recall-traverse.test.js`, and both embed-jobs
suites. All updated, and the `/records` half verified untouched in the same pass.

## The gate was inverted, not deleted

`embed-job-tools-say-which-queue.test.js` required the description to **lead** with
`THE MEDIA QUEUE, NOT THE BRAIN ONE`, because the name misled and a caller reading one line had to be
stopped. The name carries that now, so the correction becomes history — and the description names the **old**
tool, so an integrator hitting an unknown-tool error can find out why.

The rule it protects is unchanged: something must say which queue this acts on, unmissably. Only which of the
name and the prose carries it has moved.

## Five places

Both routes · the MCP tool · `integration-guide/04d-brain-ops-api.md` and `16-mcp.md` · CHANGELOG under
**Breaking**.
