### PR TITLE
fix(media): two writes were losing their result in silence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The media worker discarded a paid model result and a terminal status, both without a word.** Two writes
+  in `files/media/worker.ts` were `.catch(() => {})` with no log, no counter and no comment saying why.
+
+  The first follows `describeDocument()` — a model call with its own timeout — and is the only place its
+  description, excerpt and source land. A failed write meant the call was made and paid for, the result was
+  gone, and the job went on to report success: a file with no description and nothing anywhere saying why,
+  indistinguishable from a document there was nothing to describe.
+
+  The second writes `embeddingStatus: 'skipped'` when a conversion fails permanently, and
+  `mediaJobsFailedTotal` is incremented either way. A failed write left the METRIC saying "permanently
+  failed" while the RECORD said `processing` for ever — a dashboard and a file page disagreeing, with the
+  dashboard right.
+
+  Both now log at warn, naming what was lost rather than that something failed. **Neither throws**, and that
+  is deliberate: failing the job would retry a document whose analysis already succeeded and re-pay for the
+  model. The fix is visibility, not severity.
+
+  Found by a reliability sweep for the shape this release cycle produced four times — an operation that
+  fails and reports success. That sweep finds 118 swallowed `catch` sites in `server/src` and the great
+  majority are correct; narrowing to swallows on a WRITE, minus those whose own comment states a reason,
+  left these two.
+
+
+### Fixed
+
 - **`includeContent` read as a general size lever and is file-chunks-only, and now says so.** Its own
   description made the right general argument — every field a result carries is multiplied by `topK` — while
   the parameter touches nothing but file-passage bodies, so on a search returning entities, memories, edges

--- a/server/src/files/media/worker.ts
+++ b/server/src/files/media/worker.ts
@@ -500,10 +500,20 @@ async function processJob(
           derivedDescription = described.text;
           derivedSource = described.source;
           derivedExcerpt = described.excerpt;
+          // `describeDocument` above is a MODEL CALL with its own timeout, and this write is the only place
+          // its output lands. Swallowing the failure silently meant the call was made and paid for, the
+          // description was gone, and the job went on to report success — a file with no description and
+          // nothing anywhere saying why, indistinguishable from "there was nothing to describe".
+          //
+          // Still not a throw: failing the job would retry a document whose analysis already succeeded and
+          // re-pay for the model. What was missing is that the loss be VISIBLE.
           await col<FileMetaDoc>(`${spaceId}_files`).updateOne(
             asFilter<FileMetaDoc>({ _id: fileId }),
             { $set: metaUpdate },
-          ).catch(() => {});
+          ).catch((err: unknown) => {
+            log.warn(`Media worker: ${spaceId}/${fileId} described but the metadata write failed — the `
+              + `description, excerpt and source from this run are lost and will not be recomputed: ${err}`);
+          });
 
           // Embedding outcome drives the job result (B3): a total failure throws so
           // the existing failJob → backoff → retry path handles a transient embedder
@@ -569,10 +579,20 @@ async function processJob(
     // burning the retry budget re-reading a file the pipeline refuses to convert.
     const permanent = err instanceof ConversionUnavailableError && err.reason === 'too_large';
     if (permanent) {
+      // This write is what stops the file looking like work in progress. `mediaJobsFailedTotal` below is
+      // incremented either way, so swallowing a failure here left the METRIC saying "permanently failed"
+      // while the RECORD said `processing` for ever — a dashboard and a file page disagreeing, with the
+      // dashboard right and nothing to reconcile them.
+      //
+      // Logged rather than thrown for the same reason as the describe write: the job is already failing
+      // permanently, and rethrowing would replace an honest terminal state with a retry loop.
       await col<FileMetaDoc>(`${spaceId}_files`).updateOne(
         asFilter<FileMetaDoc>({ _id: fileId }),
         { $set: { embeddingStatus: 'skipped' } },
-      ).catch(() => {});
+      ).catch((err: unknown) => {
+        log.warn(`Media worker: ${spaceId}/${fileId} failed permanently but its status could not be written `
+          + `— the record will read 'processing' while the failure counter has already moved: ${err}`);
+      });
     }
     if (permanent || attempts >= maxAttempts) {
       mediaJobsFailedTotal.labels({ space: spaceId, media_type: mediaType }).inc();

--- a/testing/standalone/swallowed-writes-must-be-visible.test.js
+++ b/testing/standalone/swallowed-writes-must-be-visible.test.js
@@ -1,0 +1,86 @@
+/**
+ * A write whose failure is swallowed must at least be VISIBLE.
+ *
+ * ## The shape, which this cycle produced four times
+ *
+ * An operation fails and reports success. `publish.yml` pushed images and created no GitHub Release for six
+ * versions. `query` returned an envelope and dropped every row. The media worker made a paid model call and
+ * silently discarded its result. Each one is the same thing: the work happened, the result did not land, and
+ * the absence is indistinguishable from "there was nothing to write".
+ *
+ * ## Why this gate is narrow on purpose
+ *
+ * A sweep for `catch` with no handler finds **118 sites** in `server/src`, and the great majority are
+ * correct — cleanup, optional reads, probes, best-effort niceties. A gate over all of them would be noise
+ * that gets suppressed, which is worse than no gate.
+ *
+ * So it asks a narrower question, of one file: in the MEDIA WORKER, where a swallowed write means a paid
+ * model call is lost or a record is stranded mid-status, does every swallow either LOG or say in a comment
+ * why it does not need to? Both of the sites this was written for had neither.
+ *
+ * `files/media/worker.ts` is chosen because that is where the cost of silence is highest — every write there
+ * follows a model call, so a lost write is money already spent and not recoverable by a retry.
+ *
+ * Run: node --test testing/standalone/swallowed-writes-must-be-visible.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const FILE = 'server/src/files/media/worker.ts';
+const src = readFileSync(FILE, 'utf8');
+const lines = src.split(/\r?\n/);
+
+/** A catch that discards its argument — `.catch(() => …)` with no parameter. */
+const SWALLOW = /\.catch\(\s*\(\s*\)\s*=>/;
+/** The call it hangs off names a persistence operation. */
+const WRITE = /(updateOne|insertOne|replaceOne|bulkWrite|deleteOne|deleteMany|writeFile|upsert)/i;
+
+describe('the media worker never loses a write in silence', () => {
+  it('the detector finds swallows at all — otherwise this gate proves nothing', () => {
+    // Mutation check: a matcher that matches nothing is indistinguishable from a clean file.
+    assert.ok(SWALLOW.test('await thing().catch(() => {});'));
+    assert.equal(SWALLOW.test('await thing().catch((err) => log.warn(err));'), false,
+      'a catch that BINDS its error is not a swallow — that is the shape we want people to write');
+  });
+
+  it('every swallowed WRITE either logs, or says why it need not', () => {
+    const offenders = [];
+    lines.forEach((line, i) => {
+      if (!SWALLOW.test(line)) return;
+      // The statement this catch belongs to — look back for the call being awaited.
+      const stmt = lines.slice(Math.max(0, i - 5), i + 1).join(' ');
+      if (!WRITE.test(stmt)) return;
+      // Either the catch body logs, or a comment on/near the line states the reason.
+      const nearby = lines.slice(Math.max(0, i - 3), i + 4).join(' ');
+      const logs = /log\.(warn|error|info)/.test(nearby);
+      const excused = /non-fatal|best-effort|source of truth|logged at|deliberately/i.test(nearby);
+      if (!logs && !excused) offenders.push(`${FILE}:${i + 1}  ${line.trim().slice(0, 90)}`);
+    });
+
+    assert.deepEqual(offenders, [],
+      'a write in the media worker follows a model call, so losing it silently means money already spent and '
+      + 'a result that cannot be recovered by a retry. Log it at warn naming the space, the file and what was '
+      + 'lost — or write down why the loss does not matter.');
+  });
+
+  it('the two sites this was written for name what is lost, not just that something failed', () => {
+    // "Write failed" is a log nobody can act on. The describe write loses a description and an excerpt; the
+    // permanent-failure write strands a record in `processing` while the counter says it failed. An operator
+    // reading either line should know which of those they are looking at.
+    assert.match(src, /described but the metadata write failed/,
+      'the describe write must say the description and excerpt from that run are gone');
+    assert.match(src, /the record will read 'processing' while the failure counter has already moved/,
+      'the status write must name the disagreement it leaves between the metric and the record');
+  });
+
+  it('and neither was turned into a throw', () => {
+    // Failing the job would retry a document whose analysis already succeeded and re-pay for the model. The
+    // fix was visibility, not severity, and a later "tidy-up" that promotes these to throws would be a
+    // regression dressed as rigour.
+    const describeAt = src.indexOf('described but the metadata write failed');
+    const window = src.slice(Math.max(0, describeAt - 400), describeAt);
+    assert.doesNotMatch(window, /\.catch\(\s*\(\s*err[^)]*\)\s*=>\s*\{\s*throw/,
+      'the describe write must not rethrow — that re-pays for a model call that already succeeded');
+  });
+});


### PR DESCRIPTION
Found by a reliability sweep for the shape this cycle produced four times — an operation that fails and reports success.

**The describe write loses money.** `describeDocument()` is a model call with its own timeout, and the next statement is the only place its output lands. A failed write meant the call was paid for, the result gone, and the job reporting success — a file with no description, indistinguishable from one there was nothing to describe.

**The status write makes two surfaces disagree.** On a permanent conversion failure the worker writes `embeddingStatus: 'skipped'` and increments `mediaJobsFailedTotal` regardless. Swallowing the write left the metric saying "permanently failed" while the record said `processing` for ever.

**Neither throws now, deliberately** — failing the job would retry a document whose analysis already succeeded and re-pay for the model. The defect was invisibility, not severity, so both logs name *what* was lost.

**Scope:** the sweep finds 118 swallowed catches in `server/src` and most are correct. Narrowing to swallows on a WRITE, minus those whose comment states a reason, left 8 — six carry a reason, these two carried none.

The gate asks the question of one file, where every write follows a model call. Mutation-checked: removing the describe log turns it red.
