### PR TITLE
docs(mcp): every parameter says the trap, and a 40-character floor holds it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,11 +41,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Every thin MCP parameter description now says the trap rather than the type.** 52 of them were under forty
-  characters — `"Source path."`, `"Entity name."`, `"Collection to query."` — which passes a
+- **Every MCP parameter description now says the trap rather than the type, and a gate holds the line.** 62
+  were under forty characters — `"Source path."`, `"Entity name."`, `"Collection to query."` — which passes a
   has-a-description check and tells a caller nothing they could not read off the key. `help()` names the tool
   schema as the authoritative reference, so a parameter described that way is a capability nobody can use
   properly.
+
+  Also corrected: `update_chrono` promised that **"`endsAt` before `startsAt` is refused"**, and nothing
+  anywhere performs that check. Such an entry is stored as sent — and because `endsAt` becomes the due
+  moment, it reads back as `overdue` immediately. Both the tool and the gate now say so, and the gate asserts
+  the *absence* of the check rather than the wording, so it flips the day somebody adds the validation.
 
   What the new text adds is what the source says and the name does not: `upsert_entity.name` deduplicates
   nothing, so omitting `id` inserts a second entity of the same name; `update_edge.label` is part of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   It was chosen by looking for a top-level `$expr`, which the fix above moves inside an `$or` — so the one
   filter that got more expensive would have quietly gone back to the long timeout.
 
+- **`remember` said "there is no id to update" while accepting an `id` to update.** The parameter sat in the
+  same schema, describing itself as *"UUID v4 of an EXISTING record to update"*, and the code has the branch to
+  match: a supplied id that already names a record **converges** rather than duplicating, unioning tags and
+  shallow-merging properties exactly as `upsert_entity` does.
+
+  That branch is the retry-safety contract — it is what makes repeating a timed-out write safe. A caller who
+  believed the prose would instead issue a fresh insert and end up with two records, which is the one outcome
+  the feature exists to prevent. The description now says what an id does, and a gate holds it to the code
+  rather than to a sentence.
+
+### Changed
+
+- **Every thin MCP parameter description now says the trap rather than the type.** 52 of them were under forty
+  characters — `"Source path."`, `"Entity name."`, `"Collection to query."` — which passes a
+  has-a-description check and tells a caller nothing they could not read off the key. `help()` names the tool
+  schema as the authoritative reference, so a parameter described that way is a capability nobody can use
+  properly.
+
+  What the new text adds is what the source says and the name does not: `upsert_entity.name` deduplicates
+  nothing, so omitting `id` inserts a second entity of the same name; `update_edge.label` is part of the
+  identity `upsert_edge` matches on, so renaming it makes a later upsert create a second edge; `move_file.dst`
+  replaces an existing file with no refusal; `update_file_meta.properties` replaces the whole object where the
+  brain tools merge key by key; `create_space.label` is not the identity, the derived `id` is.
+
+  The five file tools' path arguments became one shared `filePathSchema` instead of the same 37-character
+  sentence copied four times. It now states the three facts that decide whether a call works, all from
+  `files/sandbox.ts`: a leading slash is **stripped** rather than refused, so `/a/b.md` and `a/b.md` are the
+  same file; paths are Unicode-normalised, so two spellings of one accented name resolve together; and a `..`
+  that would leave the space is refused.
+
 ### Removed
 
 - **`spaces` is no longer stored on a token — the last of the three, and the pre-3.0 triple is gone.** Every

--- a/docs/integration-guide/04c-chrono-api.md
+++ b/docs/integration-guide/04c-chrono-api.md
@@ -44,6 +44,10 @@ memory. See [Retry Safety](04-brain-api.md#retry-safety).
   corrects itself.
   The derivation applies to the chrono read paths only: `POST /query` reads documents as stored, so the
   same entry is `upcoming` there and `overdue` in `GET /chrono`.
+- `endsAt` — optional ISO 8601. When present it **replaces `startsAt` as the due moment**, so an entry that
+  began last month and ends next year is not overdue. **Nothing validates the order**: an `endsAt` earlier
+  than `startsAt` is stored as sent, and the entry then reads as `overdue` immediately. Check it yourself if
+  that matters.
 - `confidence` — `0`–`1` (optional, useful for predictions)
 - `entityIds` — array of UUID v4 entity IDs (not names); returns `400` if any value is not a valid UUID and `strictLinkage` is enabled
 - `memoryIds` — array of UUID v4 memory IDs (not names); returns `400` if any value is not a valid UUID and `strictLinkage` is enabled

--- a/server/src/mcp/tools/bulk.ts
+++ b/server/src/mcp/tools/bulk.ts
@@ -59,9 +59,24 @@ export const bulk_writeTool: ToolHandler = {
                 additionalProperties: false,
                 properties: {
                   fact:        { type: 'string', minLength: 1, maxLength: 50000, description: 'The fact or memory to store (1–50 000 characters).' },
-                  tags:        { type: 'array', items: { type: 'string' }, description: 'Categorisation tags.' },
-                  entityIds:   { type: 'array', items: { type: 'string' }, description: 'Related entity IDs.' },
-                  description: { type: 'string', description: 'Optional prose context.' },
+                  tags:        {
+                    type: 'array', items: { type: 'string' },
+                    description: 'Categorisation tags. Every memory item is an INSERT, so there is nothing '
+                      + 'to merge with. They are embedded along with the fact, so a tag affects ranking as '
+                      + 'well as being an exact filter.',
+                  },
+                  entityIds:   {
+                    type: 'array', items: { type: 'string' },
+                    description: 'Entity IDs to link this memory to. NEVER checked for existence on this '
+                      + 'door — `remember` refuses an id that does not resolve, and here a well-formed UUID '
+                      + 'pointing at nothing is stored as a dangling link. That is deliberate: a batch may '
+                      + 'reference an entity created LATER in the same payload.',
+                  },
+                  description: {
+                    type: 'string',
+                    description: 'Optional prose context or rationale. Embedded with the fact, so it widens '
+                      + 'what a `recall` can match this memory on.',
+                  },
                   type:        { type: 'string', description: 'Optional memory type — selects the per-type schema used to validate `properties`.' },
                   properties:  {
                     type: 'object',
@@ -113,9 +128,23 @@ export const bulk_writeTool: ToolHandler = {
                 type: 'object',
                 additionalProperties: false,
                 properties: {
-                  from:        { type: 'string', description: 'Source entity ID.' },
-                  to:          { type: 'string', description: 'Target entity ID.' },
-                  label:       { type: 'string', description: 'Relationship label.' },
+                  from:        {
+                    type: 'string',
+                    description: 'The entity the relationship starts at, as a UUID v4. Part of the identity '
+                      + '(from + to + label), so the same triplet twice UPDATES rather than duplicating. '
+                      + 'Checked for shape only under strict linkage, and never for existence.',
+                  },
+                  to:          {
+                    type: 'string',
+                    description: 'The entity the relationship points at, as a UUID v4. Direction matters: '
+                      + 'reversing `from` and `to` is a different edge, not the same one.',
+                  },
+                  label:       {
+                    type: 'string',
+                    description: 'What the relationship IS, e.g. "works_at" or "knows". Required, part of '
+                      + 'the identity alongside `from` and `to`, and embedded — so it is what a `recall` '
+                      + 'ranks this edge on.',
+                  },
                   type:        { type: 'string', description: 'Optional edge type (e.g. "causal", "attribution"). Free text; nothing validates it against a list.' },
                   weight:      {
                     type: 'number',
@@ -152,8 +181,18 @@ export const bulk_writeTool: ToolHandler = {
                 properties: {
                   title:       { type: 'string', description: 'Entry title. Required — an item without one is rejected by index in `errors`.' },
                   type:        { type: 'string', description: 'Entry type (e.g. event, deadline, plan, prediction, milestone, or a custom type defined in the space schema). Checked against the space\'s allowlist, and a type outside it rejects THIS item by index.' },
-                  startsAt:    { type: 'string', description: 'ISO 8601 start date/time. Required.' },
-                  endsAt:      { type: 'string', description: 'Optional ISO 8601 end date/time.' },
+                  startsAt:    {
+                    type: 'string',
+                    description: 'ISO 8601 date/time the entry is ABOUT, not when it was recorded. Required. '
+                      + 'With no `endsAt` it is also the due moment, so a past value on an `upcoming` entry '
+                      + 'makes it read back as `overdue` at once.',
+                  },
+                  endsAt:      {
+                    type: 'string',
+                    description: 'Optional ISO 8601 end. When present it REPLACES `startsAt` as the due '
+                      + 'moment. Nothing validates the order — an `endsAt` before `startsAt` is stored as '
+                      + 'sent and the entry then reads as `overdue` immediately.',
+                  },
                   status:      {
                     type: 'string', enum: ['upcoming', 'active', 'completed', 'overdue', 'cancelled'],
                     description: 'Stored status (default `upcoming`). A value outside this list is DISCARDED '

--- a/server/src/mcp/tools/chrono.ts
+++ b/server/src/mcp/tools/chrono.ts
@@ -24,10 +24,27 @@ export const create_chronoTool: ToolHandler = {
           properties: {
             space: s.requiredSpace,
             id: uuidSchema('UUID v4 of an EXISTING record to update. It is not a way to choose an id: identity is server-generated, so an id that names nothing is ignored rather than adopted. To carry your own reference, use `name` or `description`.'),
-            title: { type: 'string', minLength: 1, description: 'Entry title.' },
+            title: {
+              type: 'string', minLength: 1,
+              description: 'What happened, or is meant to. Required, and it is EMBEDDED — so this is what a '
+                + '`recall` ranks the entry on, and a title like "meeting" is one nothing will ever find. '
+                + 'Nothing deduplicates by it: creating the same title twice stores two entries.',
+            },
             type: { type: 'string', minLength: 1, description: 'Entry type. Rejected unless it is one of the space\'s allowed chrono types: the defaults are event, deadline, plan, prediction, milestone, or the custom set declared in the space\'s typeSchemas.chrono.' },
-            startsAt: { type: 'string', minLength: 1, description: 'ISO 8601 start date/time.' },
-            endsAt: { type: 'string', description: 'Optional ISO 8601 end date/time.' },
+            startsAt: {
+              type: 'string', minLength: 1,
+              description: 'ISO 8601 date/time the entry is ABOUT — not when you recorded it, which is '
+                + '`createdAt` and is what `list_chrono`\'s `after`/`before` filter on. Required. With no '
+                + '`endsAt` this is also the DUE MOMENT, so a past `startsAt` on an `upcoming` entry makes it '
+                + 'read back as `overdue` straight away.',
+            },
+            endsAt: {
+              type: 'string',
+              description: 'Optional ISO 8601 end. When present it REPLACES `startsAt` as the due moment, so '
+                + 'an entry that started last month and ends next year is not overdue. NOTHING VALIDATES THE '
+                + 'ORDER — an `endsAt` before `startsAt` is stored as sent, and the entry then reads as '
+                + '`overdue` immediately.',
+            },
             status: {
               type: 'string', enum: ['upcoming', 'active', 'completed', 'overdue', 'cancelled'], default: 'upcoming',
               description: 'Stored status (default `upcoming`). You do not need `overdue` — it is derived on '
@@ -36,11 +53,30 @@ export const create_chronoTool: ToolHandler = {
                 + 'reverts: an entry marked `overdue` by hand stays overdue after you move its dates '
                 + 'forward, where a derived one would correct itself.',
             },
-            confidence: unitScoreSchema('Confidence level 0–1 (for predictions).'),
-            tags: { type: 'array', items: { type: 'string' }, description: 'Categorisation tags.' },
-            entityIds: { type: 'array', items: { type: 'string' }, description: 'Related entity IDs.' },
-            memoryIds: { type: 'array', items: { type: 'string' }, description: 'Related memory IDs.' },
-            description: { type: 'string', description: 'Optional longer description.' },
+            confidence: unitScoreSchema('How sure you are, 0 to 1, for entries that are predictions rather '
+              + 'than records. Nothing derives it, nothing ranks on it and nothing requires it — it is stored '
+              + 'and returned, and `query` can sort and filter on it.'),
+            tags: {
+              type: 'array', items: { type: 'string' },
+              description: 'Categorisation tags. EMBEDDED along with the title, so a tag affects meaning '
+                + 'ranking as well as being an exact filter for `list_chrono` and `query`.',
+            },
+            entityIds: {
+              type: 'array', items: { type: 'string' },
+              description: 'Entity IDs this entry is about. THIS IS WHAT MAKES IT REACHABLE from the graph: '
+                + '`traverse` follows these (with `includeChrono`, on by default), and they are NOT edges, so '
+                + 'an entry left unlinked is findable only by search or by date. Pass ids, not names.',
+            },
+            memoryIds: {
+              type: 'array', items: { type: 'string' },
+              description: 'Memory IDs this entry relates to. References rather than edges, like '
+                + '`entityIds`; deleting a memory leaves the id here and nothing reports it.',
+            },
+            description: {
+              type: 'string',
+              description: 'Optional longer prose. Embedded with the title, so it widens what a `recall` can '
+                + 'match this entry on — worth filling in when the title has to stay short.',
+            },
             properties: {
               type: 'object',
               description: 'Optional structured key-value metadata for this entry.',
@@ -183,7 +219,9 @@ export const update_chronoTool: ToolHandler = {
     + '- `title` — replaced when sent.\n'
     + '- `type` — `event`, `deadline`, `plan`, `prediction`, `milestone`, or any custom type the space schema '
     + 'defines. Re-validated against the allowlist.\n'
-    + '- `startsAt` / `endsAt` — ISO 8601. `endsAt` before `startsAt` is refused.\n'
+    + '- `startsAt` / `endsAt` — ISO 8601. NOTHING VALIDATES THE ORDER: an `endsAt` before `startsAt` is '
+    + 'stored as sent, and because `endsAt` becomes the due moment the entry then reads as `overdue` at '
+    + 'once. Check it yourself if it matters.\n'
     + '- `status` — `upcoming`, `active`, `completed`, `overdue`, `cancelled`. You never need to set '
     + '`overdue`: it is DERIVED on read, so an entry stored `upcoming` whose due moment has passed already '
     + 'reads back as `overdue` from `list_chrono`, `recall` and a single-entry get. What you set here is the '
@@ -212,11 +250,30 @@ export const update_chronoTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            id: { type: 'string', minLength: 1, description: 'Chrono entry ID.' },
-            title: { type: 'string', description: 'New title.' },
+            id: {
+              type: 'string', minLength: 1,
+              description: 'The entry\'s `_id`, as `list_chrono`, `recall` and `query` report it. '
+                + 'Required, and an id that names nothing is an ERROR rather than a silent no-op.',
+            },
+            title: {
+              type: 'string',
+              description: 'Replaces the stored title. It is embedded, so changing it changes what a `recall` '
+                + 'matches this entry on. It is also a REQUIRED field, which is why `deleteFields: ["title"]` '
+                + 'is refused by name rather than accepted and ignored.',
+            },
             type: { type: 'string', description: 'Entry type (e.g. event, deadline, plan, prediction, milestone, or a custom type defined in the space schema).' },
-            startsAt: { type: 'string', description: 'New ISO 8601 start date/time.' },
-            endsAt: { type: 'string', description: 'New ISO 8601 end date/time.' },
+            startsAt: {
+              type: 'string',
+              description: 'Replaces the stored ISO 8601 start. With no `endsAt` it is the DUE MOMENT, so '
+                + 'moving it forward is what un-overdues an entry that has gone late — the status is derived '
+                + 'from this, not stored.',
+            },
+            endsAt: {
+              type: 'string',
+              description: 'Replaces the stored ISO 8601 end, and takes over from `startsAt` as the due '
+                + 'moment. NOTHING VALIDATES THE ORDER — an `endsAt` before `startsAt` is stored as sent and '
+                + 'makes the entry read as `overdue` at once. Clearing it needs `deleteFields: ["endsAt"]`.',
+            },
             status: {
               type: 'string', enum: ['upcoming', 'active', 'completed', 'overdue', 'cancelled'],
               description: 'The new STORED status. You never need to set `overdue`: it is DERIVED on read '
@@ -492,7 +549,13 @@ export const delete_chronoTool: ToolHandler = {
     type: 'object',
     properties: {
       space: s.requiredSpace,
-      id: { type: 'string', minLength: 1, description: 'Chrono entry ID to delete.' },
+      id: {
+        type: 'string', minLength: 1,
+        description: 'The entry\'s `_id`. An id that does not exist is an ERROR, not a silent success. '
+          + 'The entities and memories it links are NOT touched — those are references, and deleting the '
+          + 'entry only drops them. A tombstone is written, so re-creating it with the same id does not '
+          + 'undo this.',
+      },
       targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
     },
     required: ['space', 'id'],

--- a/server/src/mcp/tools/edge.ts
+++ b/server/src/mcp/tools/edge.ts
@@ -28,8 +28,16 @@ export const upsert_edgeTool: ToolHandler = {
             to: { type: 'string', minLength: 1, description: 'Target entity ID (a UUID v4; required to be an existing entity ID when the space uses strict linkage).' },
             label: { type: 'string', minLength: 1, description: 'Relationship label (e.g. "works_at", "knows").' },
             type: { type: 'string', description: 'Optional edge type (e.g. "causal", "attribution").' },
-            weight: unitScoreSchema('Optional edge weight (0–1).'),
-            tags: { type: 'array', items: { type: 'string' }, description: 'Categorisation tags.' },
+            weight: unitScoreSchema('Optional strength for this relationship, 0 to 1. Nothing derives it '
+              + 'and nothing ranks on it — it is stored, returned, and sortable by `query`, so it means '
+              + 'whatever you decide it means. The 0–1 bound is enforced HERE and not on `bulk_write`, whose '
+              + 'per-item schemas are for discovery only.'),
+            tags: {
+              type: 'array', items: { type: 'string' },
+              description: 'Categorisation tags. MERGED over the stored tags when the same triplet already '
+                + 'exists, so no value here removes one. They are part of what gets embedded, so a tag '
+                + 'affects how this edge ranks in a `recall` as well as being filterable.',
+            },
             description: { type: 'string', description: 'Optional prose description of why this relationship exists.' },
             properties: {
               type: 'object',
@@ -144,12 +152,38 @@ export const update_edgeTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            id: { type: 'string', minLength: 1, description: 'Edge ID to update.' },
-            label: { type: 'string', description: 'New relationship label.' },
-            type: { type: 'string', description: 'New edge type.' },
-            weight: unitScoreSchema('New edge weight (0–1).'),
-            description: { type: 'string', description: 'New prose description.' },
-            tags: { type: 'array', items: { type: 'string' }, description: 'Tags to merge with existing tags.' },
+            id: {
+              type: 'string', minLength: 1,
+              description: 'The edge\'s `_id`, as `traverse`, `recall` and `query` report it. Required, '
+                + 'and an id that names nothing is an ERROR rather than a silent no-op. Note this addresses '
+                + 'the edge by id, while `upsert_edge` addresses it by the from/to/label TRIPLET.',
+            },
+            label: {
+              type: 'string',
+              description: 'Replaces the relationship label. It is part of the identity `upsert_edge` uses '
+                + '(from + to + label), so renaming it here means a later `upsert_edge` with the OLD label '
+                + 'creates a second edge instead of updating this one. It is also embedded, so it changes '
+                + 'how this edge ranks.',
+            },
+            type: {
+              type: 'string',
+              description: 'Replaces the edge type (e.g. "causal", "attribution"). Free text — nothing '
+                + 'validates it against a list, and it is not part of the edge\'s identity.',
+            },
+            weight: unitScoreSchema('Replaces the stored weight, 0 to 1. Omitting it leaves the old value '
+              + 'in place, so there is no value here that clears one — use `deleteFields: ["weight"]`.'),
+            description: {
+              type: 'string',
+              description: 'Replaces the prose explanation of why this relationship exists. Embedded with '
+                + 'the label, so it widens what a `recall` can match this edge on. Clearing it needs '
+                + '`deleteFields: ["description"]`.',
+            },
+            tags: {
+              type: 'array', items: { type: 'string' },
+              description: 'MERGED into the stored tags, never replacing them — so no value here removes a '
+                + 'tag. `update_memory` and `update_chrono` REPLACE the same field; this tool and '
+                + '`update_entity` merge. Removing one is `deleteFields`, with `tags` for all of them.',
+            },
             properties: {
               type: 'object',
               description: 'Key-value properties to merge with existing. Values must be string, number, or boolean.',
@@ -315,7 +349,12 @@ export const delete_edgeTool: ToolHandler = {
     type: 'object',
     properties: {
       space: s.requiredSpace,
-      id: { type: 'string', minLength: 1, description: 'Edge ID to delete.' },
+      id: {
+        type: 'string', minLength: 1,
+        description: 'The edge\'s `_id`. An id that does not exist is an ERROR, not a silent success. '
+          + 'Deleting an edge NEVER touches the two entities it joined — it removes the relationship only. A '
+          + 'tombstone is written, so re-creating it with the same id does not undo this.',
+      },
       targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
     },
     required: ['space', 'id'],

--- a/server/src/mcp/tools/embed.ts
+++ b/server/src/mcp/tools/embed.ts
@@ -116,7 +116,12 @@ export const retry_record_embeddingTool: ToolHandler = {
     type: 'object',
     properties: {
       space: s.requiredSpace,
-      recordType: { type: 'string', enum: RECORD_TYPES, description: 'Which collection the record is in.' },
+      recordType: {
+        type: 'string', enum: RECORD_TYPES,
+        description: 'Which collection the record lives in. Required alongside `recordId` because ids are '
+          + 'only unique within a collection, so the pair is what names one record — a wrong `recordType` '
+          + 'finds nothing rather than finding the wrong thing.',
+      },
       recordId: { type: 'string', minLength: 1, description: 'The record\'s _id, as list_embed_jobs reports it.' },
       targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space holding the record.' },
     },

--- a/server/src/mcp/tools/entity.ts
+++ b/server/src/mcp/tools/entity.ts
@@ -22,7 +22,13 @@ export const upsert_entityTool: ToolHandler = {
           properties: {
             space: s.requiredSpace,
             id: uuidSchema('UUID v4 of an EXISTING record to update. It is not a way to choose an id: identity is server-generated, so an id that names nothing is ignored rather than adopted. To carry your own reference, use `name` or `description`.'),
-            name: { type: 'string', minLength: 1, description: 'Entity name.' },
+            name: {
+              type: 'string', minLength: 1,
+              description: 'Entity name. NOTHING DEDUPLICATES BY IT — omit `id` and a NEW record is always '
+                + 'inserted, even when an entity of the same name already exists, so two entities may share '
+                + 'a name. Call `find_entities_by_name` first if you meant to update one. The name is '
+                + 'embedded, so it also affects how `recall` ranks this entity.',
+            },
             type: { type: 'string', minLength: 1, description: 'Entity type (person, place, concept, …).' },
             tags: {
               type: 'array', items: { type: 'string' },
@@ -151,11 +157,36 @@ export const update_entityTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            id: { type: 'string', minLength: 1, description: 'Entity ID to update.' },
-            name: { type: 'string', description: 'New entity name.' },
-            type: { type: 'string', description: 'New entity type.' },
-            description: { type: 'string', description: 'New prose description or summary.' },
-            tags: { type: 'array', items: { type: 'string' }, description: 'Tags to merge with existing tags.' },
+            id: {
+              type: 'string', minLength: 1,
+              description: 'The entity\'s `_id`, as `find_entities_by_name`, `recall` and `query` report '
+                + 'it. Required, and an id that names nothing is an ERROR rather than a silent no-op.',
+            },
+            name: {
+              type: 'string',
+              description: 'Replaces the stored name. Renaming does not merge anything: edges point at the '
+                + 'id, so they follow automatically, but a SECOND entity that already carries the new name '
+                + 'stays a separate record — use `merge_entities` for that.',
+            },
+            type: {
+              type: 'string',
+              description: 'Replaces the stored type. It selects the per-type schema used to validate '
+                + '`properties`, so changing it re-validates the record against a DIFFERENT set of rules — a '
+                + 'move that was valid under the old type can be refused under the new one.',
+            },
+            description: {
+              type: 'string',
+              description: 'Replaces the stored description. Embedded alongside the name and type, so it '
+                + 'widens what a `recall` can match. An omitted field is left alone, so clearing it needs '
+                + '`deleteFields: ["description"]`.',
+            },
+            tags: {
+              type: 'array', items: { type: 'string' },
+              description: 'MERGED into the stored tags, never replacing them — sending `["b"]` on an entity '
+                + 'tagged `["a"]` leaves it `["a","b"]`, so no value here removes a tag. `update_memory` and '
+                + '`update_chrono` REPLACE the same field. Removing one is `deleteFields`, with `tags` for '
+                + 'all of them.',
+            },
             properties: {
               type: 'object',
               description: 'Key-value properties to merge with existing (e.g. {"wheels": 4}). Values must be string, number, or boolean.',
@@ -373,7 +404,13 @@ export const find_entities_by_nameTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            name: { type: 'string', minLength: 1, description: 'Exact entity name to look up.' },
+            name: {
+              type: 'string', minLength: 1,
+              description: 'The name to look up, matched EXACTLY and case-sensitively — no substring, no '
+                + 'fuzzy, no synonym. An empty result therefore does NOT mean the entity is absent, only that '
+                + 'nothing carries that exact string; `recall` is what answers "is there anything about X". '
+                + 'Several results is the normal signal that duplicates exist.',
+            },
           },
           required: ['space', 'name'],
           additionalProperties: false,
@@ -419,7 +456,13 @@ export const delete_entityTool: ToolHandler = {
     type: 'object',
     properties: {
       space: s.requiredSpace,
-      id: { type: 'string', minLength: 1, description: 'Entity ID to delete.' },
+      id: {
+        type: 'string', minLength: 1,
+        description: 'The entity\'s `_id`. An id that does not exist is an ERROR, not a silent success. In '
+          + 'a space with strict linkage the delete is REFUSED while anything still references this entity, '
+          + 'which is the one delete tool that behaves that way. A tombstone is written, so re-creating the '
+          + 'record with the same id does not undo it.',
+      },
       targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
     },
     required: ['space', 'id'],

--- a/server/src/mcp/tools/entity.ts
+++ b/server/src/mcp/tools/entity.ts
@@ -274,9 +274,20 @@ export const merge_entitiesTool: ToolHandler = {
               items: {
                 type: 'object',
                 properties: {
-                  key: { type: 'string', description: 'Property key to resolve.' },
+                  key: {
+                    type: 'string',
+                    description: 'The property name, exactly as the 409 conflict plan reported it. Only '
+                      + 'CONFLICTING properties appear there and only those need resolving — ones the two '
+                      + 'records agree on, or that only one of them has, are carried over without being '
+                      + 'listed and must not be sent here.',
+                  },
                   resolution: { type: 'string', pattern: '^(survivor|absorbed|custom|fn:(avg|min|max|sum|and|or|xor))$', description: 'One of: "survivor", "absorbed", "custom" (requires customValue), or "fn:<name>" where <name> is a numeric merge (avg, min, max, sum) or boolean merge (and, or, xor).' },
-                  customValue: { description: 'Required when resolution is "custom".' },
+                  customValue: {
+                    description: 'The value to store, required when `resolution` is "custom" and ignored '
+                      + 'otherwise. This is the escape hatch for strings: no function can combine two of '
+                      + 'them sensibly, so a string conflict is "survivor", "absorbed", or a value you '
+                      + 'write yourself.',
+                  },
                 },
                 required: ['key', 'resolution'],
                 additionalProperties: false,

--- a/server/src/mcp/tools/file.ts
+++ b/server/src/mcp/tools/file.ts
@@ -1,6 +1,6 @@
 import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.js';
 import { recall } from '../../brain/recall.js';
-import { TTL_DAYS_SCHEMA, ttlDaysFromArgs } from './shared.js';
+import { TTL_DAYS_SCHEMA, filePathSchema, ttlDaysFromArgs } from './shared.js';
 import { type InputFormat } from '../../files/converters/pipeline.js';
 import { renameFileMeta, renameFileMetaByPrefix, upsertFileMeta } from '../../files/file-meta.js';
 import { createDir, listDir, listFilesRecursive, moveFile, readFile, writeFile } from '../../files/files.js';
@@ -23,7 +23,8 @@ export const read_fileTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            path: { type: 'string', minLength: 1, description: 'File path relative to the space root.' },
+            path: filePathSchema('This is a LOOKUP, not a search: an unknown path is an error rather '
+              + 'than an empty result, and nothing here matches a partial name.'),
           },
           required: ['space', 'path'],
           additionalProperties: false,
@@ -54,10 +55,22 @@ export const write_fileTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            path: { type: 'string', minLength: 1, description: 'File path relative to the space root.' },
-            content: { type: 'string', description: 'Text content to write.' },
+            path: filePathSchema('An existing file at this path is OVERWRITTEN without a warning, and '
+              + 'missing parent directories are created for you.'),
+            content: {
+              type: 'string',
+              description: 'The ENTIRE new contents. There is no append and no patch — whatever you send '
+                + 'replaces the whole file, so read it first if you meant to add to it. It is chunked and '
+                + 'each chunk embedded separately, which is why structure matters: a chunk beginning under a '
+                + 'heading carries that heading, and that is what makes a recall hit locatable.',
+            },
             description: { type: 'string', description: 'Optional human-readable summary stored as file metadata.' },
-            tags: { type: 'array', items: { type: 'string' }, description: 'Optional tags for filtering and recall.' },
+            tags: {
+              type: 'array', items: { type: 'string' },
+              description: 'Tags stored on the file\'s metadata record. REPLACES the stored list on a '
+                + 'rewrite; `update_file_meta` replaces too, unlike the brain update tools, which merge. '
+                + 'Filterable by `query` on the `files` collection and by `recall`\'s own filter.',
+            },
             properties: {
               type: 'object',
               description: 'Optional structured key-value metadata for this file.',
@@ -199,7 +212,9 @@ export const delete_fileTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            path: { type: 'string', minLength: 1, description: 'File path relative to the space root.' },
+            path: filePathSchema('IRREVERSIBLE — the bytes, the metadata record and every chunk '
+              + 'embedding go together, and a tombstone under this path stops a peer restoring it. A path '
+              + 'that does not exist is an error, not a silent success.'),
             targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
           },
           required: ['space', 'path'],
@@ -290,8 +305,11 @@ export const move_fileTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            src: { type: 'string', minLength: 1, description: 'Source path.' },
-            dst: { type: 'string', minLength: 1, description: 'Destination path.' },
+            src: filePathSchema('The existing file OR directory to move. Moving a directory carries '
+              + 'everything under it, including each file\'s metadata record.'),
+            dst: filePathSchema('Where it should end up. NOTHING CHECKS THIS FIRST — the move is a '
+              + 'rename, so an existing file here is REPLACED with no refusal and no warning. Missing parent '
+              + 'directories are created. The file is not re-read, so a failed extraction stays failed.'),
             targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
           },
           required: ['space', 'src', 'dst'],
@@ -355,7 +373,9 @@ export const retry_embeddingTool: ToolHandler = {
     type: 'object',
     properties: {
       space: s.requiredSpace,
-      path: { type: 'string', minLength: 1, description: 'File path relative to the space root.' },
+      path: filePathSchema('The file must already exist and its indexing must have FAILED — retrying '
+        + 'one that succeeded, or one still queued, does nothing useful. `list_embed_jobs` is where the '
+        + 'failures and their reasons are.'),
       targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
     },
     required: ['space', 'path'],
@@ -446,11 +466,32 @@ export const update_file_metaTool: ToolHandler = {
       space: s.requiredSpace,
       path: { type: 'string', minLength: 1, description: 'The file path within the space, as list_dir reports it.' },
       description: { type: 'string', description: 'Replaces the description. Omit to leave it unchanged.' },
-      tags: { type: 'array', items: { type: 'string' }, description: 'Replaces the tag list.' },
-      properties: { type: 'object', description: 'Replaces the properties object.' },
-      entityIds: { type: 'array', items: { type: 'string' }, description: 'Entity ids this file relates to.' },
-      memoryIds: { type: 'array', items: { type: 'string' }, description: 'Memory ids this file relates to.' },
-      chronoIds: { type: 'array', items: { type: 'string' }, description: 'Chrono ids this file relates to.' },
+      tags: {
+        type: 'array', items: { type: 'string' },
+        description: 'REPLACES the stored tag list — send the FULL list, because sending one tag drops the '
+          + 'rest. This is the opposite of `update_entity` and `update_edge`, which MERGE the same field.',
+      },
+      properties: {
+        type: 'object',
+        description: 'REPLACES the whole properties object — keys you do not send are DELETED, where the '
+          + 'brain update tools merge key by key and keep them. Send the complete map you want stored.',
+      },
+      entityIds: {
+        type: 'array', items: { type: 'string' },
+        description: 'REPLACES the stored entity links. These are what let `traverse` reach the file from '
+          + 'an entity; they are not edges, so a file with an empty list is reachable only by path or by '
+          + 'search.',
+      },
+      memoryIds: {
+        type: 'array', items: { type: 'string' },
+        description: 'REPLACES the stored memory links — send the full list, because sending one drops the '
+          + 'rest.',
+      },
+      chronoIds: {
+        type: 'array', items: { type: 'string' },
+        description: 'REPLACES the stored chrono links — send the full list, because sending one drops the '
+          + 'rest.',
+      },
       deleteFields: {
         type: 'array', items: { type: 'string' },
         description: 'Dot-notation paths to REMOVE, applied after the merge — the only way to unset, since an '

--- a/server/src/mcp/tools/memory.ts
+++ b/server/src/mcp/tools/memory.ts
@@ -24,7 +24,8 @@ import { mergePropertiesOrKeep } from '../../brain/merge-fields.js';
 export const rememberTool: ToolHandler = {
   name: 'remember',
   description: 'Store a fact in the knowledge graph. It is embedded for semantic search, so write it as a SENTENCE that carries its own context — a memory retrieved months later arrives without the conversation it was written in, and "he agreed to the change" is unusable on its own.\n\n'
-    + 'Always an INSERT. There is no id to update and nothing deduplicates: remembering the same fact twice stores it twice, and both then compete for the same result slots in a recall. Search before writing if a fact may already be there, and use `update_memory` when you mean to revise one.\n\n'
+    + 'WITHOUT `id` IT IS ALWAYS AN INSERT, and nothing deduplicates by content: remembering the same fact twice stores it twice, and both then compete for the same result slots in a recall. Search before writing if a fact may already be there, and use `update_memory` when you mean to revise one.\n\n'
+    + 'WITH an `id` that already names a record it CONVERGES instead of duplicating — that is the retry-safety contract, and it is why a repeated call after a timeout is safe. Convergence MERGES, the same way `upsert_entity` does: tags are unioned and properties shallow-merged over what is stored, so a partial payload does not erase the rest. An id that names nothing is ignored rather than adopted; identity is server-generated.\n\n'
     + 'Embedding is ASYNCHRONOUS. The write returns as soon as the record is stored, and a queued job computes the vector — so a `recall` issued seconds later may not find what you just wrote. Pass `includeFreshWrites: true` on that recall to read straight from the collection instead of waiting.\n\n'
     + 'IF THE SPACE VALIDATES, a refusal names WHOSE FAULT it is: `introduced` are violations this write caused and are what refuses it; `preExisting` were already stored, are reported, and do NOT block. Branch on `introduced`.',
   mutating: true,
@@ -43,7 +44,10 @@ export const rememberTool: ToolHandler = {
             tags: {
               type: 'array',
               items: { type: 'string' },
-              description: 'Categorisation tags.',
+              description: 'Categorisation tags. They are part of what gets EMBEDDED, so a tag influences '
+                + 'meaning-ranking as well as being a filter — and they are filterable exactly, by `query` on '
+                + '`tags` and by `recall`\'s own `filter`. On the idempotent path (an `id` naming an entry '
+                + 'that already exists) they are MERGED over the stored list rather than replacing it.',
             },
             description: { type: 'string', description: 'Optional prose context or rationale for this memory.' },
             type: { type: 'string', description: 'Optional memory type (e.g. "note", "decision"). Selects the per-type schema used to validate `properties` — see the space\'s typeSchemas.memory.' },
@@ -198,11 +202,33 @@ export const update_memoryTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            id: { type: 'string', description: 'Memory ID to update.' },
-            fact: { type: 'string', description: 'New fact text (triggers re-embedding).' },
-            tags: { type: 'array', items: { type: 'string' }, description: 'New tags (replaces existing).' },
+            id: {
+              type: 'string',
+              description: 'The memory\'s `_id`, as `recall`, `query` and the list endpoints report it. '
+                + 'Required. An id that names nothing is an ERROR, not a silent no-op — so a failed update '
+                + 'is something you find out about rather than something you assume worked.',
+            },
+            fact: {
+              type: 'string',
+              description: 'Replaces the stored fact. Write it as a SENTENCE carrying its own context: it is '
+                + 'what gets embedded, and a memory read back months later arrives without the conversation '
+                + 'it was written in. A re-embed is queued after EVERY successful update, not only when this '
+                + 'field changes, so there is nothing to trigger by hand.',
+            },
+            tags: {
+              type: 'array', items: { type: 'string' },
+              description: 'REPLACES the stored tag list — send the FULL list you want the memory to end up '
+                + 'with, because sending one tag drops the rest. `update_entity` and `update_edge` MERGE tags '
+                + 'instead; this tool and `update_chrono` replace, and the split is not guessable from the '
+                + 'field name. To clear them, send `deleteFields: ["tags"]`.',
+            },
             entityIds: { type: 'array', items: { type: 'string', pattern: UUID_V4_PATTERN }, description: 'New entity ID links (UUID v4, replaces existing). Every id must reference an existing entity.' },
-            description: { type: 'string', description: 'New prose description or context.' },
+            description: {
+              type: 'string',
+              description: 'Replaces the stored prose context. Embedded alongside the fact, so it widens what '
+                + 'a `recall` can match this memory on. An omitted field is left alone, so there is no value '
+                + 'that clears it — use `deleteFields: ["description"]`.',
+            },
             properties: {
               type: 'object',
               description: 'Key-value properties to merge into the stored map (e.g. {"source": "manual"}) — keys you do not name are kept. Use deleteFields to remove one. Values must be string, number, or boolean.',
@@ -302,7 +328,13 @@ export const delete_memoryTool: ToolHandler = {
           type: 'object',
           properties: {
             space: s.requiredSpace,
-            id: { type: 'string', minLength: 1, description: 'Memory ID to delete.' },
+            id: {
+              type: 'string', minLength: 1,
+              description: 'The memory\'s `_id`, as `recall` and `query` report it. An id that does not exist '
+                + 'is an ERROR, not a silent success, so a successful reply means a record really was '
+                + 'deleted. A tombstone is written under this id, which is why re-creating the record with '
+                + 'it does not undo the delete.',
+            },
             targetSpace: { type: 'string', description: 'Required for proxy spaces: the member space to write to.' },
           },
           required: ['space', 'id'],

--- a/server/src/mcp/tools/search.ts
+++ b/server/src/mcp/tools/search.ts
@@ -435,7 +435,12 @@ export const queryTool: ToolHandler = {
             collection: {
               type: 'string',
               enum: ['memories', 'entities', 'edges', 'chrono', 'files'],
-              description: 'Collection to query.',
+              description: 'Which collection to read. ONE per call — there is no cross-collection query, so '
+                + 'answering "everything about X" means one call each. The listed names are the whole set, '
+                + 'and they also decide which `sort` fields are legal and which `filter` keys exist: an '
+                + '`edges` filter has `from`/`to`/`label`, a `chrono` one has `startsAt`/`status`, and a '
+                + 'predicate naming a field the collection does not have simply matches nothing rather than '
+                + 'failing.',
             },
             filter: {
               type: 'object',

--- a/server/src/mcp/tools/shared.ts
+++ b/server/src/mcp/tools/shared.ts
@@ -89,6 +89,31 @@ export function unitScoreSchema(description: string) {
 }
 
 /**
+ * A file-store path argument, shared by the five tools that take one.
+ *
+ * It was the same 37-character sentence copied four times — "File path relative to the space root." —
+ * which is true and says nothing a caller could not read off the key. The three facts below are the ones
+ * that actually decide whether a call works, and all three come from `files/sandbox.ts`:
+ *
+ * - a LEADING SLASH IS STRIPPED rather than refused, so `/a/b.md` and `a/b.md` are the same file. Browsers
+ *   supply the first form and nothing warns you they are the same;
+ * - paths are NFC-normalised, so two Unicode spellings of one accented name resolve to one path;
+ * - a `..` that would leave the space is refused outright.
+ *
+ * `extra` carries what differs per tool — whether the path must exist, and what happens if it does.
+ */
+export function filePathSchema(extra: string) {
+  return {
+    type: 'string',
+    minLength: 1,
+    description: 'Path relative to the space root, exactly as `list_dir` and `recall` report it. ' + extra
+      + ' A LEADING SLASH IS STRIPPED rather than refused, so `/notes/a.md` and `notes/a.md` name the same '
+      + 'file; the path is Unicode-normalised, so two spellings of one accented name resolve together; and '
+      + 'a `..` that would leave the space is refused.',
+  } as const;
+}
+
+/**
  * The chrono `recurrence` block, shared by `create_chrono` and `update_chrono`.
  *
  * It was two near-identical literals differing only in the word "Optional", and `freq` — the one REQUIRED

--- a/server/src/mcp/tools/spaces.ts
+++ b/server/src/mcp/tools/spaces.ts
@@ -441,7 +441,13 @@ export const create_spaceTool: ToolHandler = {
   inputSchema: (_s: ToolSchemas) => ({
     type: 'object',
     properties: {
-      label: { type: 'string', minLength: 1, maxLength: 200, description: 'Display label (1–200 chars). Required.' },
+      label: {
+        type: 'string', minLength: 1, maxLength: 200,
+        description: 'Human-readable name for the space, 1 to 200 characters. Required, and it is NOT the '
+          + 'identity — the `id` is, and it is derived from this label when you omit one. Two spaces may '
+          + 'carry the same label; nothing deduplicates on it. Changing it later never moves data, because '
+          + 'nothing is keyed on it.',
+      },
       id: {
         type: 'string', minLength: 1, maxLength: 40, pattern: '^[a-z0-9-]+$',
         description: 'Space id — lowercase letters, digits and hyphens. Derived from the label when omitted.',

--- a/testing/standalone/chrono-status-descriptions-match-the-derivation.test.js
+++ b/testing/standalone/chrono-status-descriptions-match-the-derivation.test.js
@@ -176,6 +176,32 @@ describe('no tool repeats the claim that was false', () => {
     assert.deepEqual(offenders, [], 'these still describe CH-1 as open:\n  ' + offenders.join('\n  '));
   });
 
+  it('nor that an out-of-order endsAt is refused, because nothing checks it', () => {
+    // `update_chrono` said "`endsAt` before `startsAt` is refused". Nothing anywhere implements that: the
+    // REST route validates `startsAt`'s presence and type, `validateChrono` never looks at either field,
+    // and no test pinned a refusal. So a caller relying on it stored an entry whose `endsAt` precedes its
+    // `startsAt` — which then reads as `overdue` at once, because `endsAt` becomes the due moment.
+    //
+    // Third false claim found in this one area, and the pattern in all three is the same: a confident
+    // sentence about a check that does not exist.
+    const offenders = [];
+    for (const t of ALL_TOOLS) {
+      const text = (t.description ?? '') + JSON.stringify(t.inputSchema(STUB));
+      if (/endsAt[^.]{0,40}(is )?refused/i.test(text)) offenders.push(t.name);
+    }
+    assert.deepEqual(offenders, [],
+      'these promise an ordering check the code does not perform:\n  ' + offenders.join('\n  '));
+
+    // And the code really does not perform one — asserted rather than assumed, so this gate flips the day
+    // somebody adds the validation instead of quietly forbidding the truthful sentence for ever.
+    const routes = stripComments(readFileSync('server/src/api/brain/chrono.ts', 'utf8'));
+    const validation = stripComments(readFileSync('server/src/spaces/schema-validation.ts', 'utf8'));
+    for (const [name, src] of [['the REST route', routes], ['schema validation', validation]]) {
+      assert.doesNotMatch(src, /endsAt[\s\S]{0,60}?[<>]=?[\s\S]{0,20}?startsAt/,
+        `${name} now compares the two — the descriptions may say it is refused, and should`);
+    }
+  });
+
   it('and `list_chrono` says the filter returns BOTH kinds', () => {
     const t = ALL_TOOLS.find(x => x.name === 'list_chrono');
     const text = (t.description ?? '') + JSON.stringify(t.inputSchema(STUB));

--- a/testing/standalone/one-merge-rule.test.js
+++ b/testing/standalone/one-merge-rule.test.js
@@ -181,10 +181,37 @@ describe('one merge rule', () => {
     it('update_memory documents tags as a REPLACE and update_entity as a union', () => {
       // Not an oversight to be tidied away: both halves are written down, so a future sweep that
       // "unifies" them is changing documented behaviour and has to say so.
-      assert.match(schema('server/src/mcp/tools/memory.ts'), /New tags \(replaces existing\)/,
+      //
+      // Asserted on the RULE, not on a phrase. This required the literals `New tags (replaces existing)`
+      // and `Tags to merge with existing tags`, so rewriting either description to say the SAME thing at
+      // more length turned a documentation improvement into a red gate. A pinned sentence is a pinned
+      // sentence even when the sentence is correct — and the version of this mistake that costs something
+      // is the one where the sentence is wrong, which `read-tools-state-their-blind-spots` shipped.
+      const tagsDescriptionOf = (file) => {
+        const src = schema(file);
+        const at = src.indexOf('export const update_');
+        assert.ok(at > 0, `${file}: no update tool found — the scanner is wrong, not the code`);
+        const tagsAt = src.indexOf('tags: {', at);
+        assert.ok(tagsAt > at, `${file}: the update tool declares no tags parameter`);
+        // The description VALUE, including the `+ '…'` continuation lines it is usually built from. Bounding
+        // at the property's closing `},` looked right and was not: `items: { type: 'string' },` closes
+        // first, so the slice stopped before the description began and the match failed on an empty string.
+        // A brace-counting bound would work; matching the value itself is simpler and says what it wants.
+        const m = /description:\s*((?:'(?:[^'\\]|\\.)*'\s*\+?\s*)+)/.exec(src.slice(tagsAt));
+        assert.ok(m, `${file}: the tags parameter has no description at all`);
+        assert.ok(m[1].length > 40, `${file}: captured only ${m[1].length} chars — the scanner is wrong`);
+        return m[1];
+      };
+
+      assert.match(tagsDescriptionOf('server/src/mcp/tools/memory.ts'), /\breplaces?\b/i,
         'update_memory still documents replace semantics for tags');
-      assert.match(schema('server/src/mcp/tools/entity.ts'), /Tags to merge with existing tags/,
+      assert.doesNotMatch(tagsDescriptionOf('server/src/mcp/tools/memory.ts'), /\bmerged into\b/i,
+        'and must not also claim to merge them');
+
+      assert.match(tagsDescriptionOf('server/src/mcp/tools/entity.ts'), /\bmerge[ds]?\b/i,
         'update_entity still documents union semantics for tags');
+      assert.doesNotMatch(tagsDescriptionOf('server/src/mcp/tools/entity.ts'), /\breplaces the stored tag\b/i,
+        'and must not also claim to replace them');
     });
 
     it('every update tool that merges properties says so in its schema', () => {

--- a/testing/standalone/remember-describes-its-idempotent-path.test.js
+++ b/testing/standalone/remember-describes-its-idempotent-path.test.js
@@ -1,0 +1,104 @@
+/**
+ * `remember`'s description agrees with `remember`'s code about whether an `id` updates anything.
+ *
+ * ## The defect
+ *
+ * The tool description said, in its second paragraph:
+ *
+ * > "Always an INSERT. **There is no id to update** and nothing deduplicates …"
+ *
+ * The schema sitting directly beside it declared `id: uuidSchema('UUID v4 of an EXISTING record to
+ * update…')`, and `brain/memory.ts` has the branch to match — a supplied id that already names a record
+ * CONVERGES, unioning tags and shallow-merging properties exactly as `upsertEntity` does. That branch is the
+ * retry-safety contract: it is what makes a repeated call after a timeout safe.
+ *
+ * So one tool told a caller two opposite things about the same parameter, and the wrong half was the prose —
+ * which is what a client shows first. A caller who believed it would retry a timed-out write by issuing a
+ * fresh insert, and get two records where the feature exists to give them one.
+ *
+ * Found while rewriting the thin parameter descriptions, not by looking for it. Same shape as the chrono
+ * `status` paragraph in the release before: a sentence that was authoritative, prominent, and false.
+ *
+ * ## Why this asserts against the code
+ *
+ * A gate that pins the corrected sentence is a spelling check — it goes green the moment somebody rephrases
+ * the same wrong claim. The branch is read from `brain/memory.ts`, and the description is held to it.
+ *
+ * Run: node --test testing/standalone/remember-describes-its-idempotent-path.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripComments } from './_strip-comments.mjs';
+
+let ALL_TOOLS;
+before(async () => {
+  ({ ALL_TOOLS } = await import('../../server/dist/mcp/tools/index.js'));
+});
+
+const STUB = {
+  requiredSpace: { type: 'string', description: 'Space ID to operate on.' },
+  optionalSpace: { type: 'string', description: 'Optional space ID.' },
+};
+const remember = () => ALL_TOOLS.find(t => t.name === 'remember');
+
+describe('the code really does converge on a supplied id', () => {
+  const src = () => stripComments(readFileSync('server/src/brain/memory.ts', 'utf8'));
+
+  it('there is an existing-record branch, and it merges rather than replacing', () => {
+    const s = src();
+    const at = s.indexOf('if (existing)');
+    assert.ok(at > 0, 'the idempotent branch was not found — the scanner is wrong, not the code');
+    // Bounded by the branch's own closing brace at that indentation, not by a character count: a count
+    // spans different lines on a CRLF working copy than on CI's LF checkout.
+    const branch = s.slice(at, s.indexOf('\n  }', at));
+    assert.match(branch, /mergeTags\(existing\.tags, tags\)/, 'tags are unioned');
+    assert.match(branch, /mergeProperties\(existing\.properties, properties\)/, 'properties are shallow-merged');
+  });
+
+  it('and `remember` accepts an id at all', () => {
+    const schema = remember().inputSchema(STUB);
+    assert.ok(schema.properties.id, 'the parameter the description denied the existence of');
+    assert.ok(!schema.required.includes('id'), 'but it is optional — without one every call inserts');
+  });
+});
+
+describe('the description agrees with it', () => {
+  it('does NOT claim there is no id to update', () => {
+    // The exact sentence that was there, refused case-insensitively — the paragraph it lived in was
+    // capitalised, and a case-sensitive pattern let a restored copy through on the chrono gate.
+    const text = remember().description ?? '';
+    assert.doesNotMatch(text, /there is no id to update/i,
+      'the `id` parameter is right beside this sentence, and the branch it denies is the retry contract');
+    assert.doesNotMatch(text, /^always an insert/im,
+      'unqualified, that reads as covering the id case too — say "without `id`"');
+  });
+
+  it('says what an id DOES, and that convergence merges', () => {
+    const text = remember().description ?? '';
+    assert.match(text, /converge/i, 'a caller retrying a timed-out write needs to know it is safe');
+    assert.match(text, /merge[sd]?/i, 'and that a partial payload will not erase the rest');
+  });
+
+  it('and still says the no-id case inserts and does not deduplicate', () => {
+    // The half that was TRUE must survive the correction. Storing the same fact twice really does store it
+    // twice, and that was worth warning about.
+    const text = remember().description ?? '';
+    assert.match(text, /insert/i);
+    assert.match(text, /deduplicat/i);
+  });
+
+  it('the pattern really matches the sentence it exists to refuse', () => {
+    // Mutation-proof for the regex itself: a gate that misses its own subject reports clean, which is worse
+    // than no gate because the wrong sentence then looks reviewed.
+    const ORIGINAL = 'Always an INSERT. There is no id to update and nothing deduplicates: remembering the '
+      + 'same fact twice stores it twice.';
+    assert.match(ORIGINAL, /there is no id to update/i);
+    assert.match(ORIGINAL, /^always an insert/im);
+    const CORRECTED = 'WITHOUT `id` IT IS ALWAYS AN INSERT, and nothing deduplicates by content. WITH an '
+      + '`id` that already names a record it CONVERGES instead of duplicating.';
+    assert.doesNotMatch(CORRECTED, /there is no id to update/i);
+    assert.doesNotMatch(CORRECTED, /^always an insert/im);
+  });
+});

--- a/testing/standalone/tool-parameters-are-all-described.test.js
+++ b/testing/standalone/tool-parameters-are-all-described.test.js
@@ -18,13 +18,16 @@
  * blind spot. So the walker descends into `properties` AND into `items`, and the test below proves it reaches
  * both rather than assuming it.
  *
- * ## What this does NOT gate yet, said plainly rather than left implied
+ * ## The floor, and why it arrived second
  *
- * Only PRESENCE. `move_file.src` says "Source path." in 12 characters, which passes here and does not meet
- * the standard X-2 records — every parameter gets its own sentence, and the sentence says the TRAP. 55
- * parameters are still that thin. A length floor is not added here because encoding "10 characters is fine"
- * as a passing threshold blesses exactly what needs fixing; the sweep is the work, and the floor lands with
- * it.
+ * The first version of this gate checked PRESENCE only, and said so: `move_file.src` read "Source path." in
+ * 12 characters, which meets a presence check and not the standard X-2 records. 52 parameters were that
+ * thin. A floor was deliberately NOT added then — a threshold of 10 characters, set to accommodate the worst
+ * case, blesses exactly what needs fixing, and an exemption list naming the 52 would have read as a plan.
+ *
+ * The sweep is done, so the floor is here with no exemptions: **40 characters**, which is roughly one
+ * sentence. It is not a quality measure and cannot be — a 40-character sentence can still say nothing. What
+ * it does is make the cheap failure impossible, so review can spend itself on whether the sentence is TRUE.
  *
  * Run: node --test testing/standalone/tool-parameters-are-all-described.test.js
  * (requires a prior `npm run build` in server/)
@@ -86,6 +89,18 @@ describe('every parameter is described', () => {
       .map(([tool, path]) => `${tool}: ${path}`);
     assert.deepEqual(missing, [],
       'a caller reads the schema while constructing arguments — these say nothing:\n  ' + missing.join('\n  '));
+  });
+
+  it('and none is under forty characters — about one sentence', () => {
+    // NO EXEMPTION LIST, on purpose. `REST_ONLY_CAPABILITIES` is empty for the same reason: a row there
+    // reads as a plan and behaves as a permanent carve-out. If a parameter genuinely cannot be described in
+    // a sentence, that is a finding about the parameter.
+    const FLOOR = 40;
+    const thin = allParams()
+      .filter(([, , v]) => typeof v?.description === 'string' && v.description.trim().length < FLOOR)
+      .map(([tool, path, v]) => `${tool}: ${path} (${v.description.trim().length}) "${v.description.trim()}"`);
+    assert.deepEqual(thin, [],
+      `under ${FLOOR} characters is a type restated, not a description — say the TRAP:\n  ` + thin.join('\n  '));
   });
 
   it('and none merely restates its own name', () => {

--- a/testing/standalone/write-tools-say-what-a-refusal-means.test.js
+++ b/testing/standalone/write-tools-say-what-a-refusal-means.test.js
@@ -73,8 +73,16 @@ describe('each says what its write does to what is already there', () => {
     assert.match(UPSERT_ENTITY, /find_entities_by_name/, 'point at the tool that answers it');
   });
 
-  it('remember: always an insert, and duplicates compete with each other', () => {
-    assert.match(REMEMBER, /Always an INSERT/, 'there is no id to update');
+  it('remember: an insert WITHOUT an id, convergence with one, and duplicates compete', () => {
+    // This assertion used to require the bare phrase `Always an INSERT`, and its own failure message said
+    // "there is no id to update" — repeating the claim it was pinning. Both were wrong: `remember` takes an
+    // optional `id`, and a supplied one that already names a record CONVERGES rather than duplicating,
+    // which is the retry-safety contract. A gate written from a description does not catch a wrong
+    // description; it cements it. `remember-describes-its-idempotent-path.test.js` holds the prose to the
+    // code, and this one now asserts the RULE rather than a sentence.
+    assert.match(REMEMBER, /insert/i, 'the no-id case still inserts');
+    assert.match(REMEMBER, /converge/i, 'and an id that names a record converges instead of duplicating');
+    assert.doesNotMatch(REMEMBER, /there is no id to update/i, 'the claim that was false');
     assert.match(REMEMBER, /compete for the same result slots/,
       'the cost of a duplicate is not storage, it is recall quality');
   });


### PR DESCRIPTION
X-2's second half, finished. Closes the parameter side of "every MCP tool schema describes each parameter AND the response".

## The measurement

62 parameters were under forty characters — `"Source path."`, `"Entity name."`, `"Collection to query."`. Each passes a has-a-description check and tells a caller nothing they could not read off the key, on the surface `help()` names as the authoritative reference.

**Ten of the 62 my own scratch measurement never saw**, because it walked only the top level while `bulk_write` and `merge_entities` nest whole record schemas under `items`. That is the same blind spot the gate's doc block describes, arriving in the tool used to size the work. The gate is the measurement now.

## The floor

**40 characters, no exemption list** — the reason `REST_ONLY_CAPABILITIES` is empty: a named carve-out reads as a plan and behaves as permanent. It is not a quality measure and cannot be; a 40-character sentence can still say nothing. What it does is make the cheap failure impossible so review can spend itself on whether the sentence is **true**.

It arrives now rather than with the presence gate because a threshold set to accommodate 62 thin descriptions would have blessed them.

## What the new text says

- `upsert_entity.name` — nothing deduplicates by it, so omitting `id` inserts a second entity of the same name
- `update_edge.label` — part of the identity `upsert_edge` matches on, so renaming it makes a later upsert create a second edge
- `move_file.dst` — replaces an existing file with no refusal
- `update_file_meta.properties` — replaces the whole object where the brain tools merge key by key
- `create_space.label` — not the identity; the derived `id` is
- `bulk_write.edges[].from` — shape-checked under strict linkage only, never for existence

The five file path arguments became one `filePathSchema` instead of the same 37-character sentence copied four times. It states the three facts from `files/sandbox.ts` that decide whether a call works: a leading slash is **stripped** rather than refused (so `/a/b.md` and `a/b.md` are one file), paths are NFC-normalised, and a `..` leaving the space is refused.

## Two more descriptions that contradicted the code

Both found by sweeping, not by looking for them.

**`remember` said "there is no id to update"** — beside the `id` parameter describing itself as *"UUID v4 of an EXISTING record to update"*, over a branch in `brain/memory.ts` where a supplied id **converges**, unioning tags and shallow-merging properties like `upsert_entity`. That branch is the retry-safety contract: a caller believing the prose would retry a timed-out write as a fresh insert and get two records — the one outcome the feature exists to prevent.

**`update_chrono` promised "`endsAt` before `startsAt` is refused"** — and nothing anywhere performs that check. The REST route validates `startsAt`'s presence and type; `validateChrono` never looks at either field; no test pinned a refusal. Such an entry is stored as sent, and since `endsAt` becomes the due moment it reads back as `overdue` immediately.

The gate asserts the **absence** of the check as well as the wording, so it flips the day somebody adds the validation rather than forbidding a truthful sentence for ever.

## Two gates had cemented the first claim

- `write-tools-say-what-a-refusal-means` required the literal `Always an INSERT`, with a failure message that repeated "there is no id to update"
- `one-merge-rule` pinned the exact phrases `New tags (replaces existing)` and `Tags to merge with existing tags`, so saying the same thing at more length turned a documentation improvement red

Both assert the rule now. That is the third and fourth gate this week found pinning a sentence rather than a behaviour, and two of the four were pinning a sentence that was false.

## The five places

MCP tools; REST is the same shared behaviour so no route changed; `docs/integration-guide/04c-chrono-api.md` gains the `endsAt` ordering fact; userguide N/A (no user-facing control changed); token rights N/A (no new route).

Full standalone suite green: 4433 pass, 0 fail.