### PR TITLE
docs(embed): excludeFromVectorSearch is one of three tiers, and false does not mean "do embed"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`excludeFromVectorSearch: false` was documented as "do embed" and does not mean that.** It is the top of
+  three tiers of one mechanism — a type schema and the space both carry `suppressEmbeddings`, resolving
+  `record > schema > space` — and a stored `false` arrives at the resolver as *not stated*, so it falls
+  through rather than overriding. Sending `false` on a record whose type or space suppresses embedding
+  therefore succeeds and changes nothing, while the MCP schema said in as many words "or return it to it
+  (false)".
+
+  Both doors now say what `false` does, and both name the other two tiers. Nothing in the record-level name
+  suggested they existed, so a record with no vector and no flag set read as a bug rather than as the space
+  setting doing its job. The record-side reference now states the tiers the schema-side page already
+  described; one direction is not parity, because a reader who starts at the record flag never opens the
+  schema page.
+
+  The traversal answer the owner asked for is unchanged and still stated: recall's `traverse` expansion walks
+  edges and never consults a vector, so an excluded record is reached exactly as before.
+
 - **Listing chrono entries by `status=overdue` hid the entries somebody had marked overdue.** `overdue` is
   worked out from the clock rather than stored — an entry left `upcoming` past its due moment is returned as
   overdue — so the filter was translated to look for exactly that: stored `upcoming`/`active`, past due.

--- a/docs/integration-guide/04-brain-api.md
+++ b/docs/integration-guide/04-brain-api.md
@@ -712,6 +712,30 @@ semantic search at retired records today by applying a filter you control, the f
 behaviour — it removes the vector the search ranks on, and the result is a quietly shorter answer with no
 error. Nothing in the record's own data is lost.
 
+#### One switch, three tiers, three names
+
+`excludeFromVectorSearch` is the **top tier of the same mechanism** the space and its type schemas call
+`suppressEmbeddings`. They resolve `record > schema > space` — the same order `ttlDays` uses — and
+`brain/suppress-embeddings.ts` is the one place that resolves them:
+
+| tier | where it lives | name |
+|---|---|---|
+| record | the record itself, via `PATCH` or an MCP `update_*` tool | `excludeFromVectorSearch` |
+| type | `typeSchemas.<kind>.<type>` on the space meta | `suppressEmbeddings` |
+| space | space meta (the Danger Zone in the UI) | `suppressEmbeddings` |
+
+Nothing in the record-level name suggests the other two exist, so **a record with no vector and no
+`excludeFromVectorSearch` is not a bug** — read `GET /api/spaces/:id/meta` before treating it as one. Files
+have no type and therefore skip the middle tier entirely: a file is governed by the record flag or the space
+setting.
+
+> **`excludeFromVectorSearch: false` means *not stated*, not *do embed*.** It falls through to the tiers
+> below instead of overriding them, so sending `false` **cannot** re-embed a record whose type or space
+> suppresses embedding — the write succeeds, and nothing changes. On a record no other tier suppresses,
+> `false` does restore the vector. To un-suppress a whole type or space, clear its `suppressEmbeddings` and
+> then run [`POST /api/spaces/:id/reembed`](06-spaces-api.md#re-embed-backfill), because nothing backfills on
+> its own.
+
 ### Partial Update with deleteFields
 
 **All five** `PATCH` update endpoints — entities, edges, memories, chrono entries and file metadata — accept an optional `deleteFields` array of dot-notation paths. This allows callers to remove specific fields from a document in the same atomic operation as normal property/tag updates.

--- a/server/src/mcp/tools/shared.ts
+++ b/server/src/mcp/tools/shared.ts
@@ -46,13 +46,20 @@ export const TTL_DAYS_SCHEMA = {
 export const EXCLUDE_FROM_VECTOR_SEARCH_SCHEMA = {
   type: 'boolean',
   description:
-    'Retire this record from semantic RANKING (true), or return it to it (false). Implemented as the ABSENCE '
-    + 'of a vector, NOT a query-time filter: an excluded record cannot be RANKED by recall even '
-    + 'deliberately, because there is no vector to rank. Everything that does not rank still reaches it in '
-    + 'full — query, list, get, the `traverse` tool, AND recall\'s own `traverse` expansion, which walks '
-    + 'edges out of a match and never consults a vector. So a record excluded here is still findable through '
-    + 'its relationships; it just stops competing on meaning. Toggling back to false re-embeds it. May be the '
-    + 'only field you send — retiring a record is a complete edit in itself.',
+    'Retire this record from semantic RANKING. Implemented as the ABSENCE of a vector, NOT a query-time '
+    + 'filter: an excluded record cannot be RANKED by recall even deliberately, because there is no vector '
+    + 'to rank. Everything that does not rank still reaches it in full — query, list, get, the `traverse` '
+    + 'tool, AND recall\'s own `traverse` expansion, which walks edges out of a match and never consults a '
+    + 'vector. So a record excluded here is still findable through its relationships; it just stops '
+    + 'competing on meaning. May be the only field you send — retiring a record is a complete edit.\n\n'
+    + 'THIS IS THE TOP OF THREE TIERS OF ONE SWITCH, and the other two are called something else. A type '
+    + 'schema carries `suppressEmbeddings`, and so does the space; they resolve `record > schema > space`, '
+    + 'the same order `ttlDays` uses. Same mechanism, three names, so finding one gives you no reason to '
+    + 'look for the others — check `get_space_meta` when a record is unembedded and this flag is not why.\n\n'
+    + '`false` MEANS "NOT STATED", NOT "DO EMBED". It falls through to the tiers below rather than '
+    + 'overriding them, so setting it false CANNOT re-embed a record whose type or space suppresses '
+    + 'embedding — the suppression there still wins, and the write succeeds while nothing changes. On a '
+    + 'record that no other tier suppresses, false does restore the vector.',
 } as const;
 
 /**

--- a/testing/standalone/one-switch-three-tiers-is-documented.test.js
+++ b/testing/standalone/one-switch-three-tiers-is-documented.test.js
@@ -1,0 +1,115 @@
+/**
+ * `excludeFromVectorSearch` and `suppressEmbeddings` are ONE switch at three tiers, and both doors say so.
+ *
+ * ## X-1, the half that needs no migration
+ *
+ * Owner, 2026-08-15: *"excludefromvector does also exclude from recalls traversal? ambigous and i want
+ * entries to be findable via traversal even if they are not embedded themselves."*
+ *
+ * The behaviour was already right — recall's `traverse` expansion walks EDGES and never consults a vector,
+ * so an excluded record is reached exactly as before. What was wrong is the vocabulary, in two ways that a
+ * caller pays for:
+ *
+ * 1. **Three names for one mechanism.** The per-record flag is `excludeFromVectorSearch`; a type schema and
+ *    the space both call it `suppressEmbeddings`; `embeddingSuppressed` resolves `record > schema > space`.
+ *    Nothing in the record-level name hints the other two exist, so a record with no vector and no flag set
+ *    reads as a bug.
+ * 2. **`false` is "not stated", not "do embed".** `embed-record.ts` maps a stored `false` to `undefined`, so
+ *    it FALLS THROUGH to the tiers below rather than overriding them. Sending `false` on a record whose type
+ *    or space suppresses embedding succeeds and changes nothing — and the MCP schema said, in as many words,
+ *    "or return it to it (false)".
+ *
+ * ## Exercised, not grepped
+ *
+ * `embeddingSuppressed` is pure, so the tier rules below are real calls. The description assertions are held
+ * to what those calls return, rather than to a phrasing — four gates this week were found pinning a sentence
+ * instead of a rule, and two of the four were pinning one that was false.
+ *
+ * Run: node --test testing/standalone/one-switch-three-tiers-is-documented.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripComments } from './_strip-comments.mjs';
+
+let embeddingSuppressed, EXCLUDE_FROM_VECTOR_SEARCH_SCHEMA;
+before(async () => {
+  ({ embeddingSuppressed } = await import('../../server/dist/brain/suppress-embeddings.js'));
+  ({ EXCLUDE_FROM_VECTOR_SEARCH_SCHEMA } = await import('../../server/dist/mcp/tools/shared.js'));
+});
+
+const DESC = () => EXCLUDE_FROM_VECTOR_SEARCH_SCHEMA.description;
+
+describe('the resolver really is one switch at three tiers', () => {
+  it('record wins over both', () => {
+    assert.equal(embeddingSuppressed({ record: true, schema: { suppressEmbeddings: false }, space: false }), true);
+    assert.equal(embeddingSuppressed({ record: false, schema: { suppressEmbeddings: true }, space: true }), false,
+      'an explicitly stored `false` at the record tier does override — the falling-through case is a SEPARATE '
+      + 'mapping in embed-record.ts, asserted below');
+  });
+
+  it('schema wins over space', () => {
+    assert.equal(embeddingSuppressed({ schema: { suppressEmbeddings: true }, space: false }), true);
+    assert.equal(embeddingSuppressed({ schema: { suppressEmbeddings: false }, space: true }), false);
+  });
+
+  it('and "not stated" falls through rather than counting as false', () => {
+    // Reading absent as `false` would make the space-wide switch do nothing for any type that had a schema
+    // at all, which is every type worth suppressing.
+    assert.equal(embeddingSuppressed({ space: true }), true, 'no record flag, no schema → the space decides');
+    assert.equal(embeddingSuppressed({ schema: {}, space: true }), true, 'a schema that says nothing is not a "no"');
+    assert.equal(embeddingSuppressed({}), false, 'and nothing anywhere means embed');
+  });
+});
+
+describe('`false` at the record tier never reaches the resolver as `false`', () => {
+  it('embed-record maps a stored false to undefined', () => {
+    // This is the whole of the trap, and it is one ternary. Bounded by the call's own closing brace rather
+    // than by a character count.
+    const src = stripComments(readFileSync('server/src/brain/embed-record.ts', 'utf8'));
+    const at = src.indexOf('embeddingSuppressed({');
+    assert.ok(at > 0, 'the suppression call was not found — the scanner is wrong, not the code');
+    const call = src.slice(at, src.indexOf('})', at));
+    assert.match(call, /record:\s*doc\['excludeFromVectorSearch'\]\s*===\s*true\s*\?\s*true\s*:\s*undefined/,
+      'a stored `false` must arrive as "not stated" — if this becomes a plain read, the docs saying `false` '
+      + 'cannot un-suppress stop being true');
+  });
+
+  it('so the description must NOT promise that false re-embeds unconditionally', () => {
+    assert.doesNotMatch(DESC(), /or return it to it \(false\)/i,
+      'the sentence that was wrong: false falls through, it does not override');
+    assert.match(DESC(), /not stated/i, 'say what false actually means');
+    assert.match(DESC(), /cannot/i, 'and that it cannot re-embed a suppressed type or space');
+  });
+});
+
+describe('both doors name all three tiers', () => {
+  it('the MCP schema names the other two and their other name', () => {
+    const d = DESC();
+    assert.match(d, /suppressEmbeddings/, 'the name the other two tiers use');
+    assert.match(d, /record\s*>\s*schema\s*>\s*space/, 'and the resolution order');
+  });
+
+  it('and it still states the traversal answer the owner asked for', () => {
+    // The question that started X-1. Losing this while adding the tier text would be a straight regression.
+    const d = DESC();
+    assert.match(d, /traverse/i, 'both traversals reach an excluded record');
+    assert.match(d, /never consults a vector|edges out of a match/i, 'and WHY, which is what makes it believable');
+  });
+
+  it('the REST reference says the same, from the record side', () => {
+    // `06a-schema-api.md` already said it from the SPACE side. One direction is not parity: a reader who
+    // starts at the record flag never opens the schema page.
+    const doc = readFileSync('docs/integration-guide/04-brain-api.md', 'utf8');
+    assert.match(doc, /suppressEmbeddings/, 'the record-side page must name the other tiers');
+    assert.match(doc, /record\s*>\s*schema\s*>\s*space/, 'and the order');
+    assert.match(doc, /means \*not stated\*|means \*\*not stated\*\*|not stated/i, 'and the false trap');
+  });
+
+  it('and the space-side page still says it too', () => {
+    const doc = readFileSync('docs/integration-guide/06a-schema-api.md', 'utf8');
+    assert.match(doc, /excludeFromVectorSearch/, 'the space page names the record tier');
+    assert.match(doc, /LOWEST of three tiers/, 'and that it is the bottom of three');
+  });
+});


### PR DESCRIPTION
X-1's half that needs no migration. The queue's last row.

## The behaviour was already right

Owner, 2026-08-15: *"excludefromvector does also exclude from recalls traversal? ambigous and i want entries to be findable via traversal even if they are not embedded themselves."*

It does not. Recall's `traverse` expansion walks **edges** out of a match and never consults a vector, so an excluded record is reached exactly as before. That sentence was added in an earlier PR and is unchanged here — a gate asserts it survives.

## What was wrong is the vocabulary, and it costs a caller twice

**Three names for one mechanism.** The per-record flag is `excludeFromVectorSearch`; a type schema and the space both call it `suppressEmbeddings`; `brain/suppress-embeddings.ts` resolves `record > schema > space`, the same order `ttlDays` uses. Nothing in the record-level name hints the other two exist — so a record with no vector and no flag set reads as a bug rather than as the space setting doing its job.

**`false` means "not stated", not "do embed".** `embed-record.ts` maps a stored `false` to `undefined`:

```ts
record: doc['excludeFromVectorSearch'] === true ? true : undefined,
```

So it falls *through* to the tiers below instead of overriding them. Sending `false` on a record whose type or space suppresses embedding succeeds and changes nothing — while the MCP schema said, in as many words, *"or return it to it (false)"*.

## Parity, in the direction that was missing

`06a-schema-api.md` already described the three tiers from the **space** side. One direction is not parity: a reader who starts at the record flag never opens the schema page. `04-brain-api.md` now carries the same table from the record side, with the `false` trap and the reembed backfill it implies.

## Gates

`one-switch-three-tiers-is-documented.test.js` exercises `embeddingSuppressed` — it is pure — and holds both descriptions to what it returns rather than to a phrasing. It also pins the ternary that makes `false` fall through, so if that becomes a plain read the documentation saying `false` cannot un-suppress stops being true and the gate says so.

Four gates this week were found pinning a sentence instead of a rule, and two of the four were pinning one that was false. This one asserts against the function.

## The five places

MCP tool schema (`EXCLUDE_FROM_VECTOR_SEARCH_SCHEMA`, shared by all four update tools); REST is the same stored field with no route change; `docs/integration-guide/04-brain-api.md` gains the record-side tier table; `06a-schema-api.md` unchanged and re-asserted; token rights N/A (no new route).

**Userguide is N/A, and here is why rather than left implied:** there is no UI control for the per-record flag — the client only passes it through on chrono — so the only user-facing surface is the space-wide Danger Zone toggle, which its own page already covers.

## What remains of X-1

The rename to one name across the three tiers. That is a stored field, so it is a **synced** data migration and must be self-healing and lazy per the migration rule — its own change, which is why this half did not wait for it.

Full standalone suite green: 4442 pass, 0 fail.