### PR TITLE
fix(chrono): status=overdue hid the entries somebody had marked overdue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Listing chrono entries by `status=overdue` hid the entries somebody had marked overdue.** `overdue` is
+  worked out from the clock rather than stored — an entry left `upcoming` past its due moment is returned as
+  overdue — so the filter was translated to look for exactly that: stored `upcoming`/`active`, past due.
+
+  But `overdue` is also a value you are allowed to store. Every write door accepts it, including the Brain's
+  own status dropdown, and it is passed through unchanged on read. So the filter returned the entries nobody
+  had touched and left out the ones somebody had deliberately marked — backwards from what the name promises.
+  It now matches both.
+
+- **Combining a chrono filter with a search could silently drop one of them.** Three separate filters wanted
+  the same two MongoDB keys and each assigned rather than accumulated: the tag pair took `$and`, the substring
+  search took `$or`, and the fix above needed an `$or` of its own. Two of those in one request and the later
+  assignment erased the earlier constraint — no error, just more rows than asked for. Compound clauses now
+  accumulate, so the mistake is no longer expressible, and the query builder is a pure exported function with
+  its combinations asserted directly.
+
+  The scan budget for those clock-comparing filters follows the decision rather than the shape of the query.
+  It was chosen by looking for a top-level `$expr`, which the fix above moves inside an `$or` — so the one
+  filter that got more expensive would have quietly gone back to the long timeout.
+
 ### Removed
 
 - **`spaces` is no longer stored on a token — the last of the three, and the pre-3.0 triple is gone.** Every

--- a/docs/integration-guide/04c-chrono-api.md
+++ b/docs/integration-guide/04c-chrono-api.md
@@ -38,9 +38,11 @@ memory. See [Retry Safety](04-brain-api.md#retry-safety).
 - `status` — `upcoming` (default), `active`, `completed`, `overdue`, `cancelled`. You never need to set
   `overdue` yourself: it is **derived on read** — an entry whose due moment (`endsAt`, or `startsAt` if
   it has none) has passed and that is not `completed`/`cancelled` is returned as `overdue`.
-  **Do not store `overdue` by hand.** It is accepted, but a stored `overdue` is then missed by the
-  `status=overdue` list filter, which looks for the derivable ones (stored `upcoming`/`active`, past due).
-  And the derivation applies to the chrono read paths only: `POST /query` reads documents as stored, so the
+  **Storing `overdue` is accepted and `status=overdue` finds it** — that filter returns both kinds, the
+  derivable ones and the ones somebody marked. It is still not worth setting: a stored `overdue` never
+  reverts, so an entry marked by hand stays overdue after you move its dates forward, where a derived one
+  corrects itself.
+  The derivation applies to the chrono read paths only: `POST /query` reads documents as stored, so the
   same entry is `upcoming` there and `overdue` in `GET /chrono`.
 - `confidence` — `0`–`1` (optional, useful for predictions)
 - `entityIds` — array of UUID v4 entity IDs (not names); returns `400` if any value is not a valid UUID and `strictLinkage` is enabled

--- a/docs/userguide/02-brain.md
+++ b/docs/userguide/02-brain.md
@@ -115,10 +115,14 @@ Chrono stores time-anchored entries: events, deadlines, plans, predictions, and 
 
 **Filtering:** The filter bar above the table lets you narrow by tag text and status. Filters apply immediately.
 
-> **"Overdue" is worked out from the clock, not stored.** An entry you left as *upcoming* whose date has
-> passed shows as **overdue** on its own — nobody has to mark it. That also means filtering by *upcoming* or
-> *active* leaves those entries out, because they are counted as overdue now. Set an entry to *completed* or
-> *cancelled* to stop it being counted that way.
+> **"Overdue" is worked out from the clock.** An entry you left as *upcoming* whose date has passed shows as
+> **overdue** on its own — nobody has to mark it. That also means filtering by *upcoming* or *active* leaves
+> those entries out, because they are counted as overdue now. Set an entry to *completed* or *cancelled* to
+> stop it being counted that way.
+>
+> The status dropdown does offer **overdue**, and filtering by it finds those entries too. You rarely want
+> it: an entry marked overdue by hand stays overdue after you move its dates forward, where one left as
+> *upcoming* corrects itself.
 
 **Editing:** Click the **⊙ view-details** button on any row to open the editable drawer, as on the other record
 tabs. Title, type, dates, status, tags, description and properties can all be changed there.

--- a/server/src/brain/chrono.ts
+++ b/server/src/brain/chrono.ts
@@ -372,28 +372,57 @@ export interface ChronoFilter {
   search?: string;
 }
 
-export async function listChrono(
+/**
+ * The Mongo filter behind `listChrono`, and whether it compares a stored date against the clock.
+ *
+ * Exported and pure so it can be asserted without a database. That matters here specifically: what this
+ * builder gets wrong is never an exception, it is a clause that silently stops applying — and a suite that
+ * needs Docker to see that is a suite nobody runs before pushing.
+ */
+export function buildChronoQuery(
   spaceId: string,
-  filter: ChronoFilter = {},
-  limit = 50,
-  skip = 0,
-  sort?: SortSpec,
-): Promise<ChronoEntry[]> {
-  const now = new Date();
+  filter: ChronoFilter,
+  now: Date,
+): { query: Record<string, unknown>; comparesAgainstTheClock: boolean } {
   const query: Record<string, unknown> = { spaceId };
+  // Whether the status filter compares a stored date against the clock, which is a per-document evaluation
+  // rather than an index lookup and therefore wants the shorter scan budget. Tracked as a DECISION rather
+  // than re-derived from `query['$expr']` at the cursor: `overdue` moved its comparison inside an `$or`, so
+  // the top-level key vanished while the scan did not, and the budget would have silently gone back to 60 s.
+  let comparesAgainstTheClock = false;
+  /**
+   * Compound clauses ACCUMULATE here instead of being assigned to `query.$or` / `query.$and` directly.
+   *
+   * Three separate filters wanted one of those two keys and each wrote it with `=`: the tag pair took `$and`,
+   * the substring search took `$or`, and the `overdue` fix below needs an `$or` of its own. Two of those in
+   * one call and the later assignment ERASES the earlier constraint — silently, and in the widening
+   * direction, which is the failure this repo produces most. Accumulating cannot express that mistake.
+   */
+  const and: Record<string, unknown>[] = [];
 
-  // Status filter is `overdue`-aware (C5): `overdue` is derived from the due moment, never stored.
+  // Status filter is `overdue`-aware (C5): `overdue` is normally DERIVED from the due moment, not stored.
   if (filter.status !== undefined) {
     // The due moment: endsAt, or startsAt when there is no end. `$toDate` so mixed-offset ISO strings
     // compare chronologically, not lexically.
     const refDate = { $toDate: { $ifNull: ['$endsAt', '$startsAt'] } };
     if (filter.status === 'overdue') {
-      query['status'] = { $in: ['upcoming', 'active'] };
-      query['$expr'] = { $lt: [refDate, now] };
+      // BOTH kinds, and the second half is the fix. `overdue` is a legal value on every write door — the
+      // enum accepts it on `create_chrono`, `update_chrono`, `bulk_write`, both REST routes and the Brain
+      // UI's own status dropdown — so a caller can store it, and `deriveChronoStatus` passes a stored one
+      // straight through. Matching only the derivable ones therefore hid exactly the entries somebody had
+      // taken the trouble to mark, from the filter that names them.
+      and.push({
+        $or: [
+          { status: 'overdue' },
+          { status: { $in: ['upcoming', 'active'] }, $expr: { $lt: [refDate, now] } },
+        ],
+      });
+      comparesAgainstTheClock = true;
     } else if (filter.status === 'upcoming' || filter.status === 'active') {
       // Exclude entries that are now derived-overdue so they don't surface under their stored status.
       query['status'] = filter.status;
       query['$expr'] = { $gte: [refDate, now] };
+      comparesAgainstTheClock = true;
     } else {
       query['status'] = filter.status; // completed / cancelled — no derivation
     }
@@ -414,11 +443,8 @@ export async function listChrono(
   // If both tags and tagsAny are provided, combine with $and
   if (filter.tagsAny && filter.tagsAny.length > 0) {
     if (filter.tags && filter.tags.length > 0) {
-      // Already have an $all constraint on tags — wrap both with $and
-      query['$and'] = [
-        { tags: { $all: filter.tags } },
-        { tags: { $in: filter.tagsAny } },
-      ];
+      // Already have an $all constraint on tags — both go through the accumulator
+      and.push({ tags: { $all: filter.tags } }, { tags: { $in: filter.tagsAny } });
       delete query['tags'];
     } else {
       query['tags'] = { $in: filter.tagsAny };
@@ -436,11 +462,26 @@ export async function listChrono(
   // Full-text substring search on title and/or description. Escaped (2b-iii-a): the raw value used to
   // reach `$regex` un-escaped, so a value like `(a+)+$` was a ReDoS / regex-injection vector.
   const search = textSearchOr(filter.search, SEARCHABLE_FIELDS.chrono);
-  if (search) query['$or'] = search.$or;
+  if (search) and.push({ $or: search.$or });
+
+  if (and.length > 0) query['$and'] = and;
+
+  return { query, comparesAgainstTheClock };
+}
+
+export async function listChrono(
+  spaceId: string,
+  filter: ChronoFilter = {},
+  limit = 50,
+  skip = 0,
+  sort?: SortSpec,
+): Promise<ChronoEntry[]> {
+  const now = new Date();
+  const { query, comparesAgainstTheClock } = buildChronoQuery(spaceId, filter, now);
 
   const entries = await col<ChronoEntry>(`${spaceId}_chrono`)
     .find(asFilter<ChronoEntry>(query))
-    .maxTimeMS(query['$expr'] ? PROPERTIES_SCAN_MAX_MS : 60_000)
+    .maxTimeMS(comparesAgainstTheClock ? PROPERTIES_SCAN_MAX_MS : 60_000)
     .sort(sort ? toMongoSort(sort) : { createdAt: -1 })
     .skip(parseSkip(skip))
     .limit(parseLimit(limit, 20, 1000))

--- a/server/src/mcp/tools/bulk.ts
+++ b/server/src/mcp/tools/bulk.ts
@@ -159,8 +159,9 @@ export const bulk_writeTool: ToolHandler = {
                     description: 'Stored status (default `upcoming`). A value outside this list is DISCARDED '
                       + 'SILENTLY — the entry is still written, with the default, and nothing appears in '
                       + '`errors`. `create_chrono` refuses the same value, because the per-item schemas here '
-                      + 'are for discovery only (`skipSchemaValidation`). Do not set `overdue`: it is derived '
-                      + 'on read from the due moment, so leaving an entry `upcoming` is what makes it overdue.',
+                      + 'are for discovery only (`skipSchemaValidation`). You do not need `overdue`: it is '
+                      + 'derived on read from the due moment, so leaving an entry `upcoming` is what makes it '
+                      + 'overdue, and a stored one never reverts when the dates move.',
                   },
                   confidence:  { type: 'number', description: 'Confidence 0 to 1, for entries that are predictions. A non-number is dropped silently and does not appear in `errors`; unlike `create_chrono`, the 0–1 bound is not enforced on this door.' },
                   description: { type: 'string', description: 'Optional longer description of the entry.' },

--- a/server/src/mcp/tools/chrono.ts
+++ b/server/src/mcp/tools/chrono.ts
@@ -30,10 +30,11 @@ export const create_chronoTool: ToolHandler = {
             endsAt: { type: 'string', description: 'Optional ISO 8601 end date/time.' },
             status: {
               type: 'string', enum: ['upcoming', 'active', 'completed', 'overdue', 'cancelled'], default: 'upcoming',
-              description: 'Stored status (default `upcoming`). Do NOT set `overdue` — it is derived on read '
-                + 'from the due moment, so an entry left `upcoming` becomes overdue on its own, and one '
-                + 'stored as `overdue` by hand is then invisible to `list_chrono`\'s `status: "overdue"` '
-                + 'filter, which looks for the derivable ones.',
+              description: 'Stored status (default `upcoming`). You do not need `overdue` — it is derived on '
+                + 'read from the due moment, so an entry left `upcoming` becomes overdue on its own and is '
+                + 'returned as such. Storing it is accepted and findable, but it is a value that never '
+                + 'reverts: an entry marked `overdue` by hand stays overdue after you move its dates '
+                + 'forward, where a derived one would correct itself.',
             },
             confidence: unitScoreSchema('Confidence level 0–1 (for predictions).'),
             tags: { type: 'array', items: { type: 'string' }, description: 'Categorisation tags.' },
@@ -375,19 +376,19 @@ export const list_chronoTool: ToolHandler = {
     + 'someone recorded it. These two parameters read `createdAt`. To ask "what is scheduled next quarter" you '
     + 'want `query` with a predicate on `startsAt`; `after`/`before` here answer "what did we write down last '
     + 'week", which is a different question and usually not the one being asked.\n\n'
-    + '`overdue` IS DERIVED FROM THE CLOCK, AND IS NEVER STORED. An entry whose due moment (`endsAt`, or '
-    + '`startsAt` when it has none) has passed and that is still `upcoming`/`active` is RETURNED as `overdue`, '
-    + 'and the filter is translated to match: `status: "overdue"` finds exactly those, and '
-    + '`status: "upcoming"` EXCLUDES them rather than including them. So both answer the truth about time, and '
-    + 'you do not need a date predicate to ask "what is late".\n\n'
+    + '`overdue` IS NORMALLY DERIVED FROM THE CLOCK. An entry whose due moment (`endsAt`, or `startsAt` when '
+    + 'it has none) has passed and that is still `upcoming`/`active` is RETURNED as `overdue`, and the filter '
+    + 'is translated to match: `status: "overdue"` finds those, and `status: "upcoming"` EXCLUDES them rather '
+    + 'than including them. So both answer the truth about time, and you do not need a date predicate to ask '
+    + '"what is late".\n\n'
+    + '`status: "overdue"` ALSO RETURNS AN ENTRY SOMEBODY STORED AS `overdue`. Nothing writes that value on '
+    + 'its own, but every write door accepts it, so both kinds come back and neither is hidden. You still do '
+    + 'not need to set it: leaving an entry `upcoming` past its date is what makes it overdue, and a stored '
+    + '`overdue` never reverts when the entry is rescheduled.\n\n'
     + 'THE STORED VALUE IS STILL WHAT SYNC AND `query` SEE. `query` reads documents as stored, so a filter of '
     + '`status: "overdue"` there matches almost nothing while this tool returns plenty — the same records, two '
     + 'answers, because only this path derives. Use this tool for status, and `query` for `startsAt`/`endsAt` '
     + 'predicates.\n\n'
-    + 'One edge, named because it is a defect rather than a design: an entry a caller EXPLICITLY stored as '
-    + '`overdue` is not matched by `status: "overdue"` here, because the translated filter looks for stored '
-    + '`upcoming`/`active`. Nothing writes `overdue` on its own, so this only bites a caller who set it by '
-    + 'hand.\n\n'
     + 'OMIT `space` TO SEARCH EVERY SPACE THE TOKEN REACHES. That is unusual — most tools require one — and it '
     + 'is what makes this the tool for "when did we ever say we would do this". Results carry their space.\n\n'
     + 'PARAMETERS:\n'
@@ -408,10 +409,11 @@ export const list_chronoTool: ToolHandler = {
             space: s.optionalSpace,
             status: {
               type: 'string', enum: ['upcoming', 'active', 'completed', 'overdue', 'cancelled'],
-              description: 'Filter by status, CLOCK-AWARE for the first three. `overdue` returns entries '
-                + 'stored `upcoming`/`active` whose due moment has passed; `upcoming` and `active` EXCLUDE '
-                + 'those same entries. `completed` and `cancelled` are plain matches on the stored value. '
-                + 'The same filter against `query` is not translated and answers differently.',
+              description: 'Filter by status, CLOCK-AWARE for the first three. `overdue` returns BOTH kinds — '
+                + 'entries stored `upcoming`/`active` whose due moment has passed, AND entries somebody '
+                + 'stored as `overdue` — while `upcoming` and `active` EXCLUDE the ones that are now late. '
+                + '`completed` and `cancelled` are plain matches on the stored value. The same filter '
+                + 'against `query` is not translated and answers differently.',
             },
             type: { type: 'string', description: 'Filter by type (e.g. event, deadline, plan, prediction, milestone, or a custom type).' },
             tags: { type: 'array', items: { type: 'string' }, description: 'Return entries containing ALL of these tags (AND semantics).' },

--- a/testing/integration/chrono-overdue-filter.test.js
+++ b/testing/integration/chrono-overdue-filter.test.js
@@ -49,8 +49,11 @@ const listByStatus = async (status) => {
 };
 
 before(async () => {
-  const cfg = JSON.parse(fs.readFileSync(path.join(CONFIGS, 'a', 'config.json'), 'utf8'));
-  tokenA = cfg.tokens[0].token;
+  // `token.txt`, which is what every other integration suite reads. Reading `config.json` works on a
+  // Windows working copy and fails in CI with `EACCES`: the container writes that file as root, while
+  // `token.txt` is deposited for the tests. The suite's existing convention was right; inventing a second
+  // way to get the same value is what cost a CI run.
+  tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
 });
 
 after(async () => {

--- a/testing/integration/chrono-overdue-filter.test.js
+++ b/testing/integration/chrono-overdue-filter.test.js
@@ -1,0 +1,132 @@
+/**
+ * Integration: `status=overdue` returns every overdue entry, against a real Mongo.
+ *
+ * `chrono-list-filter-composes.test.js` proves the QUERY the builder produces. This proves Mongo answers it
+ * the way that query is meant to — a `$or` branch carrying its own `$expr` is exactly the construction most
+ * likely to be legal-but-different from what it reads like, and no amount of asserting on the object literal
+ * would show that.
+ *
+ * ## CH-1
+ *
+ * `overdue` is derived on read, so the filter was translated to *"stored `upcoming`/`active`, past due"*. But
+ * `overdue` is also a legal stored value on every write door, so an entry a caller had marked was invisible
+ * to the filter that names it. Both kinds are matched now.
+ *
+ * Run: node --test testing/integration/chrono-overdue-filter.test.js
+ * (needs the compose stack — `npm run test:integration`)
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post, get, del } from '../sync/helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+
+let tokenA;
+const created = [];
+
+const PAST = '2020-03-01T00:00:00Z';
+const FUTURE = '2099-03-01T00:00:00Z';
+
+/** Create one entry and remember it for cleanup. Titles are unique so the assertions can find their own. */
+async function mk(title, body) {
+  const r = await post(INSTANCES.a, tokenA, '/api/brain/spaces/general/chrono', {
+    title, type: 'deadline', ...body,
+  });
+  assert.equal(r.status, 201, `creating "${title}" failed: ${JSON.stringify(r.body)}`);
+  created.push(r.body._id);
+  return r.body._id;
+}
+
+const listByStatus = async (status) => {
+  const r = await get(INSTANCES.a, tokenA, `/api/brain/spaces/general/chrono?status=${status}&limit=500`);
+  assert.equal(r.status, 200);
+  return r.body.chrono;
+};
+
+before(async () => {
+  const cfg = JSON.parse(fs.readFileSync(path.join(CONFIGS, 'a', 'config.json'), 'utf8'));
+  tokenA = cfg.tokens[0].token;
+});
+
+after(async () => {
+  for (const id of created) {
+    await del(INSTANCES.a, tokenA, `/api/brain/spaces/general/chrono/${id}`).catch(() => {});
+  }
+});
+
+describe('chrono status=overdue finds both kinds', () => {
+  let derivedId, storedId, futureId, doneId;
+
+  before(async () => {
+    derivedId = await mk('ch1 derived overdue', { startsAt: PAST, status: 'upcoming' });
+    storedId = await mk('ch1 stored overdue', { startsAt: FUTURE, status: 'overdue' });
+    futureId = await mk('ch1 still upcoming', { startsAt: FUTURE, status: 'upcoming' });
+    doneId = await mk('ch1 completed in the past', { startsAt: PAST, status: 'completed' });
+  });
+
+  it('the derived one — stored upcoming, due moment passed', async () => {
+    const ids = (await listByStatus('overdue')).map(c => c._id);
+    assert.ok(ids.includes(derivedId), 'a past-due upcoming entry is overdue and always was');
+  });
+
+  it('AND the one a caller stored as overdue — this is CH-1', async () => {
+    const ids = (await listByStatus('overdue')).map(c => c._id);
+    assert.ok(ids.includes(storedId),
+      'an entry somebody marked overdue was invisible to the filter that names it');
+  });
+
+  it('and nothing that is not overdue', async () => {
+    const ids = (await listByStatus('overdue')).map(c => c._id);
+    assert.ok(!ids.includes(futureId), 'a future entry must not be listed as overdue');
+    assert.ok(!ids.includes(doneId), 'a completed entry is never re-derived, however old');
+  });
+
+  it('the derived entry reads back AS overdue, so the filter and the row agree', async () => {
+    const rows = await listByStatus('overdue');
+    const row = rows.find(c => c._id === derivedId);
+    assert.equal(row.status, 'overdue',
+      'a row returned by the overdue filter but labelled `upcoming` is worse than not returning it');
+  });
+
+  it('status=upcoming excludes the now-overdue one and keeps the future one', async () => {
+    const ids = (await listByStatus('upcoming')).map(c => c._id);
+    assert.ok(ids.includes(futureId));
+    assert.ok(!ids.includes(derivedId), 'it is overdue now, and must not surface under its stored status');
+    assert.ok(!ids.includes(storedId), 'nor a stored `overdue` under a status it does not have');
+  });
+});
+
+describe('the status filter survives being combined', () => {
+  // The fix needed an `$or`, and `$or` was already taken by the substring search — assigned, not
+  // accumulated. Combining them is where an erased clause would show up, as MORE rows rather than an error.
+  let match, otherOverdue;
+
+  before(async () => {
+    match = await mk('ch1 combo needle overdue', { startsAt: PAST, status: 'upcoming' });
+    otherOverdue = await mk('ch1 combo haystack', { startsAt: PAST, status: 'upcoming', tags: ['ch1-combo'] });
+  });
+
+  it('status + search applies BOTH', async () => {
+    const r = await get(INSTANCES.a, tokenA,
+      '/api/brain/spaces/general/chrono?status=overdue&search=needle&limit=500');
+    assert.equal(r.status, 200);
+    const ids = r.body.chrono.map(c => c._id);
+    assert.ok(ids.includes(match), 'the entry matching both must be returned');
+    assert.ok(!ids.includes(otherOverdue),
+      'an overdue entry that does NOT match the search must be filtered out — if it is here, the search clause was erased');
+  });
+
+  it('status + tag applies both', async () => {
+    const r = await get(INSTANCES.a, tokenA,
+      '/api/brain/spaces/general/chrono?status=overdue&tags=ch1-combo&limit=500');
+    assert.equal(r.status, 200);
+    const ids = r.body.chrono.map(c => c._id);
+    assert.ok(ids.includes(otherOverdue));
+    assert.ok(!ids.includes(match), 'the untagged overdue entry must not be here');
+  });
+});

--- a/testing/standalone/chrono-list-filter-composes.test.js
+++ b/testing/standalone/chrono-list-filter-composes.test.js
@@ -1,0 +1,172 @@
+/**
+ * `listChrono`'s filter finds every overdue entry, and no clause silently erases another.
+ *
+ * ## CH-1 — the entries a caller marked were invisible to the filter that names them
+ *
+ * `overdue` is DERIVED on read (C5): an entry stored `upcoming`/`active` whose due moment has passed is
+ * returned as `overdue`. The list filter was translated to match that — and ONLY that:
+ *
+ * ```js
+ * query['status'] = { $in: ['upcoming', 'active'] };
+ * query['$expr']  = { $lt: [refDate, now] };
+ * ```
+ *
+ * But `overdue` is a legal STORED value on every write door — the enum accepts it on `create_chrono`,
+ * `update_chrono`, `bulk_write`, both REST routes, and the Brain UI's own status dropdown — and
+ * `deriveChronoStatus` passes a stored one straight through. So `status: "overdue"` returned the entries
+ * nobody had touched and hid the ones somebody had deliberately marked. Backwards.
+ *
+ * ## Why the fix needed an accumulator rather than one more clause
+ *
+ * Matching both kinds needs an `$or`. `query['$or']` was already taken — by the substring search, assigned
+ * with `=` at the bottom of the same function — and `query['$and']` was taken by the tag pair, also with
+ * `=`. Three filters, two keys, three assignments. Adding a fourth writer would have made
+ * `status: "overdue"` plus `search: "…"` drop one of the two constraints, silently and in the WIDENING
+ * direction.
+ *
+ * So compound clauses accumulate into one `$and` array. The point of these tests is less the `overdue` fix
+ * than that combinations survive: an erased clause throws nothing, logs nothing, and returns MORE rows.
+ *
+ * ## Exercised, not grepped
+ *
+ * `buildChronoQuery` was extracted for this — it is pure, so these are real calls with real verdicts and no
+ * Docker. A source-reading test could not tell a clause that is built from one that is then overwritten.
+ *
+ * Run: node --test testing/standalone/chrono-list-filter-composes.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let buildChronoQuery, deriveChronoStatus;
+before(async () => {
+  ({ buildChronoQuery } = await import('../../server/dist/brain/chrono.js'));
+  ({ deriveChronoStatus } = await import('../../server/dist/brain/chrono-status.js'));
+});
+
+const NOW = new Date('2026-08-16T12:00:00Z');
+const build = (filter) => buildChronoQuery('s1', filter, NOW);
+
+/** Every branch of an `$and` accumulator, flattened, so a test can ask "is this constraint still here". */
+const clauses = (query) => [query, ...(query['$and'] ?? [])];
+const someClause = (query, pred) => clauses(query).some(pred);
+
+describe('status: overdue matches BOTH kinds', () => {
+  it('the derived ones — stored upcoming/active, past due', () => {
+    const { query } = build({ status: 'overdue' });
+    const or = query['$and'][0]['$or'];
+    const derived = or.find(b => b['status']?.['$in']);
+    assert.deepEqual(derived['status']['$in'], ['upcoming', 'active']);
+    assert.ok(derived['$expr']['$lt'], 'compared against the clock, less-than the due moment');
+  });
+
+  it('AND an entry a caller stored as overdue — the half that was missing', () => {
+    const { query } = build({ status: 'overdue' });
+    const or = query['$and'][0]['$or'];
+    assert.ok(or.some(b => b['status'] === 'overdue'),
+      'the enum accepts `overdue` on every write door, so a stored one must be findable');
+  });
+
+  it('and the stored one is consistent with what the derivation returns for it', () => {
+    // If `deriveChronoStatus` ever stopped passing a stored `overdue` through, matching it here would
+    // return rows the caller then sees under a different status.
+    assert.equal(deriveChronoStatus({ status: 'overdue', startsAt: '2027-01-01T00:00:00Z' }, NOW), 'overdue');
+  });
+});
+
+describe('the other status branches are unchanged', () => {
+  it('upcoming and active still EXCLUDE the now-overdue ones', () => {
+    for (const s of ['upcoming', 'active']) {
+      const { query } = build({ status: s });
+      assert.equal(query['status'], s);
+      assert.ok(query['$expr']['$gte'], `${s} must exclude entries whose due moment has passed`);
+    }
+  });
+
+  it('completed and cancelled are plain matches with no clock in them', () => {
+    for (const s of ['completed', 'cancelled']) {
+      const { query, comparesAgainstTheClock } = build({ status: s });
+      assert.equal(query['status'], s);
+      assert.equal(query['$expr'], undefined, 'nothing to derive');
+      assert.equal(comparesAgainstTheClock, false);
+    }
+  });
+});
+
+describe('the scan budget follows the DECISION, not the query shape', () => {
+  /**
+   * `listChrono` chose its `maxTimeMS` by asking `query['$expr'] ? SHORT : 60_000`. Moving the `overdue`
+   * comparison inside an `$or` removes that top-level key while the per-document evaluation stays — so the
+   * budget would have quietly gone back to 60 s on the one filter that got MORE expensive. A guard on the
+   * wrong axis: it read the shape instead of the reason.
+   */
+  it('overdue compares against the clock even though $expr is no longer top-level', () => {
+    const { query, comparesAgainstTheClock } = build({ status: 'overdue' });
+    assert.equal(query['$expr'], undefined, 'it lives inside the $or now — this is the trap');
+    assert.equal(comparesAgainstTheClock, true, 'and the budget must still know that');
+  });
+
+  it('upcoming/active too', () => {
+    assert.equal(build({ status: 'active' }).comparesAgainstTheClock, true);
+  });
+
+  it('and a filter with no status does not pay for a scan', () => {
+    assert.equal(build({ search: 'x' }).comparesAgainstTheClock, false);
+    assert.equal(build({}).comparesAgainstTheClock, false);
+  });
+});
+
+describe('no clause erases another', () => {
+  it('status + search keeps both — the collision the fix would have introduced', () => {
+    const { query } = build({ status: 'overdue', search: 'launch' });
+    assert.ok(someClause(query, c => c['$or']?.some(b => b['status'] === 'overdue')),
+      'the status disjunction survived');
+    assert.ok(someClause(query, c => c['$or']?.some(b => b['title'] ?? b['description'])),
+      'and so did the substring search');
+    assert.equal(query['$and'].length, 2, 'two independent constraints, ANDed');
+  });
+
+  it('tags + tagsAny + search keeps all three', () => {
+    const { query } = build({ tags: ['a'], tagsAny: ['b', 'c'], search: 'x' });
+    assert.ok(someClause(query, c => c['tags']?.['$all']), '$all survived');
+    assert.ok(someClause(query, c => c['tags']?.['$in']), '$in survived');
+    assert.ok(someClause(query, c => c['$or']), 'search survived');
+    assert.equal(query['tags'], undefined, 'and the bare key was cleared, not left contradicting the pair');
+  });
+
+  it('all four at once', () => {
+    const { query } = build({ status: 'overdue', tags: ['a'], tagsAny: ['b'], search: 'x' });
+    assert.equal(query['$and'].length, 4, 'status, $all, $in, search — none dropped');
+  });
+
+  it('nothing ever assigns a bare top-level $or', () => {
+    // The erasure was possible because two writers shared one key. Nothing may write it directly again.
+    for (const f of [{ search: 'x' }, { status: 'overdue' }, { status: 'overdue', search: 'x' }]) {
+      assert.equal(build(f).query['$or'], undefined,
+        `\`${JSON.stringify(f)}\` put an $or at the top level, where the next writer would overwrite it`);
+    }
+  });
+
+  it('and a simple filter stays simple — no empty $and', () => {
+    const { query } = build({ type: 'deadline' });
+    assert.equal(query['$and'], undefined, 'an accumulator that always fires makes every query harder to read');
+    assert.equal(query['type'], 'deadline');
+  });
+});
+
+describe('the unrelated filters still land', () => {
+  it('space, type, date range and the single-tag box', () => {
+    const { query } = build({ type: 'event', after: '2026-01-01', before: '2026-12-31', tagLike: 'rel' });
+    assert.equal(query['spaceId'], 's1');
+    assert.equal(query['type'], 'event');
+    assert.equal(query['createdAt']['$gt'], '2026-01-01');
+    assert.equal(query['createdAt']['$lt'], '2026-12-31');
+    assert.ok(query['tags'], 'the substring tag box writes the bare key, which nothing else claims');
+  });
+
+  it('tagsAny alone stays a bare $in rather than a one-element $and', () => {
+    const { query } = build({ tagsAny: ['b'] });
+    assert.deepEqual(query['tags'], { $in: ['b'] });
+    assert.equal(query['$and'], undefined);
+  });
+});

--- a/testing/standalone/chrono-status-descriptions-match-the-derivation.test.js
+++ b/testing/standalone/chrono-status-descriptions-match-the-derivation.test.js
@@ -83,12 +83,28 @@ describe('every chrono read path applies it, which is what makes the sentences t
   });
 
   it('a list derives its OUTPUT as well as translating its filter', () => {
+    // The filter's own construction is exercised in `chrono-list-filter-composes.test.js` against
+    // `buildChronoQuery`, which is why the source reads here are only about the parts that function does not
+    // return: that the OUTPUT is derived too, and that the translation lives in `listChrono` at all.
+    //
+    // The `{0,200}` bounds below were written as character counts before that lesson landed. They are
+    // POSITIVE assertions, so a window that spans fewer lines fails loudly rather than passing quietly —
+    // but the statement bound is right either way and costs nothing.
     const s = src();
     assert.match(s, /entries\.map\(e => withDerivedStatus\(e, now\)\)/,
       'translating the filter alone would return rows whose status contradicts the filter that found them');
-    assert.match(s, /filter\.status === 'overdue'[\s\S]{0,200}?\$in: \['upcoming', 'active'\]/,
-      'and `status: "overdue"` must be translated, not matched literally');
-    assert.match(s, /filter\.status === 'upcoming' \|\| filter\.status === 'active'[\s\S]{0,200}?\$gte/,
+
+    const at = s.indexOf("filter.status === 'overdue'");
+    assert.ok(at > 0, 'the overdue branch was not found — the scanner is wrong, not the code');
+    const branch = s.slice(at, s.indexOf('} else if', at));
+    assert.match(branch, /\$in: \['upcoming', 'active'\]/,
+      '`status: "overdue"` must be TRANSLATED — the derivable entries are found by comparing the clock');
+    assert.match(branch, /status: 'overdue'/,
+      'and it must ALSO match a stored `overdue` (CH-1) — the tools now promise both kinds');
+
+    const upAt = s.indexOf("filter.status === 'upcoming' || filter.status === 'active'");
+    assert.ok(upAt > 0, 'the upcoming/active branch was not found');
+    assert.match(s.slice(upAt, s.indexOf('} else', upAt)), /\$gte/,
       '`upcoming`/`active` must EXCLUDE the now-overdue ones — the tools promise both directions');
   });
 
@@ -141,6 +157,30 @@ describe('no tool repeats the claim that was false', () => {
     for (const [re] of [[/nothing recomputes[\s\S]{0,20}status/i], [/only finds entries somebody marked overdue/i], [/stays `upcoming` after its date (has )?passed/i]]) {
       assert.doesNotMatch(CORRECTED, re);
     }
+  });
+
+  it('nor that a stored `overdue` is invisible — CH-1 is fixed, so that sentence would be the next stale one', () => {
+    // These descriptions NAMED the defect while it stood, which was right. Leaving them naming it after the
+    // filter was fixed is the same failure the whole suite is about, one release later — and the sentence
+    // reads as authoritative either way. The filter's own behaviour is proved in
+    // `chrono-list-filter-composes.test.js`; this only holds the prose to it.
+    const BAD = [
+      [/stored as `overdue`[\s\S]{0,40}(invisible|not matched|missed)/i, 'stored overdue is invisible'],
+      [/looks for the derivable ones/i, 'only the derivable ones'],
+    ];
+    const offenders = [];
+    for (const t of ALL_TOOLS) {
+      const text = (t.description ?? '') + JSON.stringify(t.inputSchema(STUB));
+      for (const [re, label] of BAD) if (re.test(text)) offenders.push(`${t.name}: "${label}"`);
+    }
+    assert.deepEqual(offenders, [], 'these still describe CH-1 as open:\n  ' + offenders.join('\n  '));
+  });
+
+  it('and `list_chrono` says the filter returns BOTH kinds', () => {
+    const t = ALL_TOOLS.find(x => x.name === 'list_chrono');
+    const text = (t.description ?? '') + JSON.stringify(t.inputSchema(STUB));
+    assert.match(text, /BOTH kinds|ALSO RETURNS AN ENTRY SOMEBODY STORED/,
+      'a caller who reads only "derived from the clock" would still not know a marked entry comes back');
   });
 
   it('and the four tools that discuss status say it is derived', () => {


### PR DESCRIPTION
## CH-1

`overdue` is derived on read (C5), so the list filter was translated to find exactly that — stored `upcoming`/`active`, past due:

```js
query['status'] = { $in: ['upcoming', 'active'] };
query['$expr']  = { $lt: [refDate, now] };
```

But `overdue` is also a legal **stored** value. The enum accepts it on `create_chrono`, `update_chrono`, `bulk_write`, both REST routes and **the Brain UI's own status dropdown**, and `deriveChronoStatus` passes a stored one straight through.

So `status=overdue` returned the entries nobody had touched and hid the ones somebody had deliberately marked. Backwards from what the name promises, and reachable from the UI without an API call.

## The fix needed an accumulator, not one more clause

Matching both kinds needs an `$or`. `query['$or']` was already taken — by the substring search, assigned with `=` at the bottom of the same function — and `query['$and']` was taken by the tag pair, also with `=`. Three filters, two keys, three assignments.

A fourth writer would have made `status=overdue` **plus** `search=` drop one of the two constraints, silently and in the widening direction. Compound clauses accumulate into one `$and` now, so the mistake is no longer expressible.

## And the scan budget was reading the shape

`maxTimeMS` was chosen by asking whether `query['$expr']` was set. The fix moves that comparison inside the `$or`, so the top-level key vanishes while the per-document evaluation stays — the one filter that got *more* expensive would have quietly gone back to the 60 s timeout. It follows an explicit `comparesAgainstTheClock` instead.

## Provable without Docker

`buildChronoQuery` is extracted and pure. What this builder gets wrong is never an exception — it is a clause that stops applying — and a suite that needs a container to see that is one nobody runs before pushing.

- `chrono-list-filter-composes.test.js` (15 assertions) — both `overdue` kinds, every other status branch unchanged, the budget decision, and that no combination erases another (`status`+`search`, `tags`+`tagsAny`+`search`, all four at once, and that nothing writes a bare top-level `$or` again)
- `chrono-overdue-filter.test.js` — integration, because Mongo answering an `$or` branch that carries its own `$expr` is exactly what asserting on an object literal cannot show. Covers the derived entry, the stored one, the exclusions, that the returned row is *labelled* overdue, and that `status`+`search` and `status`+`tags` each keep both
- Mutations run and restored: reverting to the derivable-only filter fires 6 assertions; restoring the bare `$or` assignment fires the combination ones

## Descriptions follow through

#958 named this gap on four tools and in the REST reference while it stood. Leaving those sentences after the fix is the same failure one release later, so they now say the filter returns **both** kinds — and give the real reason not to store `overdue`: it never reverts, so an entry marked by hand stays overdue after you move its dates, where a derived one corrects itself. Gated.

## The five places

REST route and MCP tool (one shared `listChrono` — no route change), `docs/integration-guide/04c-chrono-api.md`, `docs/userguide/02-brain.md` (the status dropdown is where a user stores this value), token rights N/A.