### PR TITLE
fix(brain)!: the vector we promised was never returned, was

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
+- **Every read stopped returning the embedding vector, and it had never stopped: the list routes sent it on
+  every record.** `GET /api/brain/spaces/:spaceId/entities?limit=500` answered **11.19 MB** for one space where
+  `POST /query` answered the same 100 records in **0.145 MB** — reported by aigents 2026-08-19 after it killed
+  their n8n with an out-of-memory failure, took its database down with it for a stretch, and blocked deploys.
+  They tried twelve parameter spellings looking for a switch; there was none, because the route accepted no
+  projection at all.
+
+  **The reason it went unnoticed for so long is that we published the opposite, absolutely, in four places.**
+  `/query`'s parameter description (*"always excluded and cannot be re-included"*), `recall`'s and
+  `update_memory`'s MCP descriptions (*"never returned by anything here"*), and the integration guide's own
+  *"the list routes project it out before the documents leave the database"*. An integrator who believed those
+  had no reason to look at a payload size — and none of them was true for a list route.
+
+  **Fifteen reads and twelve write returns, not the one reported.** Five list/lookup readers plus three
+  single-record getters had no projection; a shape-derived gate then found seven more, including three spelled
+  through a local variable that the gate's own first version was blind to. On the write side, an inline embed
+  put the freshly computed vector into the 201 — measured on entity, memory, chrono and edge creates with
+  `waitForEmbedding: true`, **and any create with `checkDuplicates`, which defaults to TRUE**, so it was
+  reachable with no flag at all. An ordinary edge or entity UPDATE leaked it with no flag either, from the
+  unprojected read of the existing record.
+
+  The rule now lives in one place (`brain/read-projection.ts`), is derived from `NEVER_RETURNED_FIELDS` so the
+  two cannot disagree, and is enforced by a gate that derives its own scope from the shape of the code rather
+  than from a list of known readers — because a list would pass the day somebody adds a sixteenth. Fourteen
+  places already stripped the vector when emitting a **webhook**: the rule was known, applied at every
+  webhook, and applied at zero returns.
+
+  Verified against a running instance: sixteen paths, every one clean, including `POST /traverse` and
+  `?includeDiagnostics=true` — no flag can ask for the vector back, which is what the four sentences promise.
+
+- **The brain list routes withhold `matchedText` and `embeddingModel` by default; `seq` still comes back.**
+  breituai-platform asked for this by name, taking up an offer in the 3.1.0 notes: *"matchedText is the passage
+  a second time, and a list route is the call most likely to be made in bulk."* `?includeDiagnostics=true`
+  restores both, the same parameter name `recall` uses.
+
+  **`seq` is deliberately NOT withheld here, unlike on recall** — it is the `If-Match` value, so dropping it
+  would remove the conditional-write path. The two doors therefore withhold sets that differ by one field, on
+  purpose. **This is a response-shape change** on `GET …/entities`, `…/memories`, `…/edges` and `…/chrono`.
+
+  MCP needs no matching parameter: its list tools return a formatted summary that never carried either field,
+  so there is nothing there to withhold or restore.
+
 - **The 25-record spill cliff is replaced by a byte budget, and every returned record is whole.** Owner-commissioned;
   specified by breituai-platform on request. Past 25 records a recall used to collapse to **three** inline
   results plus a download of the WHOLE set — including the three already sent. Their measurement: a real

--- a/docs/integration-guide/04-brain-api.md
+++ b/docs/integration-guide/04-brain-api.md
@@ -415,10 +415,19 @@ GET /api/brain/spaces/:spaceId/memories/:id
 > | `matchedText` | The exact text this record's vector was built from. Derived from the fields above it, and for a file chunk it is the heading plus the passage — so the passage a SECOND time |
 > | `embeddingModel` | Which model produced the vector. Identical for every record in a space |
 >
-> **These are NOT stripped here, unlike on `recall`**, where `includeDiagnostics` withholds all three by
-> default. The list routes have no field selection at all today — that asymmetry is real and is written down
-> rather than left for you to discover. If it costs your integration, say so; the structured
-> [`POST /query`](04d-brain-ops-api.md#structured-query-read-only) route accepts a `projection` and is the way to bound a read meanwhile.
+> **`matchedText` and `embeddingModel` are now withheld by DEFAULT here** — the paragraph above used
+> to say all three came back unconditionally, invited anyone it cost to say so, and an integrator did:
+> *"matchedText is the passage a second time, and a list route is the call most likely to be made in bulk."*
+> Send `?includeDiagnostics=true` to get them back, the same parameter name `recall` uses.
+>
+> **`seq` still comes back, always, and that is deliberate rather than an oversight.** It was withheld on
+> `recall` along with the other two, but on a list route it is the `If-Match` value: dropping it would remove
+> the conditional-write path, which costs more than the bytes are worth. So the two doors withhold a
+> *different* set by one field, on purpose — asked for by name by the integrator who wanted the other two gone.
+>
+> The list routes still have no `projection`; the structured
+> [`POST /query`](04d-brain-ops-api.md#structured-query-read-only) route accepts one and remains the way to
+> bound a read to named fields.
 
 ---
 
@@ -692,9 +701,16 @@ The same header, in the same spellings, is honoured on space-meta writes against
 
 **The embedding vector is never returned — by any endpoint, on either door, and there is no parameter that
 asks for it.** `POST /query` merges a mandatory exclusion into whatever projection you send and strips an
-explicit `"embedding": 1` out of it, so the vector cannot be opted back in; the list routes project it out
-before the documents leave the database. If you have been hunting for a flag to switch it off, this is why
-you could not find one.
+explicit `"embedding": 1` out of it, so the vector cannot be opted back in; every read of a record collection
+projects it out before the document leaves the database. If you have been hunting for a flag to switch it off,
+this is why you could not find one.
+
+> **This was FALSE for the list routes in 3.1.0 and every version before it.** A `?limit=500` read of the
+> entities list returned every record's vector: an integrator measured **11.19 MB** where `POST /query`
+> answered the same 100 records in **0.145 MB**. They found it by running out of memory rather than by
+> reading a response — because this paragraph told them the field could not be there, which is why the
+> correction is here and not only in the changelog. **On 3.1.0 or earlier, use `POST /query` with a
+> projection for any bulk read.**
 
 What you *can* control:
 
@@ -703,6 +719,7 @@ What you *can* control:
 | `projection` | `POST /query`, **and recall / find-similar** | any field you do not name. On recall it applies recursively, so a `traverse` answer's `_graph` is projected at every depth |
 | `includeContent: false` | recall, find-similar | file-passage **bodies**, keeping path, heading, chunk index, tags and properties |
 | `includeDiagnostics: false` *(the default)* | recall, find-similar | `matchedText`, `embeddingModel`, `seq` and the per-stage scores — **recursively**, so a `traverse` answer's `_graph` follows it at every depth |
+| `includeDiagnostics` *(query string, default off)* | the **list** routes — entities, memories, edges, chrono | `matchedText` and `embeddingModel`. **`seq` is NOT dropped here**, unlike on recall: it is the `If-Match` value, and withholding it would take away conditional writes. Send `?includeDiagnostics=true` to get the two fields back |
 
 A projection is worth reaching for rather than skipping: a bare query over a dozen records with full
 descriptions and properties is the cheapest way to overrun a token budget, and naming the four fields you

--- a/server/src/api/brain/_shared.ts
+++ b/server/src/api/brain/_shared.ts
@@ -197,3 +197,29 @@ export function preconditionFailedBody(record: string, currentSeq?: number): Rec
     ...(currentSeq === undefined ? {} : { currentSeq }),
   };
 }
+
+/**
+ * Did this list request ask for the withheld record diagnostics?
+ *
+ * `?includeDiagnostics=true` restores `matchedText` and `embeddingModel`; anything else, including absence,
+ * withholds them. `seq` is never withheld — see `LIST_WITHHELD_FIELDS` for why.
+ *
+ * ## Why the same spelling as the recall parameter, and why it is not the same list
+ *
+ * A caller who learned `includeDiagnostics` on `recall` must not have to learn a second name for the same
+ * intent, so the NAME is shared deliberately. What it restores differs by one field, because `seq` is the
+ * `If-Match` value on a list route and withholding it would take away conditional writes. That difference is
+ * a decision breituai-platform asked for by name, not drift.
+ *
+ * ## Why absence and a bad value behave the same, unlike the body flags on recall
+ *
+ * The recall route 400s on a non-boolean `includeDiagnostics`, and that is right for a JSON body where a
+ * caller wrote `"true"` and meant `true`. A QUERY STRING has no booleans at all — every value arrives as
+ * text — so there is no type error to report, and refusing `?includeDiagnostics=1` would fail a request whose
+ * intent is unmistakable while `?includeDiagnostics=yes` is a guess either way. The safe reading of anything
+ * that is not the literal `true` is the DEFAULT, which withholds: a caller who wanted the fields and typoed
+ * the value gets a smaller response and can see it, rather than a 400 on a read they can already make.
+ */
+export function listDiagnosticsAsked(req: express.Request): boolean {
+  return req.query['includeDiagnostics'] === 'true';
+}

--- a/server/src/api/brain/chrono.ts
+++ b/server/src/api/brain/chrono.ts
@@ -24,6 +24,8 @@ import { mergePropertiesOrKeep } from '../../brain/merge-fields.js';
 import {
   parseRecordSuppression, RECORD_SUPPRESS_FIELD, LEGACY_RECORD_SUPPRESS_FIELD,
 } from '../../brain/suppress-embeddings.js';
+import { withoutListDiagnostics } from '../../brain/read-projection.js';
+import { listDiagnosticsAsked } from './_shared.js';
 
 export const chronoRouter = Router();
 
@@ -372,7 +374,8 @@ chronoRouter.get('/spaces/:spaceId/chrono', globalRateLimit, requireSpaceAuth, a
   if (!page.ok) { res.status(400).json({ error: page.error }); return; }
   let total = 0;
   for (const mid of members) total += await countBrain(mid, 'chrono', await filterFor(mid));
-  res.json({ chrono: page.rows, limit, skip, total, truncated: skip + page.rows.length < total });
+  res.json({ chrono: withoutListDiagnostics(page.rows, listDiagnosticsAsked(req)),
+    limit, skip, total, truncated: skip + page.rows.length < total });
 });
 
 

--- a/server/src/api/brain/edges.ts
+++ b/server/src/api/brain/edges.ts
@@ -23,6 +23,8 @@ import { classifyEdgeUpsert, classifyUpdateViolations } from '../../brain/write-
 import { resolveEntityIdsByName } from '../../brain/entities.js';
 import { mergePropertiesOrKeep } from '../../brain/merge-fields.js';
 import { parseRecordSuppression } from '../../brain/suppress-embeddings.js';
+import { withoutListDiagnostics } from '../../brain/read-projection.js';
+import { listDiagnosticsAsked } from './_shared.js';
 
 export const edgesRouter = Router();
 
@@ -174,7 +176,8 @@ edgesRouter.get('/spaces/:spaceId/edges', globalRateLimit, requireSpaceAuth, asy
   const enriched = all.map(e => ({ ...e, fromName: nameMap.get(e.from), toName: nameMap.get(e.to) }));
   let total = 0;
   for (const mid of members) total += await countBrain(mid, 'edges', await filterFor(mid));
-  res.json({ edges: enriched, limit, skip, total, truncated: skip + enriched.length < total });
+  res.json({ edges: withoutListDiagnostics(enriched, listDiagnosticsAsked(req)),
+    limit, skip, total, truncated: skip + enriched.length < total });
 });
 
 

--- a/server/src/api/brain/entities.ts
+++ b/server/src/api/brain/entities.ts
@@ -24,6 +24,8 @@ import { classifyEntityUpsert, classifyUpdateViolations } from '../../brain/writ
 import { tagContains, textContains, propertiesValueContains } from '../../brain/tag-filter.js';
 import { mergePropertiesOrKeep, mergeTagsOrKeep } from '../../brain/merge-fields.js';
 import { parseRecordSuppression } from '../../brain/suppress-embeddings.js';
+import { withoutListDiagnostics } from '../../brain/read-projection.js';
+import { listDiagnosticsAsked } from './_shared.js';
 
 export const entitiesRouter = Router();
 
@@ -151,7 +153,8 @@ entitiesRouter.get('/spaces/:spaceId/entities', globalRateLimit, requireSpaceAut
   if (!page.ok) { res.status(400).json({ error: page.error }); return; }
   let total = 0;
   for (const mid of members) total += await countBrain(mid, 'entities', filter);
-  res.json({ entities: page.rows, limit, skip, total, truncated: skip + page.rows.length < total });
+  res.json({ entities: withoutListDiagnostics(page.rows, listDiagnosticsAsked(req)),
+    limit, skip, total, truncated: skip + page.rows.length < total });
 });
 
 

--- a/server/src/api/brain/memories.ts
+++ b/server/src/api/brain/memories.ts
@@ -25,6 +25,8 @@ import { classifyUpdateViolations } from '../../brain/write-validation.js';
 import { resolveEntityIdsByName } from '../../brain/entities.js';
 import { mergePropertiesOrKeep } from '../../brain/merge-fields.js';
 import { parseRecordSuppression } from '../../brain/suppress-embeddings.js';
+import { withoutListDiagnostics } from '../../brain/read-projection.js';
+import { listDiagnosticsAsked } from './_shared.js';
 
 export const memoriesRouter = Router();
 
@@ -203,7 +205,7 @@ memoriesRouter.get('/spaces/:spaceId/memories', globalRateLimit, requireSpaceAut
   for (const mid of members) total += await countBrain(mid, 'memories', await filterFor(mid));
 
   res.json({
-    memories: page.rows, limit, skip, total,
+    memories: withoutListDiagnostics(page.rows, listDiagnosticsAsked(req)), limit, skip, total,
     // Explicit rather than left to be derived from `total`: their third ask, and a caller that knows it received a
     // partial page does not need to work out whether it did.
     truncated: skip + page.rows.length < total,

--- a/server/src/brain/bulk.ts
+++ b/server/src/brain/bulk.ts
@@ -28,6 +28,7 @@ import type { EntityDoc, ChronoType, ChronoStatus } from '../config/types.js';
 export const BULK_MAX_PER_TYPE = 500;
 
 import { UUID_V4_RE } from './entity-refs.js';
+import { NEVER_RETURNED_PROJECTION } from './read-projection.js';
 const CHRONO_STATUSES = new Set<ChronoStatus>(['upcoming', 'active', 'completed', 'overdue', 'cancelled']);
 const MAX_FACT_LENGTH = 50_000;
 
@@ -139,7 +140,8 @@ export async function bulkWrite(spaceId: string, input: BulkInput): Promise<Bulk
       // The MERGED record, not the payload — an id that matches an existing entity makes this an
       // update, and the importer had the merge target in hand two lines later for its own counter.
       const existing = rawId
-        ? await col<EntityDoc>(`${spaceId}_entities`).findOne(asFilter<EntityDoc>({ _id: rawId, spaceId }))
+        ? await col<EntityDoc>(`${spaceId}_entities`).findOne(asFilter<EntityDoc>({ _id: rawId, spaceId }),
+          { projection: NEVER_RETURNED_PROJECTION })
         : null;
       const mergedEnt = mergeTagsAndProperties(existing as EntityDoc | null, { tags: strArray(item['tags']), properties });
       if (schemaFails('entity', i, validateEntity(meta ?? {}, { name, type, properties: mergedEnt.properties, tags: mergedEnt.tags }))) continue;

--- a/server/src/brain/chrono.ts
+++ b/server/src/brain/chrono.ts
@@ -6,6 +6,7 @@ import { nextSeq, reserveSeqBlock } from '../util/seq.js';
 import { tagContains, textContains, propertiesValueContains, PROPERTIES_SCAN_MAX_MS } from './tag-filter.js';
 import { parseLimit, parseSkip } from '../util/pagination.js';
 import { toMongoSort, type SortSpec } from './list-sort.js';
+import { NEVER_RETURNED_PROJECTION, withoutVector } from './read-projection.js';
 import { textSearchOr, SEARCHABLE_FIELDS } from './text-search.js';
 import { embed } from './embedding.js';
 import { chronoEmbedText } from './embed-text.js';
@@ -118,7 +119,8 @@ export async function createChrono(
   // `remember`.
   const existing: ChronoEntry | null = fields.id
     ? (await col<ChronoEntry>(`${spaceId}_chrono`).findOne(
-      asFilter<ChronoEntry>({ _id: fields.id, spaceId })) as ChronoEntry | null)
+      asFilter<ChronoEntry>({ _id: fields.id, spaceId }),
+      { projection: NEVER_RETURNED_PROJECTION }) as ChronoEntry | null)
     : null;
 
   const seq = await nextSeq(spaceId);
@@ -183,9 +185,9 @@ export async function createChrono(
     if ('_expireAt' in $unset) delete (converged as { _expireAt?: unknown })._expireAt;
     // `chrono.updated`, not `created` — a subscriber must be able to tell a converged retry from a new entry.
     if (actor) emitWebhookEvent({ event: 'chrono.updated', spaceId, entry: { ...converged, embedding: undefined }, ...actor });
-    return (similar || contradicts)
+    return withoutVector((similar || contradicts)
       ? { ...converged, ...(similar ? { similar } : {}), ...(contradicts ? { contradicts } : {}) }
-      : converged;
+      : converged);
   }
 
   const doc: ChronoEntry = {
@@ -226,7 +228,7 @@ export async function createChrono(
   if (!embeddingFields.embedding) await enqueueEmbedJob(spaceId, 'chrono', doc._id);
   if (actor) emitWebhookEvent({ event: 'chrono.created', spaceId, entry: { ...doc, embedding: undefined }, ...actor });
   // Advisory only — the entry is stored either way.
-  return (similar || contradicts) ? { ...doc, ...(similar ? { similar } : {}), ...(contradicts ? { contradicts } : {}) } : doc;
+  return withoutVector((similar || contradicts) ? { ...doc, ...(similar ? { similar } : {}), ...(contradicts ? { contradicts } : {}) } : doc);
 }
 
 export async function updateChrono(
@@ -238,7 +240,9 @@ export async function updateChrono(
   ttlDays?: number | null,
   ifMatchSeq?: number,
 ): Promise<ChronoEntry | null> {
-  const existing = await col<ChronoEntry>(`${spaceId}_chrono`).findOne(asFilter<ChronoEntry>({ _id: id, spaceId })) as ChronoEntry | null;
+  const existing = await col<ChronoEntry>(`${spaceId}_chrono`)
+    .findOne(asFilter<ChronoEntry>({ _id: id, spaceId }),
+      { projection: NEVER_RETURNED_PROJECTION }) as ChronoEntry | null;
   if (!existing) return null;
 
   const seq = await nextSeq(spaceId);
@@ -337,7 +341,7 @@ export async function updateChrono(
   // `embedStoredRecord` for why this replaced an inline embed built from a stale read.
   await enqueueEmbedJob(spaceId, 'chrono', updatedChrono._id);
   if (actor) emitWebhookEvent({ event: 'chrono.updated', spaceId, entry: { ...updatedChrono, embedding: undefined }, ...actor });
-  return updatedChrono;
+  return withoutVector(updatedChrono);
 }
 
 /** Return the entry with its derived status applied (a shallow copy only when the status changes). */
@@ -347,7 +351,9 @@ function withDerivedStatus(entry: ChronoEntry, now: Date = new Date()): ChronoEn
 }
 
 export async function getChronoById(spaceId: string, id: string): Promise<ChronoEntry | null> {
-  const entry = await col<ChronoEntry>(`${spaceId}_chrono`).findOne(asFilter<ChronoEntry>({ _id: id, spaceId })) as ChronoEntry | null;
+  const entry = await col<ChronoEntry>(`${spaceId}_chrono`)
+    .findOne(asFilter<ChronoEntry>({ _id: id, spaceId }),
+      { projection: NEVER_RETURNED_PROJECTION }) as ChronoEntry | null;
   return entry ? withDerivedStatus(entry) : null;
 }
 
@@ -485,7 +491,7 @@ export async function listChrono(
   const { query, comparesAgainstTheClock } = buildChronoQuery(spaceId, filter, now);
 
   const entries = await col<ChronoEntry>(`${spaceId}_chrono`)
-    .find(asFilter<ChronoEntry>(query))
+    .find(asFilter<ChronoEntry>(query), { projection: NEVER_RETURNED_PROJECTION })
     .maxTimeMS(comparesAgainstTheClock ? PROPERTIES_SCAN_MAX_MS : 60_000)
     .sort(sort ? toMongoSort(sort) : { createdAt: -1 })
     .skip(parseSkip(skip))

--- a/server/src/brain/edges.ts
+++ b/server/src/brain/edges.ts
@@ -5,6 +5,7 @@ import { col, asFilter, asDoc, asUpdate, asBulk } from '../db/mongo.js';
 import { nextSeq, reserveSeqBlock } from '../util/seq.js';
 import { parseLimit, parseSkip } from '../util/pagination.js';
 import { toMongoSort, type SortSpec } from './list-sort.js';
+import { NEVER_RETURNED_PROJECTION, withoutVector } from './read-projection.js';
 import { textSearchOr, SEARCHABLE_FIELDS } from './text-search.js';
 import { embed } from './embedding.js';
 import { edgeEmbedText } from './embed-text.js';
@@ -80,11 +81,23 @@ export async function resolveEdgeEntityNames(spaceId: string, fromId: string, to
  * An edge has no user-supplied id: `(from, to, label)` IS the identity, and three separate places
  * re-derived that filter — the upsert itself, the bulk importer's inserted-vs-updated counter, and now
  * validation. One of them getting it wrong would silently validate against the wrong record.
+ *
+ * ## It is also projected, which fixes a leak on a path nobody would look at for one
+ *
+ * `upsertEdge` spreads this document into the edge it RETURNS, and the route sends that as its 201. So an
+ * ordinary edge update — no `waitForEmbedding`, no flag of any kind — answered with the stored float array,
+ * measured against the live stack 2026-08-19. It was the only vector leak reachable without asking for an
+ * inline embed.
+ *
+ * Nothing needs the old vector: the upsert either recomputes it or leaves the stored field untouched, and the
+ * other two callers (the bulk importer's counter and `write-validation`) read `properties`.
  */
 export async function findEdgeByTriplet(
   spaceId: string, from: string, to: string, label: string,
 ): Promise<EdgeDoc | null> {
-  return await col<EdgeDoc>(`${spaceId}_edges`).findOne(asFilter<EdgeDoc>({ spaceId, from, to, label })) as EdgeDoc | null;
+  return await col<EdgeDoc>(`${spaceId}_edges`)
+    .findOne(asFilter<EdgeDoc>({ spaceId, from, to, label }),
+      { projection: NEVER_RETURNED_PROJECTION }) as EdgeDoc | null;
 }
 
 export async function upsertEdge(
@@ -159,7 +172,7 @@ export async function upsertEdge(
     else if ('_expireAt' in $unset) delete (updatedEdge as { _expireAt?: unknown })._expireAt;
     if (!embeddingFields.embedding) await enqueueEmbedJob(spaceId, 'edge', updatedEdge._id);
     if (actor) emitWebhookEvent({ event: 'edge.created', spaceId, entry: { ...updatedEdge, embedding: undefined }, ...actor });
-    return updatedEdge;
+    return withoutVector(updatedEdge);
   }
 
   const doc: EdgeDoc = {
@@ -188,7 +201,7 @@ export async function upsertEdge(
   await collection.insertOne(asDoc<EdgeDoc>(doc));
   if (!embeddingFields.embedding) await enqueueEmbedJob(spaceId, 'edge', doc._id);
   if (actor) emitWebhookEvent({ event: 'edge.created', spaceId, entry: { ...doc, embedding: undefined }, ...actor });
-  return doc;
+  return withoutVector(doc);
 }
 
 /** List edges for a space, optionally filtering by from/to entity */
@@ -217,7 +230,7 @@ export async function listEdges(
   const search = textSearchOr(filter.search, SEARCHABLE_FIELDS.edges);
   if (search) Object.assign(q, search);
   return col<EdgeDoc>(`${spaceId}_edges`)
-    .find(asFilter<EdgeDoc>(q))
+    .find(asFilter<EdgeDoc>(q), { projection: NEVER_RETURNED_PROJECTION })
     .maxTimeMS(q['$expr'] ? PROPERTIES_SCAN_MAX_MS : 60_000)
     .sort(sort ? toMongoSort(sort) : { seq: -1, createdAt: -1, _id: -1 })
     .skip(parseSkip(skip))
@@ -261,7 +274,9 @@ export async function deleteEdge(spaceId: string, edgeId: string, actor?: Webhoo
 
 /** Find an edge by exact ID */
 export async function getEdgeById(spaceId: string, id: string): Promise<EdgeDoc | null> {
-  return col<EdgeDoc>(`${spaceId}_edges`).findOne(asFilter<EdgeDoc>({ _id: id, spaceId })) as Promise<EdgeDoc | null>;
+  return col<EdgeDoc>(`${spaceId}_edges`)
+    .findOne(asFilter<EdgeDoc>({ _id: id, spaceId }),
+      { projection: NEVER_RETURNED_PROJECTION }) as Promise<EdgeDoc | null>;
 }
 
 /** Update an existing edge by ID. Partial update — only supplied fields are changed. Re-embeds when any content field changes. */
@@ -275,7 +290,8 @@ export async function updateEdgeById(
   ifMatchSeq?: number,
 ): Promise<EdgeDoc | null> {
   const collection = col<EdgeDoc>(`${spaceId}_edges`);
-  const existing = await collection.findOne(asFilter<EdgeDoc>({ _id: id, spaceId })) as EdgeDoc | null;
+  const existing = await collection.findOne(asFilter<EdgeDoc>({ _id: id, spaceId }),
+    { projection: NEVER_RETURNED_PROJECTION }) as EdgeDoc | null;
   if (!existing) return null;
 
   const seq = await nextSeq(spaceId);
@@ -555,7 +571,8 @@ export async function traverseGraph(
       } else {
         q = { spaceId: mid, $or: [{ from: { $in: frontier } }, { to: { $in: frontier } }], ...labelFilter };
       }
-      const edges = await col<EdgeDoc>(`${mid}_edges`).find(asFilter<EdgeDoc>(q)).toArray() as EdgeDoc[];
+      const edges = await col<EdgeDoc>(`${mid}_edges`)
+        .find(asFilter<EdgeDoc>(q), { projection: NEVER_RETURNED_PROJECTION }).toArray() as EdgeDoc[];
       adjacentEdges.push(...edges);
     }
 
@@ -652,7 +669,8 @@ export async function traverseGraph(
     const entityMap = new Map<string, EntityDoc>();
     for (const mid of memberIds) {
       const entities = await col<EntityDoc>(`${mid}_entities`)
-        .find(asFilter<EntityDoc>({ _id: { $in: newNeighborIds }, spaceId: mid }))
+        .find(asFilter<EntityDoc>({ _id: { $in: newNeighborIds }, spaceId: mid }),
+          { projection: NEVER_RETURNED_PROJECTION })
         .toArray() as EntityDoc[];
       for (const e of entities) entityMap.set(e._id, e);
     }
@@ -797,13 +815,19 @@ export async function traverseFromSeeds(
 
   while (frontier.length > 0 && depth < maxDepth) {
     const edges = await col<EdgeDoc>(`${spaceId}_edges`)
-      // `embedding: 0`, matching the entity query below and every other read path in the codebase. An EDGE
-      // is a searchable record with a vector of its own, and this was the ONE query that fetched it whole:
-      // the edge document is returned verbatim as `_graph[].edge`, so a `recall(traverse: n)` shipped a full
-      // float array per hop, on both doors. Nothing consumes it — `nestNeighbours` only nests the document —
-      // so this is pure subtraction, and it makes "the vector is never returned" true rather than nearly so.
+      // An EDGE is a searchable record with a vector of its own, and this query fetched it whole: the edge
+      // document is returned verbatim as `_graph[].edge`, so a `recall(traverse: n)` shipped a full float
+      // array per hop, on both doors. Nothing consumes it — `nestNeighbours` only nests the document — so
+      // dropping it is pure subtraction.
+      //
+      // **This comment used to claim it was "matching the entity query below and every other read path in
+      // the codebase". That was false, and the claim is why nobody checked.** Five readers had no projection
+      // at all — the three list functions and the two entity lookups — and a caller measured 11.19 MB from
+      // `GET /entities?limit=500` where `/query` answered 0.145 MB. All of them now share
+      // `NEVER_RETURNED_PROJECTION`, so the sentence is true; do not restate universality here again, because
+      // the constant is what makes it true and a comment cannot.
       .find(asFilter<EdgeDoc>({ $or: [{ from: { $in: frontier } }, { to: { $in: frontier } }] }))
-      .project({ embedding: 0 })
+      .project(NEVER_RETURNED_PROJECTION)
       .toArray() as EdgeDoc[];
 
     const newNeighborIds: string[] = [];
@@ -850,7 +874,7 @@ export async function traverseFromSeeds(
     // a space rename hide data in the first place.
     const entities = await col<EntityDoc>(`${spaceId}_entities`)
       .find(asFilter<EntityDoc>({ _id: { $in: newNeighborIds } }))
-      .project({ embedding: 0 })
+      .project(NEVER_RETURNED_PROJECTION)
       .toArray() as EntityDoc[];
     const entityMap = new Map<string, EntityDoc>();
     for (const e of entities) entityMap.set(e._id, e);

--- a/server/src/brain/entities.ts
+++ b/server/src/brain/entities.ts
@@ -6,6 +6,7 @@ import { col, asFilter, asDoc, asUpdate, asBulk } from '../db/mongo.js';
 import { nextSeq, reserveSeqBlock } from '../util/seq.js';
 import { parseLimit, parseSkip } from '../util/pagination.js';
 import { toMongoSort, type SortSpec } from './list-sort.js';
+import { NEVER_RETURNED_PROJECTION, withoutVector } from './read-projection.js';
 import { embed } from './embedding.js';
 import { entityEmbedText } from './embed-text.js';
 import { getConfig } from '../config/loader.js';
@@ -109,7 +110,8 @@ export async function upsertEntity(
 
   // When an id is provided, attempt to find the existing record by primary key.
   const existing: EntityDoc | null = id
-    ? (await collection.findOne(asFilter<EntityDoc>({ _id: id, spaceId })) as EntityDoc | null)
+    ? (await collection.findOne(asFilter<EntityDoc>({ _id: id, spaceId }),
+      { projection: NEVER_RETURNED_PROJECTION }) as EntityDoc | null)
     : null;
 
   const seq = await nextSeq(spaceId);
@@ -157,7 +159,7 @@ export async function upsertEntity(
     // After the write, never before: a job for a record that failed to store would be a job for nothing.
     if (!embeddingFields.embedding) await enqueueEmbedJob(spaceId, 'entity', entity._id);
     if (actor) emitWebhookEvent({ event: 'entity.updated', spaceId, entry: { ...entity, embedding: undefined }, ...actor });
-    return { entity };
+    return { entity: withoutVector(entity) };
   }
 
   // Warn when inserting without an explicit id and duplicates already exist
@@ -223,7 +225,7 @@ export async function upsertEntity(
   }
   if (actor) emitWebhookEvent({ event: 'entity.created', spaceId, entry: { ...doc, embedding: undefined }, ...actor });
   // Advisory only — the entity is stored either way.
-  return { entity: doc, warning, similar, contradicts };
+  return { entity: withoutVector(doc), warning, similar, contradicts };
 }
 
 /**
@@ -233,7 +235,7 @@ export async function upsertEntity(
  */
 export async function findEntitiesByName(spaceId: string, name: string): Promise<EntityDoc[]> {
   return col<EntityDoc>(`${spaceId}_entities`)
-    .find(asFilter<EntityDoc>({ spaceId, name }))
+    .find(asFilter<EntityDoc>({ spaceId, name }), { projection: NEVER_RETURNED_PROJECTION })
     .toArray() as Promise<EntityDoc[]>;
 }
 
@@ -247,13 +249,16 @@ export async function findEntitiesByName(spaceId: string, name: string): Promise
 export async function findEntitiesByIds(spaceId: string, ids: readonly string[]): Promise<EntityDoc[]> {
   if (ids.length === 0) return [];
   return col<EntityDoc>(`${spaceId}_entities`)
-    .find(asFilter<EntityDoc>({ _id: { $in: [...new Set(ids)] }, spaceId }))
+    .find(asFilter<EntityDoc>({ _id: { $in: [...new Set(ids)] }, spaceId }),
+      { projection: NEVER_RETURNED_PROJECTION })
     .toArray() as Promise<EntityDoc[]>;
 }
 
 /** Find an entity by exact ID */
 export async function getEntityById(spaceId: string, id: string): Promise<EntityDoc | null> {
-  return col<EntityDoc>(`${spaceId}_entities`).findOne(asFilter<EntityDoc>({ _id: id, spaceId })) as Promise<EntityDoc | null>;
+  return col<EntityDoc>(`${spaceId}_entities`)
+    .findOne(asFilter<EntityDoc>({ _id: id, spaceId }),
+      { projection: NEVER_RETURNED_PROJECTION }) as Promise<EntityDoc | null>;
 }
 
 /**
@@ -274,7 +279,8 @@ export async function updateEntityById(
   ifMatchSeq?: number,
 ): Promise<EntityDoc | null> {
   const collection = col<EntityDoc>(`${spaceId}_entities`);
-  const existing = await collection.findOne(asFilter<EntityDoc>({ _id: id, spaceId })) as EntityDoc | null;
+  const existing = await collection.findOne(asFilter<EntityDoc>({ _id: id, spaceId }),
+    { projection: NEVER_RETURNED_PROJECTION }) as EntityDoc | null;
   if (!existing) return null;
 
   const seq = await nextSeq(spaceId);
@@ -389,7 +395,7 @@ export async function listEntities(
   sort?: SortSpec,
 ): Promise<EntityDoc[]> {
   const cursor = col<EntityDoc>(`${spaceId}_entities`)
-    .find(asFilter<EntityDoc>({ ...filter, spaceId }));
+    .find(asFilter<EntityDoc>({ ...filter, spaceId }), { projection: NEVER_RETURNED_PROJECTION });
   // A properties-value filter is a collection scan by nature ($expr cannot use an index), so it
   // carries its own deadline instead of running unbounded on a large space.
   cursor.maxTimeMS(filter['$expr'] ? PROPERTIES_SCAN_MAX_MS : 60_000);

--- a/server/src/brain/memory.ts
+++ b/server/src/brain/memory.ts
@@ -28,6 +28,7 @@ import { SimilarMatch, DupeCheckOpts, checkDuplicates } from './recall.js';
 import { PROPERTIES_SCAN_MAX_MS } from './tag-filter.js';
 import { writeFilterFor, writeOutcome } from './write-precondition.js';
 import { mirrorLegacySuppression } from './suppress-embeddings.js';
+import { NEVER_RETURNED_PROJECTION, withoutVector } from './read-projection.js';
 
 /** Resolve entity IDs to their names from the database. */
 async function resolveEntityNames(spaceId: string, entityIds: string[]): Promise<string[]> {
@@ -83,7 +84,8 @@ export async function remember(
 ): Promise<MemoryDoc & { similar?: SimilarMatch[]; contradicts?: ContradictionWarning[] }> {
   // When an id is supplied, look for the record it names first — the same shape as `upsertEntity`.
   const existing: MemoryDoc | null = id
-    ? (await col<MemoryDoc>(`${spaceId}_memories`).findOne(asFilter<MemoryDoc>({ _id: id })) as MemoryDoc | null)
+    ? (await col<MemoryDoc>(`${spaceId}_memories`).findOne(asFilter<MemoryDoc>({ _id: id }),
+      { projection: NEVER_RETURNED_PROJECTION }) as MemoryDoc | null)
     : null;
 
   const names = entityNames ?? await resolveEntityNames(spaceId, entityIds);
@@ -165,9 +167,9 @@ export async function remember(
     if (!embResult) await enqueueEmbedJob(spaceId, 'memory', converged._id);
     // `memory.updated`, not `created` — a subscriber must be able to tell a converged retry from a new record.
     if (actor) emitWebhookEvent({ event: 'memory.updated', spaceId, entry: { ...converged, embedding: undefined }, ...actor });
-    return (similar || contradicts)
+    return withoutVector((similar || contradicts)
       ? { ...converged, ...(similar ? { similar } : {}), ...(contradicts ? { contradicts } : {}) }
-      : converged;
+      : converged);
   }
 
   const doc: MemoryDoc = {
@@ -206,7 +208,7 @@ export async function remember(
   }
   if (actor) emitWebhookEvent({ event: 'memory.created', spaceId, entry: { ...doc, embedding: undefined }, ...actor });
   // Advisory only — the record is stored either way.
-  return (similar || contradicts) ? { ...doc, ...(similar ? { similar } : {}), ...(contradicts ? { contradicts } : {}) } : doc;
+  return withoutVector((similar || contradicts) ? { ...doc, ...(similar ? { similar } : {}), ...(contradicts ? { contradicts } : {}) } : doc);
 }
 
 /** Update an existing memory's fact, tags, entityIds, description, or properties. Re-embeds when content fields change. */
@@ -219,7 +221,9 @@ export async function updateMemory(
   ttlDays?: number | null,
   ifMatchSeq?: number,
 ): Promise<MemoryDoc | null> {
-  const existing = await col<MemoryDoc>(`${spaceId}_memories`).findOne(asFilter<MemoryDoc>({ _id: memoryId, spaceId })) as MemoryDoc | null;
+  const existing = await col<MemoryDoc>(`${spaceId}_memories`)
+    .findOne(asFilter<MemoryDoc>({ _id: memoryId, spaceId }),
+      { projection: NEVER_RETURNED_PROJECTION }) as MemoryDoc | null;
   if (!existing) return null;
 
   const seq = await nextSeq(spaceId);

--- a/server/src/brain/read-projection.ts
+++ b/server/src/brain/read-projection.ts
@@ -1,0 +1,120 @@
+/**
+ * THE PROJECTION EVERY COLLECTION READ APPLIES — one object, because five readers each forgot it.
+ *
+ * ## What happened, and why this file exists rather than a review note
+ *
+ * `NEVER_RETURNED_FIELDS` in `recall-shape.ts` already said the right thing: *"a claim that absolute should
+ * not rest on one projection being remembered at every fetch site."* It then rested on exactly that, and
+ * five fetch sites did not remember it.
+ *
+ * aigents, 2026-08-19T0015Z §4: `GET /api/brain/spaces/<space>/entities?limit=500` returned every record's
+ * embedding vector. **One read of their orchestrator space was 11.19 MB**, against 0.145 MB for the same 100
+ * records through `POST /query`, which strips it by contract. They tried twelve parameter spellings looking
+ * for the switch — `projection`, `fields`, `select`, `exclude`, `omit`, `includeEmbedding=false`,
+ * `embedding=false`, `embedding=0`, `projection=-embedding`, `lean`, `slim`, `minimal` — and every one
+ * returned the same 11.19 MB, which is the correct behaviour of a route that accepts no projection at all.
+ *
+ * It cost them a night. n8n holds every node's items in memory for a whole execution; their dispatcher made
+ * three such reads per run for ~28 MB of items, sixteen ran at once, n8n died with *"possible out-of-memory
+ * issue"*, and its database then answered `503 Database is not ready!` to about half of everything while
+ * deploys could not land. They spent hours believing it was the unrelated recall fault.
+ *
+ * ## The part that is worse than the size, and it is the reason this is a hard rule
+ *
+ * We publish the opposite, absolutely, in three places a caller reads while constructing arguments:
+ * `/query`'s own parameter description (*"always excluded and cannot be re-included"*), `recall`'s MCP
+ * description (*"never returned by anything here, and no parameter can ask for it"*), and
+ * `update_memory`'s. **An integrator who believed those sentences had no reason to look at a payload size.**
+ * A stale absolute is invisible in a way a missing feature is not.
+ *
+ * So the vector is not withheld "by default". It is withheld, full stop, and there is no flag — which is
+ * what those three sentences already promise and what this file makes true.
+ *
+ * ## Why a projection and not a strip after the read
+ *
+ * A post-read `delete` would move the bytes over the wire from Mongo first, and the wire from Mongo is where
+ * 11 MB actually costs something. `withoutDiagnostics` still strips after the fact on the recall path, and
+ * that is the belt to this braces — but a read that never asks for the field is the fix.
+ */
+import { NEVER_RETURNED_FIELDS } from './recall-shape.js';
+
+/**
+ * The record diagnostics a LIST route withholds by default — and `seq` is deliberately not among them.
+ *
+ * breituai-platform 2026-08-17T1540Z §4, taking up an offer in the 3.1.0 notes: *"for exactly the reason
+ * 3.1.0 withheld them on the retrieval door: matchedText is the passage a second time, and a list route is
+ * the call most likely to be made in bulk."*
+ *
+ * **`seq` stays, on their explicit request**, because it is the `If-Match` value: withholding it would remove
+ * the conditional-write path, which is a worse trade than the bytes are worth. That is the whole reason this
+ * is a separate list from `RECALL_RECORD_DIAGNOSTICS` rather than a reuse of it — the recall door withholds
+ * all three, a list route withholds two, and the difference is a deliberate decision rather than drift.
+ */
+export const LIST_WITHHELD_FIELDS: readonly string[] = ['matchedText', 'embeddingModel'];
+
+/**
+ * Drop the withheld diagnostics from a page of records, unless the caller asked for them.
+ *
+ * Copies rather than deleting in place: the rows may be shared with a cache or a count, and a strip that
+ * mutated its input would thin whatever else held a reference. Measured on the live stack before this
+ * existed — `GET /entities` returned `matchedText`, `embeddingModel` AND `embedding`, and `GET /memories`
+ * the first two.
+ *
+ * A strip and not a projection, unlike the vector: this one is conditional on the request, and making it a
+ * projection would put an `includeDiagnostics` parameter through five reader signatures to save two small
+ * fields. The vector is unconditional and enormous, so it is worth projecting; these are neither.
+ */
+export function withoutListDiagnostics<T extends Record<string, unknown>>(
+  rows: readonly T[],
+  includeDiagnostics: boolean,
+): T[] {
+  if (includeDiagnostics) return rows as T[];
+  return rows.map(r => {
+    const out = { ...r } as Record<string, unknown>;
+    for (const f of LIST_WITHHELD_FIELDS) delete out[f];
+    return out as T;
+  });
+}
+
+/**
+ * The Mongo projection that withholds the embedding vector. Spread or pass it directly to `find`/`findOne`.
+ *
+ * **Built from `NEVER_RETURNED_FIELDS` rather than written as `{ embedding: 0 }`.** The two cannot then
+ * disagree, and adding a second never-returned field is one edit rather than a sweep of every reader — which
+ * is the sweep that was already missed once.
+ *
+ * An EXCLUSION projection, so every other field of the document is returned untouched. That matters for a
+ * list route: an inclusion projection would have to name every field a caller might read, and the next field
+ * anybody adds to a record would be silently absent from the API.
+ */
+export const NEVER_RETURNED_PROJECTION: Record<string, 0> =
+  Object.fromEntries(NEVER_RETURNED_FIELDS.map(f => [f, 0 as const]));
+
+/**
+ * The same rule for a WRITE's return value, where a projection cannot reach.
+ *
+ * ## Why writes needed their own answer
+ *
+ * A projection fixes reads. A write that embeds INLINE has just computed the vector in memory, so there is
+ * no read to project: `remember`, `upsert_entity`, `upsert_edge` and `create_chrono` assembled it into the
+ * document they stored AND into the document they returned, and the route sent that as its 201.
+ *
+ * Measured against the live stack 2026-08-19, all five leaked: entity, memory, chrono and edge creates with
+ * `waitForEmbedding: true`, **and any create with `checkDuplicates` — which DEFAULTS TO TRUE, because the
+ * duplicate check needs the vector up front and therefore implies the wait.** So this was reachable with no
+ * flag at all, on the commonest write there is.
+ *
+ * ## The evidence that it was an oversight and not a decision
+ *
+ * `upsertEntity` already wrote `entry: { ...doc, embedding: undefined }` when emitting its webhook. Somebody
+ * knew the vector must not leave on a webhook, and the very same object went out on the response with it
+ * intact. One rule, two places, and the weaker one winning — for the third time in this one change.
+ *
+ * Nothing downstream reads it: every internal use is the local `embeddingFields.embedding` before the write,
+ * or `doc.embedding` inside the embed queue, which reads from Mongo itself.
+ */
+export function withoutVector<T extends object>(doc: T): T {
+  const out = { ...doc } as Record<string, unknown>;
+  for (const f of NEVER_RETURNED_FIELDS) delete out[f];
+  return out as T;
+}

--- a/testing/standalone/reads-never-return-vectors.test.js
+++ b/testing/standalone/reads-never-return-vectors.test.js
@@ -1,0 +1,205 @@
+/**
+ * NO collection read returns the embedding vector — asserted over every reader, not over a list of them.
+ *
+ * ## Why this gate exists and why it is shaped this way
+ *
+ * `NEVER_RETURNED_FIELDS` in `recall-shape.ts` already carried the right argument: *"a claim that absolute
+ * should not rest on one projection being remembered at every fetch site."* It then rested on exactly that,
+ * and five fetch sites had no projection at all — `listEntities`, `findEntitiesByName`, `findEntitiesByIds`,
+ * `listEdges`, `listChrono`, plus three single-record getters and `findEdgeByTriplet`.
+ *
+ * aigents measured the consequence: **11.19 MB from `GET /entities?limit=500`** where `POST /query` answered
+ * the same 100 records in 0.145 MB. It crashed their n8n with an out-of-memory failure and took their
+ * database down with it for a stretch, and they found it by running out of memory rather than by reading a
+ * response — because we publish, in three places, that the vector can never come back.
+ *
+ * ## The gate had to be over the SHAPE, not over the five names
+ *
+ * A test naming the five would pass the day somebody adds a sixth reader, which is the whole failure being
+ * fixed: this codebase's most-produced defect is one rule with several implementations and the weaker one
+ * winning. `measurement-must-not-share-the-blind-spot` says it directly — a sweep whose scope comes from the
+ * same list as the code it audits cannot find what the list is missing. So this derives its own scope: it
+ * finds every `.find(` / `.findOne(` on a record collection in `server/src/brain/` and requires each to carry
+ * a projection.
+ *
+ * Run: node --test testing/standalone/reads-never-return-vectors.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { stripComments } from './_strip-comments.mjs';
+
+const { NEVER_RETURNED_PROJECTION, LIST_WITHHELD_FIELDS } =
+  await import('../../server/dist/brain/read-projection.js');
+
+/**
+ * The files to sweep, from `git ls-files` rather than a hand-kept list or `readdirSync`.
+ *
+ * `gitignored-files-break-local-checks`: a directory read answers with whatever is on this disk, including
+ * build output and scratch files, and differs between here and CI. What the repo HOLDS is a git question.
+ */
+const brainFiles = execFileSync('git', ['ls-files', 'server/src/brain/*.ts'], { encoding: 'utf8' })
+  .split('\n').map(l => l.trim()).filter(Boolean);
+
+/**
+ * A read of a RECORD collection — the five that hold embeddable records.
+ *
+ * Deliberately not every `col(...)` call: tombstones, embed jobs, seq counters and sync state hold no vector,
+ * and requiring a projection on them would be noise that trains the next person to add an exemption instead
+ * of a projection.
+ */
+const RECORD_COLLECTIONS = /_(entities|edges|chrono|memories|files)`/;
+
+/**
+ * ...AND THE SAME READ SPELLED THROUGH A LOCAL VARIABLE, which is the blind spot this gate shipped with.
+ *
+ * The first version matched only `col<X>(\`${spaceId}_entities\`).find(...)` on one line. Nine functions
+ * instead write `const collection = col<EntityDoc>(...)` and then `collection.findOne(...)` — and
+ * `upsertEntity` was one of them, reading the whole document into a value the route sends back as its 201.
+ * The gate reported clean while a leak sat four lines under its nose.
+ *
+ * That is `grep-both-spellings-dotted-and-bracket` exactly: a sweep scoped to one way of WRITING a thing
+ * cannot find the other, and it passes, which is worse than failing. So the scope is now derived in two
+ * passes — collect the variables assigned from a record collection, then flag reads on those too.
+ */
+const COLLECTION_ALIAS = /(?:const|let)\s+(\w+)\s*=\s*col<[^>]*>\(`\$\{\w+\}_(?:entities|edges|chrono|memories|files)`\)/;
+
+describe('the vector never leaves the database', () => {
+  it('sweeps a real set of files, so an empty sweep cannot pass', () => {
+    // The failure this prevents is the one that makes every other assertion here vacuous: a glob that matches
+    // nothing reports zero violations and looks identical to a clean codebase.
+    assert.ok(brainFiles.length >= 8,
+      `expected the brain module to hold at least 8 tracked files, found ${brainFiles.length} — the sweep's `
+      + 'scope is wrong, and every assertion below is meaningless until it is fixed');
+    assert.ok(brainFiles.some(f => f.endsWith('entities.ts')), 'entities.ts must be in scope');
+    assert.ok(brainFiles.some(f => f.endsWith('read-projection.ts')), 'the rule itself must be in scope');
+  });
+
+  it('every record-collection read carries a projection', () => {
+    const offenders = [];
+    for (const file of brainFiles) {
+      const raw = readFileSync(file, 'utf8');
+      const rawLines = raw.split(/\r?\n/);
+      /**
+       * The line number in the ORIGINAL file, not in the stripped copy.
+       *
+       * `stripComments` deletes block comments outright rather than blanking them, so its line numbers drift
+       * from the real file by however much prose sits above — in this module, by hundreds. The first version
+       * of this gate reported those numbers and every one of them opened the wrong place, which is how a gate
+       * teaches people to stop reading it.
+       */
+      const trueLine = (text) => {
+        const needle = text.trim();
+        const at = rawLines.findIndex(l => l.trim() === needle);
+        return at === -1 ? '?' : at + 1;
+      };
+      const src = stripComments(raw);
+      const lines = src.split(/\r?\n/);
+      // Pass one: which local names are a record collection in this file.
+      const aliases = new Set();
+      for (const l of lines) {
+        const m = COLLECTION_ALIAS.exec(l);
+        if (m) aliases.add(m[1]);
+      }
+      const aliasRead = aliases.size === 0 ? null
+        : new RegExp(`\\b(?:${[...aliases].join('|')})\\.(?:find|findOne)\\(`);
+      // Pass two: flag every read, spelled either way.
+      lines.forEach((line, i) => {
+        if (!RECORD_COLLECTIONS.test(line) && !(aliasRead && aliasRead.test(line))) return;
+        // The read may be chained across the following lines (`.find(...)` then `.project(...)`), so the
+        // window is the statement rather than the line. Ended at the first `;` — a structural boundary, not
+        // a character count, because `gate-windows-must-be-structural-not-character-counts` says a fixed
+        // window spans different lines on CRLF than on CI's LF and passes by looking at less.
+        const stmt = [];
+        for (let j = i; j < lines.length && j < i + 30; j++) {
+          stmt.push(lines[j]);
+          if (lines[j].includes(';')) break;
+        }
+        const window = stmt.join('\n');
+        if (!/\.find\(|\.findOne\(/.test(window)) return;                 // a count, an update, an aggregate
+        if (/countDocuments|updateOne|updateMany|deleteOne|deleteMany|bulkWrite|insert/.test(window)) return;
+        const projected = /projection:\s*NEVER_RETURNED_PROJECTION/.test(window)
+          || /\.project\(NEVER_RETURNED_PROJECTION\)/.test(window)
+          // An explicit narrow projection is stronger than the exclusion — it cannot include the vector by
+          // accident, and several readers legitimately fetch only `_id` and `seq`.
+          || /projection:\s*\{[^}]*\}/.test(window)
+          || /\.project\(\{[^}]*\}\)/.test(window);
+        if (!projected) offenders.push(`${file}:${trueLine(lines[i])}  ${lines[i].trim().slice(0, 90)}`);
+      });
+    }
+    assert.deepEqual(offenders, [],
+      'these record reads return the whole document, vector included — the defect that sent 11.19 MB to a '
+      + 'caller who had been told it could not happen:\n  ' + offenders.join('\n  '));
+  });
+
+  it('the projection is built from the field list, so the two cannot disagree', () => {
+    const src = stripComments(readFileSync('server/src/brain/read-projection.ts', 'utf8'));
+    assert.match(src, /NEVER_RETURNED_FIELDS\.map/,
+      'the projection must be derived from NEVER_RETURNED_FIELDS — a hand-written `{ embedding: 0 }` is a '
+      + 'second copy of the rule, and adding a second never-returned field would then need a sweep of every '
+      + 'reader, which is the sweep that was already missed once');
+    assert.deepEqual(NEVER_RETURNED_PROJECTION, { embedding: 0 });
+  });
+
+  it('an EXCLUSION projection, so a new record field is never silently absent from the API', () => {
+    // An inclusion projection would have to name every field a caller might read, and the next field anybody
+    // adds to a record would vanish from the list routes with nothing failing.
+    for (const v of Object.values(NEVER_RETURNED_PROJECTION)) {
+      assert.equal(v, 0, 'every entry must be an exclusion');
+    }
+  });
+
+  it('every write that emits a stripped webhook also strips its RETURN', () => {
+    /*
+     * The pairing IS the assertion, and it is why this can be checked structurally.
+     *
+     * Fourteen places wrote `entry: { ...doc, embedding: undefined }` when emitting a webhook — so the rule
+     * was known, and applied at every webhook and at zero returns. The very same object went out on the 201
+     * with the vector intact. Measured: entity, memory, chrono and edge creates all leaked with
+     * `waitForEmbedding: true`, and any create with `checkDuplicates` — which DEFAULTS TO TRUE.
+     *
+     * So: wherever a write strips for a webhook, the return in the next few lines must strip too. That
+     * catches a new write function without naming any of them, which a per-function test could not.
+     */
+    const offenders = [];
+    for (const file of brainFiles) {
+      const lines = stripComments(readFileSync(file, 'utf8')).split(/\r?\n/);
+      lines.forEach((line, i) => {
+        if (!/embedding: undefined/.test(line)) return;
+        // The return following this webhook emit, within the same block.
+        const after = lines.slice(i + 1, i + 6).join('\n');
+        if (!/\breturn\b/.test(after)) return;   // a webhook that ends a function with no value
+        if (/withoutVector\(/.test(after)) return;
+        // A `result` assembled from an already-projected read carries no vector to strip.
+        if (/return result;/.test(after)) return;
+        offenders.push(`${file}: the write emitting a stripped webhook near "${line.trim().slice(0, 60)}" `
+          + 'returns a document that was not stripped');
+      });
+    }
+    assert.deepEqual(offenders, [],
+      'a write knows the vector must not leave on a webhook and sends it on the response:\n  '
+      + offenders.join('\n  '));
+  });
+
+  it('the list routes withhold the two record diagnostics and KEEP seq', () => {
+    // `seq` is the `If-Match` value. Withholding it would remove the conditional-write path, which is why
+    // this list is not a reuse of RECALL_RECORD_DIAGNOSTICS even though it looks like a subset of it.
+    assert.deepEqual([...LIST_WITHHELD_FIELDS], ['matchedText', 'embeddingModel']);
+    assert.ok(!LIST_WITHHELD_FIELDS.includes('seq'),
+      'seq must stay — breituai-platform asked for it by name, and it is the conditional-write token');
+  });
+
+  it('all four list routes apply the strip, and none of them forgot the flag', () => {
+    // Counted rather than spot-checked: three of the four were wired in one pass, and the fourth is exactly
+    // the kind of thing a one-route test would not notice.
+    const routes = ['entities', 'memories', 'edges', 'chrono'];
+    for (const r of routes) {
+      const src = stripComments(readFileSync(`server/src/api/brain/${r}.ts`, 'utf8'));
+      assert.match(src, /withoutListDiagnostics\(/,
+        `the ${r} list route returns its rows unfiltered — matchedText is the passage a second time`);
+      assert.match(src, /listDiagnosticsAsked\(req\)/,
+        `the ${r} list route strips unconditionally, so a caller cannot ask for the diagnostics back`);
+    }
+  });
+});


### PR DESCRIPTION
`GET /api/brain/spaces/:spaceId/entities?limit=500` returned every record's **embedding vector**. aigents measured **11.19 MB** for one space where `POST /query` answers the same 100 records in **0.145 MB**. It killed their n8n with an out-of-memory failure, took its database down with it for a stretch, and blocked deploys.

They tried twelve parameter spellings looking for the switch. There was none — the route accepts no projection at all.

## Why it survived: we publish the opposite, absolutely, in four places

`/query`'s parameter description, `recall`'s and `update_memory`'s MCP descriptions, and the integration guide's own *"the list routes project it out before the documents leave the database"*. **An integrator who believed those had no reason to look at a payload size.** All four are now true, and the guide says plainly that it was false in 3.1.0 and earlier.

## Fifteen reads and twelve write returns, not the one reported

| where | how found |
|---|---|
| 5 list/lookup readers + 3 single-record getters | manual sweep of the reported area |
| 7 more | a gate deriving its scope from the SHAPE of the code |
| 3 more | widening that gate to cover reads via a local variable, which its first version was blind to |
| 12 write returns | an inline embed putting the fresh vector into the 201 |

The write side was reachable **with no flag at all**: `checkDuplicates` defaults to TRUE and implies the embed, and an ordinary entity/edge UPDATE leaked from the unprojected read of the existing record.

**Fourteen places already stripped the vector when emitting a webhook.** The rule was known, applied at every webhook, applied at zero returns.

## The diagnostics half — same routes, same commit

`matchedText` and `embeddingModel` are withheld from the list routes by default (`?includeDiagnostics=true` restores them), as breituai-platform asked. **`seq` still comes back, unlike on recall** — it is the `If-Match` value, so withholding it would remove conditional writes.

MCP needs no matching parameter: its list tools return a formatted summary that never carried either field. Verified, not assumed.

## Verification

Sixteen paths probed against a running instance, all clean — four creates with `waitForEmbedding`, a create with `checkDuplicates`, entity and edge updates with no flag, four list routes, by-name, by-id, `POST /traverse`, and `?includeDiagnostics=true` (two diagnostics back, still no vector).

Standalone **4506 pass / 0 fail**, integration **1183 pass / 0 fail**.