### PR TITLE
fix(mcp): the chrono tools said the clock is ignored; it never was

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the access token appears, and it works on the API. Nothing changes for an instance that is already
   configured — the old form returned `404` there anyway — and `/api/setup` is untouched.
 
+### Fixed
+
+- **The chrono tools said the opposite of what the code does about `status`, on four tools.** A capitalised
+  warning on `list_chrono`, repeated on `create_chrono`, `update_chrono` and `delete_chrono`, read *"NOTHING
+  RECOMPUTES `status` FROM THE CLOCK … `status: "overdue"` only finds entries somebody marked overdue. Filter
+  on the dates if you want the truth about time."*
+
+  Every clause was false. `overdue` is **derived on read** and always has been: an entry whose due moment has
+  passed and that is still `upcoming`/`active` reads back as `overdue` from `list_chrono`, `recall` and a
+  single-entry get, and the list filter is translated to match — so `status: "overdue"` finds exactly those,
+  and `status: "upcoming"` *excludes* them. The paragraph steered a caller away from the one filter that
+  answers the question, toward a date predicate they did not need.
+
+  The REST reference described it correctly the whole time. One behaviour, two contradictory descriptions,
+  and the wrong one was the one an agent reads while constructing arguments. All four now say it is derived,
+  name the one path that does **not** derive (`query`, which reads documents as stored), and warn against
+  storing `overdue` by hand — a stored `overdue` is missed by the `status=overdue` filter, which looks for
+  the derivable ones. That last point is a defect rather than a design and is now written down as one.
+
+  A gate exercises `deriveChronoStatus` and holds the sentences to what it returns, rather than checking the
+  spelling of the old paragraph.
+
 ### Changed
+
+- **Every MCP tool parameter now carries a description — including the nested ones.** 26 had none at all, so
+  a caller constructing arguments from `tools/list` — which `help()` names as the authoritative reference —
+  had nothing to read. 18 of the 26 were inside `bulk_write`'s per-item schemas, which a top-level sweep
+  reports as clean.
+
+  The new text says the trap rather than the type. `bulk_write`'s per-item schemas are for discovery only, so
+  `edges[].weight` is **not** bounded to 0–1 there while `upsert_edge` bounds it, and a `chrono[].status`
+  outside the enum is discarded silently without appearing in `errors` — a third silent loss on a tool that
+  already documented two. `upsert_entity.tags` merges rather than replaces, so no value sent there removes a
+  tag. The chrono `recurrence` block became one shared schema instead of two near-identical copies whose one
+  required field, `freq`, was undescribed in both; it now states that the rule describes an entry and
+  generates nothing.
+
+  A gate walks every schema to full depth and refuses a parameter with no description, or one that merely
+  restates its own key.
 
 - **`wipe_space` now describes what it actually does to a space, beyond removing the records.** Omitting
   `types` wipes **all five** collections rather than none — an absent filter is not a safe default. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   A gate exercises `deriveChronoStatus` and holds the sentences to what it returns, rather than checking the
   spelling of the old paragraph.
 
+- **Four source-reading gates could pass on one machine and fail on another, for a reason invisible in the
+  diff.** Each bounded the source it examined by a character count — `slice(anchor, anchor + 400)`. A count
+  bounds *distance*, and a Windows working copy stores CRLF where CI checks out LF, so the same number spans a
+  different number of lines on each. One of them examined a statement locally and its neighbour in CI. Where
+  the assertion was a negative one, the failure mode is the dangerous direction: a window that quietly shrinks
+  makes a gate pass by looking at less.
+
+  All four are bounded by structure now — an interface's own braces, a route handler's closing `});`, a
+  statement's own semicolon — and a sweep of all 409 gates confirms none of the class is left. Two of them got
+  stronger in the process: bounded by the whole `TokenRecord` interface rather than forward from a member, they
+  now catch a deleted field re-added *above* the old anchor, which the character window could never see.
+
 ### Changed
 
 - **Every MCP tool parameter now carries a description — including the nested ones.** 26 had none at all, so

--- a/docs/integration-guide/04c-chrono-api.md
+++ b/docs/integration-guide/04c-chrono-api.md
@@ -38,6 +38,10 @@ memory. See [Retry Safety](04-brain-api.md#retry-safety).
 - `status` — `upcoming` (default), `active`, `completed`, `overdue`, `cancelled`. You never need to set
   `overdue` yourself: it is **derived on read** — an entry whose due moment (`endsAt`, or `startsAt` if
   it has none) has passed and that is not `completed`/`cancelled` is returned as `overdue`.
+  **Do not store `overdue` by hand.** It is accepted, but a stored `overdue` is then missed by the
+  `status=overdue` list filter, which looks for the derivable ones (stored `upcoming`/`active`, past due).
+  And the derivation applies to the chrono read paths only: `POST /query` reads documents as stored, so the
+  same entry is `upcoming` there and `overdue` in `GET /chrono`.
 - `confidence` — `0`–`1` (optional, useful for predictions)
 - `entityIds` — array of UUID v4 entity IDs (not names); returns `400` if any value is not a valid UUID and `strictLinkage` is enabled
 - `memoryIds` — array of UUID v4 memory IDs (not names); returns `400` if any value is not a valid UUID and `strictLinkage` is enabled

--- a/docs/userguide/02-brain.md
+++ b/docs/userguide/02-brain.md
@@ -115,6 +115,11 @@ Chrono stores time-anchored entries: events, deadlines, plans, predictions, and 
 
 **Filtering:** The filter bar above the table lets you narrow by tag text and status. Filters apply immediately.
 
+> **"Overdue" is worked out from the clock, not stored.** An entry you left as *upcoming* whose date has
+> passed shows as **overdue** on its own — nobody has to mark it. That also means filtering by *upcoming* or
+> *active* leaves those entries out, because they are counted as overdue now. Set an entry to *completed* or
+> *cancelled* to stop it being counted that way.
+
 **Editing:** Click the **⊙ view-details** button on any row to open the editable drawer, as on the other record
 tabs. Title, type, dates, status, tags, description and properties can all be changed there.
 

--- a/server/src/mcp/tools/bulk.ts
+++ b/server/src/mcp/tools/bulk.ts
@@ -63,7 +63,13 @@ export const bulk_writeTool: ToolHandler = {
                   entityIds:   { type: 'array', items: { type: 'string' }, description: 'Related entity IDs.' },
                   description: { type: 'string', description: 'Optional prose context.' },
                   type:        { type: 'string', description: 'Optional memory type — selects the per-type schema used to validate `properties`.' },
-                  properties:  { type: 'object', additionalProperties: { oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }] } },
+                  properties:  {
+                    type: 'object',
+                    description: 'Key-value metadata. String, number or boolean values only — a nested '
+                      + 'object or array is not accepted. Validated against the per-type schema when `type` '
+                      + 'is set, and a failure REJECTS this item alone rather than the batch.',
+                    additionalProperties: { oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }] },
+                  },
                   ttlDays:     TTL_DAYS_SCHEMA,
                 },
                 required: ['fact'],
@@ -78,11 +84,22 @@ export const bulk_writeTool: ToolHandler = {
                 additionalProperties: false,
                 properties: {
                   id:          uuidSchema('UUID v4 of an EXISTING entity to update. It is not a way to choose an id: identity is server-generated, so an id that names nothing is ignored rather than adopted. To carry your own reference, use `name` or `description`.'),
-                  name:        { type: 'string', description: 'Entity name.' },
-                  type:        { type: 'string', description: 'Entity type.' },
-                  tags:        { type: 'array', items: { type: 'string' } },
-                  description: { type: 'string' },
-                  properties:  { type: 'object', additionalProperties: { oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }] } },
+                  name:        { type: 'string', description: 'Entity name. Nothing deduplicates by name — an item with no `id` always INSERTS, even when a record of the same name already exists.' },
+                  type:        { type: 'string', description: 'Entity type (person, place, concept, …). Validated against the space schema when the space validates.' },
+                  tags:        {
+                    type: 'array', items: { type: 'string' },
+                    description: 'Categorisation tags. MERGED over the stored tags when `id` names an '
+                      + 'existing entity, exactly as `upsert_entity` merges — so no value here removes a tag.',
+                  },
+                  description: { type: 'string', description: 'Optional prose description or summary of this entity. Replaced when sent.' },
+                  properties:  {
+                    type: 'object',
+                    description: 'Key-value metadata (string, number or boolean values only). MERGED key by '
+                      + 'key when `id` names an existing entity, and validated in its MERGED form — which is '
+                      + 'why a partial item can be accepted where the fragment alone would fail a '
+                      + 'required-property rule.',
+                    additionalProperties: { oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }] },
+                  },
                   ttlDays:     TTL_DAYS_SCHEMA,
                 },
                 required: ['name', 'type'],
@@ -99,11 +116,27 @@ export const bulk_writeTool: ToolHandler = {
                   from:        { type: 'string', description: 'Source entity ID.' },
                   to:          { type: 'string', description: 'Target entity ID.' },
                   label:       { type: 'string', description: 'Relationship label.' },
-                  type:        { type: 'string' },
-                  weight:      { type: 'number' },
-                  description: { type: 'string' },
-                  tags:        { type: 'array', items: { type: 'string' } },
-                  properties:  { type: 'object', additionalProperties: { oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }] } },
+                  type:        { type: 'string', description: 'Optional edge type (e.g. "causal", "attribution"). Free text; nothing validates it against a list.' },
+                  weight:      {
+                    type: 'number',
+                    description: 'Optional edge weight. `upsert_edge` BOUNDS this to 0–1 and this door does '
+                      + 'NOT — the per-item schemas here are for discovery only (`skipSchemaValidation`), so '
+                      + 'a weight outside 0–1 is stored as sent rather than refused. Send 0–1 to match what '
+                      + 'the single-record tool would have accepted. A non-number is dropped silently and '
+                      + 'does not appear in `errors`.',
+                  },
+                  description: { type: 'string', description: 'Optional prose description of why this relationship exists. Replaced when sent.' },
+                  tags:        {
+                    type: 'array', items: { type: 'string' },
+                    description: 'Categorisation tags. MERGED over the stored tags when the triplet already '
+                      + 'exists, exactly as `upsert_edge` merges — so no value here removes a tag.',
+                  },
+                  properties:  {
+                    type: 'object',
+                    description: 'Key-value metadata (string, number or boolean values only). MERGED key by '
+                      + 'key over an existing edge and validated in its merged form.',
+                    additionalProperties: { oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }] },
+                  },
                   ttlDays:     TTL_DAYS_SCHEMA,
                 },
                 required: ['from', 'to', 'label'],
@@ -117,17 +150,29 @@ export const bulk_writeTool: ToolHandler = {
                 type: 'object',
                 additionalProperties: false,
                 properties: {
-                  title:       { type: 'string' },
-                  type:        { type: 'string', description: 'Entry type (e.g. event, deadline, plan, prediction, milestone, or a custom type defined in the space schema).' },
-                  startsAt:    { type: 'string', description: 'ISO 8601 start date/time.' },
-                  endsAt:      { type: 'string' },
-                  status:      { type: 'string', enum: ['upcoming', 'active', 'completed', 'overdue', 'cancelled'] },
-                  confidence:  { type: 'number' },
-                  description: { type: 'string' },
-                  tags:        { type: 'array', items: { type: 'string' } },
-                  entityIds:   { type: 'array', items: { type: 'string' } },
-                  memoryIds:   { type: 'array', items: { type: 'string' } },
-                  properties:  { type: 'object', additionalProperties: { oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }] } },
+                  title:       { type: 'string', description: 'Entry title. Required — an item without one is rejected by index in `errors`.' },
+                  type:        { type: 'string', description: 'Entry type (e.g. event, deadline, plan, prediction, milestone, or a custom type defined in the space schema). Checked against the space\'s allowlist, and a type outside it rejects THIS item by index.' },
+                  startsAt:    { type: 'string', description: 'ISO 8601 start date/time. Required.' },
+                  endsAt:      { type: 'string', description: 'Optional ISO 8601 end date/time.' },
+                  status:      {
+                    type: 'string', enum: ['upcoming', 'active', 'completed', 'overdue', 'cancelled'],
+                    description: 'Stored status (default `upcoming`). A value outside this list is DISCARDED '
+                      + 'SILENTLY — the entry is still written, with the default, and nothing appears in '
+                      + '`errors`. `create_chrono` refuses the same value, because the per-item schemas here '
+                      + 'are for discovery only (`skipSchemaValidation`). Do not set `overdue`: it is derived '
+                      + 'on read from the due moment, so leaving an entry `upcoming` is what makes it overdue.',
+                  },
+                  confidence:  { type: 'number', description: 'Confidence 0 to 1, for entries that are predictions. A non-number is dropped silently and does not appear in `errors`; unlike `create_chrono`, the 0–1 bound is not enforced on this door.' },
+                  description: { type: 'string', description: 'Optional longer description of the entry.' },
+                  tags:        { type: 'array', items: { type: 'string' }, description: 'Categorisation tags. Every chrono item is an INSERT, so there is nothing to merge with.' },
+                  entityIds:   { type: 'array', items: { type: 'string' }, description: 'Entity IDs this entry concerns — what lets `traverse` reach it from that entity. NEVER checked for existence on this door, and checked for UUID shape only when the space uses strict linkage, so a well-formed id pointing at nothing is stored as a dangling link.' },
+                  memoryIds:   { type: 'array', items: { type: 'string' }, description: 'Memory IDs this entry relates to. Shape-checked under strict linkage only, and never for existence — like `entityIds`.' },
+                  properties:  {
+                    type: 'object',
+                    description: 'Key-value metadata (string, number or boolean values only), validated '
+                      + 'against the space\'s schema for this chrono type.',
+                    additionalProperties: { oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }] },
+                  },
                   ttlDays:     TTL_DAYS_SCHEMA,
                 },
                 required: ['title', 'type', 'startsAt'],

--- a/server/src/mcp/tools/chrono.ts
+++ b/server/src/mcp/tools/chrono.ts
@@ -1,5 +1,5 @@
 import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.js';
-import { UUID_V4_RE, TTL_DAYS_SCHEMA, EXCLUDE_FROM_VECTOR_SEARCH_SCHEMA, ttlDaysFromArgs, unitScoreSchema, uuidSchema } from './shared.js';
+import { UUID_V4_RE, TTL_DAYS_SCHEMA, EXCLUDE_FROM_VECTOR_SEARCH_SCHEMA, ttlDaysFromArgs, recurrenceSchema, unitScoreSchema, uuidSchema } from './shared.js';
 import { ChronoFilter, createChrono, deleteChrono, getChronoById, listChrono, updateChrono, parseRecurrence } from '../../brain/chrono.js';
 // The API layer's write gate, imported rather than reimplemented — see the note in memory.ts.
 import { assertUpdateAllowed, classifyUpdateViolations, locateForUpdate } from '../../brain/write-validation.js';
@@ -28,7 +28,13 @@ export const create_chronoTool: ToolHandler = {
             type: { type: 'string', minLength: 1, description: 'Entry type. Rejected unless it is one of the space\'s allowed chrono types: the defaults are event, deadline, plan, prediction, milestone, or the custom set declared in the space\'s typeSchemas.chrono.' },
             startsAt: { type: 'string', minLength: 1, description: 'ISO 8601 start date/time.' },
             endsAt: { type: 'string', description: 'Optional ISO 8601 end date/time.' },
-            status: { type: 'string', enum: ['upcoming', 'active', 'completed', 'overdue', 'cancelled'], default: 'upcoming', description: 'Status (default: upcoming).' },
+            status: {
+              type: 'string', enum: ['upcoming', 'active', 'completed', 'overdue', 'cancelled'], default: 'upcoming',
+              description: 'Stored status (default `upcoming`). Do NOT set `overdue` — it is derived on read '
+                + 'from the due moment, so an entry left `upcoming` becomes overdue on its own, and one '
+                + 'stored as `overdue` by hand is then invisible to `list_chrono`\'s `status: "overdue"` '
+                + 'filter, which looks for the derivable ones.',
+            },
             confidence: unitScoreSchema('Confidence level 0–1 (for predictions).'),
             tags: { type: 'array', items: { type: 'string' }, description: 'Categorisation tags.' },
             entityIds: { type: 'array', items: { type: 'string' }, description: 'Related entity IDs.' },
@@ -39,17 +45,7 @@ export const create_chronoTool: ToolHandler = {
               description: 'Optional structured key-value metadata for this entry.',
               additionalProperties: { oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }] },
             },
-            recurrence: {
-              type: 'object',
-              description: 'Optional recurrence rule, e.g. { freq: "weekly", interval: 1, until: "2027-01-01T00:00:00Z" }.',
-              properties: {
-                freq: { type: 'string', enum: ['daily', 'weekly', 'monthly', 'yearly'] },
-                interval: { type: 'integer', minimum: 1, default: 1, description: 'Repeat every N periods (positive integer, default 1).' },
-                until: { type: 'string', description: 'Optional ISO 8601 end date.' },
-              },
-              required: ['freq'],
-              additionalProperties: false,
-            },
+            recurrence: recurrenceSchema('Optional recurrence rule,'),
             targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
             checkDuplicates: { type: 'boolean', default: true, description: 'Run a semantic near-duplicate check before storing (default true). When a highly similar entry already exists, the response flags it (id + summary + score) so you can update it instead of logging the same event twice. The entry is still stored regardless. Set false to skip.' },
             checkContradictions: { type: 'boolean', default: false, description: 'Also flag existing entries that CONTRADICT this one — a near-neighbour claiming a different status, or setting the same single-valued property to a different value. Deterministic only (no model call). The entry is still stored regardless.' },
@@ -187,8 +183,10 @@ export const update_chronoTool: ToolHandler = {
     + '- `type` — `event`, `deadline`, `plan`, `prediction`, `milestone`, or any custom type the space schema '
     + 'defines. Re-validated against the allowlist.\n'
     + '- `startsAt` / `endsAt` — ISO 8601. `endsAt` before `startsAt` is refused.\n'
-    + '- `status` — `upcoming`, `active`, `completed`, `overdue`, `cancelled`. Nothing recomputes this from '
-    + 'the clock, so an entry stays `upcoming` after its date passes until something sets it.\n'
+    + '- `status` — `upcoming`, `active`, `completed`, `overdue`, `cancelled`. You never need to set '
+    + '`overdue`: it is DERIVED on read, so an entry stored `upcoming` whose due moment has passed already '
+    + 'reads back as `overdue` from `list_chrono`, `recall` and a single-entry get. What you set here is the '
+    + 'STORED value, which is what `query` and sync see.\n'
     + '- `confidence` — 0 to 1, for entries that are predictions rather than records.\n'
     + '- `tags` / `entityIds` / `memoryIds` — each REPLACES the stored list.\n'
     + '- `description` — replaced when sent.\n'
@@ -218,28 +216,46 @@ export const update_chronoTool: ToolHandler = {
             type: { type: 'string', description: 'Entry type (e.g. event, deadline, plan, prediction, milestone, or a custom type defined in the space schema).' },
             startsAt: { type: 'string', description: 'New ISO 8601 start date/time.' },
             endsAt: { type: 'string', description: 'New ISO 8601 end date/time.' },
-            status: { type: 'string', enum: ['upcoming', 'active', 'completed', 'overdue', 'cancelled'] },
-            confidence: unitScoreSchema('Confidence level 0–1.'),
-            tags: { type: 'array', items: { type: 'string' } },
-            entityIds: { type: 'array', items: { type: 'string' } },
-            memoryIds: { type: 'array', items: { type: 'string' } },
-            description: { type: 'string' },
+            status: {
+              type: 'string', enum: ['upcoming', 'active', 'completed', 'overdue', 'cancelled'],
+              description: 'The new STORED status. You never need to set `overdue`: it is DERIVED on read '
+                + 'from the due moment, so an entry left `upcoming` past its date already reads back as '
+                + '`overdue` everywhere except `query` and sync, which see the stored value. Setting '
+                + '`completed` or `cancelled` is what stops an entry being derived-overdue.',
+            },
+            confidence: unitScoreSchema('Confidence level 0 to 1, for entries that are predictions rather '
+              + 'than records. Replaced when sent; nothing derives it, and nothing refuses a prediction that '
+              + 'omits it.'),
+            tags: {
+              type: 'array', items: { type: 'string' },
+              description: 'REPLACES the stored tag list — send the FULL list you want the entry to end up '
+                + 'with, because sending one tag drops the rest. `update_entity` and `update_edge` MERGE tags '
+                + 'instead; this tool and `update_memory` replace, and the split is not guessable from the '
+                + 'field name.',
+            },
+            entityIds: {
+              type: 'array', items: { type: 'string' },
+              description: 'REPLACES the stored entity links — send the FULL list, because sending one id '
+                + 'drops the rest. These are what let `traverse` reach the entry from the entity it concerns; '
+                + 'they are NOT edges, so an entry left with an empty list is reachable only by search or by '
+                + 'date.',
+            },
+            memoryIds: {
+              type: 'array', items: { type: 'string' },
+              description: 'REPLACES the stored memory links — send the FULL list, because sending one id '
+                + 'drops the rest.',
+            },
+            description: {
+              type: 'string',
+              description: 'New prose description. Replaced when sent; an omitted field is left alone, so '
+                + 'there is no value that clears it — use `deleteFields: ["description"]`.',
+            },
             properties: {
               type: 'object',
               description: 'Key-value properties to merge into the stored map — keys you do not name are kept.',
               additionalProperties: { oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }] },
             },
-            recurrence: {
-              type: 'object',
-              description: 'Recurrence rule, e.g. { freq: "weekly", interval: 1, until: "2027-01-01T00:00:00Z" }.',
-              properties: {
-                freq: { type: 'string', enum: ['daily', 'weekly', 'monthly', 'yearly'] },
-                interval: { type: 'integer', minimum: 1, default: 1, description: 'Repeat every N periods (positive integer, default 1).' },
-                until: { type: 'string', description: 'Optional ISO 8601 end date.' },
-              },
-              required: ['freq'],
-              additionalProperties: false,
-            },
+            recurrence: recurrenceSchema('The repeat rule, replaced wholesale when sent,'),
             excludeFromVectorSearch: EXCLUDE_FROM_VECTOR_SEARCH_SCHEMA,
             deleteFields: {
               type: 'array', items: { type: 'string' },
@@ -359,14 +375,24 @@ export const list_chronoTool: ToolHandler = {
     + 'someone recorded it. These two parameters read `createdAt`. To ask "what is scheduled next quarter" you '
     + 'want `query` with a predicate on `startsAt`; `after`/`before` here answer "what did we write down last '
     + 'week", which is a different question and usually not the one being asked.\n\n'
-    + 'NOTHING RECOMPUTES `status` FROM THE CLOCK. An entry stays `upcoming` after its date has passed until '
-    + 'something sets it otherwise, so `status: "upcoming"` means "nobody has updated this", not "still in the '
-    + 'future", and `status: "overdue"` only finds entries somebody marked overdue. Filter on the dates if you '
-    + 'want the truth about time.\n\n'
+    + '`overdue` IS DERIVED FROM THE CLOCK, AND IS NEVER STORED. An entry whose due moment (`endsAt`, or '
+    + '`startsAt` when it has none) has passed and that is still `upcoming`/`active` is RETURNED as `overdue`, '
+    + 'and the filter is translated to match: `status: "overdue"` finds exactly those, and '
+    + '`status: "upcoming"` EXCLUDES them rather than including them. So both answer the truth about time, and '
+    + 'you do not need a date predicate to ask "what is late".\n\n'
+    + 'THE STORED VALUE IS STILL WHAT SYNC AND `query` SEE. `query` reads documents as stored, so a filter of '
+    + '`status: "overdue"` there matches almost nothing while this tool returns plenty — the same records, two '
+    + 'answers, because only this path derives. Use this tool for status, and `query` for `startsAt`/`endsAt` '
+    + 'predicates.\n\n'
+    + 'One edge, named because it is a defect rather than a design: an entry a caller EXPLICITLY stored as '
+    + '`overdue` is not matched by `status: "overdue"` here, because the translated filter looks for stored '
+    + '`upcoming`/`active`. Nothing writes `overdue` on its own, so this only bites a caller who set it by '
+    + 'hand.\n\n'
     + 'OMIT `space` TO SEARCH EVERY SPACE THE TOKEN REACHES. That is unusual — most tools require one — and it '
     + 'is what makes this the tool for "when did we ever say we would do this". Results carry their space.\n\n'
     + 'PARAMETERS:\n'
-    + '- `status` — `upcoming`, `active`, `completed`, `overdue`, `cancelled`. See the warning above.\n'
+    + '- `status` — `upcoming`, `active`, `completed`, `overdue`, `cancelled`. Clock-aware for the first '
+    + 'three; see above.\n'
     + '- `type` — `event`, `deadline`, `plan`, `prediction`, `milestone`, or any custom type the space schema '
     + 'defines.\n'
     + '- `tags` — entries carrying ALL of these. `tagsAny` — entries carrying ANY. Send both and both apply.\n'
@@ -380,7 +406,13 @@ export const list_chronoTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.optionalSpace,
-            status: { type: 'string', enum: ['upcoming', 'active', 'completed', 'overdue', 'cancelled'], description: 'Filter by status.' },
+            status: {
+              type: 'string', enum: ['upcoming', 'active', 'completed', 'overdue', 'cancelled'],
+              description: 'Filter by status, CLOCK-AWARE for the first three. `overdue` returns entries '
+                + 'stored `upcoming`/`active` whose due moment has passed; `upcoming` and `active` EXCLUDE '
+                + 'those same entries. `completed` and `cancelled` are plain matches on the stored value. '
+                + 'The same filter against `query` is not translated and answers differently.',
+            },
             type: { type: 'string', description: 'Filter by type (e.g. event, deadline, plan, prediction, milestone, or a custom type).' },
             tags: { type: 'array', items: { type: 'string' }, description: 'Return entries containing ALL of these tags (AND semantics).' },
             tagsAny: { type: 'array', items: { type: 'string' }, description: 'Return entries containing ANY of these tags (OR semantics).' },
@@ -432,9 +464,10 @@ export const list_chronoTool: ToolHandler = {
 export const delete_chronoTool: ToolHandler = {
   name: 'delete_chrono',
   description: 'Delete one chrono entry by its ID. IRREVERSIBLE — there is no undelete and no trash.\n\n'
-    + 'A PAST OR CANCELLED ENTRY IS USUALLY NOT A DELETE. Nothing recomputes `status` from the clock, so an '
-    + 'entry that has happened simply keeps whatever status it was given; set `status: "completed"` or '
-    + '`"cancelled"` with `update_chrono` and the entry stays as the record that it happened. Deleting is for '
+    + 'A PAST OR CANCELLED ENTRY IS USUALLY NOT A DELETE. An entry whose moment has passed reads back as '
+    + '`overdue` — derived from the clock — which is the system telling you it is unresolved, not that it is '
+    + 'rubbish. Set `status: "completed"` or `"cancelled"` with `update_chrono` and the entry stops being '
+    + 'derived-overdue while staying as the record that it happened. Deleting is for '
     + 'entries that should never have existed. If you only want it out of meaning-ranking, set '
     + '`excludeFromVectorSearch` — it stays listable by `list_chrono` and reachable by traversal.\n\n'
     + 'THE ENTITIES AND MEMORIES IT LINKS ARE NOT TOUCHED. `entityIds` and `memoryIds` are references; '

--- a/server/src/mcp/tools/entity.ts
+++ b/server/src/mcp/tools/entity.ts
@@ -24,7 +24,13 @@ export const upsert_entityTool: ToolHandler = {
             id: uuidSchema('UUID v4 of an EXISTING record to update. It is not a way to choose an id: identity is server-generated, so an id that names nothing is ignored rather than adopted. To carry your own reference, use `name` or `description`.'),
             name: { type: 'string', minLength: 1, description: 'Entity name.' },
             type: { type: 'string', minLength: 1, description: 'Entity type (person, place, concept, …).' },
-            tags: { type: 'array', items: { type: 'string' } },
+            tags: {
+              type: 'array', items: { type: 'string' },
+              description: 'Categorisation tags. MERGED over the stored tags when this upsert lands on an '
+                + 'existing record, so sending `["b"]` on an entity tagged `["a"]` leaves it `["a","b"]` — '
+                + 'there is no value here that removes a tag. Clearing them is `update_entity` with '
+                + '`deleteFields: ["tags"]`.',
+            },
             description: { type: 'string', description: 'Optional prose description or summary of this entity.' },
             properties: {
               type: 'object',

--- a/server/src/mcp/tools/shared.ts
+++ b/server/src/mcp/tools/shared.ts
@@ -88,6 +88,37 @@ export function unitScoreSchema(description: string) {
   return { type: 'number', minimum: 0, maximum: 1, description } as const;
 }
 
+/**
+ * The chrono `recurrence` block, shared by `create_chrono` and `update_chrono`.
+ *
+ * It was two near-identical literals differing only in the word "Optional", and `freq` — the one REQUIRED
+ * field — had no description in either copy. Two copies of one schema is the shape this repo produces most,
+ * so it is one function called twice rather than a second literal kept in step by hand.
+ *
+ * The trap is in the lead sentence and it is worth stating on both tools: the rule is STORED and validated
+ * (`parseRecurrence`), and nothing anywhere expands it. It describes the entry; it does not generate more.
+ */
+export function recurrenceSchema(lead: string) {
+  return {
+    type: 'object',
+    description: lead + ' e.g. { freq: "weekly", interval: 1, until: "2027-01-01T00:00:00Z" }. '
+      + 'IT DESCRIBES THE ENTRY AND GENERATES NOTHING — no further entries are created from it, and no '
+      + 'listing expands it into occurrences. If you need each occurrence to be findable by date, write '
+      + 'each one.',
+    properties: {
+      freq: {
+        type: 'string', enum: ['daily', 'weekly', 'monthly', 'yearly'],
+        description: 'How often the entry repeats. The only required field of the block, and the four values '
+          + 'listed are the whole set — anything else is refused by name rather than ignored.',
+      },
+      interval: { type: 'integer', minimum: 1, default: 1, description: 'Repeat every N periods (positive integer, default 1).' },
+      until: { type: 'string', description: 'Optional ISO 8601 date the repetition stops at. Omit for open-ended.' },
+    },
+    required: ['freq'],
+    additionalProperties: false,
+  } as const;
+}
+
 /** MongoDB operators the structured `query` filter accepts — mirrors `ALLOWED_OPERATORS` (brain/query.ts). */
 export const QUERY_FILTER_OPERATORS = [
   '$eq', '$ne', '$gt', '$gte', '$lt', '$lte', '$in', '$nin', '$and', '$or', '$nor', '$not',

--- a/testing/standalone/audit-export-is-itself-audited.test.js
+++ b/testing/standalone/audit-export-is-itself-audited.test.js
@@ -50,17 +50,22 @@ describe('the export is gated like a backup, not like a list', () => {
   });
 
   it('requires the second factor', () => {
-    const reg = ROUTE.slice(ROUteAt(), ROUteAt() + 200);
-    assert.match(reg, /requireAdminMfa/,
+    // `handler()` — this file's own bound, from the registration to its closing `});`. It was
+    // `slice(at, at + 200)`, and a CHARACTER count is the wrong axis: this working copy is CRLF and CI
+    // checks out LF, so the same number spans a different number of LINES on each. A sibling gate passed
+    // locally and failed in CI on precisely that. The helper was already here and already correct.
+    assert.match(handler(ROUTE, '/export'), /requireAdminMfa/,
       'the export must require MFA: paging through the log and taking a copy of the whole record are different acts, '
       + 'and the second belongs behind the same gate as a database backup');
-    function ROUteAt() { return ROUTE.indexOf("auditRouter.get('/export'"); }
   });
 
   it('the paged route is NOT gated behind MFA — this must stay usable for ordinary review', () => {
     // Stated so the previous assertion cannot be "satisfied" by putting MFA on everything, which would make the
     // audit page unusable and push operators towards turning MFA off.
-    const reg = ROUTE.slice(ROUTE.indexOf("auditRouter.get('/',"), ROUTE.indexOf("auditRouter.get('/',") + 120);
+    // Same bound as above, and here the axis matters twice over: this is a `doesNotMatch`, so a window that
+    // quietly grows makes the gate FAIL on the next route's prose, and one that quietly shrinks makes it
+    // pass by looking at less. Bounding at the handler's own `});` stops before either.
+    const reg = handler(ROUTE, '/');
     assert.match(reg, /requireAdmin\b/, 'the paged route should stay admin-gated');
     assert.doesNotMatch(reg, /requireAdminMfa/, 'reading a page of the log should not demand a TOTP code every time');
   });

--- a/testing/standalone/caller-supplied-ids-are-uuids.test.js
+++ b/testing/standalone/caller-supplied-ids-are-uuids.test.js
@@ -63,7 +63,14 @@ function idDeclarations(src) {
     // EVERY `required` array in the window, not the first: `update_chrono` nests a recurrence object whose own
     // `required: ['freq']` sits between the id and the schema's real one, so taking the first match read the
     // wrong list and called a required id optional.
-    const window = src.slice(m.index, m.index + 4000);
+    //
+    // The window ends at the NEXT tool, not after a fixed 4000 characters. It was a fixed count, and that is a
+    // guard on the wrong axis: it bounds DISTANCE while the thing between the id and its `required` array is
+    // parameter PROSE, which has no bound at all. Writing four sentences onto `update_chrono`'s parameters
+    // pushed its own `required: ['space', 'id']` past the cutoff, so a required id read as caller-supplied and
+    // this gate failed on a tool nobody had changed the shape of. A schema cannot outrun its own module.
+    const nextTool = src.indexOf('export const ', m.index + 1);
+    const window = src.slice(m.index, nextTool > 0 ? nextTool : undefined);
     const addressesExisting = [...window.matchAll(/required:\s*\[([^\]]*)\]/g)].some(r => /'id'/.test(r[1]));
     out.push({ line, helper: blob.startsWith('uuidSchema('), blob, addressesExisting });
   }

--- a/testing/standalone/chrono-status-descriptions-match-the-derivation.test.js
+++ b/testing/standalone/chrono-status-descriptions-match-the-derivation.test.js
@@ -1,0 +1,156 @@
+/**
+ * What the chrono tools SAY about `status` agrees with what `deriveChronoStatus` DOES.
+ *
+ * ## The defect this pins
+ *
+ * Four MCP tool descriptions carried a capitalised warning that was the opposite of the code:
+ *
+ * > "NOTHING RECOMPUTES `status` FROM THE CLOCK. An entry stays `upcoming` after its date has passed until
+ * > something sets it otherwise, so `status: "upcoming"` means "nobody has updated this", not "still in the
+ * > future", and `status: "overdue"` only finds entries somebody marked overdue. Filter on the dates if you
+ * > want the truth about time."
+ *
+ * Every clause is false. `overdue` is DERIVED on read (`brain/chrono-status.ts`, C5) and applied on every
+ * chrono read path; `listChrono` translates the filter, so `status: "overdue"` finds exactly the derived ones
+ * and `status: "upcoming"` EXCLUDES them. The paragraph therefore steered a caller away from the one filter
+ * that answers the question, toward a date predicate it did not need.
+ *
+ * `docs/integration-guide/04c-chrono-api.md` described it CORRECTLY the whole time. Two surfaces, one
+ * behaviour, two contradictory descriptions — and the wrong one was the one an agent reads while
+ * constructing arguments. That is the exact cost CLAUDE.md records for a stale schema sentence.
+ *
+ * ## Why this asserts against the function, not against the docs
+ *
+ * A gate that only refuses the old wording is a spelling check: it goes green the moment somebody rephrases
+ * the same wrong claim. So the derivation is EXERCISED here — it is a pure function with no database — and
+ * the sentences are held to what it returns.
+ *
+ * Run: node --test testing/standalone/chrono-status-descriptions-match-the-derivation.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripComments } from './_strip-comments.mjs';
+
+let deriveChronoStatus, ALL_TOOLS;
+before(async () => {
+  ({ deriveChronoStatus } = await import('../../server/dist/brain/chrono-status.js'));
+  ({ ALL_TOOLS } = await import('../../server/dist/mcp/tools/index.js'));
+});
+
+/** The space fragments the router injects; only their presence matters here. */
+const STUB = {
+  requiredSpace: { type: 'string', description: 'Space ID to operate on.' },
+  optionalSpace: { type: 'string', description: 'Optional space ID.' },
+};
+
+const NOW = new Date('2026-08-16T12:00:00Z');
+const PAST = '2026-01-01T00:00:00Z';
+const FUTURE = '2027-01-01T00:00:00Z';
+
+describe('what the code actually does', () => {
+  it('a past-due upcoming entry reads back as overdue — nobody marks it', () => {
+    assert.equal(deriveChronoStatus({ status: 'upcoming', startsAt: PAST }, NOW), 'overdue');
+    assert.equal(deriveChronoStatus({ status: 'active', startsAt: PAST }, NOW), 'overdue');
+  });
+
+  it('the due moment is endsAt when there is one, startsAt otherwise', () => {
+    // An event that started last month and runs until next year is NOT overdue. Reading only `startsAt`
+    // would call every in-progress entry late, which is the opposite error.
+    assert.equal(deriveChronoStatus({ status: 'active', startsAt: PAST, endsAt: FUTURE }, NOW), 'active');
+    assert.equal(deriveChronoStatus({ status: 'upcoming', startsAt: FUTURE }, NOW), 'upcoming');
+  });
+
+  it('completed and cancelled are never re-derived', () => {
+    assert.equal(deriveChronoStatus({ status: 'completed', startsAt: PAST }, NOW), 'completed');
+    assert.equal(deriveChronoStatus({ status: 'cancelled', startsAt: PAST }, NOW), 'cancelled');
+  });
+
+  it('and a hand-stored `overdue` is passed straight through', () => {
+    // Which is why storing it is a bad idea: the `listChrono` filter looks for stored `upcoming`/`active`,
+    // so this record is invisible to `status: "overdue"`. The descriptions now say so by name.
+    assert.equal(deriveChronoStatus({ status: 'overdue', startsAt: FUTURE }, NOW), 'overdue');
+  });
+});
+
+describe('every chrono read path applies it, which is what makes the sentences true', () => {
+  const src = () => stripComments(readFileSync('server/src/brain/chrono.ts', 'utf8'));
+
+  it('a single-entry get derives', () => {
+    assert.match(src(), /getChronoById[\s\S]{0,300}?withDerivedStatus/,
+      'the tools say a get reads back overdue');
+  });
+
+  it('a list derives its OUTPUT as well as translating its filter', () => {
+    const s = src();
+    assert.match(s, /entries\.map\(e => withDerivedStatus\(e, now\)\)/,
+      'translating the filter alone would return rows whose status contradicts the filter that found them');
+    assert.match(s, /filter\.status === 'overdue'[\s\S]{0,200}?\$in: \['upcoming', 'active'\]/,
+      'and `status: "overdue"` must be translated, not matched literally');
+    assert.match(s, /filter\.status === 'upcoming' \|\| filter\.status === 'active'[\s\S]{0,200}?\$gte/,
+      '`upcoming`/`active` must EXCLUDE the now-overdue ones — the tools promise both directions');
+  });
+
+  it('recall derives too', () => {
+    assert.match(stripComments(readFileSync('server/src/brain/recall.ts', 'utf8')), /status: deriveChronoStatus\(/,
+      'recall presents a chrono hit\'s status, and `update_chrono` names it as one of the deriving paths');
+  });
+
+  it('but `query` does NOT — which the tools now state as a difference', () => {
+    // If query ever starts deriving, "the same records, two answers" becomes false and the sentence
+    // pointing a caller at `list_chrono` for status stops being advice.
+    assert.doesNotMatch(stripComments(readFileSync('server/src/brain/query.ts', 'utf8')), /deriveChronoStatus/,
+      'query reads documents as stored; that contrast is now written into three tool descriptions');
+  });
+});
+
+describe('no tool repeats the claim that was false', () => {
+  it('nothing says the clock is ignored', () => {
+    // CASE-INSENSITIVE, and that is not a detail: the sentence being refused was CAPITALISED in three of the
+    // four tools, and the first draft of this pattern was `/[Nn]othing recomputes/`. Restoring the exact
+    // paragraph this gate exists to refuse left it green. Its own mutation check is what said so.
+    // Whole-body, not description-only, for the same reason — on `create_chrono` the claim lived in the
+    // parameter schema rather than in the prose.
+    const BAD = [
+      [/nothing recomputes[\s\S]{0,20}status/i, 'nothing recomputes'],
+      [/only finds entries somebody marked overdue/i, 'somebody marked overdue'],
+      [/stays `upcoming` after its date (has )?passed/i, 'stays upcoming'],
+    ];
+    const offenders = [];
+    for (const t of ALL_TOOLS) {
+      const text = (t.description ?? '') + JSON.stringify(t.inputSchema(STUB));
+      for (const [re, label] of BAD) if (re.test(text)) offenders.push(`${t.name}: "${label}"`);
+    }
+    assert.deepEqual(offenders, [],
+      'these describe the opposite of `deriveChronoStatus`:\n  ' + offenders.join('\n  '));
+  });
+
+  it('and the pattern really matches the paragraph it exists to refuse', () => {
+    // Mutation-proof for the regex. A gate that misses its own subject reports clean, which is worse than
+    // having no gate: the wrong sentence then looks reviewed.
+    const ORIGINAL = 'NOTHING RECOMPUTES `status` FROM THE CLOCK. An entry stays `upcoming` after its date '
+      + 'has passed until something sets it otherwise, so `status: "upcoming"` means "nobody has updated '
+      + 'this", and `status: "overdue"` only finds entries somebody marked overdue.';
+    assert.match(ORIGINAL, /nothing recomputes[\s\S]{0,20}status/i);
+    assert.match(ORIGINAL, /only finds entries somebody marked overdue/i);
+    assert.match(ORIGINAL, /stays `upcoming` after its date (has )?passed/i);
+    // And not the corrected wording, or the gate can never go green.
+    const CORRECTED = '`overdue` IS DERIVED FROM THE CLOCK, AND IS NEVER STORED. An entry whose due moment '
+      + 'has passed and that is still `upcoming`/`active` is RETURNED as `overdue`.';
+    for (const [re] of [[/nothing recomputes[\s\S]{0,20}status/i], [/only finds entries somebody marked overdue/i], [/stays `upcoming` after its date (has )?passed/i]]) {
+      assert.doesNotMatch(CORRECTED, re);
+    }
+  });
+
+  it('and the four tools that discuss status say it is derived', () => {
+    // Presence, not spelling: each of these had a wrong paragraph, so each must now carry the right one.
+    // Checked across the description AND the schema, because on `create_chrono` the correction lives in the
+    // parameter rather than in the prose.
+    for (const name of ['create_chrono', 'update_chrono', 'list_chrono', 'delete_chrono']) {
+      const t = ALL_TOOLS.find(x => x.name === name);
+      const text = (t.description ?? '') + JSON.stringify(t.inputSchema(STUB));
+      assert.match(text, /derive[ds]?/i, `${name} must tell a caller that overdue is derived`);
+    }
+  });
+});

--- a/testing/standalone/legacy-admin-field-is-gone.test.js
+++ b/testing/standalone/legacy-admin-field-is-gone.test.js
@@ -35,6 +35,31 @@ import { stripComments } from './_strip-comments.mjs';
 
 const src = (p) => stripComments(readFileSync(p, 'utf8'));
 
+/**
+ * The whole `TokenRecord` interface, bounded by its own braces.
+ *
+ * Two earlier shapes both failed, in different ways, and neither failure was visible in a diff:
+ *
+ * 1. **An anchor INSIDE the thing being removed.** `spaces?: string[]` anchored this scan until `spaces` was
+ *    itself deleted, which broke two gates at once.
+ * 2. **A fixed CHARACTER window** — `slice(at, at + 400)`. A count bounds distance, and this working copy is
+ *    CRLF while CI checks out LF, so the same number covers a different number of LINES on each. A sibling
+ *    gate passed here and failed in CI for exactly that reason, with nothing in the diff to show why.
+ *
+ * The interface's own braces are neither. They also make the check STRONGER than the forward-only window it
+ * replaces: a field re-added above the old anchor is caught too.
+ */
+function tokenRecordBlock() {
+  const types = src('server/src/config/types.ts');
+  const at = types.indexOf('export interface TokenRecord {');
+  assert.ok(at > 0, 'the TokenRecord interface was not found — the scanner is wrong, not the code');
+  const end = types.indexOf('\n}', at);
+  assert.ok(end > at, 'the interface has no closing brace at column 0 — the bound is wrong');
+  const block = types.slice(at, end);
+  assert.match(block, /\bid: string;/, 'and this really is TokenRecord, not an empty slice');
+  return block;
+}
+
 let isInstanceAdmin, migrateToken;
 before(async () => {
   ({ isInstanceAdmin } = await import('../../server/dist/auth/middleware.js'));
@@ -43,12 +68,7 @@ before(async () => {
 
 describe('the field is gone from the record and the plumbing', () => {
   it('TokenRecord no longer declares it', () => {
-    const types = src('server/src/config/types.ts');
-    // Anchored on `peerInstanceId`: `spaces?: string[]` was the previous anchor and has since been deleted
-    // too, which broke both of these gates at once — an anchor inside the thing being removed cannot last.
-    const at = types.indexOf('peerInstanceId?: string');
-    assert.ok(at > 0, 'the TokenRecord block was not found — the scanner is wrong, not the code');
-    assert.doesNotMatch(types.slice(at, at + 400), /\n\s+admin: boolean;/, 'the stored field must be gone');
+    assert.doesNotMatch(tokenRecordBlock(), /\n\s+admin: boolean;/, 'the stored field must be gone');
   });
 
   it('nothing writes it onto a record — on either minting path', () => {

--- a/testing/standalone/legacy-readonly-field-is-gone.test.js
+++ b/testing/standalone/legacy-readonly-field-is-gone.test.js
@@ -41,12 +41,16 @@ before(async () => {
 
 describe('the field is gone from the record and from the plumbing', () => {
   it('TokenRecord no longer declares it', () => {
+    // Bounded by the interface's own braces. It was `slice(anchor, anchor + 400)`, and both halves of that
+    // were wrong: the anchor sat inside a field that later got deleted, and a CHARACTER count covers a
+    // different number of LINES in a CRLF working copy than in CI's LF checkout. A sibling gate passed here
+    // and failed in CI on exactly that difference. See the same helper in
+    // `legacy-admin-field-is-gone.test.js`.
     const types = src('server/src/config/types.ts');
-    // Anchored on `peerInstanceId`: `spaces?: string[]` was the previous anchor and has since been deleted
-    // too, which broke both of these gates at once — an anchor inside the thing being removed cannot last.
-    const at = types.indexOf('peerInstanceId?: string');
-    assert.ok(at > 0, 'the TokenRecord block was not found — the scanner is wrong, not the code');
-    const block = types.slice(at, at + 400);
+    const at = types.indexOf('export interface TokenRecord {');
+    assert.ok(at > 0, 'the TokenRecord interface was not found — the scanner is wrong, not the code');
+    const block = types.slice(at, types.indexOf('\n}', at));
+    assert.match(block, /\bid: string;/, 'and this really is TokenRecord, not an empty slice');
     assert.doesNotMatch(block, /readOnly\?: boolean;/, 'the stored field must be gone');
   });
 

--- a/testing/standalone/read-tools-state-their-blind-spots.test.js
+++ b/testing/standalone/read-tools-state-their-blind-spots.test.js
@@ -61,9 +61,16 @@ describe('list_chrono: the date filter answers a different question', () => {
       'the range moved off createdAt — rewrite the warning rather than leaving it wrong');
   });
 
-  it('says status is not recomputed from the clock', () => {
-    assert.match(CHRONO, /NOTHING RECOMPUTES `status` FROM THE CLOCK/,
-      'filtering status: upcoming to find future entries is the natural mistake');
+  it('says `overdue` IS derived from the clock', () => {
+    // THIS ASSERTION USED TO PIN THE OPPOSITE, and that is the lesson worth keeping. It required the
+    // sentence "NOTHING RECOMPUTES `status` FROM THE CLOCK" — which was false, and had been false since C5
+    // shipped the derivation. A gate written from a description rather than from the code does not catch a
+    // wrong description; it CEMENTS it, and turns rewriting it into a test failure that looks like a
+    // regression. `deriveChronoStatus` is exercised against these claims in
+    // `chrono-status-descriptions-match-the-derivation.test.js`, which is what this one should have done.
+    assert.match(CHRONO, /DERIVED FROM THE CLOCK/,
+      'an entry left `upcoming` past its date reads back as `overdue`, and the list filter is translated to match');
+    assert.doesNotMatch(CHRONO, /nothing recomputes/i, 'the old claim must not come back in any casing');
   });
 
   it('and the default order really is newest-written first', () => {

--- a/testing/standalone/tool-parameters-are-all-described.test.js
+++ b/testing/standalone/tool-parameters-are-all-described.test.js
@@ -118,14 +118,25 @@ describe('the claims those descriptions make are still true', () => {
   it('an unknown bulk chrono status is dropped, not reported', () => {
     // Source-read because exercising it needs Mongo. Comments stripped: the line above the normalisation
     // explains it, so a raw read matches its own explanation. This repo has a rule about that.
+    //
+    // Bounded by the STATEMENT — from `const status` to its own semicolon — and NOT by a character count.
+    // It was `slice(at, at + 200)`, which passed here and failed in CI: this checkout is CRLF and CI's is
+    // LF, so 200 characters covers a different number of LINES in each. The window reached the NEXT
+    // statement's `errors.push` only on the machine with the shorter line endings. A count bounds distance;
+    // what the assertion is about is one statement, and nothing in the diff shows the difference.
     const src = stripComments(readFileSync('server/src/brain/bulk.ts', 'utf8'));
-    const at = src.indexOf('CHRONO_STATUSES.has');
-    assert.ok(at > 0, 'the status normalisation was not found — the scanner is wrong, not the code');
-    const window = src.slice(at, at + 200);
-    assert.match(window, /:\s*undefined/,
+    const start = src.indexOf('const status = ');
+    assert.ok(start > 0, 'the status normalisation was not found — the scanner is wrong, not the code');
+    const stmt = src.slice(start, src.indexOf(';', start) + 1);
+    assert.match(stmt, /CHRONO_STATUSES\.has/, 'and this is the statement that normalises it');
+    assert.match(stmt, /:\s*undefined/,
       'an unrecognised status must fall back rather than throw — the description says so');
-    assert.doesNotMatch(window, /errors\.push/,
+    assert.doesNotMatch(stmt, /errors\.push/,
       'and it must NOT be reported; if it starts being reported, `chrono[].status` stops being a silent drop');
+    // The next statement DOES report, which is the contrast the description draws — and proves this window
+    // really stops where it says it does rather than swallowing the neighbour.
+    assert.match(src.slice(start, start + stmt.length + 200), /errors\.push/,
+      'the ttlDays check right after it is reported; if it were not, the slice is not bounded where it claims');
   });
 
   it('nothing expands a recurrence rule into further entries', () => {

--- a/testing/standalone/tool-parameters-are-all-described.test.js
+++ b/testing/standalone/tool-parameters-are-all-described.test.js
@@ -1,0 +1,145 @@
+/**
+ * Every MCP tool parameter carries a description — including the nested ones.
+ *
+ * ## Why this is not documentation polish
+ *
+ * `help()` tells a caller that the tool schema IS the authoritative reference, and a caller constructing
+ * arguments reads `tools/list`, not our docs. A parameter with no `description` is not "undocumented" — it
+ * is a capability nobody can discover, because there is nothing to read.
+ *
+ * X-2's first half described every TOOL. This is the second half, and it was never measured: 26 parameters
+ * across four tools had no description at all when this gate was written.
+ *
+ * ## The nesting is the whole point
+ *
+ * 8 of those 26 were at the top level. **18 were inside `bulk_write`'s per-item schemas** — `entities[].tags`,
+ * `chrono[].status`, `edges[].weight` and the rest — which a top-level-only sweep reports as clean. That is
+ * this repo's most common defect shape arriving in a measurement: the check and the thing it checks shared a
+ * blind spot. So the walker descends into `properties` AND into `items`, and the test below proves it reaches
+ * both rather than assuming it.
+ *
+ * ## What this does NOT gate yet, said plainly rather than left implied
+ *
+ * Only PRESENCE. `move_file.src` says "Source path." in 12 characters, which passes here and does not meet
+ * the standard X-2 records — every parameter gets its own sentence, and the sentence says the TRAP. 55
+ * parameters are still that thin. A length floor is not added here because encoding "10 characters is fine"
+ * as a passing threshold blesses exactly what needs fixing; the sweep is the work, and the floor lands with
+ * it.
+ *
+ * Run: node --test testing/standalone/tool-parameters-are-all-described.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripComments } from './_strip-comments.mjs';
+
+let ALL_TOOLS;
+before(async () => {
+  ({ ALL_TOOLS } = await import('../../server/dist/mcp/tools/index.js'));
+});
+
+// The REAL fragments the router injects (`router.ts:131-132`). A short stub here would make `space` look
+// thin on 39 tools and bury the actual gaps — the first draft of this measurement did exactly that.
+const SCHEMAS = {
+  requiredSpace: { type: 'string', description: 'Space ID to operate on. Use list_spaces to discover available spaces.' },
+  optionalSpace: { type: 'string', description: 'Optional space ID. Omit to search across all accessible spaces.' },
+};
+
+/** Every property in a JSON Schema, at every depth, as `path -> node`. */
+function walkProperties(node, path = '', out = []) {
+  if (!node || typeof node !== 'object') return out;
+  for (const [key, value] of Object.entries(node.properties ?? {})) {
+    out.push([`${path}${key}`, value]);
+    walkProperties(value, `${path}${key}.`, out);
+    // Array items: `bulk_write` puts four whole record schemas here and nowhere else.
+    if (value?.items && typeof value.items === 'object') walkProperties(value.items, `${path}${key}[].`, out);
+  }
+  return out;
+}
+
+const allParams = () => ALL_TOOLS.flatMap(t => walkProperties(t.inputSchema(SCHEMAS)).map(([p, v]) => [t.name, p, v]));
+
+describe('the walker reaches where the gaps were', () => {
+  it('descends into nested objects and into array items', () => {
+    // Mutation-proof for the SCANNER. A walker that only reads the top level passes this whole suite while
+    // 18 undescribed parameters sit one level down, which is how they survived X-2's first pass.
+    const paths = walkProperties(ALL_TOOLS.find(t => t.name === 'bulk_write').inputSchema(SCHEMAS)).map(([p]) => p);
+    assert.ok(paths.includes('chrono[].status'), 'array items must be walked');
+    assert.ok(paths.includes('memories[].properties'), 'and every collection, not just the first');
+
+    const chrono = walkProperties(ALL_TOOLS.find(t => t.name === 'update_chrono').inputSchema(SCHEMAS)).map(([p]) => p);
+    assert.ok(chrono.includes('recurrence.freq'), 'nested objects must be walked');
+  });
+
+  it('walks a plausible number of parameters', () => {
+    // A scanner that silently returned [] would pass every assertion below it.
+    const n = allParams().length;
+    assert.ok(n > 250, `only walked ${n} parameters across ${ALL_TOOLS.length} tools — the walker is broken`);
+  });
+});
+
+describe('every parameter is described', () => {
+  it('none is missing a description', () => {
+    const missing = allParams()
+      .filter(([, , v]) => typeof v?.description !== 'string' || v.description.trim().length === 0)
+      .map(([tool, path]) => `${tool}: ${path}`);
+    assert.deepEqual(missing, [],
+      'a caller reads the schema while constructing arguments — these say nothing:\n  ' + missing.join('\n  '));
+  });
+
+  it('and none merely restates its own name', () => {
+    // `tags: { description: "Tags." }` is the shape that passes a presence check while telling a caller
+    // nothing it could not read off the key. Compared with punctuation and case removed.
+    const bare = (s) => s.toLowerCase().replace(/[^a-z]/g, '');
+    const echoes = allParams()
+      .filter(([, path, v]) => typeof v?.description === 'string' && bare(v.description) === bare(path.split('.').pop().replace('[]', '')))
+      .map(([tool, path]) => `${tool}: ${path}`);
+    assert.deepEqual(echoes, [], 'these describe nothing beyond the key:\n  ' + echoes.join('\n  '));
+  });
+});
+
+describe('the claims those descriptions make are still true', () => {
+  /**
+   * Several new sentences say a bound is enforced on `create_chrono`/`upsert_edge` and NOT on `bulk_write`.
+   * That is true because of one line, and if the line goes the sentences become lies that read as facts —
+   * which is the exact cost CLAUDE.md records for a stale schema description.
+   */
+  it('bulk_write really does skip per-item schema validation', () => {
+    const bulk = ALL_TOOLS.find(t => t.name === 'bulk_write');
+    assert.equal(bulk.skipSchemaValidation, true,
+      'the item descriptions say the 0–1 bounds are not enforced here; remove this flag and they stop being true');
+    for (const name of ['create_chrono', 'upsert_edge']) {
+      assert.notEqual(ALL_TOOLS.find(t => t.name === name).skipSchemaValidation, true,
+        `${name} is the door the bulk descriptions contrast with — it must still validate`);
+    }
+  });
+
+  it('an unknown bulk chrono status is dropped, not reported', () => {
+    // Source-read because exercising it needs Mongo. Comments stripped: the line above the normalisation
+    // explains it, so a raw read matches its own explanation. This repo has a rule about that.
+    const src = stripComments(readFileSync('server/src/brain/bulk.ts', 'utf8'));
+    const at = src.indexOf('CHRONO_STATUSES.has');
+    assert.ok(at > 0, 'the status normalisation was not found — the scanner is wrong, not the code');
+    const window = src.slice(at, at + 200);
+    assert.match(window, /:\s*undefined/,
+      'an unrecognised status must fall back rather than throw — the description says so');
+    assert.doesNotMatch(window, /errors\.push/,
+      'and it must NOT be reported; if it starts being reported, `chrono[].status` stops being a silent drop');
+  });
+
+  it('nothing expands a recurrence rule into further entries', () => {
+    // `recurrenceSchema` says the rule generates nothing. It is stored and validated only.
+    const src = stripComments(readFileSync('server/src/brain/chrono.ts', 'utf8'));
+    assert.doesNotMatch(src, /expandRecurrence|generateOccurrences/,
+      'a generator would make "IT DESCRIBES THE ENTRY AND GENERATES NOTHING" false on both chrono tools');
+  });
+
+  it('the recurrence block is ONE schema, called twice', () => {
+    // It was two near-identical literals differing by the word "Optional", and `freq` was undescribed in
+    // both. Two copies of one schema is the shape this repo produces most.
+    const src = stripComments(readFileSync('server/src/mcp/tools/chrono.ts', 'utf8'));
+    assert.equal((src.match(/recurrenceSchema\(/g) ?? []).length, 2, 'both tools must call the helper');
+    assert.doesNotMatch(src, /freq: \{ type: 'string', enum:/, 'and neither may keep its own copy');
+  });
+});


### PR DESCRIPTION
## The defect

A capitalised warning on `list_chrono`, repeated on `create_chrono`, `update_chrono` and `delete_chrono`:

> NOTHING RECOMPUTES `status` FROM THE CLOCK. An entry stays `upcoming` after its date has passed until something sets it otherwise, so `status: "upcoming"` means "nobody has updated this", not "still in the future", and `status: "overdue"` only finds entries somebody marked overdue. Filter on the dates if you want the truth about time.

Every clause is false. `overdue` is **derived on read** (`brain/chrono-status.ts`, C5) and applied on every chrono read path — `getChronoById`, `listChrono` output, `recall`. `listChrono` also translates the filter, so `status: "overdue"` finds exactly the derived ones and `status: "upcoming"` *excludes* them.

The paragraph steered a caller away from the one filter that answers the question, toward a date predicate they did not need.

`docs/integration-guide/04c-chrono-api.md` described it correctly the whole time. One behaviour, two contradictory descriptions, and the wrong one is the one an agent reads while constructing arguments — the exact cost CLAUDE.md records.

### A gate had cemented it

`read-tools-state-their-blind-spots.test.js:64` **required** the false sentence to be present. A gate written from a description rather than from the code does not catch a wrong description; it makes rewriting it look like a regression. Replaced with one that exercises `deriveChronoStatus` and holds the sentences to what it returns.

## X-2's parameter half, which was never measured

297 parameters across 44 tools, **26 with no description at all**. 8 top-level; **18 inside `bulk_write`'s per-item schemas**, which a top-level-only sweep reports as clean — the measurement and its subject shared a blind spot.

The new text says the trap rather than the type:

- `bulk_write`'s item schemas are discovery-only (`skipSchemaValidation`), so `edges[].weight` is **not** bounded to 0–1 there while `upsert_edge` bounds it
- a `chrono[].status` outside the enum is discarded silently and never appears in `errors` — a third silent loss on a tool that already documented two
- `upsert_entity.tags` merges, so no value sent there removes a tag
- the chrono `recurrence` block became one shared schema instead of two near-identical copies whose one required field, `freq`, was undescribed in both

## Collateral

`update_chrono`'s longer parameter prose pushed its own `required: ['space','id']` past `caller-supplied-ids-are-uuids`' 4000-character window, so a required id read as caller-supplied. The window now ends at the next tool — it was bounding *distance* while the thing in between is unbounded prose.

## Found and deliberately not fixed here

**CH-1**: `list_chrono` with `status: "overdue"` misses an entry a caller stored as `overdue`, because the translated filter looks for stored `upcoming`/`active`. Nothing writes `overdue` on its own, so it only bites a caller who set it by hand. It changes what a query returns, so it wants its own test and CHANGELOG line. All four tools and the REST reference now name it rather than leaving it implied.

## Gates

- `chrono-status-descriptions-match-the-derivation.test.js` — exercises the pure derivation, pins every read path that applies it, pins that `query` does *not*, and refuses the old wording case-insensitively (its own mutation check caught that the first pattern missed the CAPITALISED original)
- `tool-parameters-are-all-described.test.js` — walks to full depth, refuses an undescribed parameter or one that restates its key
- Mutations run and restored: nested description removed → fires; walker's `items` descent removed → fires; echo description → fires; false wording restored → fires; `listChrono` output derivation removed → fires; `query` importing the derivation → fires

## The five places

REST route (unchanged — behaviour is unchanged), MCP tools, `docs/integration-guide/04c-chrono-api.md`, `docs/userguide/02-brain.md` (the Chrono filter bar is user-visible), token rights (N/A — no new route).