### PR TITLE
fix(publish): the workflow pushed images and never announced them

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,11 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 permissions:
-  contents: read
+  # `contents: write` so the run can create the GitHub Release. It was `read`, which is why the
+  # announcement half never existed: images went to both registries on every `v*` tag while
+  # `v2.6.0` through `v3.0.1` got no Release at all, and the page showed 2.5.1 as Latest for
+  # five weeks.
+  contents: write
   packages: write
 
 jobs:
@@ -168,3 +172,39 @@ jobs:
               exit 1
             fi
           done
+
+      # The half a PERSON reads. The images above are the half a machine consumes, and until 3.1.0 only that
+      # half had a mechanism — six tags shipped with no Release and nothing noticed, because nothing was
+      # watching for an absence.
+      #
+      # LAST, deliberately: after the image is pushed and after the licence checks have passed against the
+      # published artefact. A Release is an announcement, and announcing a build that then fails its own
+      # NOTICE verification is worse than announcing nothing.
+      #
+      # The notes come from the CHANGELOG section for this tag, through the same extraction `release-gate.mjs`
+      # uses to check it is dated and non-empty. `release-notes.mjs` exits non-zero when the section is
+      # missing or thin, so a tag pushed without closing `[Unreleased]` fails here instead of publishing a
+      # release that describes nothing.
+      - name: Create the GitHub Release from the CHANGELOG
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          node scripts/release-notes.mjs "$VERSION" release-notes.md
+
+          # `--latest` is a DECISION, not a default. `gh` marks a new release latest unless told otherwise,
+          # which is right for a forward release and wrong for a backfilled older one — that would announce an
+          # superseded version as newest. So it is claimed only when this tag really is the highest.
+          HIGHEST="$(git tag --list 'v*' --sort=-v:refname | head -n1)"
+          if [ "$GITHUB_REF_NAME" = "$HIGHEST" ]; then LATEST=true; else LATEST=false; fi
+          echo "tag=$GITHUB_REF_NAME highest=$HIGHEST latest=$LATEST"
+
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "Release already exists — updating its notes rather than failing the publish."
+            gh release edit "$GITHUB_REF_NAME" --notes-file release-notes.md --latest="$LATEST"
+          else
+            gh release create "$GITHUB_REF_NAME" \
+              --title "Ythril $VERSION" \
+              --notes-file release-notes.md \
+              --latest="$LATEST"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Publishing a tag pushed the images and never announced them, so six releases were invisible.**
+  `publish.yml` triggers on `v*`, builds, and pushes to both registries — correctly, every time. It did not
+  create a **GitHub Release**, and nothing else did, so `v2.6.0`, `v2.7.0`, `v2.8.0`, `v2.8.1`, `v3.0.0` and
+  `v3.0.1` shipped as images with no entry on the Releases page. It showed **2.5.1 as Latest for five
+  weeks**, which for anyone watching the repository read as a project that had stopped.
+
+  Nothing noticed because nothing was watching for an ABSENCE: every check asked whether something that
+  happened was correct, none asked whether it had happened at all.
+
+  The workflow now creates the Release as its LAST step — after the image is pushed and after the licence
+  checks pass against the published artefact, because announcing a build that then fails its own NOTICE
+  verification is worse than announcing nothing. The notes are the CHANGELOG section for the tag, through
+  the same extraction the release gate uses to check that section is dated and non-empty; a tag pushed
+  without closing `[Unreleased]` now fails there instead of publishing a release that describes nothing.
+
+  `--latest` is computed from whether the tag really is the highest rather than left to `gh`'s default, so
+  backfilling an older release cannot announce a superseded version as newest. A re-run updates the notes
+  instead of erroring after the images have already gone out.
+
+
 ## [3.1.0] — 2026-08-17
 
 ### Breaking

--- a/scripts/changelog-section.mjs
+++ b/scripts/changelog-section.mjs
@@ -1,0 +1,52 @@
+/**
+ * The CHANGELOG section for one version — one implementation, two callers.
+ *
+ * ## Why it is a module rather than a regex in each place
+ *
+ * `release-gate.mjs` already located a version's section to check it is dated and non-empty. `publish.yml`
+ * now needs the same section as the body of a GitHub Release. Two copies of "where does this version's
+ * section start and stop" is the defect this repo produces most, and here it has a specific failure mode:
+ * the gate would keep passing on a correct CHANGELOG while the workflow published half of it, and nobody
+ * compares a release body against anything.
+ *
+ * ## Bounded by the next heading, never by a count
+ *
+ * The 3.1.0 body is ~74 KB. A slice bounded by a character count would ship a truncated release note that
+ * reads as complete — and a count spans different lines on a CRLF working copy than in CI's LF checkout,
+ * so it would not even truncate in the same place twice.
+ */
+
+/** Match a dated release heading for `version`, e.g. `## [3.1.0] — 2026-08-17`. Both dash forms. */
+export function headingFor(version) {
+  return new RegExp(`^## \\[${version.replace(/\./g, '\\.')}\\]\\s+[—-]\\s+(\\d{4}-\\d{2}-\\d{2})`, 'm');
+}
+
+/**
+ * The whole section for `version`, heading included, or `null` when there is no dated heading for it.
+ *
+ * Line endings are normalised to `\n` first so the same offsets hold on either checkout.
+ */
+export function changelogSection(changelogText, version) {
+  const text = changelogText.split(/\r?\n/).join('\n');
+  const m = headingFor(version).exec(text);
+  if (!m) return null;
+  const start = m.index;
+  // Search from start+1 so the section's OWN heading does not terminate it.
+  const next = text.slice(start + 1).search(/^## \[/m);
+  return next < 0 ? text.slice(start) : text.slice(start, start + 1 + next);
+}
+
+/**
+ * The section's content lines — what the gate counts to refuse an empty release.
+ *
+ * Headings and blank lines are not content: a section holding nothing but `### Fixed` asserts that something
+ * was fixed and names none of it, which is a stronger and falser statement than saying nothing at all.
+ */
+export function sectionContentLines(section) {
+  return section.split('\n').slice(1).filter(l => l.trim() && !/^#{1,3} /.test(l.trim()));
+}
+
+/** The body for a release note: the section without its own `## [x.y.z] — date` heading line. */
+export function releaseBody(section) {
+  return section.split('\n').slice(1).join('\n').trim();
+}

--- a/scripts/release-gate.mjs
+++ b/scripts/release-gate.mjs
@@ -35,6 +35,7 @@ import { readFileSync, existsSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { changelogSection, sectionContentLines, headingFor } from './changelog-section.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const R = '\x1b[0m';
@@ -89,9 +90,13 @@ function checkChangelog(version) {
   const eolSplit = read('CHANGELOG.md').split(/\r?\n/);
   const text = eolSplit.join('\n');
 
-  // (a) a dated section for THIS version
-  const heading = new RegExp(`^## \\[${version.replace(/\./g, '\\.')}\\]\\s+[—-]\\s+(\\d{4}-\\d{2}-\\d{2})`, 'm');
-  const m = heading.exec(text);
+  // (a) a dated section for THIS version.
+  //
+  // The locating is `changelog-section.mjs`'s, shared with `release-notes.mjs`, which turns the same section
+  // into a GitHub Release body. Two copies of "where does this version's section start and stop" would let
+  // this gate keep passing on a correct CHANGELOG while the workflow published a truncated one — and nobody
+  // compares a release body against anything.
+  const m = headingFor(version).exec(text);
   if (!m) {
     fail('changelog', `no dated section for ${version}. Expected a line like "## [${version}] — YYYY-MM-DD". `
       + 'The version was bumped without closing [Unreleased] into it, so every change in this release is filed '
@@ -101,10 +106,8 @@ function checkChangelog(version) {
 
   // (b) that section has real content — a version can be tagged with an empty one, and an empty release section
   //     is worse than none: it asserts that nothing changed.
-  const start = m.index;
-  const nextHeading = text.slice(start + 1).search(/^## \[/m);
-  const body = nextHeading < 0 ? text.slice(start) : text.slice(start, start + 1 + nextHeading);
-  const contentLines = body.split('\n').slice(1).filter(l => l.trim() && !/^#{1,3} /.test(l.trim()));
+  const body = changelogSection(text, version);
+  const contentLines = sectionContentLines(body);
   if (contentLines.length < 3) {
     fail('changelog', `the ${version} section has ${contentLines.length} content line(s). An empty release section `
       + 'claims nothing changed, which is a stronger and falser statement than saying nothing at all.');

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * Print the CHANGELOG body for a version, for `gh release create --notes-file`.
+ *
+ * Usage: node scripts/release-notes.mjs 3.1.0 [out.md]
+ *
+ * Exits non-zero and says why when the section is missing or empty, so `publish.yml` fails loudly rather
+ * than creating a Release with an empty body. A release note that says nothing is worse than a missing one:
+ * it asserts that nothing changed.
+ *
+ * ## Why this exists at all
+ *
+ * `publish.yml` pushed images on every `v*` tag and created no GitHub Release, and nothing noticed for six
+ * versions — `v2.6.0` through `v3.0.1` shipped as images while the Releases page showed **2.5.1 as Latest
+ * for five weeks**. The images were the half a machine consumes and the Release is the half a person reads,
+ * and only one of them had a mechanism.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { changelogSection, sectionContentLines, releaseBody } from './changelog-section.mjs';
+
+const version = process.argv[2];
+const outPath = process.argv[3];
+
+if (!version) {
+  console.error('usage: node scripts/release-notes.mjs <version> [outfile]');
+  process.exit(2);
+}
+
+const section = changelogSection(readFileSync('CHANGELOG.md', 'utf8'), version);
+if (!section) {
+  console.error(`No dated CHANGELOG section for ${version}. Expected a line like "## [${version}] — YYYY-MM-DD".`);
+  console.error('The tag was pushed without closing [Unreleased] into a dated heading, so there are no notes to publish.');
+  process.exit(1);
+}
+
+const content = sectionContentLines(section);
+if (content.length < 3) {
+  console.error(`The ${version} CHANGELOG section has ${content.length} content line(s).`);
+  console.error('Publishing that as a release note would announce a version and describe none of it.');
+  process.exit(1);
+}
+
+const body = releaseBody(section);
+if (outPath) {
+  writeFileSync(outPath, body + '\n', 'utf8');
+  console.error(`wrote ${body.length} chars of notes for ${version} to ${outPath}`);
+} else {
+  process.stdout.write(body + '\n');
+}

--- a/testing/standalone/publish-announces-the-release.test.js
+++ b/testing/standalone/publish-announces-the-release.test.js
@@ -1,0 +1,113 @@
+/**
+ * Publishing a tag creates the GitHub Release, and its notes come from the CHANGELOG.
+ *
+ * ## What this is for
+ *
+ * `publish.yml` triggers on `v*`, builds, and pushes to both registries — correctly, every time. It did not
+ * create a **GitHub Release**, and nothing else did either, so `v2.6.0`, `v2.7.0`, `v2.8.0`, `v2.8.1`,
+ * `v3.0.0` and `v3.0.1` all shipped as images with no entry on the Releases page. It showed **2.5.1 from
+ * 2026-08-07 as Latest** for six versions and five weeks, which for anyone watching read as a project that
+ * had stopped.
+ *
+ * Nothing noticed because nothing was watching for an ABSENCE. Every existing check asked whether a thing
+ * that happened was correct; none asked whether a thing had happened at all. Found by hand while cutting
+ * 3.1.0 — `gh release list` beside `git tag`.
+ *
+ * ## Gated on the RULE
+ *
+ * The section extraction is exercised by calling it, not grepped: a release body is the one artefact nobody
+ * proof-reads, and a truncating slice would ship notes that read as complete. The workflow assertions are
+ * about the properties that were wrong or that are easy to get wrong — the permission, the ordering, and
+ * `--latest` being a decision rather than a default.
+ *
+ * Run: node --test testing/standalone/publish-announces-the-release.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { changelogSection, sectionContentLines, releaseBody } from '../../scripts/changelog-section.mjs';
+
+const wf = readFileSync('.github/workflows/publish.yml', 'utf8');
+const changelog = readFileSync('CHANGELOG.md', 'utf8');
+
+describe('the section extraction is one implementation, and it is bounded structurally', () => {
+  it('finds a real release and stops at the next heading', () => {
+    const s = changelogSection(changelog, '3.1.0');
+    assert.ok(s, 'no 3.1.0 section — this gate is measuring nothing');
+    assert.match(s, /^## \[3\.1\.0\]/, 'starts at its own heading');
+    assert.equal((s.match(/^## \[/gm) ?? []).length, 1,
+      'the section swallowed a later release — it must stop at the next `## [` heading');
+    assert.doesNotMatch(s, /^## \[3\.0\.1\]/m, 'and specifically not reach the previous release');
+  });
+
+  it('the body drops the heading and keeps everything else', () => {
+    const s = changelogSection(changelog, '3.1.0');
+    const body = releaseBody(s);
+    assert.doesNotMatch(body, /^## \[3\.1\.0\]/, 'the heading is the Release title, not part of its notes');
+    assert.ok(body.length > 1000,
+      `the 3.1.0 notes came out ${body.length} chars. A truncating extraction ships notes that read as `
+      + 'complete, which is the failure a character-bounded slice would produce and nobody would proof-read.');
+  });
+
+  it('a version with no dated heading returns null rather than a wrong section', () => {
+    // The failure that matters: a tag pushed without closing `[Unreleased]`. Returning the NEXT section
+    // would publish another release's notes under this version's name.
+    assert.equal(changelogSection(changelog, '99.99.99'), null);
+    assert.equal(changelogSection('## [Unreleased]\n\n### Fixed\n\n- a thing\n', '3.1.0'), null,
+      'an undated [Unreleased] is not a release section');
+  });
+
+  it('content lines ignore headings, so an empty section cannot pass as full', () => {
+    const empty = '## [9.9.9] — 2026-01-01\n\n### Fixed\n\n### Changed\n';
+    assert.equal(sectionContentLines(empty).length, 0,
+      'a section holding only headings claims something changed and names none of it');
+    assert.ok(sectionContentLines(changelogSection(changelog, '3.1.0')).length >= 3);
+  });
+});
+
+describe('the workflow announces what it published', () => {
+  it('creates a Release', () => {
+    assert.match(wf, /gh release create/,
+      'publish.yml pushes images and never announces them — six tags shipped invisibly that way');
+    assert.match(wf, /release-notes\.mjs/,
+      'the notes must come from the CHANGELOG, not be typed into the workflow');
+  });
+
+  it('has the permission to do it', () => {
+    // The reason it never existed: `contents: read` cannot create a Release, and a missing permission fails
+    // at the API rather than at review time.
+    const perms = wf.slice(wf.indexOf('permissions:'), wf.indexOf('jobs:'));
+    assert.match(perms, /contents:\s*write/,
+      'contents: write is required to create a Release; with `read` the step fails at the API');
+  });
+
+  it('announces LAST — after the image and after the licence checks', () => {
+    // A Release is an announcement. Announcing a build that then fails its own NOTICE verification is worse
+    // than announcing nothing, so the ordering is the assertion rather than a comment.
+    const create = wf.indexOf('gh release create');
+    const push = wf.indexOf('Build and push');
+    const notice = wf.indexOf('Verify the licence and notices are in the published image');
+    assert.ok(push > -1 && notice > -1, 'the workflow changed shape — this gate is measuring nothing');
+    assert.ok(create > push, 'the Release must come after the image is pushed');
+    assert.ok(create > notice, 'and after the published image passes its licence checks');
+  });
+
+  it('treats `--latest` as a decision, not a default', () => {
+    // `gh` marks a new release latest unless told otherwise. Correct for a forward release, wrong for a
+    // backfilled older one — that would announce a superseded version as newest, which is precisely what
+    // filling the six-release backlog would do.
+    assert.match(wf, /--latest="?\$\{?LATEST/,
+      'the workflow must pass an explicit --latest computed from whether this tag is the highest');
+    assert.match(wf, /git tag --list 'v\*' --sort=-v:refname/,
+      'and compute it from the tags rather than assuming the newest push is the newest version');
+  });
+
+  it('re-running a tag updates the notes instead of failing the publish', () => {
+    // `gh release create` errors when the release exists. A re-run — a retried publish, a re-pushed tag —
+    // would then fail AFTER the images were already pushed, reporting a broken release for a build that
+    // succeeded.
+    assert.match(wf, /gh release view .* >\/dev\/null 2>&1/,
+      'the step must check for an existing Release');
+    assert.match(wf, /gh release edit/, 'and update it rather than erroring');
+  });
+});


### PR DESCRIPTION
Found while cutting 3.1.0. `publish.yml` has been pushing images to both registries correctly on every `v*` tag and creating **no GitHub Release** — so `v2.6.0` through `v3.0.1` shipped invisibly and the Releases page showed **2.5.1 as Latest for five weeks**.

Nothing noticed because nothing was watching for an absence: every check here asks whether something that happened was correct, none asked whether it had happened at all. `contents: read` is why it could never have worked.

**The step goes last** — after the image is pushed and after the licence checks pass against the published artefact, because announcing a build that then fails its own NOTICE verification is worse than announcing nothing. The gate asserts that ordering rather than trusting the comment.

**The notes come from the CHANGELOG through one extraction.** `release-gate.mjs` already located a version's section; that locating moved to `scripts/changelog-section.mjs` and is shared with `scripts/release-notes.mjs`. Two copies would let the gate keep passing on a correct CHANGELOG while the workflow published a truncated one — and a release body is the one artefact nobody proof-reads. Bounded by the next `## [` heading, never by a count: the 3.1.0 body is 73 KB.

Two things easy to get wrong, both gated: `--latest` is computed from whether the tag is really the highest (so a backfill cannot announce a superseded version as newest), and a re-run edits the existing Release rather than erroring after the images have gone out.

The six that already shipped without a Release are outward-facing and retroactive — filed as P-10 with a recommendation rather than done here.