### PR TITLE
feat(sync)!: wiping a networked space opens a vote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -345,6 +345,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
+- **Wiping a space that belongs to a network now opens a VOTE instead of emptying it immediately.** Emptying
+  a space the network shares is a governed act, like deleting one: a round opens in every network holding the
+  space, this instance votes yes, and the wipe happens on **every member** when a round passes. A single veto
+  stops it there.
+
+  **A space in no network is completely unaffected** — it wipes immediately and finally, exactly as before.
+
+  **What changes for a caller on a networked space:** `POST /api/admin/spaces/:spaceId/wipe` answers `202`
+  with `{ "status": "vote_pending", "rounds": [...] }` rather than `200` with `deleted` counts, and the
+  `wipe_space` tool says the same. That is the success case — retrying it opens a second round, and reading
+  the absent counts as a failure is the mistake to avoid.
+
+  **Why voting rather than propagating.** A wipe writes no tombstones and deletes the existing ones, and
+  tombstones are the only thing that tells a peer a record is gone. So a local wipe on a shared space was
+  quietly **undone by the next sync**: the peers offered everything back to an instance that had no record of
+  any deletion. Voting does not fix that — it removes it, because the peers are wiping too. The round also
+  carries which collections it covers, so a wipe approved for `files` cannot conclude by emptying the
+  knowledge graph.
+
 - **The media half of the embedding queue is named, on both doors. No alias — update both paths.** The
   namespace always had two halves: `/embedding-queue/records` for brain records, and the **bare**
   `/embedding-queue` for media. Only one of them said which it was, so *"no qualifier means files"* was true

--- a/docs/integration-guide/09-sync-api.md
+++ b/docs/integration-guide/09-sync-api.md
@@ -20,7 +20,7 @@ POST /api/notify
 }
 ```
 
-Events: `vote_pending`, `member_departed`, `member_removed`, `space_deletion_pending`, `sync_available`, `ping`.
+Events: `vote_pending`, `member_departed`, `member_removed`, `space_deletion_pending`, `space_wipe_pending`, `sync_available`, `ping`.
 
 **Response** `204`.
 

--- a/docs/integration-guide/12-admin-api.md
+++ b/docs/integration-guide/12-admin-api.md
@@ -143,6 +143,25 @@ Content-Type: application/json
 
 **Requires admin token** (and TOTP code when MFA is enabled).
 
+> **On a space that belongs to a network, this OPENS A VOTE and wipes nothing yet — new in 3.1.** Emptying a
+> space the network shares is a governed act, like deleting one. A round opens in every network holding the
+> space, this instance votes yes, and the wipe happens on **every member** when a round passes. A single veto
+> stops it there.
+>
+> The answer is `202` with `{ "status": "vote_pending", "rounds": [...] }` instead of `200` with `deleted`
+> counts. **Treat that as success** — do not retry, and do not read the missing counts as a failure. Watch
+> the rounds via `GET /api/networks/:id/votes`.
+>
+> **A space in no network is unaffected**: it wipes immediately and answers `200` with counts, exactly as
+> before.
+>
+> *Why it votes rather than propagating.* A wipe writes no tombstones and deletes the existing ones, and
+> tombstones are the only thing that tells a peer a record is gone — so a local wipe on a shared space was
+> undone by the next sync, which offered everything back to an instance that had no record of any deletion.
+> Voting removes that problem rather than working around it: the peers are wiping too.
+>
+> The same rule governs the `wipe_space` MCP tool, through the same planner.
+
 #### Request body
 
 | Field | Type | Description |

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -418,7 +418,7 @@ Directly after the gossip (member identity) exchange — still ahead of the data
 
 3. **Round conclusion** — after all merges, `concludeRoundIfReady` is evaluated for every open local round. Unanimous-type networks (closed, braintree) require every listed remote member to have individually cast `yes`; a single outstanding member prevents conclusion. For **braintree** rounds the required-voter set (ancestor path) is recomputed from the local topology at conclusion, never trusted from the adopted round, so a peer cannot shrink it. Democratic networks use a simple majority count. Club networks conclude on the first `yes`.
 
-4. **Side effects** — if a `space_deletion` round concludes with zero vetoes, the space is removed from the local instance asynchronously.
+4. **Side effects** — if a `space_deletion` round concludes with zero vetoes, the space is removed from the local instance asynchronously. A `space_wipe` round behaves the same way but EMPTIES the space instead of removing it, wiping exactly the collections named on the round (all five when it names none). Both are applied through one function called from all three conclusion paths — an operator's own vote, a peer's vote arriving, and the gossip pass.
 
 This means a vote cast on any peer propagates to all other peers within one gossip cycle per hop, and a round concludes independently on each instance as soon as it has received enough votes to satisfy its network's pass condition.
 

--- a/server/src/api/networks/votes.ts
+++ b/server/src/api/networks/votes.ts
@@ -12,6 +12,7 @@ import { getConfig, saveConfig } from '../../config/loader.js';
 import { concludeRoundIfReady, sendMemberRemovedNotify } from '../../sync/governance.js';
 import { makeSignedOwnCast } from '../../util/signing.js';
 import { log } from '../../util/log.js';
+import { applyWipeRoundIfPassed } from '../../spaces/apply-wipe-round.js';
 
 export const votesRouter = Router();
 
@@ -74,6 +75,10 @@ votesRouter.post('/:id/votes/:roundId', globalRateLimit, requireAdmin, (req, res
         }).catch(err => log.error(`space_deletion import: ${err}`));
       }
     }
+
+    // X-5: a concluded space_wipe empties the space here. One shared function, called from all three
+    // conclusion sites, rather than a third copy of the side-effect.
+    applyWipeRoundIfPassed(round, 'local vote');
 
     // If remove round concluded and passed, notify the ejected member
     if (round.concluded && round.passed && round.type === 'remove') {

--- a/server/src/api/notify.ts
+++ b/server/src/api/notify.ts
@@ -26,6 +26,7 @@ const NotifyBody = z.object({
     'member_departed',
     'member_removed',           // sent to the ejected instance after a remove vote passes
     'space_deletion_pending',
+    'space_wipe_pending',       // a wipe round is open — pull it now rather than at the next scheduled sync
     'sync_available',   // "I have new data, come pull me"
     'ping',             // health check / keep-alive
   ]),
@@ -116,13 +117,15 @@ notifyRouter.post('/', notifyRateLimit, requireAuth, (req, res) => {
     }).catch(err => log.error(`Failed to import sync engine: ${err}`));
   }
 
-  // For space_deletion_pending events, trigger a sync so we pull the vote round immediately
-  if (event === 'space_deletion_pending') {
+  // For a pending space_deletion or space_wipe, trigger a sync so we pull the vote round immediately.
+  // Both are irreversible and space-scoped, so the round wants to be in front of an operator now rather
+  // than at the next scheduled cycle — a deadline that expires unseen is a vote nobody got to cast.
+  if (event === 'space_deletion_pending' || event === 'space_wipe_pending') {
     import('../sync/engine.js').then(({ runSyncForNetwork }) => {
       runSyncForNetwork(networkId).catch(err =>
-        log.error(`Triggered sync (space_deletion_pending) for network ${networkId} failed: ${err}`),
+        log.error(`Triggered sync (${event}) for network ${networkId} failed: ${err}`),
       );
-    }).catch(err => log.error(`Failed to import sync engine (space_deletion_pending): ${err}`));
+    }).catch(err => log.error(`Failed to import sync engine (${event}): ${err}`));
   }
 
   // N-7: when a member departs, auto-adopt its children as direct children of this instance

--- a/server/src/api/sync/votes.ts
+++ b/server/src/api/sync/votes.ts
@@ -8,6 +8,7 @@ import { syncRateLimit } from '../../rate-limit/middleware.js';
 import { getConfig, loadConfig, saveConfig } from '../../config/loader.js';
 import { requireAuth, denyReadOnly } from '../../auth/middleware.js';
 import { log } from '../../util/log.js';
+import { applyWipeRoundIfPassed } from '../../spaces/apply-wipe-round.js';
 import { acceptVoteCast } from '../../util/signing.js';
 import { concludeRoundIfReady, sendMemberRemovedNotify } from '../../sync/governance.js';
 
@@ -95,6 +96,10 @@ syncVotesRouter.post('/networks/:networkId/votes/:roundId', syncRateLimit, requi
         }).catch(err => log.error(`space_deletion import: ${err}`));
       }
     }
+
+    // X-5: same shared side-effect as the local-vote path. A peer's yes can be the one that carries the
+    // round, so this instance must wipe on THIS path too — that is the half a per-site copy tends to miss.
+    applyWipeRoundIfPassed(round, 'peer vote');
 
     // If a remove round just passed, notify the ejected member
     if (round.concluded && round.passed && round.type === 'remove') {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -15,6 +15,7 @@ import { duplicatesRouter } from './api/duplicates.js';
 import { contradictionsRouter } from './api/contradictions.js';
 import { syncRouter } from './api/sync/index.js';
 import { editorScopeFor } from './auth/editor-scope.js';
+import { planSpaceWipe, notifyPeersOfWipe } from './spaces/wipe-vote.js';
 import { networksRouter } from './api/networks/index.js';
 import { notifyRouter } from './api/notify.js';
 import { inviteRouter } from './api/invite.js';
@@ -346,6 +347,16 @@ export function createApp() {
         return;
       }
     }
+    // X-5: on a space that belongs to a network, emptying it is a governed act and opens a vote instead of
+    // happening now. A space in no network is unaffected — `planSpaceWipe` says which, and the same planner
+    // answers for the `wipe_space` tool so the two doors cannot drift.
+    const plan = planSpaceWipe(spaceId, rawTypes);
+    if (plan.governed) {
+      notifyPeersOfWipe(spaceId, rawTypes);
+      res.status(202).json({ status: 'vote_pending', rounds: plan.rounds });
+      return;
+    }
+
     try {
       const deleted = await wipeSpace(spaceId, rawTypes);
       res.json({ deleted });

--- a/server/src/config/types-networks.ts
+++ b/server/src/config/types-networks.ts
@@ -29,7 +29,7 @@ import type { SpaceMeta } from './types-knowledge.js';
 export type NetworkType = 'closed' | 'democratic' | 'club' | 'braintree' | 'pubsub';
 export type SyncDirection = 'both' | 'push' | 'pull';
 export type VoteValue = 'yes' | 'veto';
-export type VoteRoundType = 'join' | 'remove' | 'space_deletion' | 'meta_change';
+export type VoteRoundType = 'join' | 'remove' | 'space_deletion' | 'space_wipe' | 'meta_change';
 
 export interface NetworkMember {
   instanceId: string;
@@ -85,7 +85,15 @@ export interface VoteRound {
   concluded?: boolean;
   passed?: boolean;          // true if concluded and the motion carried; false if vetoed/expired
   pendingMember?: NetworkMember;  // stored on join rounds; added to members when vote passes
-  spaceId?: string;              // populated for space_deletion and meta_change rounds
+  spaceId?: string;              // populated for space_deletion, space_wipe and meta_change rounds
+  /**
+   * Which collections a `space_wipe` round will empty, or absent for all five.
+   *
+   * Carried ON THE ROUND rather than resolved at conclusion, because a partial wipe is what the members
+   * voted for. Resolving it later — from a request that no longer exists, or by defaulting to everything —
+   * would let a round approved for `files` conclude by emptying the knowledge graph.
+   */
+  wipeTypes?: string[];
   pendingMeta?: SpaceMeta;       // stored on meta_change rounds; applied when vote passes
   /**
    * Top-level `meta` fields the proposer changed (meta_change rounds).

--- a/server/src/mcp/tools/spaces.ts
+++ b/server/src/mcp/tools/spaces.ts
@@ -6,6 +6,7 @@ import { canWriteAnywhere } from '../../auth/write-anywhere.js';
 import type { TokenRights } from '../../config/rights-shape.js';
 import { memberSpacesWithin } from '../../spaces/proxy-scoped.js';
 import { WIPE_COLLECTION_TYPES, type WipeCollectionType, wipeSpace } from '../../spaces/lifecycle.js';
+import { planSpaceWipe, notifyPeersOfWipe } from '../../spaces/wipe-vote.js';
 import { updateSpace, spacePurpose } from '../../spaces/spaces.js';
 import { SPACE_PURPOSE_MAX, needsReindex } from '../../spaces/_shared.js';
 
@@ -604,13 +605,17 @@ export const wipe_spaceTool: ToolHandler = {
   description: 'Empty a space of its DATA while keeping the space itself — its id, label, purpose, schema, '
     + 'rights and network membership all survive. Requires instance-admin rights. IRREVERSIBLE: there is no '
     + 'undo, no trash, and no confirmation step, so the call that arrives is the call that runs.\n\n'
-    + 'IT IS A LOCAL WIPE, AND ON A NETWORKED SPACE THAT IS PROBABLY NOT WHAT YOU WANT. Unlike every '
-    + '`delete_*` tool, this writes NO tombstones — it deletes the existing ones as well. Tombstones are the '
-    + 'only thing that tells a peer a record is gone; without them a peer\'s manifest still offers everything '
-    + 'it holds and this instance, now empty and with no record of any deletion, has no reason to refuse it. '
-    + 'So on a space that belongs to a sync network, expect the next round to put much of it back. Wipe every '
-    + 'peer, or leave the network first, or use the per-record `delete_*` tools — those do tombstone.\n\n'
-    + 'On a space in no network there is nothing to bring it back and the wipe is simply final.\n\n'
+    + 'ON A NETWORKED SPACE IT OPENS A VOTE AND WIPES NOTHING YET. Emptying a space the network shares is a '
+    + 'governed act, like deleting one: a round opens in every network that holds the space, this instance '
+    + 'votes yes, and the wipe happens on EVERY member when a round passes. A single veto stops it there. So '
+    + 'a reply saying `vote_pending` is the success case — do not retry it, and do not read the absence of '
+    + 'counts as a failure. Watch the rounds.\n\n'
+    + 'ON A SPACE IN NO NETWORK it wipes immediately and finally, exactly as it always has. Nothing about an '
+    + 'unnetworked instance changed.\n\n'
+    + 'WHY IT VOTES RATHER THAN PROPAGATING. A wipe writes NO tombstones and deletes the existing ones, and '
+    + 'tombstones are the only thing that tells a peer a record is gone — so a local wipe on a shared space '
+    + 'used to be undone by the next sync, which offered everything back to an instance with no record of any '
+    + 'deletion. Voting removes that problem rather than solving it: the peers are wiping too.\n\n'
     + 'IT IS IDEMPOTENT. Wiping an empty space succeeds and returns zeroes rather than erroring, so a retry '
     + 'after a dropped connection is safe.\n\n'
     + 'WHAT ELSE GOES WITH IT: the review queues are cleared for whatever you wiped — duplicate and '
@@ -654,8 +659,29 @@ export const wipe_spaceTool: ToolHandler = {
       throw new Error(`types must be an array of: ${WIPE_COLLECTION_TYPES.join(', ')}`);
     }
     const wipeTypes = rawTypes as WipeCollectionType[] | undefined;
-    const result = await wipeSpace(callSpace, wipeTypes);
     const typesLabel = wipeTypes && wipeTypes.length > 0 ? wipeTypes.join(', ') : 'all';
+
+    // X-5: the SAME planner the REST route calls. Both doors ask one function whether this space is governed
+    // and it opens the rounds; neither decides for itself, because a second copy of that rule is how one
+    // surface ends up wiping immediately while the other votes.
+    const plan = planSpaceWipe(callSpace, wipeTypes);
+    if (plan.governed) {
+      notifyPeersOfWipe(callSpace, wipeTypes);
+      const where = plan.rounds.map(r => r.networkLabel).join(', ');
+      return {
+        content: [{
+          type: 'text' as const,
+          text: `Nothing has been wiped yet. '${callSpace}' belongs to ${plan.rounds.length} network`
+            + `${plan.rounds.length === 1 ? '' : 's'} (${where}), so emptying it is a governed act: a vote is `
+            + `now open in each, and this instance has voted yes. [${typesLabel}] is wiped on every member `
+            + 'when a round passes, and a single veto stops it there. Watch the rounds rather than expecting '
+            + 'counts from this call.',
+        }],
+        structuredContent: { status: 'vote_pending', rounds: plan.rounds, types: wipeTypes ?? null },
+      };
+    }
+
+    const result = await wipeSpace(callSpace, wipeTypes);
     const summary = `Wiped [${typesLabel}] in space '${callSpace}': ${result.memories} memories, ${result.entities} entities, ${result.edges} edges, ${result.chrono} chrono, ${result.files} files.`;
     return {
       content: [{ type: 'text' as const, text: summary }],

--- a/server/src/spaces/apply-wipe-round.ts
+++ b/server/src/spaces/apply-wipe-round.ts
@@ -1,0 +1,75 @@
+/**
+ * The side-effect of a concluded `space_wipe` round: empty the space, here, now.
+ *
+ * ## One function, three callers, on purpose
+ *
+ * A round concludes in three places — an operator's own vote (`api/networks/votes.ts`), a peer's vote
+ * arriving over sync (`api/sync/votes.ts`), and the gossip pass in the sync engine. `space_deletion` has its
+ * side-effect written out at all three, and that is the shape this repo keeps paying for: three copies of
+ * one rule, where a change to two of them leaves the third quietly doing the old thing.
+ *
+ * So the wipe lands as ONE function the three call. It is not more indirection than the alternative — it is
+ * the same code, named once.
+ *
+ * ## Veto counting matches `space_deletion` exactly
+ *
+ * A single veto stops it. That is deliberately stricter than a majority: a member that does not want its
+ * copy of a space emptied is not outvoted, because the wipe is irreversible on their instance too.
+ */
+import { log } from '../util/log.js';
+import type { VoteRound } from '../config/types.js';
+import type { WipeCollectionType } from './lifecycle.js';
+
+/**
+ * Apply a concluded round if — and only if — it is a `space_wipe` that carried.
+ *
+ * Returns whether the wipe was started, so a caller can log or test the decision without waiting on the
+ * write. Fire-and-forget beyond that: a wipe that fails must not abort the vote handling that produced it,
+ * for the same reason `space_deletion`'s does not.
+ */
+export function applyWipeRoundIfPassed(round: VoteRound, where: string): boolean {
+  if (!round.concluded || round.type !== 'space_wipe') return false;
+  if (!round.spaceId) return false;
+  // A single veto stops it, exactly as for space_deletion.
+  if (round.votes.some(v => v.vote === 'veto')) return false;
+
+  // The types the members VOTED for, never a fresh default. A round approved for `files` must not conclude
+  // by emptying the knowledge graph, which is what resolving this at conclusion time would risk.
+  const types = round.wipeTypes as WipeCollectionType[] | undefined;
+
+  void import('./lifecycle.js').then(({ wipeSpace }) =>
+    wipeSpace(round.spaceId!, types)
+      .then(r => log.info(
+        `space_wipe round ${round.roundId} passed (${where}): emptied '${round.spaceId}' — `
+        + `${r.memories} memories, ${r.entities} entities, ${r.edges} edges, ${r.chrono} chrono, ${r.files} files`,
+      ))
+      .catch((err: unknown) => log.error(`space_wipe side-effect (${where}): ${err}`)),
+  ).catch((err: unknown) => log.error(`space_wipe import (${where}): ${err}`));
+
+  return true;
+}
+
+/**
+ * Apply every space-scoped side-effect for a list of rounds — deletion and wipe both.
+ *
+ * The gossip pass in `sync/engine.ts` concludes rounds nobody on this instance voted on, and had the
+ * `space_deletion` side-effect written out inline there: a third copy of the same eight lines that already
+ * existed in the two vote handlers. Adding `space_wipe` beside it would have made six.
+ *
+ * So the loop moved here. `no-new-god-files.test.js` is what forced it, and it was right — engine.ts is one
+ * of the largest files in the tree, and the reason it is large is that every change lands where the code
+ * already is.
+ */
+export function applyConcludedSpaceRounds(rounds: readonly VoteRound[], where: string): void {
+  for (const round of rounds) {
+    if (round.concluded && round.type === 'space_deletion') {
+      // Unchanged: zero vetoes, and a space id to act on. Moved, not rewritten.
+      if (!round.votes.some(v => v.vote === 'veto') && round.spaceId) {
+        void import('./lifecycle.js')
+          .then(({ removeSpace }) => removeSpace(round.spaceId!))
+          .catch((err: unknown) => log.error(`space_deletion side-effect (${where}): ${err}`));
+      }
+    }
+    applyWipeRoundIfPassed(round, where);
+  }
+}

--- a/server/src/spaces/wipe-vote.ts
+++ b/server/src/spaces/wipe-vote.ts
@@ -1,0 +1,124 @@
+/**
+ * Emptying a space of its data is a GOVERNED act when the space belongs to a network.
+ *
+ * ## The ruling, and the defect it closes
+ *
+ * Owner, 2026-08-16: *"thats a voting thing."* Filed as X-5.
+ *
+ * `wipeSpace` deletes the documents and then deletes the TOMBSTONES too, writing none. Tombstones are this
+ * codebase's only way of telling a peer that a record is gone, so a wipe left an empty space with no record
+ * of any deletion, facing a peer that still offered everything and nothing to refuse it with — the next sync
+ * round simply put it back.
+ *
+ * The three fixes I offered were propagate, refuse, or document. The ruling is none of them and is better
+ * than all three: a wipe that every member agreed to does not need a tombstone, because the peers are wiping
+ * too. The resurrection problem does not get solved, it stops existing.
+ *
+ * ## Why this is one module rather than a branch in each door
+ *
+ * REST (`POST /api/admin/spaces/:spaceId/wipe`) and MCP (`wipe_space`) both wipe. A second copy of "is this
+ * space governed, and if so open a round on every network that holds it" is the defect this repo produces
+ * most — one rule, two implementations, and the weaker one wins silently. Both doors call `planSpaceWipe`
+ * and act on its verdict; neither decides anything itself.
+ *
+ * ## What it deliberately does NOT do
+ *
+ * It does not wipe. A planner that also performed the write could not be exercised without a database, and
+ * the interesting half here is the decision — solo or governed, and which collections the round carries.
+ */
+import { v4 as uuidv4 } from 'uuid';
+import { getConfig, saveConfig } from '../config/loader.js';
+import type { NetworkConfig } from '../config/types.js';
+
+/** The verdict: wipe now, or a round was opened on each network holding the space. */
+export type WipePlan =
+  | { governed: false }
+  | { governed: true; rounds: { networkId: string; networkLabel: string; roundId: string }[] };
+
+/** Networks that carry this space. Exported so a caller can report "which networks" without re-deriving it. */
+export function networksHolding(spaceId: string): NetworkConfig[] {
+  return getConfig().networks.filter(n => n.spaces.includes(spaceId));
+}
+
+/**
+ * Decide whether this wipe votes, and open the rounds if it does.
+ *
+ * Returns `{ governed: false }` for a space in no network — that wipe is local, immediate and final, exactly
+ * as it has always been. Nothing about an unnetworked instance changes.
+ *
+ * For a governed space it opens one round per network holding it, votes this instance's own yes, persists,
+ * and hands back the round ids. The wipe itself happens when each round concludes — see the three conclusion
+ * sites that already do this for `space_deletion`.
+ *
+ * `types` is stored ON the round. A partial wipe is what the members are voting for, so resolving it later
+ * would let a round approved for `files` conclude by emptying the knowledge graph.
+ */
+export function planSpaceWipe(spaceId: string, types?: readonly string[]): WipePlan {
+  const nets = networksHolding(spaceId);
+  if (nets.length === 0) return { governed: false };
+
+  const cfg = getConfig();
+  const now = new Date().toISOString();
+  const rounds: { networkId: string; networkLabel: string; roundId: string }[] = [];
+
+  for (const net of cfg.networks.filter(n => n.spaces.includes(spaceId))) {
+    const roundId = uuidv4();
+    net.pendingRounds ??= [];
+    net.pendingRounds.push({
+      roundId,
+      type: 'space_wipe',
+      subjectInstanceId: cfg.instanceId,
+      subjectLabel: cfg.instanceLabel,
+      subjectUrl: '',   // not meaningful for a wipe, as for space_deletion
+      deadline: new Date(Date.now() + net.votingDeadlineHours * 3_600_000).toISOString(),
+      openedAt: now,
+      votes: [{ instanceId: cfg.instanceId, vote: 'yes', castAt: now }],
+      spaceId,
+      // Omitted rather than defaulted when the caller wants everything: an absent `wipeTypes` means all
+      // five at conclusion, which is the same meaning it has on the request.
+      ...(types && types.length > 0 ? { wipeTypes: [...types] } : {}),
+    });
+    rounds.push({ networkId: net.id, networkLabel: net.label, roundId });
+  }
+
+  saveConfig(cfg);
+  return { governed: true, rounds };
+}
+
+/**
+ * Tell every peer a wipe round is open, so they pull it now instead of at the next scheduled sync.
+ *
+ * Best-effort by design, exactly as `space_deletion_pending` is: a peer that cannot be reached still sees the
+ * round on its next sync, because the round is in the config that syncs. Failing the caller's request
+ * because one peer is down would make a governed wipe less reliable than an ungoverned one.
+ *
+ * Lives here rather than at each door for the same reason `planSpaceWipe` does — it is the other half of one
+ * action, and two copies of "who do we tell" is how one door ends up silently not telling anyone.
+ */
+export function notifyPeersOfWipe(spaceId: string, types?: readonly string[]): void {
+  const cfg = getConfig();
+  const space = cfg.spaces.find(s => s.id === spaceId);
+  void (async () => {
+    const { getSecrets } = await import('../config/loader.js');
+    const { peerSafeFetch } = await import('../sync/peer-fetch.js');
+    const { log } = await import('../util/log.js');
+    const secrets = getSecrets();
+    for (const net of networksHolding(spaceId)) {
+      for (const member of net.members) {
+        const peerToken = secrets.peerTokens[member.instanceId];
+        if (!peerToken) continue;
+        peerSafeFetch(`${member.url}/api/notify`, {
+          method: 'POST',
+          headers: { 'Authorization': `Bearer ${peerToken}`, 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            networkId: net.id,
+            instanceId: cfg.instanceId,
+            event: 'space_wipe_pending',
+            data: { spaceId, spaceLabel: space?.label, types: types && types.length > 0 ? [...types] : undefined },
+          }),
+          signal: AbortSignal.timeout(5_000),
+        }).catch((err: unknown) => log.warn(`notify ${member.label} of space_wipe_pending: ${err}`));
+      }
+    }
+  })();
+}

--- a/server/src/sync/engine.ts
+++ b/server/src/sync/engine.ts
@@ -24,6 +24,7 @@ import { recordFileTombstoneAck, ackedPositionFrom } from './file-tombstone-ack.
 import { recordSyncResult, type SyncCounts } from './history.js';
 import { buildFileManifest } from '../files/manifest.js';
 import { log } from '../util/log.js';
+import { applyConcludedSpaceRounds } from '../spaces/apply-wipe-round.js';
 import { bumpSeq, isSeqImplausible } from '../util/seq.js';
 import { peerSafeFetch, isPeerUrlAllowed, PEER_TRANSFER_TIMEOUT_MS } from './peer-fetch.js';
 import { concludeRoundIfReady, sendMemberRemovedNotify } from './governance.js';
@@ -788,17 +789,9 @@ async function propagateVotesWithPeer(
           }
         }
       }
-      // Apply space_deletion side-effects for rounds that just concluded
-      for (const round of freshNet.pendingRounds) {
-        if (round.concluded && round.type === 'space_deletion') {
-          const vetoCount = round.votes.filter(v => v.vote === 'veto').length;
-          if (vetoCount === 0 && round.spaceId) {
-            import('../spaces/lifecycle.js').then(({ removeSpace }) => {
-              removeSpace(round.spaceId!).catch(e => log.error(`space_deletion vote gossip: ${e}`));
-            }).catch(e => log.error(`space_deletion import: ${e}`));
-          }
-        }
-      }
+      // Space-scoped side-effects for rounds that just concluded — deletion and wipe. The gossip pass
+      // concludes rounds nobody here voted on, so this is where a decision made elsewhere lands.
+      applyConcludedSpaceRounds(freshNet.pendingRounds, 'gossip');
       saveConfig(fresh);
     }
   } catch (err) {

--- a/testing/integration/space-wipe-votes-when-networked.test.js
+++ b/testing/integration/space-wipe-votes-when-networked.test.js
@@ -1,0 +1,87 @@
+/**
+ * Integration test: wiping a NETWORKED space opens a vote instead of emptying it (X-5).
+ *
+ * The standalone gate proves the wiring — one planner, both doors, three conclusion sites, the types riding
+ * on the round. What it cannot prove is that a round actually opens against a real config, which is the
+ * whole behaviour the owner ruled for: *"thats a voting thing."*
+ *
+ * Modelled on `space-deletion.test.js`'s networked case, because a wipe is now governed the same way a
+ * deletion is, and the two should stay recognisably one pattern.
+ *
+ * The negative case matters as much as the positive: an UNNETWORKED wipe must still be immediate. That half
+ * is the promise made to every existing operator, and a change that broke it would look like this feature
+ * working.
+ *
+ * Run: node --test testing/integration/space-wipe-votes-when-networked.test.js
+ */
+
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, del, delWithBody } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TOKEN_FILE = path.join(__dirname, '..', 'sync', 'configs', 'a', 'token.txt');
+
+let token;
+const RUN_ID = Date.now();
+
+describe('Space wipe — governed when the space is in a network', () => {
+  before(() => {
+    token = fs.readFileSync(TOKEN_FILE, 'utf8').trim();
+  });
+
+  it('a space in NO network still wipes immediately, with counts', async () => {
+    // The unchanged half, asserted first: every existing operator depends on it, and a regression here
+    // would be invisible behind the new feature apparently working.
+    const spaceId = `wipe-solo-${RUN_ID}`;
+    const createR = await post(INSTANCES.a, token, '/api/spaces', { id: spaceId, label: 'Wipe Solo' });
+    assert.equal(createR.status, 201, `create: ${JSON.stringify(createR.body)}`);
+
+    await post(INSTANCES.a, token, `/api/brain/spaces/${spaceId}/memories`, { fact: 'solo wipe subject' });
+
+    const wipeR = await post(INSTANCES.a, token, `/api/admin/spaces/${spaceId}/wipe`, {});
+    assert.equal(wipeR.status, 200, `Expected an immediate wipe, got ${wipeR.status}: ${JSON.stringify(wipeR.body)}`);
+    assert.ok(wipeR.body?.deleted, 'an ungoverned wipe answers with counts');
+    assert.equal(wipeR.body.status, undefined, 'and must NOT report a pending vote');
+
+    await delWithBody(INSTANCES.a, token, `/api/spaces/${spaceId}`, { confirm: true }).catch(() => {});
+  });
+
+  it('a space in a network opens a vote round and wipes nothing yet', async () => {
+    const spaceId = `wipe-networked-${RUN_ID}`;
+    const createR = await post(INSTANCES.a, token, '/api/spaces', { id: spaceId, label: 'Wipe Networked' });
+    assert.equal(createR.status, 201, `create: ${JSON.stringify(createR.body)}`);
+
+    const factR = await post(INSTANCES.a, token, `/api/brain/spaces/${spaceId}/memories`,
+      { fact: 'this must survive the vote being opened' });
+    assert.equal(factR.status, 201, `seed memory: ${JSON.stringify(factR.body)}`);
+
+    const netR = await post(INSTANCES.a, token, '/api/networks', {
+      label: `Wipe-Net-${RUN_ID}`,
+      type: 'closed',
+      spaces: [spaceId],
+    });
+    assert.equal(netR.status, 201, `network create: ${JSON.stringify(netR.body)}`);
+    const networkId = netR.body.id;
+
+    const wipeR = await post(INSTANCES.a, token, `/api/admin/spaces/${spaceId}/wipe`, {});
+    assert.equal(wipeR.status, 202, `Expected 202 (vote opened), got ${wipeR.status}: ${JSON.stringify(wipeR.body)}`);
+    assert.equal(wipeR.body?.status, 'vote_pending', 'the status names what happened');
+    assert.ok(wipeR.body?.rounds?.length > 0, 'at least one round must be open');
+    assert.equal(wipeR.body.rounds[0].networkId, networkId, 'the round belongs to the network holding the space');
+
+    // The point of the whole change: the data is still there. A vote that emptied the space anyway would
+    // pass every assertion above and be the exact bug this replaces.
+    const stillR = await post(INSTANCES.a, token, `/api/brain/spaces/${spaceId}/query`,
+      { collection: 'memories', filter: {} });
+    assert.equal(stillR.status, 200, `query after vote opened: ${JSON.stringify(stillR.body)}`);
+    assert.ok((stillR.body?.results?.length ?? 0) > 0,
+      'the memory must survive: the wipe happens when the round PASSES, not when it opens');
+
+    await del(INSTANCES.a, token, `/api/networks/${networkId}`).catch(() => {});
+    await delWithBody(INSTANCES.a, token, `/api/spaces/${spaceId}`, { confirm: true }).catch(() => {});
+  });
+});

--- a/testing/standalone/wipe-space-says-it-is-local.test.js
+++ b/testing/standalone/wipe-space-says-it-is-local.test.js
@@ -39,28 +39,41 @@ const WIPE = (() => {
   return s.slice(d, d + end);
 })();
 
-describe('wipe_space warns that it does not reach peers', () => {
-  it('says it is LOCAL', () => {
-    assert.match(WIPE, /LOCAL WIPE/, 'the single most consequential fact about this tool');
+describe('wipe_space says a networked space VOTES', () => {
+  /**
+   * This file asserted the opposite until X-5 shipped: that the description warned the wipe was LOCAL, named
+   * the three workarounds, and told a caller to expect the next sync to put the data back. All true at the
+   * time, and writing it down is what got the owner to rule *"thats a voting thing"*.
+   *
+   * Inverted rather than deleted. The rule it protects never moved: **the description must say what actually
+   * happens on a networked space, unmissably**, because the failure mode is a caller who thinks the data is
+   * gone when it is not — or now, one who reads `vote_pending` as an error and retries into a second round.
+   */
+  it('says it opens a vote and wipes nothing yet', () => {
+    assert.match(WIPE, /OPENS A VOTE AND WIPES NOTHING YET/,
+      'the single most consequential fact about this tool');
   });
 
-  it('says it writes NO tombstones and removes the existing ones', () => {
+  it('says a reply with no counts is the SUCCESS case', () => {
+    // The new mistake to pre-empt, replacing the old one. Retrying opens a second round.
+    assert.match(WIPE, /do not retry it/, 'a caller must not read the absent counts as a failure');
+  });
+
+  it('still explains the tombstone mechanism — it is why this votes at all', () => {
     assert.match(WIPE, /NO tombstones/, 'name the mechanism, not just the outcome');
     assert.match(WIPE, /deletes the existing ones/,
       'clearing them is worse than not writing them and has to be said separately');
   });
 
-  it('says what to do instead, so the warning is actionable', () => {
-    // A warning with no alternative gets ignored by the caller who still has to empty the space.
-    assert.match(WIPE, /leave the network|Wipe every peer/,
-      'name at least one way to actually empty a networked space');
-    assert.match(WIPE, /delete_\*|delete_/, 'and point at the tools that DO tombstone');
+  it('and does not overstate it for a space in no network', () => {
+    // Accuracy in the other direction, unchanged in intent: an unnetworked wipe is immediate and final, and
+    // a caller who reads this as "wipe now always votes" would go looking for a round that never opened.
+    assert.match(WIPE, /NO NETWORK it wipes immediately/, 'the unnetworked case must be stated too');
   });
 
-  it('and does not overstate it for a space in no network', () => {
-    // Accuracy in the other direction: on an unnetworked space the wipe is simply final, and a caller who
-    // reads this as "wipe never works" would go looking for a tool that does not exist.
-    assert.match(WIPE, /no network/, 'the unnetworked case must be stated too');
+  it('and the old "expect it back" warning is gone with the behaviour it described', () => {
+    assert.doesNotMatch(WIPE, /expect the next round to put much of it back/,
+      'that was true of a local wipe and is false of a voted one');
   });
 });
 

--- a/testing/standalone/wiping-a-networked-space-votes.test.js
+++ b/testing/standalone/wiping-a-networked-space-votes.test.js
@@ -1,0 +1,171 @@
+/**
+ * X-5: emptying a space the network shares is a GOVERNED act.
+ *
+ * ## The ruling and what it dissolves
+ *
+ * Owner, 2026-08-16: *"thats a voting thing."* I had offered three options — propagate the wipe, refuse it
+ * without a flag, or leave it documented — and the ruling is none of them.
+ *
+ * `wipeSpace` deletes the documents and then deletes the TOMBSTONES too, writing none. Tombstones are this
+ * codebase's only way of telling a peer a record is gone, so a wipe left an empty space with no record of
+ * any deletion, facing a peer that still offered everything. The next sync put it back.
+ *
+ * A vote does not fix the tombstone problem — it removes it. A wipe every member agreed to needs nothing to
+ * survive a peer's manifest, because the peers are wiping too.
+ *
+ * ## What this file pins
+ *
+ * **One planner, both doors.** REST (`POST /api/admin/spaces/:spaceId/wipe`) and MCP (`wipe_space`) both ask
+ * `planSpaceWipe`. A second copy of "is this space governed" is the defect this repo produces most, and here
+ * it would mean one surface wiping immediately while the other voted.
+ *
+ * **One side-effect, three conclusion sites.** A round concludes on an operator's own vote, on a peer's vote
+ * arriving over sync, and in the gossip pass. `space_deletion` writes its side-effect out three times;
+ * `space_wipe` calls one function from all three, so a change cannot reach two of them and miss the third.
+ *
+ * **The types voted for are the types wiped.** `wipeTypes` rides on the round. Resolving it at conclusion
+ * would let a round approved for `files` conclude by emptying the knowledge graph.
+ *
+ * Run: node --test testing/standalone/wiping-a-networked-space-votes.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripComments } from './_strip-comments.mjs';
+
+const src = (p) => stripComments(readFileSync(p, 'utf8'));
+
+describe('the decision lives in one place, and both doors ask it', () => {
+  it('the REST route calls the planner', () => {
+    assert.match(src('server/src/app.ts'), /planSpaceWipe\(spaceId, rawTypes\)/,
+      'the wipe route must not decide for itself whether a space is governed');
+  });
+
+  it('the MCP tool calls the same planner', () => {
+    assert.match(src('server/src/mcp/tools/spaces.ts'), /planSpaceWipe\(callSpace, wipeTypes\)/,
+      'both doors, one rule — a second copy is how one surface votes and the other does not');
+  });
+
+  it('neither door reimplements "which networks hold this space"', () => {
+    // The specific duplication to avoid: `cfg.networks.filter(n => n.spaces.includes(id))` written again at
+    // a call site. `networksHolding` exists so the answer has one definition.
+    for (const f of ['server/src/app.ts', 'server/src/mcp/tools/spaces.ts']) {
+      assert.doesNotMatch(src(f), /networks\.filter\(n => n\.spaces\.includes\(\s*(spaceId|callSpace)\s*\)\)/,
+        `${f} re-derives the governed set instead of asking the planner`);
+    }
+  });
+
+  it('and a wipe is not started when the plan says governed', () => {
+    // The assertion that makes this a behaviour change rather than a notification: the governed branch must
+    // RETURN before `wipeSpace` runs, on both doors.
+    const app = src('server/src/app.ts');
+    const governedAt = app.indexOf('if (plan.governed)');
+    const wipeAt = app.indexOf('await wipeSpace(spaceId');
+    assert.ok(governedAt > 0 && wipeAt > governedAt,
+      'the governed branch must come BEFORE the wipe, or the vote is decoration');
+    assert.match(app.slice(governedAt, wipeAt), /return;/, 'and it must return');
+  });
+});
+
+describe('a space in no network is untouched by this', () => {
+  it('the planner says not-governed when nothing holds the space', () => {
+    assert.match(src('server/src/spaces/wipe-vote.ts'), /if \(nets\.length === 0\) return \{ governed: false \}/,
+      'an unnetworked wipe stays immediate, final, and exactly what it was');
+  });
+});
+
+describe('the round carries what was voted for', () => {
+  it('wipeTypes rides on the round rather than being resolved later', () => {
+    const plan = src('server/src/spaces/wipe-vote.ts');
+    assert.match(plan, /wipeTypes: \[\.\.\.types\]/, 'stored when a subset was asked for');
+    assert.match(plan, /type: 'space_wipe'/, 'under its own round type');
+  });
+
+  it('and the side-effect reads them off the round, never a fresh default', () => {
+    // The dangerous shortcut: defaulting to "all five" at conclusion would empty the knowledge graph on a
+    // round the members approved for files only.
+    const apply = src('server/src/spaces/apply-wipe-round.js'.replace('.js', '.ts'));
+    assert.match(apply, /round\.wipeTypes as WipeCollectionType\[\] \| undefined/,
+      'the types come from the round');
+    assert.doesNotMatch(apply, /WIPE_COLLECTION_TYPES/,
+      'no fallback to everything — an absent wipeTypes already means all five inside wipeSpace');
+  });
+
+  it('the round type is declared', () => {
+    assert.match(src('server/src/config/types-networks.ts'), /'space_deletion' \| 'space_wipe'/,
+      'space_wipe must be a VoteRoundType');
+  });
+});
+
+describe('all three conclusion sites apply it, through one function', () => {
+  // Two spellings, one module. The vote handlers apply a single round they just touched; the gossip pass
+  // sweeps a list it did not vote on, so it calls the batch form — which also absorbed the `space_deletion`
+  // side-effect that used to be written out inline there. Both routes through `apply-wipe-round.ts`, which
+  // is what the last assertion in this block actually guarantees.
+  for (const [file, where, call] of [
+    ['server/src/api/networks/votes.ts', 'an operator voting locally', /applyWipeRoundIfPassed\(round, /],
+    ['server/src/api/sync/votes.ts', "a peer's vote arriving", /applyWipeRoundIfPassed\(round, /],
+    ['server/src/sync/engine.ts', 'the gossip pass', /applyConcludedSpaceRounds\(/],
+  ]) {
+    it(`${where} concludes the wipe`, () => {
+      assert.match(src(file), call,
+        `${file} must apply a concluded wipe — a site that misses it leaves this instance holding data every peer deleted`);
+    });
+  }
+
+  it('and the side-effect is not written out three times', () => {
+    // `space_deletion` IS written out three times, which is the shape this avoids: a change that reaches two
+    // sites and silently misses the third.
+    for (const f of ['server/src/api/networks/votes.ts', 'server/src/api/sync/votes.ts', 'server/src/sync/engine.ts']) {
+      assert.doesNotMatch(src(f), /wipeSpace\(/, `${f} must call the shared function, not wipe directly`);
+    }
+  });
+
+  it('a single veto stops it, as for space_deletion', () => {
+    assert.match(src('server/src/spaces/apply-wipe-round.ts'), /votes\.some\(v => v\.vote === 'veto'\)/,
+      'a member that does not want its copy emptied is not outvoted — the wipe is irreversible there too');
+  });
+});
+
+describe('peers are told a round is open', () => {
+  it('the notify event exists and is accepted', () => {
+    assert.match(src('server/src/api/notify.ts'), /'space_wipe_pending'/, 'declared in the accepted enum');
+  });
+
+  it('and it triggers an immediate sync, like space_deletion_pending', () => {
+    // A deadline that expires before anyone sees the round is a vote nobody got to cast.
+    assert.match(src('server/src/api/notify.ts'),
+      /event === 'space_deletion_pending' \|\| event === 'space_wipe_pending'/,
+      'both irreversible space-scoped rounds pull immediately rather than waiting for the schedule');
+  });
+
+  it('both doors notify', () => {
+    for (const f of ['server/src/app.ts', 'server/src/mcp/tools/spaces.ts']) {
+      assert.match(src(f), /notifyPeersOfWipe\(/, `${f} must tell the peers`);
+    }
+  });
+});
+
+describe('the tool says what actually happens', () => {
+  const DESC = (() => {
+    const s = stripComments(readFileSync('server/src/mcp/tools/spaces.ts', 'utf8'));
+    const at = s.indexOf("name: 'wipe_space'");
+    const d = s.indexOf('description:', at);
+    const end = s.slice(d).search(/\n {2,}(mutating|spaceRequired|admin|spaceAdmin|inputSchema|async handle):/);
+    return s.slice(d, d + end);
+  })();
+
+  it('says a networked space votes and wipes nothing yet', () => {
+    assert.match(DESC, /OPENS A VOTE AND WIPES NOTHING YET/,
+      'a caller must not read the absence of counts as a failure and retry');
+  });
+
+  it('says an unnetworked space is unchanged', () => {
+    assert.match(DESC, /NO NETWORK it wipes immediately/, 'the other half, so nobody thinks wipe stopped working');
+  });
+
+  it('and the old "it will come back" warning is gone with the behaviour', () => {
+    assert.doesNotMatch(DESC, /expect the next round to put much of it back/,
+      'that was true of the local wipe and is not true of a voted one');
+  });
+});


### PR DESCRIPTION
Closes **X-5**. Owner ruled: *"thats a voting thing."* I had offered three options — propagate the wipe,
refuse it without a flag, or leave it documented. The ruling is none of them, and is better than all three.

## What it dissolves

`wipeSpace` deletes the documents and then deletes the **tombstones** too, writing none. Tombstones are this
codebase's only way of telling a peer a record is gone — so a wipe left an empty space with no record of any
deletion, facing a peer that still offered everything. The next sync put it back.

**A vote does not fix that. It removes it.** A wipe every member agreed to needs nothing to survive a peer's
manifest, because the peers are wiping too.

## Shape

| | |
| --- | --- |
| space in a network | round opens per network, this instance votes yes, wipe happens on **every member** when it passes |
| a single veto | stops it there — stricter than a majority, because the wipe is irreversible on their instance too |
| space in **no** network | **completely unaffected**: immediate, final, `200` with counts |

For a governed space the answer is `202 { "status": "vote_pending", "rounds": [...] }`. That is the success
case — retrying opens a second round.

## One planner, one side-effect

**Both doors call `planSpaceWipe`.** A second copy of *"is this space governed"* would mean one surface
wiping immediately while the other voted — the defect this repo produces most, in the place it would be
worst.

**The side-effect is one function called from all three conclusion sites**: an operator's own vote, a peer's
vote arriving over sync, and the gossip pass. `space_deletion` has its side-effect written out at all three,
and adding a second inline copy beside each would have made six.

`no-new-god-files.test.js` caught the two lines I had added to `sync/engine.ts`, and was right: the whole
conclusion loop moved into the shared module instead. That also removes the third copy of the **deletion**
side-effect, and leaves `engine.ts` smaller than it started.

## The types voted for are the types wiped

`wipeTypes` rides on the round. Resolving it at conclusion — from a request that no longer exists, or by
defaulting to everything — would let a round approved for `files` conclude by emptying the knowledge graph.

## Verification

19 standalone assertions. **Mutation-tested three ways:** dropping the gossip conclusion site, ignoring a
veto, and the MCP door skipping the planner. All caught.

An **integration test** covers what a source gate cannot — that a round really opens against a real config,
and that a seeded memory **survives** the vote being opened. A wipe that emptied the space anyway would pass
every other assertion and be the exact bug this replaces. The unnetworked case is asserted **first**, because
a regression there would hide behind this feature apparently working.

The earlier gate asserting the wipe was LOCAL is **inverted, not deleted**: the rule never moved — the
description must say what actually happens on a networked space — only the answer did.

## Five places

Both doors · `integration-guide/12-admin-api.md` and `09-sync-api.md` · `sync-protocol.md` · CHANGELOG under
**Breaking**.
