### PR TITLE
feat(tokens): spaces is no longer stored — the pre-3.0 triple is gone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- **`spaces` is no longer stored on a token — the last of the three, and the pre-3.0 triple is gone.** Every
+  scoping decision has read the rights matrix for some time; this release closed three separate holes where
+  one had not, each a check shaped `if (token.spaces)` that meant *unrestricted* on a token whose scope lived
+  only in the matrix. With nothing consulting the allowlist first, the field itself could go.
+
+  **Creating a scoped token is unchanged.** Send `spaces: ["research"]` and you get a matrix row for that
+  space, exactly as before; responses still carry `spaces`, derived. Tokens created earlier keep their
+  scope — the load-time migration reads the stored value to build their matrix, and OIDC sessions keep their
+  own copy because they are built per request from a claim mapping and have no matrix.
+
+  Removing it surfaced two more places reading the allowlist alone, both now on the matrix: which peer tokens
+  a sync watermark is computed for, and which tokens a space-restricted administrator can see in the token
+  list. Both would have treated every modern token as unrestricted.
+
 - **`admin` is no longer stored on a token either — the second of the three pre-3.0 fields.** Every check had
   already moved to the rights matrix in this release, and the seven places that each asked *"is this an
   instance admin"* their own way became one predicate first, against evidence that the two answers were

--- a/server/src/api/brain/search.ts
+++ b/server/src/api/brain/search.ts
@@ -6,6 +6,7 @@
 import { Router } from 'express';
 import { requireSpaceAuth, denyReadOnly } from '../../auth/middleware.js';
 import { spacesWhereTokenMay } from '../../auth/reachable-spaces.js';
+import { legacySpacesOf } from '../../auth/legacy-spaces.js';
 import type { TokenRights } from '../../config/rights-shape.js';
 import { summariseActivity } from '../../metrics/space-activity-store.js';
 import { globalRateLimit } from '../../rate-limit/middleware.js';
@@ -642,7 +643,7 @@ searchRouter.post('/spaces/:spaceId/find-similar', globalRateLimit, requireSpace
     // business having its records ranked here.
     crossSpaceIds = spacesWhereTokenMay(
       (req.authToken as { rights?: TokenRights } | undefined)?.rights,
-      req.authToken?.spaces,
+      legacySpacesOf(req.authToken),
       'knowledge',
       'read',
     );

--- a/server/src/api/duplicates.ts
+++ b/server/src/api/duplicates.ts
@@ -10,6 +10,7 @@
 
 import { Router } from 'express';
 import { requireAuth, requireAdminMfa, denyReadOnly } from '../auth/middleware.js';
+import { legacySpacesOf } from '../auth/legacy-spaces.js';
 import { globalRateLimit } from '../rate-limit/middleware.js';
 import { col, asFilter, asUpdate } from '../db/mongo.js';
 import { spacesWhereTokenMay } from '../auth/reachable-spaces.js';
@@ -290,7 +291,7 @@ duplicatesRouter.post('/:id/reopen', globalRateLimit, requireAuth, denyReadOnly,
 // Returns 409 with the merge plan if the pair has a property-value conflict.
 duplicatesRouter.post('/:id/merge', globalRateLimit, requireAuth, denyReadOnly, async (req, res) => {
   try {
-    const found = await findCandidate(req.params['id'] as string, req.authToken?.spaces, (req.authToken as { rights?: TokenRights } | undefined)?.rights);
+    const found = await findCandidate(req.params['id'] as string, legacySpacesOf(req.authToken), (req.authToken as { rights?: TokenRights } | undefined)?.rights);
     if (!found) { res.status(404).json({ error: 'Duplicate candidate not found' }); return; }
     const { doc, spaceId } = found;
     if (doc.type !== 'entity') { res.status(400).json({ error: 'Merge is only supported for entity candidates' }); return; }

--- a/server/src/api/spaces.ts
+++ b/server/src/api/spaces.ts
@@ -7,6 +7,7 @@ import {
   requireAdminOrSpaceAdminMfaScoped, isInstanceAdmin,
 } from '../auth/middleware.js';
 import { globalRateLimit } from '../rate-limit/middleware.js';
+import { editorScopeFor } from '../auth/editor-scope.js';
 import { getConfig, saveConfig, getSecrets, getDataRoot, getSchemaLibrary, getDocumentProcessingConfig, getMediaEmbeddingConfig, getStorageConfig } from '../config/loader.js';
 import { capDocExtractionMode } from '../files/converters/extraction-level.js';
 import { slugify, SPACE_PURPOSE_MAX, needsReindex } from '../spaces/_shared.js';
@@ -131,10 +132,18 @@ spacesRouter.get('/', globalRateLimit, requireAuth, async (req, res) => {
   const dataRoot = getDataRoot();
   const GiB = 1024 ** 3;
 
-  // Respect token space-scope restrictions: if the token is scoped to specific
-  // spaces, only return those spaces. Full-access tokens (no `spaces` field)
-  // receive the full list.
-  const tokenSpaces = req.authToken && 'spaces' in req.authToken ? req.authToken.spaces : undefined;
+  /**
+   * Respect token space-scope: a scoped token sees only the spaces it reaches. The MATRIX decides.
+   *
+   * This asked `'spaces' in req.authToken`, which stopped being true for every PAT the moment the field was
+   * deleted — so the guard silently became "unrestricted" and the listing showed every space on the instance
+   * to a token scoped to one. That is the fourth instance of one shape this release, and the first I caused
+   * rather than found: a legacy read that answers "no restriction" once the thing it reads is gone.
+   *
+   * `editorScopeFor` is the resolution every other scope decision uses — matrix first, the allowlist only
+   * for a record carrying no matrix, and `undefined` for genuinely unrestricted.
+   */
+  const tokenSpaces = editorScopeFor(req.authToken);
   const visibleSpaces = tokenSpaces
     ? cfg.spaces.filter(s => tokenSpaces.includes(s.id))
     : cfg.spaces;

--- a/server/src/api/tokens.ts
+++ b/server/src/api/tokens.ts
@@ -40,6 +40,10 @@ function withReadOnlyAlias<T extends { rights?: unknown }>(t: T): T & { readOnly
   return {
     ...t,
     readOnly: !canWriteAnywhere(rights),
+    // spaces joined the alias when it was deleted from the record, for the same reason as the other two:
+    // the response shape is a published contract, and editorScopeFor gives the same answer the stored
+    // array did — the spaces this token reaches, or undefined for unrestricted.
+    spaces: editorScopeFor(t as { rights?: TokenRights | null }) as string[] | undefined,
     // `admin` joined the alias when it was deleted from the record, for the same reason and by the same
     // measurement: `schema-library.test.js` asserts a library token comes back `admin: false`, and that
     // assertion lives only in the Docker-only suite that `preflight` cannot run. Found by grepping those
@@ -191,7 +195,11 @@ tokensRouter.get('/', requireAdminOrSpaceAdmin, (req, res) => {
   const callerSpaces = editorScopeFor(req.authToken);
   const all = listTokens().map(withReadOnlyAlias);
   const visible = callerSpaces
-    ? all.filter(t => t.schemaLibrary || (t.spaces?.every(s => callerSpaces.includes(s)) ?? false))
+    // `editorScopeFor` rather than the raw allowlist: it is the same resolution the mint and edit guards
+    // use, and reading `spaces` here would show a space-restricted admin every modern token as unrestricted
+    // and therefore hide all of them.
+    ? all.filter(t => t.schemaLibrary || ((editorScopeFor(t) ?? []).every(s => callerSpaces.includes(s))
+      && editorScopeFor(t) !== undefined))
     : all;
   res.json({ tokens: visible });
 });

--- a/server/src/auth/editor-scope.ts
+++ b/server/src/auth/editor-scope.ts
@@ -159,7 +159,7 @@ export type EditableRights = {
  */
 export function refusalsOutsideEditorScope(input: {
   editorSpaces: readonly string[] | undefined;
-  target: Pick<TokenRecord, 'spaces' | 'schemaLibrary'> | undefined;
+  target: { spaces?: string[]; schemaLibrary?: boolean; rights?: TokenRights | null } | undefined;
   rights: EditableRights | undefined;
 }): string[] {
   const { editorSpaces, target, rights } = input;
@@ -173,10 +173,14 @@ export function refusalsOutsideEditorScope(input: {
   // rename above succeeded. A `schemaLibrary` token has no space access at all, so it is inside any scope; a token
   // with NO allowlist reaches every space and is therefore outside every restricted scope.
   if (target && !target.schemaLibrary) {
-    if (!target.spaces) {
+    // The target's own scope, MATRIX first — `editorScopeFor` is the same resolution applied to the EDITOR,
+    // so both sides of this comparison now answer one question one way. Reading the raw allowlist here
+    // would call every token minted since 2.9 unrestricted, and refuse a space administrator every edit.
+    const targetSpaces = editorScopeFor(target);
+    if (!targetSpaces) {
       out.push('that token is unrestricted (it reaches every space), so a space-restricted administrator cannot edit it');
     } else {
-      const outside = target.spaces.filter(s => !editorSpaces.includes(s));
+      const outside = targetSpaces.filter(s => !editorSpaces.includes(s));
       if (outside.length > 0) {
         out.push(`that token reaches space(s) outside your scope: ${outside.join(', ')}`);
       }

--- a/server/src/auth/legacy-spaces.ts
+++ b/server/src/auth/legacy-spaces.ts
@@ -1,0 +1,30 @@
+/**
+ * The pre-3.0 `spaces` allowlist, read from wherever it still legitimately lives.
+ *
+ * ## Why a helper rather than a property access
+ *
+ * `spaces` is gone from `TokenRecord` (D-8d). It survives on `OidcTokenRecord` — built per request from a
+ * claim mapping, carrying no matrix — and inside stored config, which `migrateToken` reads to derive a matrix
+ * for a token minted before the matrix existed.
+ *
+ * Every remaining reader is a FALLBACK: it consults `rights` first and reaches for this only when there is
+ * none. Those readers take `TokenRecord | OidcTokenRecord`, so after the deletion each one needs the same
+ * narrowing — and writing that narrowing out ten times is how the next person ends up with ten slightly
+ * different answers to one question.
+ *
+ * ## The absent/empty distinction is the whole point
+ *
+ * An **absent** allowlist means every space. An **empty** one means none. Reading empty as absent turns the
+ * narrowest token into the widest, and this codebase has shipped that bug more than once — `rights-migration`
+ * documents it, `reachable-spaces` documents it, and three scope holes closed in this release were variants
+ * of it.
+ *
+ * So this returns `undefined` and `[]` as the distinct values they are, and never collapses them to a
+ * truthiness check. Callers must branch on `=== undefined`.
+ */
+
+/** The token's legacy allowlist, or `undefined` when it has none (which means every space). */
+export function legacySpacesOf(record: unknown): string[] | undefined {
+  const spaces = (record as { spaces?: unknown } | null | undefined)?.spaces;
+  return Array.isArray(spaces) ? spaces as string[] : undefined;
+}

--- a/server/src/auth/middleware.ts
+++ b/server/src/auth/middleware.ts
@@ -9,6 +9,7 @@ import { spaceAdminSpacesFor, isSpaceAdminFor } from './editor-scope.js';
 import type { OidcTokenRecord } from './oidc.js';
 import { resolveMemberSpaces } from '../spaces/proxy.js';
 import { reachesSpace } from './space-reach.js';
+import { legacySpacesOf } from './legacy-spaces.js';
 import { requiredRung, satisfies } from './required-rung.js';
 import { effectiveRung } from './mint-cap.js';
 import { authAttemptsTotal } from '../metrics/registry.js';
@@ -370,7 +371,7 @@ function spaceTargets(spaceId: string | undefined, record?: Omit<TokenRecord, 'h
     // Same asymmetry as the reach check, for the same reason: `spaces === undefined` is unrestricted and
     // reaches everything, while an EMPTY allowlist reaches nothing. Reading empty as absent would turn the
     // narrowest token into the widest — the bug we removed three copies of in 2.6.0.
-    : record.spaces === undefined ? all : all.filter(sid => record.spaces!.includes(sid));
+    : legacySpacesOf(record) === undefined ? all : all.filter(sid => legacySpacesOf(record)!.includes(sid));
 
   // Narrowing a real (non-proxy) space to nothing must not silently become "check no space at all": the reach
   // guard owns that refusal, and handing back the original keeps its 403 the one a caller sees.
@@ -441,7 +442,7 @@ function enforceSpaceScope(
   const rights = (record as { rights?: Parameters<typeof reachesSpace>[0] }).rights;
   const reachable = rights
     ? targets.filter(sid => reachesSpace(rights, sid))
-    : record.spaces === undefined ? targets : targets.filter(sid => record.spaces!.includes(sid));
+    : legacySpacesOf(record) === undefined ? targets : targets.filter(sid => legacySpacesOf(record)!.includes(sid));
 
   if (reachable.length === 0) {
     res.status(403).json({ error: `Token does not have access to space '${spaceId}'` });

--- a/server/src/auth/tokens.ts
+++ b/server/src/auth/tokens.ts
@@ -202,7 +202,6 @@ export async function createToken(opts: {
     createdAt: new Date().toISOString(),
     lastUsed: null,
     expiresAt: opts.expiresAt ?? null,
-    spaces: opts.spaces,
     peerInstanceId: opts.peerInstanceId,
     ...(opts.schemaLibrary ? { schemaLibrary: true } : {}),
     // Stored only when it says something. `inherit` IS the absent state, so writing it would put a field on
@@ -266,7 +265,6 @@ export async function createOAuthToken(opts: {
     createdAt: new Date().toISOString(),
     lastUsed: null,
     expiresAt: opts.ttlMs === null ? null : new Date(Date.now() + opts.ttlMs).toISOString(),
-    spaces: opts.spaces,
     oauthClientId: opts.clientId,
     // ALWAYS stored, for the reason spelled out on `createToken` above — and this is the path that fix
     // MISSED. `createToken` was given an unconditional matrix because a token minted after boot had none

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -7,7 +7,14 @@ export interface TokenRecord {
   createdAt: string;    // ISO8601
   lastUsed: string | null;
   expiresAt: string | null;
-  spaces?: string[];    // allowlist of space IDs; omit = all spaces
+  // `spaces` was REMOVED in 3.1 (D-8d), the last of the pre-3.0 triple. Nothing consults it first any more:
+  // every scoping decision reads `rights` — `reachesSpace`, `editorScopeFor`, `spacesWhereTokenMay` — and
+  // three separate holes were closed on the way, each one a check written `if (token.spaces)` that meant
+  // "unrestricted" on a token whose scope lived only in the matrix.
+  //
+  // It survives where it is still MEANINGFUL: as an INPUT to `migrateToken`, which derives a matrix for a
+  // token minted before the matrix existed, and on `OidcTokenRecord`, which is built per request from a
+  // claim mapping and carries no matrix at all. Every fallback that reads it now reads it from there.
   // `admin` was REMOVED in 3.1 (D-8d), the second of the pre-3.0 triple. Nothing decides on it any more:
   // `isInstanceAdmin` reads `rights.instanceAdmin`, and the seven places that each asked the question their
   // own way were unified onto that one predicate first, in its own change, against evidence that the two

--- a/server/src/mcp/oauth.ts
+++ b/server/src/mcp/oauth.ts
@@ -43,6 +43,7 @@ import { createOAuthToken, findMatchingToken } from '../auth/tokens.js';
 import { authRateLimit } from '../rate-limit/middleware.js';
 import { log } from '../util/log.js';
 import { isInstanceAdmin } from '../auth/instance-admin.js';
+import { legacySpacesOf } from '../auth/legacy-spaces.js';
 import { envInt } from '../config/env-num.js';
 import type { TokenRecord } from '../config/types.js';
 
@@ -350,7 +351,7 @@ async function handleConsent(req: Request, res: Response): Promise<void> {
     // authorising token's `rights` are carried through directly below. The minted token derives its matrix
     // from those, so this flag no longer shapes anything; it stays only until the identity shape itself is
     // trimmed, and `false` is the value that cannot narrow or widen what `rights` already says.
-    identity: { admin: isInstanceAdmin(record), readOnly: false, spaces: record.spaces,
+    identity: { admin: isInstanceAdmin(record), readOnly: false, spaces: legacySpacesOf(record),
       rights: (record as { rights?: TokenRecord['rights'] }).rights },
     expiresAt: now + AUTH_CODE_TTL_MS,
   });

--- a/server/src/mcp/router.ts
+++ b/server/src/mcp/router.ts
@@ -12,6 +12,7 @@ import { getConfig } from '../config/loader.js';
 import { log } from '../util/log.js';
 import { reachesSpace } from '../auth/space-reach.js';
 import { toolRightsRefusal, spaceAdminRefusal } from './tool-rights-guard.js';
+import { legacySpacesOf } from '../auth/legacy-spaces.js';
 import type { TokenRights } from '../config/rights-shape.js';
 import { memberSpacesWithin } from '../spaces/proxy-scoped.js';
 import { ALL_TOOLS, TOOLS_BY_NAME, type ToolSchemas } from './tools/index.js';
@@ -352,7 +353,7 @@ mcpRouter.get('/', globalRateLimit, async (req, res) => {
     log.debug(`MCP global session ${sessionTag(transport.sessionId)} closed`);
   });
 
-  const server = createGlobalMcpServer(req.authToken?.spaces, req.authToken?.id, req.authToken?.name,
+  const server = createGlobalMcpServer(legacySpacesOf(req.authToken), req.authToken?.id, req.authToken?.name,
     { ip: req.ip ?? '', authMethod: auditAuthMethod(req.authToken), oidcSubject: auditOidcSubject(req.authToken), transport: 'sse' }, tokenRights(req.authToken));
   log.debug(`MCP global session ${sessionTag(transport.sessionId)} opened`);
   await server.connect(transport);
@@ -384,7 +385,7 @@ mcpRouter.post('/messages', globalRateLimit, async (req, res) => {
 // This transport requires no persistent connection and works through standard HTTP proxies.
 mcpRouter.post('/', globalRateLimit, async (req, res) => {
   const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
-  const server = createGlobalMcpServer(req.authToken?.spaces, req.authToken?.id, req.authToken?.name,
+  const server = createGlobalMcpServer(legacySpacesOf(req.authToken), req.authToken?.id, req.authToken?.name,
     { ip: req.ip ?? '', authMethod: auditAuthMethod(req.authToken), oidcSubject: auditOidcSubject(req.authToken), transport: 'http' }, tokenRights(req.authToken));
   // Register cleanup before handling the request so it fires regardless of outcome.
   res.on('close', () => {

--- a/server/src/spaces/rename.ts
+++ b/server/src/spaces/rename.ts
@@ -237,10 +237,6 @@ export function applySpaceRenameToConfig(cfg: Config, space: SpaceConfig, oldId:
    * unreviewable.
    */
   for (const tok of cfg.tokens) {
-    if (tok.spaces) {
-      const idx = tok.spaces.indexOf(oldId);
-      if (idx !== -1) tok.spaces[idx] = newId;
-    }
     const perSpace = tok.rights?.perSpace;
     if (perSpace && perSpace[oldId] !== undefined && perSpace[newId] === undefined) {
       perSpace[newId] = perSpace[oldId]!;

--- a/server/src/sync/served-watermark.ts
+++ b/server/src/sync/served-watermark.ts
@@ -23,6 +23,8 @@
  * enumerated rather than defaulted, so a caller can log WHY nothing happened.
  */
 import { getConfig, saveConfigSoon } from '../config/loader.js';
+import { reachesSpace } from '../auth/space-reach.js';
+import { legacySpacesOf } from '../auth/legacy-spaces.js';
 import type { Config, NetworkMember } from '../config/types.js';
 
 /** The subset of a member this decision needs — so the pure part is testable without a config. */
@@ -53,7 +55,11 @@ export type TombstoneFloor =
 export function peerTokensReaching(cfg: Config, spaceId: string): string[] {
   return (cfg.tokens ?? [])
     .filter(t => typeof t.peerInstanceId === 'string' && t.peerInstanceId !== '')
-    .filter(t => t.spaces === undefined || t.spaces.includes(spaceId))
+    // Matrix first. This read the legacy allowlist alone, which is `undefined` on every token minted
+    // since 2.9 — so every peer token counted as reaching every space, and the watermark was computed
+    // against peers that could not see it.
+    .filter(t => (t.rights ? reachesSpace(t.rights, spaceId) : (legacySpacesOf(t) ?? []).includes(spaceId)
+      || legacySpacesOf(t) === undefined))
     .map(t => t.peerInstanceId as string);
 }
 

--- a/testing/standalone/legacy-admin-field-is-gone.test.js
+++ b/testing/standalone/legacy-admin-field-is-gone.test.js
@@ -44,7 +44,9 @@ before(async () => {
 describe('the field is gone from the record and the plumbing', () => {
   it('TokenRecord no longer declares it', () => {
     const types = src('server/src/config/types.ts');
-    const at = types.indexOf('spaces?: string[]');
+    // Anchored on `peerInstanceId`: `spaces?: string[]` was the previous anchor and has since been deleted
+    // too, which broke both of these gates at once — an anchor inside the thing being removed cannot last.
+    const at = types.indexOf('peerInstanceId?: string');
     assert.ok(at > 0, 'the TokenRecord block was not found — the scanner is wrong, not the code');
     assert.doesNotMatch(types.slice(at, at + 400), /\n\s+admin: boolean;/, 'the stored field must be gone');
   });

--- a/testing/standalone/legacy-admin-field-is-gone.test.js
+++ b/testing/standalone/legacy-admin-field-is-gone.test.js
@@ -127,6 +127,22 @@ describe('the search shape that missed one', () => {
       'these read a deleted field — ask `isInstanceAdmin` / the rights matrix instead:\n  ' + offenders.join('\n  '));
   });
 
+  it('nor probes for them with `in`, which answers "unrestricted" once they are gone', () => {
+    // The fourth instance of this shape, and the first I caused rather than found. `GET /api/spaces` asked
+    // `'spaces' in req.authToken` — true while the field existed, false for every PAT the moment it was
+    // deleted — so the listing silently stopped filtering and showed a scoped token every space on the
+    // instance.
+    //
+    // `in` is invisible to a property-access sweep, exactly as bracket notation was. Same lesson, third
+    // spelling: search for the QUESTION, not for one way of writing it.
+    const files = execSync('git ls-files "server/src/**/*.ts"', { encoding: 'utf8' })
+      .split('\n').map(s => s.trim()).filter(Boolean);
+    const probes = files.filter(f =>
+      /['"](?:spaces|admin|readOnly)['"]\s+in\s+/.test(stripComments(readFileSync(f, 'utf8'))));
+    assert.deepEqual(probes, [],
+      'these probe for a deleted field and read its absence as "no restriction":\n  ' + probes.join('\n  '));
+  });
+
   it('and the detector really matches the bracket form that got through', () => {
     // Mutation-proof for the pattern itself: a gate whose regex misses the case it was written for is worse
     // than none, because it reports clean.

--- a/testing/standalone/legacy-readonly-field-is-gone.test.js
+++ b/testing/standalone/legacy-readonly-field-is-gone.test.js
@@ -42,7 +42,9 @@ before(async () => {
 describe('the field is gone from the record and from the plumbing', () => {
   it('TokenRecord no longer declares it', () => {
     const types = src('server/src/config/types.ts');
-    const at = types.indexOf('spaces?: string[]');
+    // Anchored on `peerInstanceId`: `spaces?: string[]` was the previous anchor and has since been deleted
+    // too, which broke both of these gates at once — an anchor inside the thing being removed cannot last.
+    const at = types.indexOf('peerInstanceId?: string');
     assert.ok(at > 0, 'the TokenRecord block was not found — the scanner is wrong, not the code');
     const block = types.slice(at, at + 400);
     assert.doesNotMatch(block, /readOnly\?: boolean;/, 'the stored field must be gone');

--- a/testing/standalone/proxy-reach.test.js
+++ b/testing/standalone/proxy-reach.test.js
@@ -202,7 +202,9 @@ describe('the proxy lens narrows instead of failing closed', () => {
     // The conflation that granted whole instances on three routes in 2.6.0. It must not come back inside the
     // narrowing, where it would turn the narrowest token into the widest.
     const fn = src.slice(src.indexOf('function spaceTargets'), src.indexOf('function enforceAreaRung'));
-    assert.match(fn, /record\.spaces === undefined \? all :/,
+    // Spelled `legacySpacesOf(record)` since the field left `TokenRecord` (D-8d). The RULE it encodes is
+    // untouched, and the rule is what this asserts.
+    assert.match(fn, /legacySpacesOf\(record\) === undefined \? all :/,
       'absent means unrestricted; length === 0 would read empty as absent');
     assert.ok(!/spaces\?\.length === 0|spaces\.length === 0/.test(fn),
       'an empty allowlist must not be treated as unrestricted');

--- a/testing/standalone/rename-carries-token-rights.test.js
+++ b/testing/standalone/rename-carries-token-rights.test.js
@@ -25,6 +25,8 @@
  */
 import { describe, it, before } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripComments } from './_strip-comments.mjs';
 
 let applySpaceRenameToConfig;
 before(async () => {
@@ -67,10 +69,12 @@ describe('the matrix row follows the rename', () => {
   });
 
   it('a token with no matrix at all does not throw', () => {
-    // Pre-matrix records exist until the field goes; the re-key must skip them rather than crash a rename.
-    const cfg = cfgWith([{ id: 't1', spaces: ['old'] }, { id: 't2' }]);
-    applySpaceRenameToConfig(cfg, space(cfg), 'old', 'new');
-    assert.deepEqual(cfg.tokens[0].spaces, ['new'], 'the legacy allowlist still moves');
+    // A record with no `rights` must be SKIPPED, not crash the rename. It no longer gets an allowlist
+    // re-keyed either — `TokenRecord.spaces` was deleted in the change that followed this one, and its only
+    // remaining readers derive a matrix from it at load. A stored config still holding one is pre-migration
+    // by definition, and the boot backfill gives it a matrix before any rename can reach it.
+    const cfg = cfgWith([{ id: 't1' }, { id: 't2' }]);
+    assert.doesNotThrow(() => applySpaceRenameToConfig(cfg, space(cfg), 'old', 'new'));
   });
 
   it('every token is carried, not just the first', () => {
@@ -104,23 +108,19 @@ describe('it refuses to overwrite an existing row', () => {
   });
 });
 
-describe('the legacy half still works while the field exists', () => {
-  it('the allowlist is re-keyed too', () => {
-    const cfg = cfgWith([{ id: 't1', spaces: ['other', 'old'] }]);
-    applySpaceRenameToConfig(cfg, space(cfg), 'old', 'new');
-    assert.deepEqual(cfg.tokens[0].spaces, ['other', 'new'], 'position preserved, id updated');
-  });
-
-  it('and a token holding BOTH shapes has both carried', () => {
-    // The state a pre-matrix token is in after the boot backfill: allowlist and matrix, both naming the
-    // space. Missing either leaves it half-scoped.
-    const cfg = cfgWith([{
-      id: 't1',
-      spaces: ['old'],
-      rights: { instanceAdmin: false, createSpaces: false, floor: null, perSpace: { old: ALL('write') } },
-    }]);
-    applySpaceRenameToConfig(cfg, space(cfg), 'old', 'new');
-    assert.deepEqual(cfg.tokens[0].spaces, ['new']);
-    assert.deepEqual(cfg.tokens[0].rights.perSpace['new'], ALL('write'));
+describe('the legacy half went with the field', () => {
+  it('the allowlist is no longer re-keyed, because it no longer exists', () => {
+    // These two cases asserted that `tok.spaces` was carried, which was the ONLY thing the rename did until
+    // the fix above. `TokenRecord.spaces` was deleted in the change that followed, so re-keying it would be
+    // dead code wearing the shape of a safeguard — and the matrix re-key is what carries a token's scope.
+    //
+    // Inverted rather than deleted, so a reader finding no allowlist handling in `rename.ts` can see it was
+    // removed deliberately rather than forgotten.
+    // Comments stripped: the doc block above the loop EXPLAINS the old `tok.spaces` re-key, so a raw read
+    // fires on the sentence describing the fix. This repo has a rule about that, and this is the third time
+    // it has applied.
+    const src = stripComments(readFileSync('server/src/spaces/rename.ts', 'utf8'));
+    assert.doesNotMatch(src, /tok\.spaces/, 'nothing should re-key a deleted field');
+    assert.match(src, /perSpace\[newId\] = perSpace\[oldId\]/, 'the matrix re-key is the whole of it now');
   });
 });

--- a/testing/standalone/space-guard-reads-rights.test.js
+++ b/testing/standalone/space-guard-reads-rights.test.js
@@ -52,7 +52,9 @@ describe('the space guard', () => {
 
   it('keeps the legacy branch for records with no rights', () => {
     // OIDC tokens are built per request and never reach the config backfill. Removing this refuses them all.
-    assert.match(guardBody(), /record\.spaces/,
+    // Spelled `legacySpacesOf(record)` since the field left `TokenRecord` (D-8d). It still lives on the
+    // OIDC record, which is exactly who this branch serves.
+    assert.match(guardBody(), /legacySpacesOf\(record\)/,
       'the fallback is gone; every OIDC caller would be refused, and no unit test stands one up');
   });
 


### PR DESCRIPTION
The last of the three legacy token fields. **No token's access changes.**

## Why it could go

Every scoping decision reads the rights matrix. This release closed **three separate holes** where one had not — each a check shaped if (token.spaces), which means *unrestricted* on a token whose scope lives only in the matrix: the sync read routes (#939), cross-space recall and signing-key rotation (#949). With nothing consulting the allowlist first, the field itself could go.

## What survives, and where

| survives | because |
| --- | --- |
| \migrateToken\ reads stored config | a pre-matrix token keeps its scope |
| \OidcTokenRecord\ keeps its own | built per request from a claim mapping, no matrix |
| \createToken\ accepts it | scoped minting stays sayable |
| the API response carries it | derived via \editorScopeFor\ |

Every remaining fallback reads it through **one helper**, \legacySpacesOf\, rather than ten hand-written narrowings that would drift into ten answers.

Three integration assertions read \spaces\ off a response, and they live only in the Docker-only suite \preflight\ cannot run. Found by grepping those suites **before** pushing — as with the other two fields, and unlike the first time.

## Removing it surfaced two more of the same hole

- **\served-watermark\** asked which peer tokens reach a space by reading the allowlist alone, so every peer token minted since 2.9 counted as reaching **every** space.
- **The token list filter** did the same, which would have shown a space-restricted administrator every modern token as unrestricted and therefore hidden all of them.

Both are on the matrix now. Neither was in the plan; both were the plan's whole point.

## Gates updated, not loosened

Four pinned the deleted spelling. Each now asserts the same **rule** through the helper — absent means unrestricted, empty means nothing.

The two field-deletion gates were also **re-anchored**: they located the \TokenRecord\ block by \spaces?: string[]\, which is an anchor inside the thing being removed and could not last.

The rename gate's legacy half is **inverted rather than deleted**, so a reader finding no allowlist handling in \ename.ts\ can see it went deliberately.

Closes the field half of **D-8d**.