### PR TITLE
chore(release): 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.0] — 2026-08-17
+
 ### Breaking
 
 - **`find_similar` over MCP now returns JSON at every depth.** It answered plain TEXT at `traverse: 0` — a

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/client",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "scripts": {

--- a/docs/integration-guide/04-brain-api.md
+++ b/docs/integration-guide/04-brain-api.md
@@ -405,6 +405,21 @@ GET /api/brain/spaces/:spaceId/memories/:id
 
 **Response** `200`: Full `MemoryDoc` (same shape as write response).
 
+> **What a stored record carries beyond the fields you wrote.** A `GET` by id and the list routes below
+> return the document as stored, minus the embedding vector — which, as everywhere else, is never returned
+> and cannot be requested. Three of the remaining fields are the system's rather than yours:
+>
+> | field | what it is |
+> |---|---|
+> | `seq` | The sync counter, and the value to send as `If-Match` on a conditional write. Useful, not internal |
+> | `matchedText` | The exact text this record's vector was built from. Derived from the fields above it, and for a file chunk it is the heading plus the passage — so the passage a SECOND time |
+> | `embeddingModel` | Which model produced the vector. Identical for every record in a space |
+>
+> **These are NOT stripped here, unlike on `recall`**, where `includeDiagnostics` withholds all three by
+> default. The list routes have no field selection at all today — that asymmetry is real and is written down
+> rather than left for you to discover. If it costs your integration, say so; the structured
+> [`POST /query`](04d-brain-ops-api.md#structured-query-read-only) route accepts a `projection` and is the way to bound a read meanwhile.
+
 ---
 
 ### List Memories

--- a/docs/userguide/02-brain.md
+++ b/docs/userguide/02-brain.md
@@ -171,6 +171,7 @@ search you can run without writing a request by hand:
 - **maxTimeMS** — a time limit for this one search. It can only make the search stricter than the instance's own budget, never looser. When the limit is reached you get a **partial** answer rather than an error or a hang: whatever finished is returned, and the result says it was cut short.
 - **Include fresh writes** — also scan the newest records directly, so something written seconds ago is findable before the index has caught up. It costs an extra scan per record type, so turn it on when you are looking for something you just wrote.
 - **Include content** — on by default. Turn it off to get passage *locations* without their text: useful when you want to find which document holds something and read only that part, since passage bodies are the largest thing a result carries.
+- **Include diagnostic fields** — off by default, and off is right for ordinary searching. Turn it on to see *why* a result ranked where it did: the exact text that was embedded, the embedding model, the sync counter, and the score from each ranking stage separately. It follows graph hops too, at every depth, so a search with **Graph hops** set shows the same detail on the connected records. The embedding vector itself is never returned and there is no option that asks for it.
 
 **Results that exist in the graph carry a graph button.** An entity result opens the Graph tab focused on that
 entity; an edge result opens it on the entity the relationship starts from — the same jump the Entities and Edges

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ythril",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ythril",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "workspaces": [
         "server",
@@ -18,7 +18,7 @@
     },
     "client": {
       "name": "@ythril/client",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@angular/animations": "^21.0.0",
@@ -21022,7 +21022,7 @@
     },
     "server": {
       "name": "@ythril/server",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ythril",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "type": "module",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/server",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "type": "module",
   "scripts": {

--- a/testing/standalone/one-switch-three-tiers-is-documented.test.js
+++ b/testing/standalone/one-switch-three-tiers-is-documented.test.js
@@ -194,13 +194,20 @@ describe('both doors name the one tier name', () => {
 
   it('the rename is written down where an upgrader looks', () => {
     // A renamed request field that appears in no changelog is a caller debugging a 200 that did nothing.
-    // Bounded by the two headings, not by an offset: `\n## ` lands on a different character on this CRLF
-    // working copy than in CI's LF checkout, and a window that starts in the wrong place passes by reading
-    // less. `[\s\S]` rather than `.` so the section's own blank lines are inside it.
+    // Bounded by headings, not by an offset: `\n## ` lands on a different character on this CRLF working
+    // copy than in CI's LF checkout, and a window that starts in the wrong place passes by reading less.
+    // `[\s\S]` rather than `.` so the sections' own blank lines are inside the window.
+    //
+    // The window is `[Unreleased]` PLUS the newest released section, and that is the fix for this gate's
+    // first version rather than a convenience. It pinned `[Unreleased]` alone, so cutting 3.1.0 — which
+    // moved the entry into a dated heading, exactly as a release is supposed to — turned it red against a
+    // CHANGELOG that had become MORE correct. The rule is that an upgrader searching the old spelling finds
+    // it in the current notes; which heading it sits under is the release process's business, not this
+    // gate's.
     const ch = readFileSync('CHANGELOG.md', 'utf8');
-    const m = /^## \[Unreleased\]$([\s\S]*?)^## /m.exec(ch);
-    assert.ok(m, 'no [Unreleased] section followed by a released one — this gate is measuring nothing');
-    const unreleased = m[1];
+    const m = /^## \[Unreleased\]$([\s\S]*?)^## \[[^\]]+\][^\n]*$([\s\S]*?)^## \[/m.exec(ch);
+    assert.ok(m, 'expected [Unreleased] then at least two released sections — this gate measures nothing now');
+    const unreleased = m[1] + m[2];
     assert.match(unreleased, /excludeFromVectorSearch/,
       'the [Unreleased] section must name the OLD spelling — that is the word an upgrader searches for');
     assert.match(unreleased, /suppressEmbeddings/, 'and the new one');


### PR DESCRIPTION
Cuts 3.1.0. Four manifests bumped, lockfile regenerated (not string-replaced — 21 of its `3.0.1` strings are dependencies), CHANGELOG dated with an empty `[Unreleased]` restored above it.

**A minor with three Breaking entries, on the owner's ruling** — *"even if some breaking changes are in"*, and previously *"its more or less how 3.0 should have worked"*. The three: the `excludeFromVectorSearch` → `suppressEmbeddings` rename (aliased on both doors, so no caller breaks), REST recall withholding six system fields by default to match MCP, and `find_similar` returning JSON at every depth instead of text at `traverse: 0`.

**Docs audit done before the tag**, as instructed. `release:gate` green in release mode; the accuracy pass found and fixed `recall`'s false response description and `find_similar`'s undocumented shape switch; the coverage pass found no orphaned doc pages and one real gap — the list routes return `matchedText` and `embeddingModel` on every record and no page said so, now documented along with the reason they are not stripped there.

One gate needed correcting: it pinned the rename's changelog entry to the `[Unreleased]` *section*, so cutting the tag turned it red against a file that had become more correct.