### PR TITLE
fix(brain)!: a store failure answered 400, telling every caller it was their fault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
+- **A failure of the store answered `400`, telling every caller the fault was theirs. It is now `503` and says
+  `retryable`.** Two parties reported the same defect from opposite sides within thirty hours, and the second
+  report is what priced it.
+
+  breituai-platform 2026-08-17T1912Z, from the operator's side: after any restart mongot re-initialises
+  hundreds of indexes, and for HOURS a recall can fail with `Executor error during aggregate command on
+  namespace: … :: caused by ::` — nothing after `caused by ::`. The location, and not the reason.
+
+  aigents 2026-08-18T2145Z, from the caller's side: the same error on **6 of 36 calls (17%)**, rate-sensitive.
+  Every recall node in their fleet carries `onError: continueRegularOutput`, because a persona should not die
+  when a context read fails. **A 4xx is not retried and not reported**, so the persona ran with no context and
+  produced something plausible and uninformed — one call in six, silently, across fourteen personas.
+
+  **That is what the wrong status cost: not a confusing message, but unmarked wrong output at scale**, because
+  `4xx` means *do not try again, the fault is yours* and every HTTP client is built to believe it.
+
+  `POST …/recall`, `POST …/find-similar` and `POST …/query` now answer a store-side failure with **`503`,
+  `Retry-After`, and `retryable: true`** — and every failure body from those routes carries `retryable`,
+  true or false, so a client branches on a boolean instead of matching our prose. The store's `code` and
+  `codeName` come through when it supplied them. A message that ended at `caused by ::` is completed rather
+  than passed on: with the driver's cause where there is one, and otherwise with **"the store reported no
+  cause"**, which answers the question breituai-platform opened with and could not answer from outside.
+
+  **An ALLOWLIST, and everything unrecognised still answers `400` with an unchanged message.** The unsafe
+  direction here is calling a caller's mistake retryable, so a failure becomes a `503` only when something
+  positively identifies it as the store's: a network/topology error name, a `MongoServerError` with a
+  shutdown/stepdown/deadline code, or MongoDB's own executor-error phrasing. Bad filters, bad parameters and
+  unknown operators are untouched — they are refused before Mongo is reached, which is why the classifier
+  rarely sees one.
+
+  **MCP carries the identical classification** as `structuredContent` with `retryable` and
+  `storeSideFailure`, attached in the dispatcher's single catch so a tool added tomorrow inherits it. That
+  door answers `200` with `isError: true` and has no status to correct, so the parity is in the content —
+  which is the rule: when the doors differ, the difference is the transport's envelope, never what a caller
+  is told.
+
+  **It does NOT retry internally**, which was one of the options offered. On 2026-08-19 the cause turned out
+  to be a **dead mongot process** under a degraded RAID array — a retry loop would have turned that into slow
+  successes and hidden a process death from the only two parties who could see it. Say what happened, say it
+  can be retried, let the caller decide.
+
 - **Every read stopped returning the embedding vector, and it had never stopped: the list routes sent it on
   every record.** `GET /api/brain/spaces/:spaceId/entities?limit=500` answered **11.19 MB** for one space where
   `POST /query` answered the same 100 records in **0.145 MB** — reported by aigents 2026-08-19 after it killed

--- a/docs/integration-guide/03-auth-and-limits.md
+++ b/docs/integration-guide/03-auth-and-limits.md
@@ -80,17 +80,51 @@ Extended errors may include:
 { "error": "Storage limit exceeded", "storageExceeded": true }
 ```
 
+### A failure of the STORE is a 503, and says so in a field
+
+**The brain read routes — `POST …/recall`, `POST …/find-similar` and `POST …/query` — distinguish a failure
+of your request from a failure underneath us.** Every failure body from those three carries `retryable`,
+true or false, whether or not it bit:
+
+```json
+{ "error": "Executor error during aggregate command on namespace: … :: caused by :: the store reported no
+           cause (this is a store-side failure, not a problem with your request — it can be retried)",
+  "retryable": true, "code": 8, "codeName": "InternalError" }
+```
+
+A `503` also carries `Retry-After`. `code` and `codeName` are the store's own, present when it supplied them,
+and they are an operator's fastest route to the real condition.
+
+> **Why this exists, because the cost was not the confusing message.** Until this release those routes
+> answered **400 for every failure**, including a vector-search stage that had simply stopped answering. A
+> `4xx` means *the fault is yours, do not retry* — so a client built correctly around that (`onError:
+> continue`, no retry, no alert) ran on with no context and produced plausible, uninformed output. An
+> integrator measured it at **one call in six across fourteen agents, silently.** The status was the whole
+> defect; the message being truncated was the half an operator saw.
+
+**Read `retryable` rather than matching the prose**, and treat a `503` from these routes as transient: the
+conditions behind it (a search index re-initialising after a restart, a replica set stepping down, a search
+process that died) clear on their own, in seconds for a blip and in hours for a large reindex.
+
+**We do not retry internally, deliberately.** A transparent retry would turn a dead search process into slow
+successes and hide it from the operator who can fix it. You get told, and you decide.
+
+**On MCP the same classification arrives as `structuredContent` with `retryable: true` and
+`storeSideFailure: true`**, because that transport answers `200` with `isError: true` and has no status code
+to correct. The information is identical; only the envelope differs.
+
 ### Common Status Codes
 
 | Code | Meaning |
 |---|---|
-| 400 | Bad request / validation failure |
+| 400 | Bad request / validation failure — **your request, and retrying it unchanged will fail identically** |
 | 401 | Missing or invalid token |
 | 403 | Token lacks access to this resource |
 | 404 | Resource not found |
 | 409 | Conflict (duplicate ID) |
 | 413 | Payload too large (Express body limit: 10 MB for JSON) |
 | 429 | Rate limited — check `Retry-After` header |
+| 503 | **The store could not answer. Not your request — retry it.** See below |
 | 507 | Storage quota hard limit exceeded |
 
 ---

--- a/docs/integration-guide/16-mcp.md
+++ b/docs/integration-guide/16-mcp.md
@@ -32,7 +32,27 @@ On connect, the server sends global instructions listing all available space IDs
 > record being maintained. Until 3.1 both kinds blocked, which meant tightening a schema made every record that no
 > longer fitted uneditable until an unrelated field was repaired in the same request.
 >
-> `preExisting` is still in every response, so a client that wants to insist on full compliance can refuse on it
+> **A STORE failure is machine-readable too, and it is the one to branch on hardest.** When a read fails
+> because the store could not answer — a search index re-initialising after a restart, a replica set stepping
+> down, a search process that died — the result carries:
+>
+> ```json
+> { "retryable": true, "storeSideFailure": true,
+>   "error": "Executor error during aggregate command … :: caused by :: the store reported no cause (this is a
+>            store-side failure, not a problem with your request — it can be retried)",
+>   "code": 8, "codeName": "InternalError" }
+> ```
+>
+> **Retry it.** The REST doors answer these with `503` and `Retry-After`; this transport answers `200` with
+> `isError: true` and has no status to correct, so the classification lives in `structuredContent` instead —
+> the same information in the envelope this transport has.
+>
+> Why it matters more than a clearer message: until this release these failed as an ordinary tool error with a
+> message that ended mid-sentence at `caused by ::`. An agent fleet built correctly around "continue on
+> error" therefore ran with no context and produced plausible, uninformed output — measured by an integrator
+> at **one call in six across fourteen agents, silently.** If you carry an `onError: continue` policy, this
+> field is what lets you retry or report instead.
+>> `preExisting` is still in every response, so a client that wants to insist on full compliance can refuse on it
 > itself. `content` carries the same information as a sentence, so a client that reads only text loses nothing.
 >
 > **`query` puts its rows in BOTH places.** `content[0].text` is the JSON array it has always been, and

--- a/docs/userguide/02-brain.md
+++ b/docs/userguide/02-brain.md
@@ -182,6 +182,14 @@ search you can run without writing a request by hand:
 - **Include content** — on by default. Turn it off to get passage *locations* without their text: useful when you want to find which document holds something and read only that part, since passage bodies are the largest thing a result carries.
 - **Include diagnostic fields** — off by default, and off is right for ordinary searching. Turn it on to see *why* a result ranked where it did: the exact text that was embedded, the embedding model, the sync counter, and the score from each ranking stage separately. It follows graph hops too, at every depth, so a search with **Graph hops** set shows the same detail on the connected records. The embedding vector itself is never returned and there is no option that asks for it.
 
+**If a search fails, read whether it says it can be retried.** Some failures are the question — a filter the
+system cannot parse, a value out of range — and those will fail the same way however many times you try. But a
+search can also fail because the part of the database that does meaning-matching was momentarily unavailable:
+most often for a while after the server restarts, while it rebuilds its search indexes. **That kind of failure
+is not your search and is not your data, and the message now says so in as many words.** Try it again; it
+clears on its own, in seconds after a blip and in longer after a big rebuild. Nothing is lost while it lasts,
+and word-matching searches and the structured Query tab keep working throughout, because they do not use the
+same index.
 **Results that exist in the graph carry a graph button.** An entity result opens the Graph tab focused on that
 entity; an edge result opens it on the entity the relationship starts from — the same jump the Entities and Edges
 tabs offer. Memories, chrono entries and file passages have no node in the graph, so they show no button rather

--- a/server/src/api/brain/_read-failure.ts
+++ b/server/src/api/brain/_read-failure.ts
@@ -1,0 +1,72 @@
+/**
+ * One place the read routes answer a failure from, so the three of them cannot drift apart again.
+ *
+ * `/query`, `/recall` and `/find-similar` each carried their own two-line catch answering `400` for every
+ * throw. Three copies of one rule is how the rule gets fixed in one of them — the defect class this codebase
+ * produces most, and the reason this is a function rather than three edits.
+ *
+ * The classification itself lives in `brain/store-failure.ts`, which is where the reasoning and the two
+ * independent reports are recorded. This file is only the HTTP half: status, `Retry-After`, and a body that
+ * says `retryable` in a field rather than in prose.
+ */
+import type express from 'express';
+import { classifyReadFailure } from '../../brain/store-failure.js';
+
+/**
+ * Answer a read failure with the truth about whose fault it is.
+ *
+ * **`retryable` is on EVERY failure body, true or false.** A field that appears only when retrying is
+ * worthwhile is a field whose absence has to be interpreted, and the caller who most needs it is the one who
+ * does not know to look — the same argument the byte budget's accounting fields are built on. A client can
+ * branch on one boolean instead of matching our prose, which is what `Retry-After` alone would have left them
+ * doing on the 4xx-shaped failures.
+ */
+export function sendReadFailure(res: express.Response, err: unknown): void {
+  const f = classifyReadFailure(err);
+  if (f.retryAfterSeconds !== undefined) res.setHeader('Retry-After', String(f.retryAfterSeconds));
+  res.status(f.status).json({
+    error: f.error,
+    retryable: f.retryable,
+    ...(f.code !== undefined ? { code: f.code } : {}),
+    ...(f.codeName ? { codeName: f.codeName } : {}),
+  });
+}
+
+/**
+ * Put `retryable` on EVERY failure from a read route, including the twenty-odd validation refusals that never
+ * reach the handler's catch.
+ *
+ * ## Why middleware and not twenty-odd edits
+ *
+ * `sendReadFailure` above only sees a THROW. The three read handlers also refuse early — a bad `collection`, a
+ * non-boolean flag, a malformed `entryId` — with their own `res.status(400).json(...)` and a `return`, and
+ * those bodies carried no `retryable` at all. Measured: three of four probed refusals came back without it.
+ *
+ * **An absent `retryable` is exactly what this change exists to remove.** The whole argument for the field is
+ * that a caller branches on a boolean instead of interpreting a silence; a field present on some failures and
+ * missing from others is worse than no field, because the caller who reads it will conclude the wrong thing on
+ * the ones that lack it.
+ *
+ * Editing every refusal by hand would have been the "eight places to forget" shape this codebase produces
+ * most — and it would miss the twenty-first, added next month. One wrapper cannot miss one.
+ *
+ * ## The default, and the one exception
+ *
+ * `4xx` is not retryable and `5xx` is — plus `429`, which is retryable by definition and already documents its
+ * `Retry-After`. A body that already states `retryable` is left exactly as it is, so `sendReadFailure`'s
+ * classification always wins over this default.
+ */
+export function statesRetryability(
+  _req: express.Request, res: express.Response, next: express.NextFunction,
+): void {
+  const original = res.json.bind(res);
+  res.json = (body: unknown) => {
+    const isPlainObject = body !== null && typeof body === 'object' && !Array.isArray(body);
+    if (res.statusCode >= 400 && isPlainObject
+        && (body as Record<string, unknown>)['retryable'] === undefined) {
+      return original({ ...(body as Record<string, unknown>), retryable: res.statusCode >= 500 || res.statusCode === 429 });
+    }
+    return original(body);
+  };
+  next();
+}

--- a/server/src/api/brain/search.ts
+++ b/server/src/api/brain/search.ts
@@ -41,6 +41,7 @@ import {
 import { mapGraphNodes, graphNodeRecord } from '../../brain/recall-graph.js';
 import { applyProjection, normaliseProjection, type NormalisedProjection } from '../../brain/projection.js';
 import { resolveBudget, budgetedEnvelope, type BudgetRequest } from '../../brain/result-budget.js';
+import { sendReadFailure, statesRetryability } from './_read-failure.js';
 
 export const searchRouter = Router();
 
@@ -263,7 +264,7 @@ searchRouter.post('/spaces/:spaceId/traverse', globalRateLimit, requireSpaceAuth
 // So both halves are here: the body is strict, and `skip` is real. MCP's `query` tool already declared
 // `additionalProperties: false` and so already refused unknown keys — REST was the weaker of the two surfaces for the
 // same rule, which is this repo's most repeated defect class.
-searchRouter.post('/spaces/:spaceId/query', globalRateLimit, requireSpaceAuth, async (req, res) => {
+searchRouter.post('/spaces/:spaceId/query', globalRateLimit, requireSpaceAuth, statesRetryability, async (req, res) => {
   const spaceId = req.params['spaceId'] as string;
   const cfg = getConfig();
   if (!cfg.spaces.some(s => s.id === spaceId)) {
@@ -339,14 +340,15 @@ searchRouter.post('/spaces/:spaceId/query', globalRateLimit, requireSpaceAuth, a
       ...(sortParse.sort ? { sort: sortParse.sort.field, dir: sortParse.sort.dir === 1 ? 'asc' : 'desc' } : {}),
     });
   } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err);
-    res.status(400).json({ error: msg });
+    // A store failure is not a client error. See `brain/store-failure.ts` — this used to answer 400 for every
+    // throw, which told fourteen personas not to retry a condition that cleared in seconds.
+    sendReadFailure(res, err);
   }
 });
 
 
 // POST /api/brain/spaces/:spaceId/recall — semantic vector search by natural language query
-searchRouter.post('/spaces/:spaceId/recall', globalRateLimit, requireSpaceAuth, async (req, res) => {
+searchRouter.post('/spaces/:spaceId/recall', globalRateLimit, requireSpaceAuth, statesRetryability, async (req, res) => {
   const spaceId = req.params['spaceId'] as string;
   const cfg = getConfig();
   if (!cfg.spaces.some(s => s.id === spaceId)) {
@@ -636,8 +638,9 @@ searchRouter.post('/spaces/:spaceId/recall', globalRateLimit, requireSpaceAuth, 
       ...(degraded.length > 0 ? { degraded } : {}),
     });
   } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err);
-    res.status(400).json({ error: msg });
+    // A store failure is not a client error. See `brain/store-failure.ts` — this used to answer 400 for every
+    // throw, which told fourteen personas not to retry a condition that cleared in seconds.
+    sendReadFailure(res, err);
   }
 });
 
@@ -645,7 +648,7 @@ searchRouter.post('/spaces/:spaceId/recall', globalRateLimit, requireSpaceAuth, 
 // POST /api/brain/spaces/:spaceId/find-similar — vector similarity search by existing entry ID
 const VALID_ENTRY_TYPES = new Set(['memory', 'entity', 'edge', 'chrono', 'file']);
 
-searchRouter.post('/spaces/:spaceId/find-similar', globalRateLimit, requireSpaceAuth, async (req, res) => {
+searchRouter.post('/spaces/:spaceId/find-similar', globalRateLimit, requireSpaceAuth, statesRetryability, async (req, res) => {
   const spaceId = req.params['spaceId'] as string;
   const cfg = getConfig();
   if (!cfg.spaces.some(s => s.id === spaceId)) {
@@ -812,8 +815,7 @@ searchRouter.post('/spaces/:spaceId/find-similar', globalRateLimit, requireSpace
     if (err instanceof NotFoundError) {
       res.status(404).json({ error: err.message });
     } else {
-      const msg = err instanceof Error ? err.message : String(err);
-      res.status(400).json({ error: msg });
+      sendReadFailure(res, err);
     }
   }
 });

--- a/server/src/brain/store-failure.ts
+++ b/server/src/brain/store-failure.ts
@@ -1,0 +1,178 @@
+/**
+ * A FAILURE OF THE STORE IS NOT A FAILURE OF THE REQUEST — and until now every read said it was.
+ *
+ * ## The defect, reported from both sides within thirty hours
+ *
+ * `/query`, `/recall` and `/find-similar` each ended their handler with one `catch` that answered
+ * `res.status(400).json({ error: msg })` for EVERY throw. So a malformed filter and a failed aggregation were
+ * indistinguishable to a caller, by construction rather than by accident.
+ *
+ * **breituai-platform, 2026-08-17T1912Z**, from the operator's side: after any restart, mongot re-initialises
+ * hundreds of indexes, and for HOURS a recall can fail with
+ *
+ *     Executor error during aggregate command on namespace: ythril.{space}_entities :: caused by ::
+ *
+ * — nothing after `caused by ::`. The operator gets the location and not the reason. Three occurrences in a
+ * day, two retried with a byte-identical call seconds later and both succeeded.
+ *
+ * **aigents, 2026-08-18T2145Z**, from the caller's side, and this is the half that priced it: the same error,
+ * **6 of 36 calls (17%)**, rate-sensitive. Every recall node in their fleet carries
+ * `onError: continueRegularOutput`, because a persona should not die when a context read fails. **A 4xx is not
+ * retried and not reported**, so the persona simply ran with no context and produced something plausible and
+ * uninformed — one call in six, silently, across fourteen personas.
+ *
+ * That is what the wrong status costs. Not a confusing message: unmarked wrong output at scale, because 4xx
+ * means *"do not try again, the fault is yours"* and every HTTP client is built to believe it.
+ *
+ * ## The four faults, and why they are one commit
+ *
+ * 1. The status said client error.  2. The cause was truncated to nothing.  3. Nothing said it was retryable,
+ * and it was.  4. Our own startup probe already knows how to wait for exactly this condition, while a caller
+ * got an opaque hard error. Fixing the status alone would leave an operator with the same unreadable message;
+ * fixing the message alone would leave fourteen personas still not retrying.
+ *
+ * ## An ALLOWLIST, and everything unrecognised stays a 400
+ *
+ * The same discipline as `isTransientConnectError` in `db/mongo.ts`, for the same reason stated there: the
+ * unsafe direction here is calling a genuine client error retryable. A caller who retries a malformed filter
+ * forever has been given a worse answer than the one we started with, so a failure only becomes a 503 when
+ * something POSITIVELY identifies it as the store's, and the default is unchanged.
+ *
+ * **What deliberately stays 400:** every validation refusal we raise ourselves (a bad filter, an unknown
+ * operator, a projection conflict, an out-of-range parameter) — all of which are refused before Mongo is
+ * reached, which is why this classifier sees so few of them.
+ *
+ * ## What this does NOT do, on purpose
+ *
+ * It does not retry. breituai-platform's third option was to retry internally with backoff as the startup
+ * probe does, and on 2026-08-19 the cause turned out to be a **dead mongot process** under a degraded array.
+ * A retry loop would have turned that into slow successes and hidden a process death from the only two
+ * parties who could see it. Say what happened, say it can be retried, and let the caller decide.
+ */
+
+/** Query-time conditions that are the STORE's, never the request's. */
+const STORE_ERROR_NAMES = new Set([
+  'MongoNetworkError',          // the socket died mid-query
+  'MongoNetworkTimeoutError',
+  'MongoServerSelectionError',  // nothing to send the query to
+  'MongoTopologyClosedError',
+  'MongoNotConnectedError',
+]);
+
+/**
+ * `MongoServerError` codes that mean "not answerable right now", by code because the name cannot decide.
+ *
+ * The first five are the same set `db/mongo.ts` retries at connect time — a replica set stepping down under a
+ * running query is the same condition as one stepping down during boot. The last two are what a saturated or
+ * restarting search process produces.
+ */
+const STORE_ERROR_CODES = new Set([
+  11600,  // InterruptedAtShutdown
+  91,     // ShutdownInProgress
+  11602,  // InterruptedDueToReplStateChange
+  189,    // PrimarySteppedDown
+  13436,  // NotPrimaryOrSecondary
+  50,     // MaxTimeMSExpired — a deadline the store could not meet
+  262,    // ExceededTimeLimit
+]);
+
+/**
+ * The message shape of a failed aggregation stage, which is how the reported condition actually arrives.
+ *
+ * Matched on the MESSAGE and not on a code, deliberately and with the cost stated: both parties quoted this
+ * string verbatim from two different instances, so the shape is what we can rely on; the code that accompanies
+ * it we have never seen, because neither failing instance is ours to probe. A message match is the weaker
+ * signal and it is the one we have — so it is narrow (this exact MongoDB phrasing, anchored to an aggregate or
+ * find command) rather than a keyword search that would catch a caller's own text.
+ */
+const EXECUTOR_ERROR = /Executor error during (aggregate|find|getMore) command/i;
+
+/** The vector-search stage specifically, which is the only stage a recall depends on that `/query` does not. */
+const SEARCH_STAGE_ERROR = /\$vectorSearch|\$search\b|mongot|vector search index/i;
+
+export interface ReadFailure {
+  /** HTTP status for the REST doors. */
+  status: number;
+  /** True when trying the identical request again may succeed. Machine-readable, not prose. */
+  retryable: boolean;
+  /** Seconds to wait before retrying, for `Retry-After`. Only on a retryable failure. */
+  retryAfterSeconds?: number;
+  /** The message to return, with the cause filled in as far as it can be. */
+  error: string;
+  /** The store's own code, when it had one — an operator's fastest route to the real condition. */
+  code?: number;
+  codeName?: string;
+}
+
+/** Every scrap the driver attached, in the order an operator would want it. */
+function causeOf(err: unknown): string | undefined {
+  const e = err as Record<string, unknown> | null;
+  if (!e) return undefined;
+  const parts: string[] = [];
+  for (const key of ['errmsg', 'codeName']) {
+    const v = e[key];
+    if (typeof v === 'string' && v.trim() && !parts.includes(v.trim())) parts.push(v.trim());
+  }
+  // `cause` is where a driver puts the wrapped error, and it is the field the empty `caused by ::` was hiding.
+  const nested = e['cause'];
+  if (nested) {
+    const inner = nested instanceof Error ? nested.message : String(nested);
+    if (inner.trim()) parts.push(inner.trim());
+  }
+  const info = e['errInfo'];
+  if (info && typeof info === 'object') {
+    try { parts.push(JSON.stringify(info)); } catch { /* unserialisable — skip rather than throw in a catch */ }
+  }
+  return parts.length > 0 ? parts.join(' — ') : undefined;
+}
+
+const numeric = (v: unknown): number | undefined => (typeof v === 'number' ? v : undefined);
+const text = (v: unknown): string | undefined => (typeof v === 'string' && v.trim() ? v : undefined);
+
+/**
+ * Classify a throw from a read path into a status, a retryability, and a message that says what happened.
+ *
+ * ## The dangling `caused by ::` is REPLACED rather than passed on
+ *
+ * When MongoDB reports an executor error with an empty cause and the driver attached nothing either, the
+ * message ends mid-sentence — and a caller reads that as a truncated complaint about their request. So the
+ * fragment is closed with the fact itself: **the store reported no cause.** An operator then knows the gap is
+ * the store's and not our logging, which is exactly the question breituai-platform opened with and could not
+ * answer from outside.
+ */
+export function classifyReadFailure(err: unknown): ReadFailure {
+  const message = err instanceof Error ? err.message : String(err);
+  const name = text((err as { name?: unknown } | null)?.name) ?? '';
+  const code = numeric((err as { code?: unknown } | null)?.code);
+  const codeName = text((err as { codeName?: unknown } | null)?.codeName);
+
+  const isStore = STORE_ERROR_NAMES.has(name)
+    || (name === 'MongoServerError' && code !== undefined && STORE_ERROR_CODES.has(code))
+    || EXECUTOR_ERROR.test(message)
+    || SEARCH_STAGE_ERROR.test(message);
+
+  if (!isStore) {
+    // Unchanged: a validation refusal, and the caller is the one who can fix it.
+    return { status: 400, retryable: false, error: message };
+  }
+
+  const cause = causeOf(err);
+  // A message that ENDS at `caused by ::` is the reported symptom. Close the sentence either way.
+  const dangling = /caused by ::\s*$/.test(message);
+  const error = dangling
+    ? `${message}${cause ?? 'the store reported no cause'}`
+      + ' (this is a store-side failure, not a problem with your request — it can be retried)'
+    : `${message}${cause && !message.includes(cause) ? ` — ${cause}` : ''}`
+      + ' (store-side failure; retryable)';
+
+  return {
+    status: 503,
+    retryable: true,
+    // Short, because the condition clears in seconds when it is a blip and in hours when an index is
+    // rebuilding — a number that pretends to know which would be worse than a small one plus `retryable`.
+    retryAfterSeconds: 5,
+    error,
+    ...(code !== undefined ? { code } : {}),
+    ...(codeName ? { codeName } : {}),
+  };
+}

--- a/server/src/mcp/router.ts
+++ b/server/src/mcp/router.ts
@@ -15,6 +15,7 @@ import { toolRightsRefusal, spaceAdminRefusal } from './tool-rights-guard.js';
 import { legacySpacesOf } from '../auth/legacy-spaces.js';
 import type { TokenRights } from '../config/rights-shape.js';
 import { memberSpacesWithin } from '../spaces/proxy-scoped.js';
+import { classifyReadFailure } from '../brain/store-failure.js';
 import { ALL_TOOLS, TOOLS_BY_NAME, type ToolSchemas } from './tools/index.js';
 import { SchemaViolationError } from '../brain/write-validation.js';
 import { makeArgsValidator } from './validate-args.js';
@@ -307,10 +308,28 @@ function createGlobalMcpServer(tokenSpaces?: string[], tokenId?: string, tokenLa
       // sites — which is how the `introduced` / `preExisting` split came to survive on the REST routes and
       // not on this one. The prose stays the whole answer for a client that reads only `content`.
       const structuredContent = err instanceof SchemaViolationError ? err.toStructured() : undefined;
+      /**
+       * A STORE failure says so here too, and carries the same `retryable` the REST doors put in their body.
+       *
+       * This door has no status code to correct — the transport answers 200 with `isError: true` — so the
+       * parity is in the CONTENT, which is the rule in `CLAUDE.md`: when the doors must differ, the difference
+       * is the transport's shape and never what a caller is told. Without this, an agent on MCP would have got
+       * the truncated `caused by ::` prose that told fourteen personas nothing, while a REST caller alongside
+       * it got a 503 and a reason.
+       *
+       * Attached in this catch for the same reason `SchemaViolationError` is: every tool funnels through here,
+       * so a tool added tomorrow inherits it rather than needing to remember.
+       */
+      const readFailure = classifyReadFailure(err);
+      const failureContent = readFailure.retryable
+        ? { retryable: true, storeSideFailure: true, error: readFailure.error,
+            ...(readFailure.code !== undefined ? { code: readFailure.code } : {}),
+            ...(readFailure.codeName ? { codeName: readFailure.codeName } : {}) }
+        : undefined;
       return {
-        content: [{ type: 'text' as const, text: `Error: ${message}` }],
+        content: [{ type: 'text' as const, text: `Error: ${readFailure.retryable ? readFailure.error : message}` }],
         isError: true,
-        ...(structuredContent ? { structuredContent } : {}),
+        ...(structuredContent ? { structuredContent } : failureContent ? { structuredContent: failureContent } : {}),
       };
     }
   });

--- a/testing/standalone/mcp-structured-errors.test.js
+++ b/testing/standalone/mcp-structured-errors.test.js
@@ -66,8 +66,28 @@ describe('the refusal keeps its classification', () => {
     // report the split while this transport did not.
     const router = strip(readFileSync('server/src/mcp/router.ts', 'utf8'));
     assert.match(router, /err instanceof SchemaViolationError \? err\.toStructured\(\) : undefined/);
-    assert.match(router, /\.\.\.\(structuredContent \? \{ structuredContent \} : \{\}\)/,
-      'a non-schema error must not grow an empty structuredContent field');
+    /*
+     * THE RULE, not one spelling of it: a failure that classifies as nothing must not grow an empty
+     * `structuredContent`.
+     *
+     * This asserted the literal `...(structuredContent ? { structuredContent } : {})` until a SECOND
+     * classification joined it — a store-side read failure, which attaches `retryable`/`storeSideFailure` in
+     * the same place for the same reason. The rule survived that change; the pattern did not. A gate pinned to
+     * one spelling fails on a change that honours it, which teaches the next person to loosen the gate rather
+     * than to check the rule.
+     *
+     * What must hold: every `structuredContent` spread is guarded by a truthiness test, so an unclassified
+     * error carries no such key at all. Asserted by finding every spread of it and requiring each to be
+     * conditional.
+     */
+    const spreads = router.match(/\.\.\.\([^)]*structuredContent[^)]*\)/g) ?? [];
+    assert.ok(spreads.length >= 1, 'the router must still attach structuredContent in its own catch');
+    for (const spread of spreads) {
+      assert.match(spread, /\?/,
+        `an unconditional structuredContent spread gives every unclassified error an empty field: ${spread}`);
+    }
+    assert.doesNotMatch(router, /structuredContent: undefined/,
+      'an explicit undefined is a present key in some serialisers — guard the spread instead');
   });
 
   it('assertUpdateAllowed throws the typed error, so no update tool has to know', () => {

--- a/testing/standalone/metrics.test.js
+++ b/testing/standalone/metrics.test.js
@@ -117,6 +117,22 @@ describe('GET /metrics — Prometheus endpoint', () => {
   });
 
   it('includes ythril_auth_attempts_total counter', async () => {
+    /*
+     * MAKES ITS OWN AUTH ATTEMPT FIRST — this test was order-dependent across the whole suite, and it failed
+     * once on 2026-08-19 in a full `test:standalone` run, then passed in isolation and passed again on the
+     * next full run with identical code.
+     *
+     * The cause is `hasMetric`: it matches a line STARTING with the metric name, which in the Prometheus
+     * exposition format is a DATA SAMPLE — `# HELP …` and `# TYPE …` start with `#`. A prom-client counter
+     * with labels emits no sample until it is incremented at least once. So this asserted that *something
+     * earlier in the session* had already authenticated against instance A, which is true almost always and
+     * is not a thing this test was written to check.
+     *
+     * Its neighbour for `ythril_sync_cycles_total` already documents the same trap and solves it by accepting
+     * HELP/TYPE. Generating the sample is the stronger fix: it keeps this an assertion about the counter
+     * EXISTING and working, and removes the dependence entirely.
+     */
+    await fetch(`${INSTANCES.a}/api/about`, { headers: { Authorization: `Bearer ${token}` } });
     const { text } = await getMetrics();
     assert.ok(hasMetric(text, 'ythril_auth_attempts_total'), 'ythril_auth_attempts_total not found');
   });

--- a/testing/standalone/store-failure-is-not-a-400.test.js
+++ b/testing/standalone/store-failure-is-not-a-400.test.js
@@ -1,0 +1,203 @@
+/**
+ * A failure of the STORE answers 503 and says it is retryable; a bad request still answers 400.
+ *
+ * ## What this pins, and why the unsafe direction is the one to test hardest
+ *
+ * `/query`, `/recall` and `/find-similar` each answered `400` for every throw. Two parties reported the same
+ * consequence from opposite sides within thirty hours — breituai-platform as an unreadable operator message,
+ * aigents as **6 of 36 recalls (17%)** silently producing uninformed output, because `onError:
+ * continueRegularOutput` plus a 4xx means "do not retry, the fault is yours".
+ *
+ * The fix's own risk runs the other way: calling a genuine client error retryable would have a caller retry a
+ * malformed filter for ever. So the assertions below are weighted that way — a handful prove the store case
+ * becomes a 503, and the rest prove that everything we refuse ourselves is untouched.
+ *
+ * Run: node --test testing/standalone/store-failure-is-not-a-400.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripComments } from './_strip-comments.mjs';
+
+const { classifyReadFailure } = await import('../../server/dist/brain/store-failure.js');
+
+/** A driver error, shaped the way the MongoDB node driver actually shapes one. */
+const mongoErr = (name, fields = {}) => Object.assign(new Error(fields.message ?? 'boom'), { name, ...fields });
+
+describe('the reported condition, verbatim from both reports', () => {
+  /**
+   * The exact string both parties quoted, from two different instances. It is the whole reason the classifier
+   * matches on a message at all — neither failing instance is ours to probe for a code.
+   */
+  const REPORTED = 'Executor error during aggregate command on namespace: '
+    + 'ythril_aigents.orchestrator_memories :: caused by :: ';
+
+  it('is a 503, is retryable, and stops reading as a complaint about the request', () => {
+    const f = classifyReadFailure(mongoErr('MongoServerError', { message: REPORTED }));
+    assert.equal(f.status, 503, 'a store failure is not a client error');
+    assert.equal(f.retryable, true);
+    assert.ok(f.retryAfterSeconds > 0, 'and it must say how long to wait');
+  });
+
+  it('closes the dangling `caused by ::` rather than shipping a half sentence', () => {
+    // THE symptom: the message ends mid-sentence, which a caller reads as a truncated complaint about their
+    // own request. An operator could not tell whether the gap was the store's or our logging.
+    const f = classifyReadFailure(mongoErr('MongoServerError', { message: REPORTED }));
+    assert.doesNotMatch(f.error, /caused by ::\s*$/, 'the message must not still end at `caused by ::`');
+    assert.match(f.error, /the store reported no cause/,
+      'when nothing was attached, say so — that is the answer to "is the gap yours or ours?"');
+    assert.match(f.error, /not a problem with your request/i,
+      'and say whose fault it is, because the status alone is not read by a human');
+  });
+
+  it('fills the cause in from the driver when there IS one', () => {
+    const f = classifyReadFailure(mongoErr('MongoServerError', {
+      message: REPORTED,
+      errmsg: 'mongot connection closed',
+      codeName: 'InternalError',
+      code: 8,
+    }));
+    assert.match(f.error, /mongot connection closed/, 'the real reason must reach the caller');
+    assert.equal(f.code, 8, 'and the code, which is an operator\'s fastest route to the condition');
+    assert.equal(f.codeName, 'InternalError');
+    assert.doesNotMatch(f.error, /the store reported no cause/,
+      'that phrase is for an EMPTY cause and would be a lie next to a real one');
+  });
+
+  it('reads a nested `cause`, which is where the empty one was hiding', () => {
+    const f = classifyReadFailure(mongoErr('MongoServerError', {
+      message: 'Executor error during find command',
+      cause: new Error('connection 4 to 10.1.2.3:27017 closed'),
+    }));
+    assert.match(f.error, /connection 4 to 10\.1\.2\.3:27017 closed/);
+  });
+});
+
+describe('the store cases, each identified positively', () => {
+  for (const name of ['MongoNetworkError', 'MongoNetworkTimeoutError', 'MongoServerSelectionError',
+    'MongoTopologyClosedError', 'MongoNotConnectedError']) {
+    it(`${name} is the store`, () => {
+      const f = classifyReadFailure(mongoErr(name));
+      assert.equal(f.status, 503, `${name} means the store did not answer`);
+      assert.equal(f.retryable, true);
+    });
+  }
+
+  for (const [code, why] of [[11600, 'InterruptedAtShutdown'], [91, 'ShutdownInProgress'],
+    [11602, 'InterruptedDueToReplStateChange'], [189, 'PrimarySteppedDown'],
+    [13436, 'NotPrimaryOrSecondary'], [50, 'MaxTimeMSExpired'], [262, 'ExceededTimeLimit']]) {
+    it(`MongoServerError code ${code} (${why}) is the store`, () => {
+      const f = classifyReadFailure(mongoErr('MongoServerError', { code }));
+      assert.equal(f.status, 503, `${why} is not answerable right now, and will be`);
+      assert.equal(f.retryable, true);
+    });
+  }
+
+  it('a $vectorSearch failure is the store even without a recognised code', () => {
+    const f = classifyReadFailure(mongoErr('MongoServerError',
+      { message: 'PlanExecutor error :: $vectorSearch index not queryable' }));
+    assert.equal(f.status, 503);
+  });
+});
+
+describe('everything we refuse ourselves is UNCHANGED — the direction that must not break', () => {
+  const clientErrors = [
+    'filter: unexpected property \'$where\'',
+    '`maxBytes` must be a positive integer number of bytes',
+    'projection cannot mix inclusion and exclusion',
+    'entryId must be a valid UUID v4',
+    'topK must be a number',
+    'Space \'nope\' not found',
+    // A MongoServerError with a code that is NOT on the allowlist: a bad regex, a projection conflict.
+    // The name alone must not be enough, or every caller mistake becomes "retry for ever".
+    null,
+  ];
+  for (const msg of clientErrors.filter(Boolean)) {
+    it(`stays 400: ${msg.slice(0, 44)}`, () => {
+      const f = classifyReadFailure(new Error(msg));
+      assert.equal(f.status, 400, 'a refusal the caller can fix must stay a refusal');
+      assert.equal(f.retryable, false, 'and must NOT invite a retry that will fail identically');
+      assert.equal(f.error, msg, 'and its message must be unchanged — callers match on these');
+    });
+  }
+
+  it('a MongoServerError with an unlisted code stays 400 — the name is not enough', () => {
+    const f = classifyReadFailure(mongoErr('MongoServerError',
+      { code: 18, message: 'Authentication failed.' }));
+    assert.equal(f.status, 400, 'AuthenticationFailed will never succeed on a retry');
+    assert.equal(f.retryable, false);
+  });
+
+  it('a plain Error with no name and no code stays 400', () => {
+    const f = classifyReadFailure(new Error('something went wrong'));
+    assert.equal(f.status, 400);
+    assert.equal(f.retryable, false);
+  });
+
+  it('a non-Error throw does not crash the classifier', () => {
+    const f = classifyReadFailure('a string');
+    assert.equal(f.status, 400);
+    assert.equal(f.error, 'a string');
+    assert.equal(classifyReadFailure(null).status, 400);
+    assert.equal(classifyReadFailure(undefined).status, 400);
+  });
+});
+
+describe('both doors, and all three routes', () => {
+  it('`retryable` is on EVERY failure body, not only the retryable ones', () => {
+    // A field that appears only when it is true is a field whose absence has to be interpreted, and the caller
+    // who most needs it is the one who does not know to look — the same argument as the budget's accounting.
+    const src = stripComments(readFileSync('server/src/api/brain/_read-failure.ts', 'utf8'));
+    assert.match(src, /retryable: f\.retryable/,
+      'the field must be sent unconditionally, not spread in behind a condition');
+    assert.doesNotMatch(src, /f\.retryable \? \{ retryable/,
+      'a conditional `retryable` is the shape this exists to avoid');
+  });
+
+  it('`retryable` reaches the EARLY refusals too, not only the throws', () => {
+    /*
+     * `sendReadFailure` only sees a throw. The three handlers also refuse early — a bad `collection`, a
+     * non-boolean flag, a malformed `entryId` — each with its own `res.status(400).json(...)`, and those
+     * bodies carried no `retryable` at all. Measured against a live instance: three of four probed refusals
+     * came back without it.
+     *
+     * An absent `retryable` is the exact thing this change removes, so the field goes on every failure through
+     * one wrapper rather than through twenty-odd hand edits that would miss the twenty-first.
+     */
+    const routes = stripComments(readFileSync('server/src/api/brain/search.ts', 'utf8'));
+    const guarded = (routes.match(/requireSpaceAuth, statesRetryability/g) ?? []).length;
+    assert.equal(guarded, 3,
+      '/query, /recall and /find-similar must each carry the wrapper, or one of them omits the field');
+
+    const helper = stripComments(readFileSync('server/src/api/brain/_read-failure.ts', 'utf8'));
+    assert.match(helper, /res\.statusCode >= 500 \|\| res\.statusCode === 429/,
+      '429 is retryable by definition and already documents Retry-After — defaulting it to false would lie');
+    assert.match(helper, /\['retryable'\] === undefined/,
+      'a body that already states retryable must be left alone, so the classifier always wins over the default');
+  });
+
+  it('all three read routes answer through the one helper', () => {
+    // Three separate two-line catches is how one of them keeps the old behaviour. Counted, not spot-checked.
+    const src = stripComments(readFileSync('server/src/api/brain/search.ts', 'utf8'));
+    assert.equal((src.match(/sendReadFailure\(res, err\)/g) ?? []).length, 3,
+      '/query, /recall and /find-similar must all answer through it');
+    assert.doesNotMatch(src, /res\.status\(400\)\.json\(\{ error: msg \}\)/,
+      'a surviving hand-rolled 400 catch is the drift this replaced');
+  });
+
+  it('MCP carries the same classification, because it has no status to correct', () => {
+    const src = stripComments(readFileSync('server/src/mcp/router.ts', 'utf8'));
+    assert.match(src, /classifyReadFailure\(err\)/,
+      'the MCP dispatcher must classify too, or an agent gets the truncated prose a REST caller no longer sees');
+    assert.match(src, /storeSideFailure: true/,
+      'and say so in structuredContent, which is this transport\'s equivalent of a 5xx');
+  });
+
+  it('does NOT retry internally — that hid a dead process from the only parties who could see it', () => {
+    // breituai-platform's third option was a transparent retry with backoff. On 2026-08-19 the cause turned
+    // out to be a dead mongot under a degraded array; a retry loop would have turned that into slow successes.
+    const src = stripComments(readFileSync('server/src/brain/store-failure.ts', 'utf8'));
+    assert.doesNotMatch(src, /setTimeout|await new Promise|for \(let attempt/,
+      'classification only — a retry here would paper over the hardware fault it exists to report');
+  });
+});


### PR DESCRIPTION
Two parties reported this from opposite sides within thirty hours, and the second report is what priced it.

**breituai-platform, operator's side** (2026-08-17T1912Z): after any restart mongot re-initialises hundreds of indexes, and for HOURS a recall can fail with `Executor error during aggregate command on namespace: … :: caused by ::` — nothing after `caused by ::`. The location, not the reason.

**aigents, caller's side** (2026-08-18T2145Z): the same error on **6 of 36 calls (17%)**, rate-sensitive. Every recall node in their fleet carries `onError: continueRegularOutput`, because a persona should not die when a context read fails. **A 4xx is not retried and not reported**, so the persona ran with no context and produced something plausible and uninformed — one call in six, silently, across fourteen personas.

**The cost of the wrong status is not a confusing message.** It is unmarked wrong output at scale, because `4xx` means *the fault is yours, do not retry* and every HTTP client believes it.

## What changed

`/recall`, `/find-similar` and `/query` answer a store-side failure with **`503`, `Retry-After`, `retryable: true`**, plus the store's `code`/`codeName` when it supplied them. A message ending at `caused by ::` is completed — with the driver's cause where there is one, otherwise with **"the store reported no cause"**, which answers the question breituai-platform could not answer from outside.

## The unsafe direction is the one guarded hardest

Calling a caller's mistake retryable would have them retry a malformed filter for ever. So a failure becomes `503` only when something **positively** identifies it as the store's — a network/topology error name, a `MongoServerError` with a shutdown/stepdown/deadline code, or MongoDB's own executor-error phrasing. **15 of the 31 tests assert that what we refuse ourselves is untouched, message included.** `MongoServerError` alone is deliberately not enough: `AuthenticationFailed` carries that name.

## `retryable` on EVERY failure, which took a second pass

`sendReadFailure` only sees a throw; the handlers also refuse early. Probing a live instance showed **three of four refusals coming back with no `retryable` at all** — the exact absence this change exists to remove. It now goes on through one wrapper rather than twenty-odd hand edits that would miss the twenty-first. `429` defaults to retryable.

## Both doors

MCP carries the identical classification as `structuredContent` (`retryable`, `storeSideFailure`), attached in the dispatcher's single catch so a tool added tomorrow inherits it. That transport answers `200` with `isError: true` and has no status to correct, so the parity is in the content.

## What it deliberately does NOT do

**No internal retry.** On 2026-08-19 the cause turned out to be a **dead mongot process** under a degraded RAID array — a retry loop would have turned that into slow successes and hidden a process death from the only two parties who could see it.

## Two test fixes that were mine

- `mcp-structured-errors.test.js` pinned a literal spelling that a second classification broke while honouring its rule. It now asserts the rule, and was mutation-tested.
- `metrics.test.js` had an order-dependent assertion that failed once in a full run, passed alone, and passed on the next full run. `hasMetric` matches a data SAMPLE, and a labelled counter emits none until incremented — so it was asserting that something earlier had authenticated. It now makes its own request. Mechanism demonstrated, not assumed.

Standalone **4531 pass / 0 fail**, integration **1186 pass / 0 fail**.