### PR TITLE
feat(auth): every instance-admin check reads the rights matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,17 +40,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **`wipe_space` now warns that it does not reach sync peers, which is the most consequential thing about
-  it.** Every per-record delete writes a tombstone, because a tombstone is the only thing that tells a peer a
-  record is gone. Wiping does the opposite: it deletes the data and then deletes the **tombstones** too,
-  writing none. On a space that belongs to a sync network that leaves an empty space with no record of any
-  deletion, facing a peer that still offers everything it holds — so the next round puts much of it back. The
-  old description said the space and its configuration are preserved and nothing about sync, which reads as
-  though the data is gone for good. It now says the wipe is local, and names the three ways to actually empty
-  a networked space. It also says that omitting `types` wipes **all five** collections rather than none, that
-  the duplicate and contradiction queues are cleared along with the records they point at, and that wiping an
-  already-empty space succeeds with zeroes rather than erroring. Whether wiping *should* propagate is a real
-  question with three defensible answers, so it is filed rather than decided.
+- **`wipe_space` now describes what it actually does to a space, beyond removing the records.** Omitting
+  `types` wipes **all five** collections rather than none — an absent filter is not a safe default. The
+  duplicate and contradiction queues are cleared along with the records they point at, because a finding is a
+  claim about two records and once those are gone it is not stale but *unopenable*. Wiping an already-empty
+  space succeeds with zeroes rather than erroring. And on a networked space it now opens a vote — see
+  **Breaking** below, which is the behaviour this description originally only warned about.
+
+- **Every instance-admin check now reads the rights matrix.** `enforceAdmin` — the one function behind every
+  admin route — gated on the deprecated `admin` boolean, and six other places asked the same question their
+  own way: the space-admin guard, the scoped guard, the peer-relay check, the trusted-relay check, the
+  `maxGiB` carve-out, and the last-admin lockout guard. Seven copies of one authorization question, where a
+  copy that drifts means a token reaching a route it never could, with no error to show for it. They all ask
+  one predicate now, which reads `rights.instanceAdmin` and falls back to the old flag only for a record
+  carrying no matrix — an OIDC session, which is built per request and legitimately has none. **No token's
+  access changes**: the two were proven to answer identically across every storable token shape before the
+  switch was made, in its own change, and the mint route refuses `admin` as an input so a divergent pair
+  cannot be created.
 
 - **`bulk_write` now says where it loses data quietly.** Anything past **500 entries per collection is
   discarded before validation** — it appears in neither the inserted counts nor the error list, so a 600-item

--- a/server/src/api/notify.ts
+++ b/server/src/api/notify.ts
@@ -8,7 +8,7 @@
 
 import { Router } from 'express';
 import { z } from 'zod';
-import { requireAuth } from '../auth/middleware.js';
+import { requireAuth, isInstanceAdmin } from '../auth/middleware.js';
 import { notifyRateLimit } from '../rate-limit/middleware.js';
 import { getConfig, saveConfig } from '../config/loader.js';
 import { revokePeerCredentialsIfOrphaned } from '../auth/tokens.js';
@@ -88,7 +88,7 @@ notifyRouter.post('/', notifyRateLimit, requireAuth, (req, res) => {
   // send events as the local instance (self-test pings).
   if (instanceId !== cfg.instanceId) {
     const authToken = req.authToken as { peerInstanceId?: string; admin?: boolean };
-    if (!authToken.admin && authToken.peerInstanceId !== instanceId) {
+    if (!isInstanceAdmin(authToken) && authToken.peerInstanceId !== instanceId) {
       res.status(403).json({ error: 'Token is not authorised for the claimed instanceId' });
       return;
     }

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -4,7 +4,7 @@ import { registerActivityResetRoute } from './spaces-activity.js';
 import path from 'path';
 import {
   requireAuth, requireSpaceAuthScoped, requireAdmin, requireAdminMfa, requireAdminMfaScoped,
-  requireAdminOrSpaceAdminMfaScoped,
+  requireAdminOrSpaceAdminMfaScoped, isInstanceAdmin,
 } from '../auth/middleware.js';
 import { globalRateLimit } from '../rate-limit/middleware.js';
 import { getConfig, saveConfig, getSecrets, getDataRoot, getSchemaLibrary, getDocumentProcessingConfig, getMediaEmbeddingConfig, getStorageConfig } from '../config/loader.js';
@@ -278,7 +278,7 @@ spacesRouter.patch('/:id', globalRateLimit, requireAdminOrSpaceAdminMfaScoped('i
   //
   // Checked against `record.admin` for the same reason the guard is: it is the instance-admin bit, and a space
   // administrator is by construction not it.
-  if (req.body?.maxGiB !== undefined && !req.authToken?.admin) {
+  if (req.body?.maxGiB !== undefined && !(req.authToken && isInstanceAdmin(req.authToken))) {
     res.status(403).json({
       error: 'maxGiB is an instance setting: a space administrator may change this space\'s settings but not '
         + 'its share of the host\'s storage. Ask an instance administrator to change the quota.',

--- a/server/src/api/sync/tombstones.ts
+++ b/server/src/api/sync/tombstones.ts
@@ -10,7 +10,7 @@ import { col, asFilter, asUpdate } from '../../db/mongo.js';
 import { syncRateLimit } from '../../rate-limit/middleware.js';
 import { getDataRoot } from '../../config/loader.js';
 import { listTombstones, applyRemoteTombstone } from '../../brain/tombstones.js';
-import { requireAuth, denyReadOnly } from '../../auth/middleware.js';
+import { requireAuth, denyReadOnly, isInstanceAdmin } from '../../auth/middleware.js';
 import { log } from '../../util/log.js';
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -89,7 +89,7 @@ syncTombstonesRouter.post('/tombstones', syncRateLimit, requireAuth, denyReadOnl
     // A peer token may only delete content it authored (peerInstanceId === tombstone issuer);
     // a trusted local/admin token (no peerInstanceId) may relay any tombstone.
     const callerPeerId = (req.authToken as Record<string, unknown>)?.['peerInstanceId'] as string | undefined;
-    const trustedRelay = !callerPeerId && req.authToken?.admin === true;
+    const trustedRelay = !callerPeerId && !!req.authToken && isInstanceAdmin(req.authToken);
     await Promise.all(parsed.data.map(t =>
       applyRemoteTombstone(t as TombstoneDoc, { peerInstanceId: callerPeerId, trustedRelay }),
     ));

--- a/server/src/api/tokens.ts
+++ b/server/src/api/tokens.ts
@@ -1,6 +1,6 @@
 ﻿import { Router } from 'express';
 import type { Request, Response } from 'express';
-import { requireAuth, requireAdminOrSpaceAdmin, requireAdminOrSpaceAdminMfa } from '../auth/middleware.js';
+import { requireAuth, requireAdminOrSpaceAdmin, requireAdminOrSpaceAdminMfa, isInstanceAdmin } from '../auth/middleware.js';
 import { authRateLimit, globalRateLimit } from '../rate-limit/middleware.js';
 import { createToken, listTokens, revokeToken, regenerateToken, renameToken, setTokenRights, setTokenMfa } from '../auth/tokens.js';
 import { isMfaEnabled, verifyMfaCode } from '../auth/totp.js';
@@ -503,7 +503,7 @@ tokensRouter.delete('/:id', requireAdminOrSpaceAdminMfa, async (req, res) => {
     return;
   }
   // Prevent locking out all admin access
-  if (target.admin && all.filter(t => t.admin).length === 1) {
+  if (isInstanceAdmin(target) && all.filter(t => isInstanceAdmin(t)).length === 1) {
     res.status(409).json({ error: 'Cannot revoke the last admin token' });
     return;
   }

--- a/server/src/auth/middleware.ts
+++ b/server/src/auth/middleware.ts
@@ -216,9 +216,34 @@ async function resolveAuthOrFail(
   return { record, bearer };
 }
 
-/** Enforce `admin: true`; writes 403 and returns false when the token is not admin. */
+/**
+ * Is this token an instance administrator? The MATRIX decides, with the legacy flag as the fallback.
+ *
+ * One function, because this question is asked by `enforceAdmin`, by `enforceAdminOrSpaceAdmin`, and by the
+ * scoped guard — three call sites that read `record.admin` directly until now. Three copies of one
+ * authorization predicate is how this repo produces its most expensive defects, and here the failure mode is
+ * the worst available: a token reaching a route it never could, silently.
+ *
+ * `rights` absent means the record never passed the config backfill — an OIDC session, built per request from
+ * the identity — so the legacy flag answers for it. Every PAT carries a matrix: `createToken` always writes
+ * one and a boot migration backfills the rest.
+ *
+ * **The two provably agree**, which is why this switch is safe to make at all:
+ * `instance-admin-agrees-with-the-legacy-flag.test.js` exercises `migrateToken` over all nine storable legacy
+ * shapes, and the mint route refuses `admin` as an input so a divergent pair cannot be created. That evidence
+ * landed in its own PR first, deliberately — see `auth/space-reach.ts` for why this feature does it that way.
+ */
+export function isInstanceAdmin(
+  record: Pick<TokenRecord, 'admin'> | OidcTokenRecord | { admin?: boolean },
+): boolean {
+  const rights = (record as { rights?: TokenRights | null }).rights;
+  if (rights) return rights.instanceAdmin === true;
+  return (record as { admin?: boolean }).admin === true;
+}
+
+/** Enforce instance-admin; writes 403 and returns false when the token is not one. */
 function enforceAdmin(res: Response, record: Omit<TokenRecord, 'hash'> | OidcTokenRecord): boolean {
-  if (!record.admin) {
+  if (!isInstanceAdmin(record)) {
     res.status(403).json({ error: 'Admin token required' });
     return false;
   }
@@ -249,7 +274,7 @@ function enforceAdminOrSpaceAdmin(
   res: Response,
   record: Omit<TokenRecord, 'hash'> | OidcTokenRecord,
 ): boolean {
-  if (record.admin) return true;
+  if (isInstanceAdmin(record)) return true;
   // Narrowed rather than cast wholesale: `rights` is the only field this decision reads, and naming it here
   // is what stops the predicate quietly growing a second input later.
   const withRights = record as { rights?: TokenRights | null };
@@ -635,7 +660,7 @@ export function requireAdminOrSpaceAdminMfaScoped(paramName: string) {
     const { record, bearer } = auth;
     const spaceId = req.params[paramName] as string | undefined;
 
-    if (!record.admin) {
+    if (!isInstanceAdmin(record)) {
       // Narrowed to the one field the decision reads, for the same reason `enforceAdminOrSpaceAdmin` does it.
       const withRights = record as { rights?: TokenRights | null };
       if (!spaceId || !isSpaceAdminFor(withRights.rights, spaceId)) {

--- a/testing/standalone/enforce-admin-reads-the-matrix.test.js
+++ b/testing/standalone/enforce-admin-reads-the-matrix.test.js
@@ -1,0 +1,128 @@
+/**
+ * `enforceAdmin` — the one function behind every admin route — now asks the rights matrix.
+ *
+ * ## The change this is, and the change it is not
+ *
+ * It reads `rights.instanceAdmin`, falling back to the legacy `admin` boolean only for a record that carries
+ * no matrix. That fallback is not decoration: an OIDC session is built per request from the identity and
+ * legitimately has none, while every PAT carries one — `createToken` always writes it and a boot migration
+ * backfills the rest.
+ *
+ * **No token's access changes.** The two provably answer the same question, which is what the previous PR
+ * established over all nine storable legacy shapes, and the mint route refuses `admin` as an input so a
+ * divergent pair cannot be created. This is the switch that evidence existed for.
+ *
+ * ## Why one predicate rather than five
+ *
+ * `record.admin` was read directly at five decision sites: this guard, the space-admin guard, the scoped
+ * guard, the peer-relay check in `notify`, the trusted-relay check in `sync/tombstones`, the `maxGiB`
+ * carve-out, and the last-admin lockout guard. Five copies of one authorization question, and the failure
+ * mode of a copy that drifts is the worst available — a token reaching a route it never could, silently.
+ *
+ * They all call `isInstanceAdmin` now. That is also what makes the field deletion mechanical rather than a
+ * hunt.
+ *
+ * Run: node --test testing/standalone/enforce-admin-reads-the-matrix.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripComments } from './_strip-comments.mjs';
+
+const src = (p) => stripComments(readFileSync(p, 'utf8'));
+
+let isInstanceAdmin, migrateToken;
+before(async () => {
+  ({ isInstanceAdmin } = await import('../../server/dist/auth/middleware.js'));
+  ({ migrateToken } = await import('../../server/dist/auth/rights-migration.js'));
+});
+
+const rights = (over = {}) => ({ instanceAdmin: false, createSpaces: false, floor: null, perSpace: {}, ...over });
+
+describe('the predicate reads the matrix first', () => {
+  it('a matrix saying instanceAdmin is an admin', () => {
+    assert.equal(isInstanceAdmin({ rights: rights({ instanceAdmin: true }) }), true);
+  });
+
+  it('a matrix saying otherwise is NOT — even with the legacy flag set', () => {
+    // The direction that matters. If a record ever carries a stale `admin: true` beside a matrix that says
+    // no, the matrix wins — otherwise the deprecated field would still be granting access.
+    assert.equal(isInstanceAdmin({ admin: true, rights: rights({ instanceAdmin: false }) }), false);
+  });
+
+  it('and a matrix saying yes wins over a legacy flag saying no', () => {
+    assert.equal(isInstanceAdmin({ admin: false, rights: rights({ instanceAdmin: true }) }), true);
+  });
+
+  it('a record with NO matrix falls back to the legacy flag', () => {
+    // OIDC sessions are built per request and legitimately carry no matrix. Refusing them here would be a
+    // silent narrowing — the opposite failure, and just as bad.
+    assert.equal(isInstanceAdmin({ admin: true }), true);
+    assert.equal(isInstanceAdmin({ admin: false }), false);
+    assert.equal(isInstanceAdmin({}), false);
+  });
+
+  it('and an admin rung on every space is still NOT an instance admin', () => {
+    // The distinction SA-1 rests on: administering every space that exists today says nothing about spaces
+    // created tomorrow, nor about instance-shaped routes. Only `instanceAdmin` or a floor does.
+    const everySpace = rights({ perSpace: { a: allAdmin(), b: allAdmin() } });
+    assert.equal(isInstanceAdmin({ rights: everySpace }), false);
+  });
+
+  const allAdmin = () => ({ knowledge: 'admin', files: 'admin', schema: 'admin', dataQuality: 'admin' });
+});
+
+describe('it agrees with the migration for every legacy shape', () => {
+  // The same nine shapes the evidence PR checked, now asserted through the PREDICATE rather than through
+  // `migrateToken` alone — so the guard and the migration cannot drift apart either.
+  for (const [label, legacy] of [
+    ['plain write', {}],
+    ['plain write, scoped', { spaces: ['qa'] }],
+    ['read-only', { readOnly: true }],
+    ['read-only, scoped', { readOnly: true, spaces: ['qa'] }],
+    ['admin', { admin: true }],
+    ['admin, scoped', { admin: true, spaces: ['qa'] }],
+    ['admin AND read-only', { admin: true, readOnly: true }],
+    ['empty allowlist', { spaces: [] }],
+    ['schema-library', { schemaLibrary: true, spaces: [] }],
+  ]) {
+    it(label, () => {
+      const migrated = { admin: legacy.admin === true, rights: migrateToken(legacy) };
+      assert.equal(isInstanceAdmin(migrated), legacy.admin === true && !legacy.schemaLibrary,
+        'the guard must answer what the legacy flag answered, for every storable shape');
+    });
+  }
+});
+
+describe('every decision site asks the one predicate', () => {
+  it('the three guards in middleware.ts', () => {
+    const mw = src('server/src/auth/middleware.ts');
+    assert.doesNotMatch(mw, /if \(!record\.admin\)/, 'no guard may read the legacy field directly');
+    assert.doesNotMatch(mw, /if \(record\.admin\) return true;/, 'nor the space-admin one');
+    assert.match(mw, /isInstanceAdmin\(record\)/, 'all of them go through the predicate');
+  });
+
+  it('and the four outside it', () => {
+    // Each of these was a separate copy of "is this an instance admin", and each would have had to be found
+    // by hand when the field is deleted.
+    for (const [f, what] of [
+      ['server/src/api/notify.ts', 'the peer-relay check'],
+      ['server/src/api/sync/tombstones.ts', 'the trusted-relay check'],
+      ['server/src/api/spaces.ts', 'the maxGiB carve-out'],
+      ['server/src/api/tokens.ts', 'the last-admin lockout guard'],
+    ]) {
+      assert.match(src(f), /isInstanceAdmin\(/, `${what} in ${f} must ask the predicate`);
+    }
+  });
+
+  it('nothing left reads `.admin` to make an authorization decision', () => {
+    // Scoped to the auth-bearing modules. `oidc.ts` maps a CLAIM to the flag, which is where the flag is
+    // legitimately produced rather than consumed, and `rights-migration.ts` reads it to build the matrix.
+    for (const f of ['server/src/auth/middleware.ts']) {
+      const body = src(f).replace(/return \(record as \{ admin\?: boolean \}\)\.admin === true;/, '');
+      assert.doesNotMatch(body, /\brecord\.admin\b/,
+        `${f} still reads the legacy field outside the one fallback`);
+    }
+  });
+});

--- a/testing/standalone/instance-admin-agrees-with-the-legacy-flag.test.js
+++ b/testing/standalone/instance-admin-agrees-with-the-legacy-flag.test.js
@@ -96,12 +96,28 @@ describe('where they CAN diverge, and what stops it', () => {
   });
 });
 
-describe('the guard has not moved yet — this PR changes nothing', () => {
-  it('enforceAdmin still reads the legacy boolean', () => {
-    // Asserted so the sequencing is explicit. When the guard does move, THIS assertion is the one that
-    // fails, which is the moment to re-read everything above rather than to renumber it.
+describe('the guard has moved onto the matrix, and this evidence is why it could', () => {
+  /**
+   * This block asserted the OPPOSITE for exactly one release: that `enforceAdmin` still read
+   * `record.admin`, so the sequencing was explicit and the switch could not be slipped in unnoticed.
+   *
+   * It fired the moment the guard moved — which was its whole purpose, and the instruction it carried was
+   * *"re-read everything above rather than renumber it"*. Re-read: the agreement assertions above are
+   * unchanged and still pass, so the switch rests on the same evidence it was designed to rest on.
+   *
+   * What this file keeps proving is the AGREEMENT. The behaviour of the moved guard belongs to
+   * `enforce-admin-reads-the-matrix.test.js`, and duplicating it here would give two files one subject.
+   */
+  it('enforceAdmin no longer reads the legacy boolean directly', () => {
     const mw = stripComments(readFileSync('server/src/auth/middleware.ts', 'utf8'));
-    assert.match(mw, /function enforceAdmin\([\s\S]{0,200}?if \(!record\.admin\)/,
-      'the switch to rights.instanceAdmin is the NEXT step, deliberately not this one');
+    assert.doesNotMatch(mw, /function enforceAdmin\([\s\S]{0,200}?if \(!record\.admin\)/,
+      'the switch has happened; the agreement above is what made it safe');
+  });
+
+  it('and the agreement remains the thing that justifies it', () => {
+    // The guard now asks one predicate. If that predicate ever stops agreeing with the migration, the tests
+    // above fail — which is the tie between this file and the switch, and the reason it is not deleted.
+    const mw = stripComments(readFileSync('server/src/auth/middleware.ts', 'utf8'));
+    assert.match(mw, /export function isInstanceAdmin/, 'one predicate, whose agreement this file pins');
   });
 });

--- a/testing/standalone/space-admin-reaches-its-own-space-settings.test.js
+++ b/testing/standalone/space-admin-reaches-its-own-space-settings.test.js
@@ -194,7 +194,10 @@ describe('the MCP door widens with the REST one', () => {
 describe('maxGiB stays with the instance', () => {
   it('PATCH /:id refuses it from a token that is not an instance admin', () => {
     const stripped = stripComments(SPACES);
-    assert.match(stripped, /maxGiB !== undefined && !req\.authToken\?\.admin/,
+    // The predicate moved from the legacy `req.authToken?.admin` to `isInstanceAdmin` when every
+    // instance-admin check was unified. The rule is identical — this field needs the INSTANCE bit — so the
+    // assertion follows the spelling rather than being loosened to "some check exists".
+    assert.match(stripped, /maxGiB !== undefined && !\(req\.authToken && isInstanceAdmin\(req\.authToken\)\)/,
       'a space administrator must not set its share of the host disk');
     assert.match(stripped, /res\.status\(403\)/, 'and the refusal is a 403, not a silent drop');
   });


### PR DESCRIPTION
The switch the previous PR's evidence was for. **No token's access changes.**

## Seven copies of one authorization question

`enforceAdmin` — the one function behind every admin route — gated on the deprecated `admin` boolean. Six
other places asked the same question their own way:

| where | what it decides |
| --- | --- |
| `enforceAdmin` | every admin route |
| `enforceAdminOrSpaceAdmin` | the token routes |
| `requireAdminOrSpaceAdminMfaScoped` | a space's own settings |
| `api/notify.ts` | whether a caller may relay for another instance |
| `api/sync/tombstones.ts` | the trusted-relay path |
| `api/spaces.ts` | the `maxGiB` carve-out |
| `api/tokens.ts` | the last-admin lockout guard |

The failure mode of a copy that drifts is the worst available: a token reaching a route it never could, with
no error and nothing in the response to say so. They all call `isInstanceAdmin` now.

## Why this was safe to do

`instance-admin-agrees-with-the-legacy-flag.test.js` (merged separately, one PR ago) exercised `migrateToken`
over all nine storable legacy shapes and found the two answer identically; the mint route refuses `admin` as
an input, so a divergent pair cannot be created.

That sequencing is the shape `auth/space-reach.ts` records for exactly this change:

> the replacement lands first, next to a test that asserts it agrees with the legacy rule for every token
> shape. Only once the two provably answer the same question does the guard move onto it.

**That evidence file carried an assertion designed to fail the moment the guard moved** — and it did, in this
PR's preflight. Its instruction was *"re-read everything above rather than renumber it"*; re-read, the
agreement assertions are unchanged and still pass, so the switch rests on the evidence it was designed to
rest on. The block is inverted, not deleted.

## The fallback is load-bearing

A record with **no matrix** falls back to the legacy flag. Not decoration: an OIDC session is built per
request from the identity and legitimately carries none, while every PAT has one — `createToken` always
writes it and a boot migration backfills the rest. Dropping the fallback would be a silent **narrowing**, and
the gate mutation-tests that direction too.

## What it still does not grant

An `admin` rung on every space is **not** an instance admin. Administering every space that exists today says
nothing about spaces created tomorrow, nor about instance-shaped routes — only `instanceAdmin` or a floor
does. That distinction is what SA-1 rests on, and it is asserted here so unifying the predicate cannot
quietly erode it.

## Verification

17 assertions. **Mutation-tested both directions:** letting a stale legacy flag still grant admin fails;
dropping the OIDC fallback fails.

One earlier gate **updated rather than loosened** — SA-1's `maxGiB` assertion follows the new spelling
instead of being weakened to "some check exists".

Part of **D-8d**. Deleting the `admin` field is now mechanical: seven call sites became one.
