### PR TITLE
fix(spaces): renaming a space no longer strips every token's access to it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -517,6 +517,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Renaming a space no longer strips every token's access to it.** The rename updated each token's pre-3.0
+  `spaces` allowlist and nothing at all updated the rights matrix — so a token's `perSpace` row stayed under
+  the OLD id, which now named nothing, and the token silently lost the space it had rights in. That is
+  **every token created since 2.9**, because the rights editor writes the matrix and nothing writes the
+  allowlist: the half being maintained was the half nobody has.
+
+  It failed quietly at both ends — no error when renaming, and later a `403` that reads as though the rights
+  were never granted. Both halves are carried now, with the rung unchanged, because a rename is not a
+  re-grant. A token that somehow already holds rights under the new id keeps them rather than being
+  overwritten.
+
 - **Join labels in the data-model diagram no longer run across the next column.** Reported with a screenshot:
   `implements · 113` and `refines · 53` ended on top of the neighbouring card, and `conflicts` was clipped.
   Each join gets its own vertical lane and its label sits beside that lane, growing rightward — and the gap

--- a/server/src/spaces/rename.ts
+++ b/server/src/spaces/rename.ts
@@ -211,11 +211,40 @@ export function applySpaceRenameToConfig(cfg: Config, space: SpaceConfig, oldId:
     }
   }
 
-  // Update token scopes
+  /**
+   * Update token scopes — the rights MATRIX as well as the legacy allowlist.
+   *
+   * ## The defect this closes
+   *
+   * Only `tok.spaces` was re-keyed here. Nothing anywhere touched `rights.perSpace`, so renaming a space
+   * silently stripped every matrix-scoped token's access to it: the row stayed under the OLD id, which now
+   * names nothing, and the token simply stopped reaching a space it had rights in.
+   *
+   * That is every token minted since 2.9 — the rights editor writes `perSpace` and nothing writes the
+   * allowlist. So the half that was maintained was the half nobody has, and the failure is silent on both
+   * sides: no error at rename time, and later a 403 that looks like the rights were never granted.
+   *
+   * One rule — a token's scope follows a rename — with two implementations, and the live one missing. That
+   * is the defect class this codebase names as the one it produces most, and it was hiding inside the
+   * mechanism for renaming.
+   *
+   * ## Why the collision check
+   *
+   * `perSpace` is keyed by space id, so re-keying is a move within an object rather than an index swap. A
+   * row already at `newId` would be overwritten by one that used to be somewhere else — quietly widening or
+   * narrowing that token. It cannot happen through the rename route (which refuses a `newId` that exists),
+   * but this function is also reached on resume after a crash, so the guard is cheap and the alternative is
+   * unreviewable.
+   */
   for (const tok of cfg.tokens) {
     if (tok.spaces) {
       const idx = tok.spaces.indexOf(oldId);
       if (idx !== -1) tok.spaces[idx] = newId;
+    }
+    const perSpace = tok.rights?.perSpace;
+    if (perSpace && perSpace[oldId] !== undefined && perSpace[newId] === undefined) {
+      perSpace[newId] = perSpace[oldId]!;
+      delete perSpace[oldId];
     }
   }
 

--- a/testing/integration/space-rename.test.js
+++ b/testing/integration/space-rename.test.js
@@ -267,6 +267,46 @@ describe('Space rename', () => {
     assert.ok(tok, 'Token should still exist');
     assert.ok(tok.spaces?.includes(newId), `Token spaces should include '${newId}'`);
     assert.ok(!tok.spaces?.includes(oldId), `Token spaces should NOT include '${oldId}'`);
+
+    // The RIGHTS MATRIX, which is the half that actually governs access — and the half this test used to
+    // miss. It asserted only on `spaces`, the pre-3.0 allowlist, which the rename did maintain. So it
+    // stayed green while every matrix-scoped token silently lost the renamed space: the `perSpace` row
+    // stayed under an id that no longer named anything.
+    //
+    // Every token minted today carries a matrix, including this one — `createToken` derives it from the
+    // `spaces` sent above — so the case this test covered was the case nobody has.
+    assert.ok(tok.rights?.perSpace, 'a token minted today carries a rights matrix');
+    assert.ok(tok.rights.perSpace[newId],
+      `Token rights should hold a row for '${newId}', got: ${JSON.stringify(Object.keys(tok.rights.perSpace))}`);
+    assert.equal(tok.rights.perSpace[oldId], undefined,
+      `Token rights must not keep a row under the dead id '${oldId}'`);
+  });
+
+  it('and the renamed space is still REACHABLE with that token', async () => {
+    // The assertion that cannot pass on a technicality: read with the scoped token itself. Checking the
+    // stored shape proves the re-key ran; this proves it produced access — which is what was missing, as a
+    // 403 that read as though the rights had never been granted.
+    const oldId = `reach-rename-${RUN_ID}`;
+    const newId = `reach-renamed-${RUN_ID}`;
+    await post(INSTANCES.a, tokenA, '/api/spaces', { id: oldId, label: 'Reach Rename' });
+
+    const tokenR = await post(INSTANCES.a, tokenA, '/api/tokens', {
+      name: `Reach token ${RUN_ID}`, spaces: [oldId],
+    });
+    assert.equal(tokenR.status, 201, JSON.stringify(tokenR.body));
+    const scoped = tokenR.body.plaintext;
+
+    const before = await get(INSTANCES.a, scoped, `/api/brain/spaces/${oldId}/entities`);
+    assert.equal(before.status, 200,
+      `scoped token should reach its space before the rename: ${JSON.stringify(before.body)}`);
+
+    const renameR = await patch(INSTANCES.a, tokenA, `/api/spaces/${oldId}/rename`, { newId });
+    assert.equal(renameR.status, 200, JSON.stringify(renameR.body));
+    createdSpaceIds.push(newId);
+
+    const after = await get(INSTANCES.a, scoped, `/api/brain/spaces/${newId}/entities`);
+    assert.equal(after.status, 200,
+      `scoped token must still reach the space after it is renamed: ${JSON.stringify(after.body)}`);
   });
 
   it('Rename built-in general space is rejected', async () => {

--- a/testing/standalone/rename-carries-token-rights.test.js
+++ b/testing/standalone/rename-carries-token-rights.test.js
@@ -1,0 +1,126 @@
+/**
+ * Renaming a space carries every token's scope with it — the rights MATRIX, not only the legacy allowlist.
+ *
+ * ## The defect
+ *
+ * `applySpaceRenameToConfig` re-keyed `tok.spaces` and nothing anywhere touched `rights.perSpace`. So a
+ * rename silently stripped every matrix-scoped token's access to the space: the row stayed under the OLD id,
+ * which now names nothing.
+ *
+ * That is **every token minted since 2.9**. The rights editor writes `perSpace`; nothing writes the
+ * allowlist — the mint route's own refusal map tells a caller to use `rights.perSpace` instead. So the half
+ * that was maintained was the half nobody has.
+ *
+ * It fails silently at both ends: no error when renaming, and later a 403 that reads as though the rights
+ * were never granted. Found while measuring the `spaces` field deletion — and worth fixing first, because
+ * deleting the field without this would have removed the only rename handling that existed.
+ *
+ * ## Exercised, not grepped
+ *
+ * `applySpaceRenameToConfig` is exported and operates on a plain config object, so these are real calls with
+ * real verdicts. A source-reading test could not tell a re-key that runs from one that is unreachable.
+ *
+ * Run: node --test testing/standalone/rename-carries-token-rights.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let applySpaceRenameToConfig;
+before(async () => {
+  ({ applySpaceRenameToConfig } = await import('../../server/dist/spaces/rename.js'));
+});
+
+const ALL = (r) => ({ knowledge: r, files: r, schema: r, dataQuality: r });
+
+/** A config holding one space and whatever tokens a test needs. */
+const cfgWith = (tokens) => ({
+  instanceId: 'i', instanceLabel: 'I',
+  spaces: [{ id: 'old', label: 'Old' }],
+  networks: [],
+  tokens,
+});
+
+const space = (cfg) => cfg.spaces.find(s => s.id === 'old') ?? cfg.spaces[0];
+
+describe('the matrix row follows the rename', () => {
+  it('perSpace is re-keyed from the old id to the new one', () => {
+    const cfg = cfgWith([{ id: 't1', rights: { instanceAdmin: false, createSpaces: false, floor: null, perSpace: { old: ALL('write') } } }]);
+    applySpaceRenameToConfig(cfg, space(cfg), 'old', 'new');
+
+    const perSpace = cfg.tokens[0].rights.perSpace;
+    assert.deepEqual(perSpace['new'], ALL('write'), 'the row must move to the new id');
+    assert.equal(perSpace['old'], undefined, 'and must not be left behind under a name that no longer exists');
+  });
+
+  it('the rung is carried unchanged — a rename is not a re-grant', () => {
+    const cfg = cfgWith([{ id: 't1', rights: { instanceAdmin: false, createSpaces: false, floor: null, perSpace: { old: { knowledge: 'admin', files: 'read', schema: 'none', dataQuality: 'write' } } } }]);
+    applySpaceRenameToConfig(cfg, space(cfg), 'old', 'new');
+    assert.deepEqual(cfg.tokens[0].rights.perSpace['new'],
+      { knowledge: 'admin', files: 'read', schema: 'none', dataQuality: 'write' });
+  });
+
+  it('a token with a row for a DIFFERENT space is untouched', () => {
+    const cfg = cfgWith([{ id: 't1', rights: { instanceAdmin: false, createSpaces: false, floor: null, perSpace: { other: ALL('read') } } }]);
+    applySpaceRenameToConfig(cfg, space(cfg), 'old', 'new');
+    assert.deepEqual(Object.keys(cfg.tokens[0].rights.perSpace), ['other']);
+  });
+
+  it('a token with no matrix at all does not throw', () => {
+    // Pre-matrix records exist until the field goes; the re-key must skip them rather than crash a rename.
+    const cfg = cfgWith([{ id: 't1', spaces: ['old'] }, { id: 't2' }]);
+    applySpaceRenameToConfig(cfg, space(cfg), 'old', 'new');
+    assert.deepEqual(cfg.tokens[0].spaces, ['new'], 'the legacy allowlist still moves');
+  });
+
+  it('every token is carried, not just the first', () => {
+    // A loop that returned early would pass a single-token fixture and strip everyone else.
+    const mk = () => ({ instanceAdmin: false, createSpaces: false, floor: null, perSpace: { old: ALL('write') } });
+    const cfg = cfgWith([{ id: 'a', rights: mk() }, { id: 'b', rights: mk() }, { id: 'c', rights: mk() }]);
+    applySpaceRenameToConfig(cfg, space(cfg), 'old', 'new');
+    for (const t of cfg.tokens) {
+      assert.deepEqual(t.rights.perSpace['new'], ALL('write'), `${t.id} lost its scope`);
+      assert.equal(t.rights.perSpace['old'], undefined, `${t.id} kept a dead key`);
+    }
+  });
+});
+
+describe('it refuses to overwrite an existing row', () => {
+  it('a token already holding rights at the NEW id keeps them', () => {
+    // `perSpace` is keyed by id, so re-keying is a move within an object rather than an index swap: a row
+    // already at `newId` would be silently replaced by one that used to be somewhere else, widening or
+    // narrowing that token with nothing to show for it.
+    //
+    // The rename route refuses a `newId` that already exists, so this is unreachable through the API — but
+    // this function is also reached on resume after a crash, and an unreviewable clobber is not worth the
+    // two lines it saves.
+    const cfg = cfgWith([{
+      id: 't1',
+      rights: { instanceAdmin: false, createSpaces: false, floor: null, perSpace: { old: ALL('read'), new: ALL('admin') } },
+    }]);
+    applySpaceRenameToConfig(cfg, space(cfg), 'old', 'new');
+    assert.deepEqual(cfg.tokens[0].rights.perSpace['new'], ALL('admin'),
+      'the existing row wins — a rename must not silently re-grant');
+  });
+});
+
+describe('the legacy half still works while the field exists', () => {
+  it('the allowlist is re-keyed too', () => {
+    const cfg = cfgWith([{ id: 't1', spaces: ['other', 'old'] }]);
+    applySpaceRenameToConfig(cfg, space(cfg), 'old', 'new');
+    assert.deepEqual(cfg.tokens[0].spaces, ['other', 'new'], 'position preserved, id updated');
+  });
+
+  it('and a token holding BOTH shapes has both carried', () => {
+    // The state a pre-matrix token is in after the boot backfill: allowlist and matrix, both naming the
+    // space. Missing either leaves it half-scoped.
+    const cfg = cfgWith([{
+      id: 't1',
+      spaces: ['old'],
+      rights: { instanceAdmin: false, createSpaces: false, floor: null, perSpace: { old: ALL('write') } },
+    }]);
+    applySpaceRenameToConfig(cfg, space(cfg), 'old', 'new');
+    assert.deepEqual(cfg.tokens[0].spaces, ['new']);
+    assert.deepEqual(cfg.tokens[0].rights.perSpace['new'], ALL('write'));
+  });
+});


### PR DESCRIPTION
## The defect

`applySpaceRenameToConfig` re-keyed `tok.spaces` and **nothing anywhere touched `rights.perSpace`**. A
rename left the row under the **old** id — which now names nothing — and the token silently lost the space it
had rights in.

That is **every token created since 2.9**. The rights editor writes `perSpace`; nothing writes the allowlist,
and the mint route's own refusal map tells a caller to use `rights.perSpace` instead. **So the half being
maintained was the half nobody has.**

It failed quietly at both ends: no error when renaming, and later a `403` that reads as though the rights had
never been granted.

## The existing test pinned the working half

`space-rename.test.js` has had a case called **"Rename updates token scopes"** the whole time. It asserted on
`tok.spaces` — the allowlist the rename *did* maintain — and stayed green while the matrix broke underneath
it.

That shape is worth naming: a test named for the rule, asserting the copy that was not load-bearing.

It now asserts the matrix too, and a second case **reads the renamed space back with the scoped token**.
Checking the stored shape proves the re-key ran; only the read proves it produced access — which is what was
actually missing.

## Found while measuring, not while looking

This surfaced while measuring the `spaces` field deletion: `rename.ts` was three of the twenty-two type
errors. Fixing it first was not optional — deleting the field without adding the `perSpace` re-key would have
removed the only rename handling that existed and made the silent loss total.

## The collision guard

`perSpace` is keyed by id, so re-keying is a **move within an object** rather than an index swap: a row
already at `newId` would be silently replaced by one that used to be somewhere else, widening or narrowing
that token.

Unreachable through the rename route, which refuses an existing `newId` — but this function is also reached
on **resume after a crash**, and an unreviewable clobber is not worth the two lines it saves.

## Verification

`rename-carries-token-rights.test.js` — 8 tests, exercising the real exported function against a plain config
object rather than reading source.

**Mutation-tested:** removing the re-key fails four assertions; dropping the collision guard fails one.

Part of **D-8d**, and a prerequisite for deleting `spaces` — the last of the three legacy fields.
