### PR TITLE
feat(tokens): admin is no longer stored on a token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- **`admin` is no longer stored on a token either — the second of the three pre-3.0 fields.** Every check had
+  already moved to the rights matrix in this release, and the seven places that each asked *"is this an
+  instance admin"* their own way became one predicate first, against evidence that the two answers were
+  identical for every storable token shape. With one reader instead of seven, removing the field was
+  mechanical.
+
+  **Creating an admin token is unchanged**, and so is every existing token's access. Send `admin: true` and
+  you get `instanceAdmin` plus `createSpaces` plus the admin rung everywhere, exactly as before; the result
+  lives only in the matrix now. Tokens created earlier keep their scope — the load-time migration still reads
+  the stored flag to derive their rights.
+
+  **OIDC sessions keep their own flag**, because they are built per request from a claim mapping and carry no
+  matrix; the predicate falls back to it for exactly that case.
+
+  **If you read `admin` off a token record, read `rights.instanceAdmin` instead.** Note it is *not* the same
+  as holding the admin rung in every space — that grants those spaces, and says nothing about spaces created
+  tomorrow or about instance-shaped routes.
+
+  Three MCP handlers also stopped re-checking it. Each sits inside a tool the dispatcher already refuses
+  without instance-admin rights, so the check was a second copy of a rule enforced above it — the same shape
+  that once made a tool refuse a space administrator its own guard had just admitted.
+
 - **`readOnly` is no longer stored on a token — the first of the three pre-3.0 fields to go.** Nothing had
   decided on it since 3.0: every write check reads the rights matrix, and the copy threaded from the token
   record through the MCP server into every tool's call context turned out to be read by **no tool at all** —

--- a/docs/integration-guide/07-tokens-api.md
+++ b/docs/integration-guide/07-tokens-api.md
@@ -145,7 +145,7 @@ POST /api/tokens
 | Field | Notes |
 |---|---|
 | `name` | Required. Human-readable label. |
-| `admin` | `true` for full admin scope. Mutually exclusive with `schemaLibrary`. |
+| `admin` | `true` for full admin scope. Mutually exclusive with `schemaLibrary`. Still accepted and still returned; **no longer stored** — see below. |
 | `readOnly` | Block all writes. Ignored when `schemaLibrary` is `true` (always read-only). Still accepted and still returned; **no longer stored** — see below. |
 | `spaces` | Array of space IDs to scope this token. Omit for all-spaces access. Must be empty or omitted when `schemaLibrary` is `true`. |
 | `expiresAt` | ISO 8601 expiry timestamp. Omit for non-expiring. |
@@ -165,7 +165,21 @@ POST /api/tokens
 > the stored boolean could not express and answered `false` for. Tokens created before 3.1 keep their scope:
 > the load-time migration still reads the stored flag to derive their matrix.
 >
-> `admin` and `spaces` are unchanged for now and follow separately.
+> `spaces` is unchanged for now and follows separately.
+
+<!-- markdownlint-disable-next-line MD028 -->
+
+> **`admin` is no longer STORED either — 3.1, and again nothing you send or read changes.** Sending it still
+> does what it always did: the token gets `instanceAdmin`, `createSpaces`, and the admin rung in every space
+> it reaches. Responses still carry it, derived from `rights.instanceAdmin`.
+>
+> **If you branch on it, read `rights.instanceAdmin`.** And note what it is *not*: holding the `admin` rung
+> in every space is a different thing. That grants those spaces, and says nothing about spaces created
+> tomorrow or about instance-shaped routes like creating a space or joining a network — only `instanceAdmin`
+> or an all-spaces floor does.
+>
+> **OIDC sessions are unaffected.** They are built per request from a claim mapping and carry no matrix, so
+> the flag is where their answer legitimately lives; every admin check falls back to it for exactly that case.
 
 **Response** `201`:
 

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -276,7 +276,7 @@ spacesRouter.patch('/:id', globalRateLimit, requireAdminOrSpaceAdminMfaScoped('i
   // whole volume, which is the instance's to give — so the guard admits them to the route and this refuses the
   // single field, rather than the route staying shut over one number.
   //
-  // Checked against `record.admin` for the same reason the guard is: it is the instance-admin bit, and a space
+  // Asks `isInstanceAdmin` for the same reason every guard does: it is the instance-admin question, and a space
   // administrator is by construction not it.
   if (req.body?.maxGiB !== undefined && !(req.authToken && isInstanceAdmin(req.authToken))) {
     res.status(403).json({

--- a/server/src/api/sync/_shared.ts
+++ b/server/src/api/sync/_shared.ts
@@ -10,6 +10,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { col, asFilter, asDoc } from '../../db/mongo.js';
 import { getConfig } from '../../config/loader.js';
 import { reachesSpace } from '../../auth/space-reach.js';
+import { isInstanceAdmin } from '../../auth/instance-admin.js';
 import type { TokenRights } from '../../config/rights-shape.js';
 import { log } from '../../util/log.js';
 import { isSeqImplausible, MAX_INGEST_SEQ } from '../../util/seq.js';
@@ -385,9 +386,20 @@ export function spaceAllowed(
  * defeating the documented one-way flow.
  *
  * Returns true if the write must be REJECTED (403).
+ *
+ * ## The admin half asks the matrix (D-8d)
+ *
+ * This read `authToken['admin']` — bracket notation, which is exactly why it survived the audit that moved
+ * every other instance-admin check onto `isInstanceAdmin`. A `git grep` for `record.admin` / `.admin` in
+ * dotted form does not match it, so the sweep reported clean while this one kept reading a field that was
+ * being deleted.
+ *
+ * The consequence was not subtle and was not a 403 anybody would have puzzled over: with the field gone,
+ * every admin token became a non-peer here, and the whole sync WRITE surface refused it. CI caught it as
+ * fifty-one failures in brain CRUD, because the integration suite seeds records through this endpoint.
  */
 export function isNonPeerSyncWrite(authToken: Record<string, unknown> | undefined): boolean {
-  if (authToken?.['admin'] === true) return false;
+  if (authToken && isInstanceAdmin(authToken as { admin?: boolean; rights?: TokenRights | null })) return false;
   return !callerPeerId(authToken);
 }
 

--- a/server/src/api/tokens.ts
+++ b/server/src/api/tokens.ts
@@ -35,8 +35,17 @@ export const tokensRouter = Router();
  * nobody ever set the boolean on but which holds only `read` — a case the stored flag could not express, and
  * answered `false` for.
  */
-function withReadOnlyAlias<T extends { rights?: unknown }>(t: T): T & { readOnly: boolean } {
-  return { ...t, readOnly: !canWriteAnywhere(t.rights as TokenRights | undefined) };
+function withReadOnlyAlias<T extends { rights?: unknown }>(t: T): T & { readOnly: boolean; admin: boolean } {
+  const rights = t.rights as TokenRights | undefined;
+  return {
+    ...t,
+    readOnly: !canWriteAnywhere(rights),
+    // `admin` joined the alias when it was deleted from the record, for the same reason and by the same
+    // measurement: `schema-library.test.js` asserts a library token comes back `admin: false`, and that
+    // assertion lives only in the Docker-only suite that `preflight` cannot run. Found by grepping those
+    // suites BEFORE pushing this time, rather than by a red CI run as with `readOnly`.
+    admin: rights?.instanceAdmin === true,
+  };
 }
 
 // GET /api/auth/me — returns the current token's metadata (used by the Angular SPA to verify a PAT)

--- a/server/src/auth/instance-admin.ts
+++ b/server/src/auth/instance-admin.ts
@@ -1,0 +1,45 @@
+/**
+ * Is this token an instance administrator? The MATRIX decides, with the legacy flag as the fallback.
+ *
+ * ## One predicate, because it used to be seven
+ *
+ * `enforceAdmin`, `enforceAdminOrSpaceAdmin`, the scoped guard, the peer-relay check in `notify`, the
+ * trusted-relay check in `sync/tombstones`, the `maxGiB` carve-out and the last-admin lockout guard each
+ * read `record.admin` their own way. Seven copies of one authorization question, where a copy that drifts
+ * means a token reaching a route it never could — with no error and nothing in the response to say so.
+ *
+ * ## Why it lives in its own module rather than in `middleware.ts`
+ *
+ * `mcp/oauth.ts` needs it to stamp an identity, and `middleware.ts` already imports `mcpResourceMetadataUrl`
+ * from `mcp/oauth.ts`. Putting the predicate in the middleware closed that loop — `no-runtime-import-cycles`
+ * caught it, and it was right: in ESM a cycle is legal until one side reads a binding during evaluation, at
+ * which point it is `undefined` and the failure lands far from the cause.
+ *
+ * The predicate depends on nothing but the rights shape, so it has no business living in either file.
+ *
+ * ## The fallback is load-bearing
+ *
+ * A record with no matrix falls back to the legacy boolean. An OIDC session is built per request from a claim
+ * mapping and legitimately carries no matrix, while every PAT has one — `createToken` always writes it and a
+ * boot migration backfills the rest. Dropping the fallback would be a silent NARROWING: every OIDC admin
+ * would lose access, which is the opposite failure and just as bad.
+ *
+ * ## The two provably agree
+ *
+ * `instance-admin-agrees-with-the-legacy-flag.test.js` exercises `migrateToken` over all nine storable legacy
+ * shapes, and the mint route refuses `admin` as an input so a divergent pair cannot be created. That evidence
+ * landed before the guards moved onto this, deliberately — see `auth/space-reach.ts` for why this feature
+ * sequences that way.
+ */
+import type { TokenRights } from '../config/rights-shape.js';
+
+export function isInstanceAdmin(
+  // Structural, and deliberately NOT `Pick<TokenRecord, 'admin'>`: the field is gone from that type, and a
+  // signature naming it would have to change again the day the OIDC record drops it too. What this reads is
+  // a matrix, with a legacy boolean as the fallback — so that is what it asks for.
+  record: { admin?: boolean; rights?: TokenRights | null },
+): boolean {
+  const rights = record.rights;
+  if (rights) return rights.instanceAdmin === true;
+  return record.admin === true;
+}

--- a/server/src/auth/middleware.ts
+++ b/server/src/auth/middleware.ts
@@ -16,6 +16,10 @@ import { logAuthFailure } from '../audit/middleware.js';
 import { mcpResourceMetadataUrl } from '../mcp/oauth.js';
 import { canWriteAnywhere } from './write-anywhere.js';
 import type { TokenRights } from '../config/rights-shape.js';
+// Re-exported so the guards here and every existing importer keep one name for one rule. The definition
+// lives in its own module because `mcp/oauth.ts` needs it too, and this file already imports from there.
+export { isInstanceAdmin } from './instance-admin.js';
+import { isInstanceAdmin } from './instance-admin.js';
 
 // Augment Express Request type
 declare global {
@@ -216,30 +220,6 @@ async function resolveAuthOrFail(
   return { record, bearer };
 }
 
-/**
- * Is this token an instance administrator? The MATRIX decides, with the legacy flag as the fallback.
- *
- * One function, because this question is asked by `enforceAdmin`, by `enforceAdminOrSpaceAdmin`, and by the
- * scoped guard — three call sites that read `record.admin` directly until now. Three copies of one
- * authorization predicate is how this repo produces its most expensive defects, and here the failure mode is
- * the worst available: a token reaching a route it never could, silently.
- *
- * `rights` absent means the record never passed the config backfill — an OIDC session, built per request from
- * the identity — so the legacy flag answers for it. Every PAT carries a matrix: `createToken` always writes
- * one and a boot migration backfills the rest.
- *
- * **The two provably agree**, which is why this switch is safe to make at all:
- * `instance-admin-agrees-with-the-legacy-flag.test.js` exercises `migrateToken` over all nine storable legacy
- * shapes, and the mint route refuses `admin` as an input so a divergent pair cannot be created. That evidence
- * landed in its own PR first, deliberately — see `auth/space-reach.ts` for why this feature does it that way.
- */
-export function isInstanceAdmin(
-  record: Pick<TokenRecord, 'admin'> | OidcTokenRecord | { admin?: boolean },
-): boolean {
-  const rights = (record as { rights?: TokenRights | null }).rights;
-  if (rights) return rights.instanceAdmin === true;
-  return (record as { admin?: boolean }).admin === true;
-}
 
 /** Enforce instance-admin; writes 403 and returns false when the token is not one. */
 function enforceAdmin(res: Response, record: Omit<TokenRecord, 'hash'> | OidcTokenRecord): boolean {

--- a/server/src/auth/tokens.ts
+++ b/server/src/auth/tokens.ts
@@ -203,7 +203,6 @@ export async function createToken(opts: {
     lastUsed: null,
     expiresAt: opts.expiresAt ?? null,
     spaces: opts.spaces,
-    admin: opts.admin ?? false,
     peerInstanceId: opts.peerInstanceId,
     ...(opts.schemaLibrary ? { schemaLibrary: true } : {}),
     // Stored only when it says something. `inherit` IS the absent state, so writing it would put a field on
@@ -268,7 +267,6 @@ export async function createOAuthToken(opts: {
     lastUsed: null,
     expiresAt: opts.ttlMs === null ? null : new Date(Date.now() + opts.ttlMs).toISOString(),
     spaces: opts.spaces,
-    admin: opts.admin ?? false,
     oauthClientId: opts.clientId,
     // ALWAYS stored, for the reason spelled out on `createToken` above — and this is the path that fix
     // MISSED. `createToken` was given an unconditional matrix because a token minted after boot had none

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -8,7 +8,14 @@ export interface TokenRecord {
   lastUsed: string | null;
   expiresAt: string | null;
   spaces?: string[];    // allowlist of space IDs; omit = all spaces
-  admin: boolean;       // true = may access admin-gated routes
+  // `admin` was REMOVED in 3.1 (D-8d), the second of the pre-3.0 triple. Nothing decides on it any more:
+  // `isInstanceAdmin` reads `rights.instanceAdmin`, and the seven places that each asked the question their
+  // own way were unified onto that one predicate first, in its own change, against evidence that the two
+  // answered identically for every storable token shape.
+  //
+  // It survives where it is still MEANINGFUL: as an INPUT to `migrateToken`, which derives a matrix for a
+  // token minted before the matrix existed, and on `OidcTokenRecord`, which is built per request from a
+  // claim mapping and carries no matrix at all. What is gone is the stored field.
   // `readOnly` was REMOVED in 3.1 (D-8d). It was the second of the pre-3.0 triple and the first to go,
   // because nothing decided on it any more: `toolIsVisible` asks `canWriteAnywhere(rights)`, every REST
   // guard asks `effectiveRung`, and the `ToolContext.readOnly` that was threaded through four layers to

--- a/server/src/mcp/oauth.ts
+++ b/server/src/mcp/oauth.ts
@@ -42,6 +42,7 @@ import { getPublicBaseUrl } from '../config/public-url.js';
 import { createOAuthToken, findMatchingToken } from '../auth/tokens.js';
 import { authRateLimit } from '../rate-limit/middleware.js';
 import { log } from '../util/log.js';
+import { isInstanceAdmin } from '../auth/instance-admin.js';
 import { envInt } from '../config/env-num.js';
 import type { TokenRecord } from '../config/types.js';
 
@@ -349,7 +350,7 @@ async function handleConsent(req: Request, res: Response): Promise<void> {
     // authorising token's `rights` are carried through directly below. The minted token derives its matrix
     // from those, so this flag no longer shapes anything; it stays only until the identity shape itself is
     // trimmed, and `false` is the value that cannot narrow or widen what `rights` already says.
-    identity: { admin: !!record.admin, readOnly: false, spaces: record.spaces,
+    identity: { admin: isInstanceAdmin(record), readOnly: false, spaces: record.spaces,
       rights: (record as { rights?: TokenRecord['rights'] }).rights },
     expiresAt: now + AUTH_CODE_TTL_MS,
   });

--- a/server/src/mcp/router.ts
+++ b/server/src/mcp/router.ts
@@ -87,7 +87,7 @@ function tokenRights(record: unknown): TokenRights | undefined {
  * BY NO TOOL. Every mutating decision asks the rights matrix instead: `canWriteAnywhere` for visibility,
  * `effectiveRung` per call. Deleting the field is what makes that provable rather than merely true today.
  */
-function createGlobalMcpServer(tokenSpaces?: string[], isAdmin?: boolean, tokenId?: string, tokenLabel?: string,
+function createGlobalMcpServer(tokenSpaces?: string[], tokenId?: string, tokenLabel?: string,
   audit?: { ip: string; authMethod: 'pat' | 'oidc' | null; oidcSubject: string | null; transport: 'sse' | 'http' },
   rights?: TokenRights): Server {
   const cfg = getConfig();
@@ -287,7 +287,6 @@ function createGlobalMcpServer(tokenSpaces?: string[], isAdmin?: boolean, tokenI
         accessibleSpaces,
         accessibleSpaceIds,
         tokenSpaces,
-        isAdmin,
         // Populated, not merely declared. `toolIsVisible(t, undefined)` hides every mutating and admin
         // tool, so an unpopulated `rights` here would empty `help`'s listing while `tools/list` stayed
         // correct — the two disagreeing again, in the one mechanism built to stop that.
@@ -353,7 +352,7 @@ mcpRouter.get('/', globalRateLimit, async (req, res) => {
     log.debug(`MCP global session ${sessionTag(transport.sessionId)} closed`);
   });
 
-  const server = createGlobalMcpServer(req.authToken?.spaces, req.authToken?.admin, req.authToken?.id, req.authToken?.name,
+  const server = createGlobalMcpServer(req.authToken?.spaces, req.authToken?.id, req.authToken?.name,
     { ip: req.ip ?? '', authMethod: auditAuthMethod(req.authToken), oidcSubject: auditOidcSubject(req.authToken), transport: 'sse' }, tokenRights(req.authToken));
   log.debug(`MCP global session ${sessionTag(transport.sessionId)} opened`);
   await server.connect(transport);
@@ -385,7 +384,7 @@ mcpRouter.post('/messages', globalRateLimit, async (req, res) => {
 // This transport requires no persistent connection and works through standard HTTP proxies.
 mcpRouter.post('/', globalRateLimit, async (req, res) => {
   const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
-  const server = createGlobalMcpServer(req.authToken?.spaces, req.authToken?.admin, req.authToken?.id, req.authToken?.name,
+  const server = createGlobalMcpServer(req.authToken?.spaces, req.authToken?.id, req.authToken?.name,
     { ip: req.ip ?? '', authMethod: auditAuthMethod(req.authToken), oidcSubject: auditOidcSubject(req.authToken), transport: 'http' }, tokenRights(req.authToken));
   // Register cleanup before handling the request so it fires regardless of outcome.
   res.on('close', () => {

--- a/server/src/mcp/tools/spaces.ts
+++ b/server/src/mcp/tools/spaces.ts
@@ -472,13 +472,10 @@ export const create_spaceTool: ToolHandler = {
     additionalProperties: false,
   }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
-    const { args: a, isAdmin } = ctx;
-    if (!isAdmin) {
-      return {
-        content: [{ type: 'text' as const, text: 'Error: create_space requires an admin token' }],
-        isError: true,
-      };
-    }
+    // Authorised by `admin: true` in the dispatcher, which refuses this tool unless the token's matrix says
+    // `instanceAdmin`. The `if (!isAdmin)` that stood here was a second copy of that rule, reading the legacy
+    // boolean — and a second copy of an authorization rule is what this codebase pays most for.
+    const { args: a } = ctx;
 
     // `purpose` is the current name for what the create body still calls `description`. Translated here rather than
     // widening the body schema: the REST field is the deprecated spelling, and a tool that took the deprecated name
@@ -561,13 +558,10 @@ export const reindexTool: ToolHandler = {
     additionalProperties: false,
   }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
-    const { callSpace, isAdmin, accessibleSpaceIds } = ctx;
-    if (!isAdmin) {
-      return {
-        content: [{ type: 'text' as const, text: 'Error: reindex requires an admin token' }],
-        isError: true,
-      };
-    }
+    // Authorised by `admin: true` in the dispatcher, which refuses this tool unless the token's matrix says
+    // `instanceAdmin`. The `if (!isAdmin)` that stood here was a second copy of that rule, reading the legacy
+    // boolean — and a second copy of an authorization rule is what this codebase pays most for.
+    const { callSpace, accessibleSpaceIds } = ctx;
 
     const { planReindex, startReindex } = await import('../../brain/reindex.js');
     const space = getConfig().spaces.find(s => s.id === callSpace);
@@ -647,13 +641,10 @@ export const wipe_spaceTool: ToolHandler = {
           additionalProperties: false,
         }),
   async handle(ctx: ToolContext): Promise<ToolResult> {
-    const { args: a, callSpace, isAdmin } = ctx;
-    if (!isAdmin) {
-      return {
-        content: [{ type: 'text' as const, text: 'Error: wipe_space requires an admin token' }],
-        isError: true,
-      };
-    }
+    // Authorised by `admin: true` in the dispatcher, which refuses this tool unless the token's matrix says
+    // `instanceAdmin`. The `if (!isAdmin)` that stood here was a second copy of that rule, reading the legacy
+    // boolean — and a second copy of an authorization rule is what this codebase pays most for.
+    const { args: a, callSpace } = ctx;
     const rawTypes = Array.isArray(a['types']) ? (a['types'] as unknown[]) : undefined;
     if (rawTypes !== undefined && rawTypes.some(t => typeof t !== 'string' || !WIPE_COLLECTION_TYPES.includes(t as WipeCollectionType))) {
       throw new Error(`types must be an array of: ${WIPE_COLLECTION_TYPES.join(', ')}`);
@@ -744,7 +735,9 @@ export const list_tokensTool: ToolHandler = {
 
     const lines = tokens.map(t => {
       const bits = [
-        t.admin ? 'instance-admin' : null,
+        // Derived from the MATRIX (D-8d): `admin` is gone from the record, and the matrix is what every
+        // guard has read since the predicate was unified.
+        t.rights?.instanceAdmin ? 'instance-admin' : null,
         // Derived from the MATRIX, not from the deleted `readOnly` flag (D-8d). "Read-only" is now a
         // property of what the rights say — no write rung anywhere — rather than a boolean somebody set,
         // which also makes it correct for a token that was never given the flag but holds only `read`.

--- a/server/src/mcp/tools/types.ts
+++ b/server/src/mcp/tools/types.ts
@@ -27,7 +27,10 @@ export interface ToolContext {
   accessibleSpaces: SpaceConfig[];
   accessibleSpaceIds: string[];
   tokenSpaces?: string[];
-  isAdmin?: boolean;
+  // `isAdmin` was REMOVED in 3.1 (D-8d), following `readOnly` out for the same reason and by the same route.
+  // The dispatcher decides from the matrix — `toolIsVisible` refuses an `admin: true` tool unless
+  // `rights.instanceAdmin` — so the three handlers that re-checked it were each a second copy of a rule
+  // already enforced above them, reading a boolean that no longer exists.
   /** True when the calling token is read-only (mutating tools are gated out). */
   // `readOnly` was REMOVED here in 3.1 (D-8d). It was declared, threaded from the token record through
   // `createGlobalMcpServer` into every tool's context — and read by none of them. Every mutating decision

--- a/testing/standalone/instance-admin-agrees-with-the-legacy-flag.test.js
+++ b/testing/standalone/instance-admin-agrees-with-the-legacy-flag.test.js
@@ -117,7 +117,12 @@ describe('the guard has moved onto the matrix, and this evidence is why it could
   it('and the agreement remains the thing that justifies it', () => {
     // The guard now asks one predicate. If that predicate ever stops agreeing with the migration, the tests
     // above fail — which is the tie between this file and the switch, and the reason it is not deleted.
-    const mw = stripComments(readFileSync('server/src/auth/middleware.ts', 'utf8'));
-    assert.match(mw, /export function isInstanceAdmin/, 'one predicate, whose agreement this file pins');
+    // The predicate moved to `auth/instance-admin.ts` when `mcp/oauth.ts` needed it too and the import graph
+    // closed a cycle. `middleware.ts` re-exports it, so every existing importer keeps one name for one rule
+    // — which is what this assertion is actually about.
+    assert.match(stripComments(readFileSync('server/src/auth/instance-admin.ts', 'utf8')),
+      /export function isInstanceAdmin/, 'one predicate, whose agreement this file pins');
+    assert.match(stripComments(readFileSync('server/src/auth/middleware.ts', 'utf8')),
+      /export \{ isInstanceAdmin \}/, 'and one name for it, wherever a caller already imported from');
   });
 });

--- a/testing/standalone/legacy-admin-field-is-gone.test.js
+++ b/testing/standalone/legacy-admin-field-is-gone.test.js
@@ -86,6 +86,62 @@ describe('the field is gone from the record and the plumbing', () => {
   });
 });
 
+describe('the search shape that missed one', () => {
+  /**
+   * `isNonPeerSyncWrite` read `authToken['admin']` — BRACKET notation. Every audit I ran used the dotted
+   * form (`record.admin`, `.admin`), which does not match it, so the sweep reported clean while the sync
+   * WRITE guard kept reading a field that was being deleted.
+   *
+   * The consequence was not subtle: with the field gone, every admin token became a non-peer there and the
+   * whole sync write surface refused it. CI reported it as fifty-one failures in brain CRUD, because the
+   * integration suite seeds records through that endpoint — nowhere near the change, and nothing in the
+   * message pointing at it.
+   *
+   * So this asserts on the SHAPE rather than on the instance: no property access of the legacy fields in
+   * either spelling, outside the places that legitimately own them.
+   */
+  const OWNERS = [
+    'server/src/auth/instance-admin.ts',   // the predicate's own fallback
+    'server/src/auth/oidc.ts',             // OidcTokenRecord, built from a claim mapping
+    'server/src/auth/rights-migration.ts', // LegacyToken, the migration input
+    'server/src/auth/tokens.ts',           // feeds migrateToken at mint time
+  ];
+
+  it('nothing outside the owners reads the legacy fields, in EITHER spelling', () => {
+    const files = execSync('git ls-files "server/src/**/*.ts"', { encoding: 'utf8' })
+      .split('\n').map(s => s.trim()).filter(Boolean).filter(f => !OWNERS.includes(f));
+    assert.ok(files.length > 100, `only walked ${files.length} modules — the enumeration is broken`);
+
+    // Both spellings, and `readOnly` too — it was deleted one PR earlier and deserves the same guard.
+    // `?.` is two characters, and the first draft of this pattern allowed only a bare `?` before the
+    // bracket — so it did not match `authToken?.['admin']`, the exact access it exists to catch. Its own
+    // mutation check is what said so.
+    // The accessor is REQUIRED, and that took two goes. Making it optional matched the bare words `t admin`
+    // inside ordinary prose — "the last admin token" — and flagged two files that read nothing. A pattern
+    // that cries wolf gets loosened until it catches nothing, which is how the original miss happened.
+    const BAD = /\b(?:authToken|record|token|target|t)\s*\??\.\s*(?:admin|readOnly)\b|\b(?:authToken|record|token|target|t)\s*\??\.?\s*\[\s*['"](?:admin|readOnly)['"]\s*\]/;
+    const offenders = files.filter(f => BAD.test(stripComments(readFileSync(f, 'utf8'))));
+    assert.deepEqual(offenders, [],
+      'these read a deleted field — ask `isInstanceAdmin` / the rights matrix instead:\n  ' + offenders.join('\n  '));
+  });
+
+  it('and the detector really matches the bracket form that got through', () => {
+    // Mutation-proof for the pattern itself: a gate whose regex misses the case it was written for is worse
+    // than none, because it reports clean.
+    // `?.` is two characters, and the first draft of this pattern allowed only a bare `?` before the
+    // bracket — so it did not match `authToken?.['admin']`, the exact access it exists to catch. Its own
+    // mutation check is what said so.
+    // The accessor is REQUIRED, and that took two goes. Making it optional matched the bare words `t admin`
+    // inside ordinary prose — "the last admin token" — and flagged two files that read nothing. A pattern
+    // that cries wolf gets loosened until it catches nothing, which is how the original miss happened.
+    const BAD = /\b(?:authToken|record|token|target|t)\s*\??\.\s*(?:admin|readOnly)\b|\b(?:authToken|record|token|target|t)\s*\??\.?\s*\[\s*['"](?:admin|readOnly)['"]\s*\]/;
+    assert.ok(BAD.test("if (authToken?.['admin'] === true) return false;"), 'the shape that escaped');
+    assert.ok(BAD.test('if (record.admin) return true;'), 'and the dotted one');
+    assert.ok(!BAD.test('rights.instanceAdmin === true'), 'but not the matrix field');
+    assert.ok(!BAD.test("mapping.admin ? evaluateClaimRule(payload, mapping.admin) : false"), 'nor a claim rule');
+  });
+});
+
 describe('what still answers the question', () => {
   it('one predicate, reading the matrix', () => {
     assert.equal(isInstanceAdmin({ rights: { instanceAdmin: true, createSpaces: false, floor: null, perSpace: {} } }), true);

--- a/testing/standalone/legacy-admin-field-is-gone.test.js
+++ b/testing/standalone/legacy-admin-field-is-gone.test.js
@@ -1,0 +1,132 @@
+/**
+ * The second pre-3.0 token field is deleted: `TokenRecord.admin`.
+ *
+ * ## Why it could go now, and not before
+ *
+ * Two changes had to land first, and deliberately did so separately:
+ *
+ * 1. **The evidence** — `instance-admin-agrees-with-the-legacy-flag.test.js` proved `rights.instanceAdmin`
+ *    and the boolean answer identically for all nine storable token shapes.
+ * 2. **The switch** — seven call sites that each read `record.admin` their own way became one predicate,
+ *    `isInstanceAdmin`.
+ *
+ * With one reader instead of seven, deleting the field is mechanical rather than a hunt. That sequencing is
+ * the shape `auth/space-reach.ts` records for the change in this feature where a mistake is silent widening.
+ *
+ * ## What must NOT disappear with it
+ *
+ * - **`migrateToken` still reads it.** `LegacyToken` is its own interface over raw stored config, so a token
+ *   minted before the matrix keeps its scope — including `createSpaces`, which the migration also derives
+ *   from the old flag.
+ * - **`OidcTokenRecord` keeps its own `admin`.** An OIDC session is built per request from a claim mapping
+ *   and carries no matrix, so the flag is where its answer legitimately lives. `isInstanceAdmin`'s fallback
+ *   is what serves it.
+ * - **`createToken` still accepts it**, feeding `migrateToken`. "Mint an admin token" must stay sayable
+ *   without hand-building a matrix.
+ *
+ * Run: node --test testing/standalone/legacy-admin-field-is-gone.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { stripComments } from './_strip-comments.mjs';
+
+const src = (p) => stripComments(readFileSync(p, 'utf8'));
+
+let isInstanceAdmin, migrateToken;
+before(async () => {
+  ({ isInstanceAdmin } = await import('../../server/dist/auth/middleware.js'));
+  ({ migrateToken } = await import('../../server/dist/auth/rights-migration.js'));
+});
+
+describe('the field is gone from the record and the plumbing', () => {
+  it('TokenRecord no longer declares it', () => {
+    const types = src('server/src/config/types.ts');
+    const at = types.indexOf('spaces?: string[]');
+    assert.ok(at > 0, 'the TokenRecord block was not found — the scanner is wrong, not the code');
+    assert.doesNotMatch(types.slice(at, at + 400), /\n\s+admin: boolean;/, 'the stored field must be gone');
+  });
+
+  it('nothing writes it onto a record — on either minting path', () => {
+    // Two paths mint: `createToken` and the OAuth one. The second was missed once before, when the matrix
+    // was made unconditional, so it is asserted by count rather than by finding one.
+    const tokens = src('server/src/auth/tokens.ts');
+    assert.doesNotMatch(tokens, /^ {4}admin: opts\.admin \?\? false,/m, 'no record literal may carry it');
+    assert.equal((tokens.match(/^ {6}admin: opts\.admin \?\? false,/gm) ?? []).length, 2,
+      'both minting paths must still FEED migrateToken with it — that is the whole safety property');
+  });
+
+  it('ToolContext no longer declares isAdmin, and the MCP server no longer takes it', () => {
+    assert.doesNotMatch(src('server/src/mcp/tools/types.ts'), /isAdmin\?: boolean;/,
+      'it followed readOnly out for the same reason');
+    assert.doesNotMatch(src('server/src/mcp/router.ts'), /createGlobalMcpServer\(tokenSpaces\?: string\[\], isAdmin/,
+      'the parameter must be gone from the signature');
+  });
+
+  it('and no tool re-checks it, because the dispatcher already refused them', () => {
+    // The three handlers that did — create_space, reindex, wipe_space — are each declared `admin: true`, so
+    // `toolIsVisible` refuses the call before the handler runs. A second copy one layer down is the shape
+    // that made `update_space` refuse a space administrator the guard had just admitted.
+    // `git grep` exits 1 on no match, and shell `||` is not portable here — catch instead, as the readOnly
+    // gate does. No match IS the passing case.
+    let out = '';
+    try {
+      out = execSync('git grep -n "ctx\\.isAdmin" -- server/src', { encoding: 'utf8', stdio: 'pipe' }).trim();
+    } catch { out = ''; }
+    assert.equal(out, '', `these still read a context flag that no longer exists:\n${out}`);
+
+    // And the destructure form, which is how all three actually read it.
+    let destructured = '';
+    try {
+      destructured = execSync('git grep -n ", isAdmin }" -- server/src', { encoding: 'utf8', stdio: 'pipe' }).trim();
+    } catch { destructured = ''; }
+    assert.equal(destructured, '', `these still destructure it off the context:\n${destructured}`);
+  });
+});
+
+describe('what still answers the question', () => {
+  it('one predicate, reading the matrix', () => {
+    assert.equal(isInstanceAdmin({ rights: { instanceAdmin: true, createSpaces: false, floor: null, perSpace: {} } }), true);
+    assert.equal(isInstanceAdmin({ rights: { instanceAdmin: false, createSpaces: false, floor: null, perSpace: {} } }), false);
+  });
+
+  it('and the OIDC fallback, which is now its only legacy reader', () => {
+    // An OIDC record carries no matrix by design. Without this branch every OIDC admin would lose access —
+    // a silent NARROWING, which is the opposite failure and just as bad.
+    assert.equal(isInstanceAdmin({ admin: true }), true);
+    assert.equal(isInstanceAdmin({}), false);
+  });
+
+  it('OidcTokenRecord keeps its own admin field', () => {
+    assert.match(src('server/src/auth/oidc.ts'), /admin: perms\.admin/,
+      'the claim mapping is where that flag is legitimately produced');
+  });
+
+  it('the token listing derives instance-admin from the matrix', () => {
+    assert.match(src('server/src/mcp/tools/spaces.ts'), /t\.rights\?\.instanceAdmin \? 'instance-admin'/,
+      'not from a field that no longer exists');
+  });
+});
+
+describe('a pre-matrix token keeps everything the flag gave it', () => {
+  it('migrateToken still turns admin into instanceAdmin', () => {
+    assert.equal(migrateToken({ admin: true }).instanceAdmin, true);
+    assert.equal(migrateToken({}).instanceAdmin, false);
+  });
+
+  it('and into createSpaces, which is easy to forget', () => {
+    // The migration derives TWO instance-level flags from the one boolean. A deletion that preserved only
+    // the first would quietly remove space-creation from every legacy admin.
+    assert.equal(migrateToken({ admin: true }).createSpaces, true);
+    assert.equal(migrateToken({}).createSpaces, false);
+  });
+
+  it('and still gives it the admin rung, not merely the flags', () => {
+    const r = migrateToken({ admin: true, spaces: ['qa'] });
+    for (const area of ['knowledge', 'files', 'schema', 'dataQuality']) {
+      assert.equal(r.perSpace.qa[area], 'admin', `${area} must come back as admin`);
+    }
+  });
+});


### PR DESCRIPTION
The second of the three pre-3.0 token fields. **No token's access changes.**

## Why it was mechanical

Two changes landed first, deliberately separately:

1. **The evidence** — `rights.instanceAdmin` and the boolean proven to answer identically across all nine
   storable token shapes.
2. **The switch** — seven call sites that each read `record.admin` their own way became one predicate.

With one reader instead of seven, deleting the field is a rename, not a hunt.

## What survives, and why each one matters

| survives | because |
| --- | --- |
| `migrateToken` reads it | over `LegacyToken`, its own interface on raw stored config — a pre-3.1 token keeps its scope |
| `OidcTokenRecord` keeps its own | built per request from a claim mapping, carries no matrix; the predicate's fallback serves it |
| `createToken` accepts it | *"mint an admin token"* must stay sayable without hand-building a matrix |
| the API response carries it | derived from `rights.instanceAdmin` |

Two of those are asserted in ways worth naming:

- **`createSpaces`, not just `instanceAdmin`.** The migration derives **two** instance-level flags from the
  one boolean. A deletion that preserved only the first would quietly remove space-creation from every legacy
  admin, and nothing would report it.
- **Both minting paths.** `createToken` and the OAuth path each feed `migrateToken`. The gate counts **two**,
  because the OAuth path was missed once before when the matrix was made unconditional.

## The Docker-only suites were checked before pushing

`schema-library.test.js` asserts a library token comes back `admin: false`, and that assertion lives only in
the suite `preflight` cannot run. Found by grepping it **before** pushing this time — rather than by a red CI
run, which is how the same thing was found for `readOnly` two PRs ago.

## Three handlers stopped re-checking it

`create_space`, `reindex` and `wipe_space` each re-read `ctx.isAdmin` inside a tool declared `admin: true` —
which the dispatcher already refuses without instance-admin rights. A second copy of a rule enforced above
it, and the exact shape that once made `update_space` refuse a space administrator its own guard had just
admitted.

With those gone, `ctx.isAdmin` follows `readOnly` out of the tool context entirely.

## One import cycle, caught and broken properly

Putting the predicate in `middleware.ts` closed a loop with `mcp/oauth.ts`, which `middleware.ts` already
imports from. `no-runtime-import-cycles` caught it and was right — in ESM a cycle is legal until one side
reads a binding during evaluation, at which point it is `undefined` and the failure lands far from the cause.

The predicate depends on nothing but the rights shape, so it belongs in neither file: it lives in
`auth/instance-admin.ts`, and `middleware.ts` re-exports it so every existing call site keeps one name for
one rule.

## Verification

**Mutation-tested:** legacy admins silently losing `createSpaces` fails; dropping the OIDC fallback fails.

Part of **D-8d**. `spaces` is the last of the three.
