### PR TITLE
fix(mcp): help's structuredContent was an index with no guide in it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`help`'s `structuredContent` was an index with no guide in it, so a client that reads that field found the
+  discovery tool empty.** It now carries `guide`, byte-identical to `content[0].text`.
+
+  breituai-platform reported this on 2026-08-17 as *"the section index plus `matched` and no bodies, in both
+  modes"* and it was filed as `help()` returning no section bodies. **It never did that.** Measured on
+  2026-08-19 against the same unchanged code: `content[0].text` is **76,754 characters** with all six section
+  bodies, while `structuredContent` was **599**. Their own report identifies where they read — `matched`
+  exists nowhere in the prose.
+
+  **`query` had the identical defect and was fixed; `help` was overlooked, and the comment beside `query`'s
+  repair is why.** It claimed *"the only tool with that shape — every other structuredContent in this layer
+  carries its own payload"*, which was true of the eight it described and false of the ninth. A universal
+  claim in a comment stops the next person checking, so it is replaced by
+  `mcp-structured-content-carries-its-payload.test.js`, which sweeps every tool and refuses a
+  `structuredContent` assembled from metadata keys alone.
+
+  **This was the worst tool to get wrong.** A client that asks what exists, receives an index, and concludes
+  the guide is unreachable does not then hunt for the parameter that would have corrected it — two further
+  reported items were raised downstream of that belief. The tool description now names both fields, since it
+  is what a caller reads while constructing arguments and it did not say.
+
+  Nothing breaks: `content[0].text` was and remains complete, so a client reading the prose is unaffected.
 - **The media worker discarded a paid model result and a terminal status, both without a word.** Two writes
   in `files/media/worker.ts` were `.catch(() => {})` with no log, no counter and no comment saying why.
 

--- a/docs/integration-guide/16-mcp.md
+++ b/docs/integration-guide/16-mcp.md
@@ -65,6 +65,20 @@ On connect, the server sends global instructions listing all available space IDs
 > rows, which reads as a page that returned nothing rather than as a payload the client dropped. If you
 > built against the old shape nothing changes: `content` was, and remains, complete.
 >
+> **`help` does the same, and it is the one that cost somebody a day.** `structuredContent.guide` carries the
+> rendered guide, byte-identical to `content[0].text`, alongside `sections` (the index as `{id, title}`),
+> `matched` and `restOnly`.
+>
+> Until this release `help`'s `structuredContent` was the index and the capability map with **no guide at
+> all** — the same defect `query` had, on the one tool whose entire job is telling you what exists. An
+> integrator reading `structuredContent` received six section titles, concluded the guide was unreachable,
+> and reported it as `help()` returning no section bodies. It never did: `content[0].text` was 76,754
+> characters of them at the time, on the version they were running.
+>
+> **If you are on an older instance, read `content[0].text` — the guide is there, complete, and always was.**
+> A gate now sweeps every tool and refuses a `structuredContent` built from metadata alone, because the
+> comment beside `query`'s fix claimed no other tool had that shape and one did.
+>
 > **The consequence to plan for: tightening a schema freezes the records that no longer fit it.** Remove a value from
 > an `enum` and every stored record still carrying it is uneditable until that field is repaired — even an edit to an
 > unrelated field like `description`. Under `warn` the same violations are reported and the write proceeds. Branch on

--- a/server/src/mcp/tools/help.ts
+++ b/server/src/mcp/tools/help.ts
@@ -45,7 +45,14 @@ export const helpTool: ToolHandler = {
     + 'line. Omit it for the complete guide.\n\n'
     + 'RESPONSE: the matching sections, or the whole guide when `query` is omitted. A query matching NOTHING '
     + 'returns the section index rather than an empty answer — so a reply that is a list of section names '
-    + 'means your keywords missed, and the fix is fewer words or a tool name.',
+    + 'means your keywords missed, and the fix is fewer words or a tool name.\n\n'
+    + 'THE GUIDE IS IN BOTH `content[0].text` AND `structuredContent.guide`, and this paragraph exists '
+    + 'because it was in `content` alone. `structuredContent` also carries `sections` (the index, as '
+    + '{id, title}), `matched` (which sections your query hit) and `restOnly` (capabilities that exist over '
+    + 'REST and have no tool). A client that surfaces `structuredContent` in preference to `content` '
+    + 'therefore used to receive the index and NO guide — and reported, reasonably, that the guide was '
+    + 'unreachable. If you see `sections` and no `guide`, the instance predates that fix and the prose is in '
+    + '`content[0].text`, complete, on every version.',
   // Deliberately not mutating, not admin, not spaceRequired: read-only and instance-global.
   inputSchema: (_s: ToolSchemas) => ({
     type: 'object',
@@ -98,13 +105,34 @@ export const helpTool: ToolHandler = {
 
     // The gap, machine-readable, beside the prose. breituai-platform asked for a capability map because their
     // agents BRANCH on it, and because a hole they can read is an afternoon they do not spend discovering it.
-    // `structuredContent` rather than more text: a client that reads only `content` loses nothing.
     //
     // `sections` is always present so a caller can discover what to search for without a second call, and `matched`
     // distinguishes "your query matched these" from "nothing matched, here is the index" without parsing English.
+    //
+    // ## `guide` CARRIES THE PROSE, and its absence is what made this tool look broken
+    //
+    // This block used to hold the index and the capability map ALONE, on the note — deleted above — that "a client
+    // that reads only `content` loses nothing". True, and the OPPOSITE client is the one that breaks: a client
+    // surfacing `structuredContent` in preference to `content` received six `{id, title}` pairs, `matched`, and no
+    // guide at all.
+    //
+    // breituai-platform reported exactly that on 2026-08-17 as *"the section index plus `matched` and no bodies,
+    // in both modes"* — and filed it as `help()` returning no section bodies, which it never did: measured
+    // 2026-08-19, `content[0].text` is 76,754 characters with every body, and `structuredContent` was 599. Their
+    // own report identifies where they read, because **`matched` exists nowhere in the prose.**
+    //
+    // **`query` had the identical defect and was fixed; this tool was overlooked, and it is the worst one to
+    // overlook.** A client that asks the discovery tool what exists, gets an index, and concludes the guide is
+    // unreachable does not then go looking for the parameter that would have corrected it — so two other reported
+    // items exist downstream of this one. The comment beside `query`'s fix even claimed it was "the only tool with
+    // that shape"; a sweep of every tool on 2026-08-19 found this was the single exception, which is why
+    // `mcp-structured-content-carries-its-payload.test.js` now asserts the shape instead of a comment claiming it.
     return {
       content: [{ type: 'text' as const, text }],
       structuredContent: {
+        // Byte-identical to `content[0].text`, deliberately. A second rendering would be a second implementation
+        // of the guide, which is the defect this tool's own header warns about for the searched-vs-full paths.
+        guide: text,
         restOnly: restOnlyCapabilityMap(),
         sections: sections.map(s => ({ id: s.id, title: s.title })),
         ...(query ? { query, matched: matchedIds } : {}),

--- a/server/src/mcp/tools/search.ts
+++ b/server/src/mcp/tools/search.ts
@@ -641,8 +641,15 @@ export const queryTool: ToolHandler = {
     //
     // That is the worst shape a result can have: the answer is absent and the metadata says how many rows were
     // returned, so it reads as a successful empty-ish page rather than as a client that dropped the payload. It is
-    // also the only tool with that shape — every other structuredContent in this layer carries its own payload.
     // The MCP spec's own framing is that structuredContent is the structured form of the SAME result, not a sidecar.
+    //
+    // **THIS COMMENT USED TO CLAIM IT WAS "the only tool with that shape — every other structuredContent in this
+    // layer carries its own payload". THAT WAS FALSE, and the claim is why nobody checked.** `help` had the
+    // identical shape: an index plus a capability map, with the entire guide in `content` alone. breituai-platform
+    // then reported the guide as unreachable and filed it as `help()` returning no bodies — which it never did.
+    //
+    // A universal claim cannot live in a comment. `mcp-structured-content-carries-its-payload.test.js` now sweeps
+    // every tool and asserts it, so the next overlooked one fails a test instead of being described as impossible.
     return {
       content: [
         {

--- a/testing/standalone/mcp-structured-content-carries-its-payload.test.js
+++ b/testing/standalone/mcp-structured-content-carries-its-payload.test.js
@@ -1,0 +1,152 @@
+/**
+ * `structuredContent` is the structured form of the SAME answer — never a sidecar of metadata about one.
+ *
+ * ## The rule, and the two tools that broke it
+ *
+ * The MCP spec's framing is that `structuredContent` is the structured form of the result. A client may
+ * legitimately surface it in preference to `content`, and several do — Claude Code was observed doing exactly
+ * that on 2026-08-15, four calls in a row, while a tool that returns no `structuredContent` rendered its whole
+ * body in the same session.
+ *
+ * So a tool whose `structuredContent` holds only metadata hands that client **the worst shape a result can
+ * have**: the answer is absent while the metadata says how much of it there was, so it reads as a successful
+ * thin page rather than as a client that dropped the payload.
+ *
+ * `query` had it: `{count: 25, total: 32, limit, skip}` and not one row. Fixed — `results` now goes in both.
+ *
+ * **`help` had it too, and survived that fix because a COMMENT claimed the problem was unique.** Beside
+ * `query`'s repair someone wrote *"It is also the only tool with that shape — every other structuredContent in
+ * this layer carries its own payload."* True of the eight it described; false of the ninth. breituai-platform
+ * then reported the guide as unreachable, filed it as `help()` returning no section bodies (it never did —
+ * 76,754 characters of them, measured), and two further items were raised downstream because the discovery
+ * surface read as blind.
+ *
+ * **A comment cannot hold a universal claim. This file is that claim, enforced.**
+ *
+ * Run: node --test testing/standalone/mcp-structured-content-carries-its-payload.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { stripComments } from './_strip-comments.mjs';
+
+/** From git, not the filesystem — see `gitignored-files-break-local-checks`. */
+const toolFiles = execFileSync('git', ['ls-files', 'server/src/mcp/tools/*.ts'], { encoding: 'utf8' })
+  .split('\n').map(l => l.trim()).filter(Boolean);
+
+/**
+ * Keys that describe an answer rather than BEING one.
+ *
+ * A `structuredContent` built only from these is the defect. Anything else present means the payload — the
+ * rows, the record, the outcome, the violations, the guide — is in there with them.
+ */
+const METADATA_ONLY_KEYS = new Set([
+  'count', 'total', 'limit', 'skip', 'sort', 'dir',      // paging facts — `query`'s original defect
+  'sections', 'matched', 'query',                        // an index — `help`'s
+  'restOnly',                                            // a capability map ABOUT the instance
+  'space', 'recordType', 'recordId', 'path', 'id',       // locators
+]);
+
+/**
+ * Flatten `...(cond ? { a, b: c } : {})` into `a, b: c` so its keys are classified like any other.
+ *
+ * Without this, a conditional spread reads as an opaque payload and satisfies the check by itself — which is
+ * exactly how the pre-fix `help` passed: `{restOnly, sections, ...(query ? {query, matched} : {})}` is metadata
+ * top to bottom, and the spread was the only thing that looked like content. Verified by mutation: with this
+ * in place, removing `guide` makes the sweep fire; without it, the sweep stayed green.
+ */
+function flattenSpreads(literal) {
+  return literal.replace(/\.\.\.\([^?]*\?\s*\{/g, '').replace(/\}\s*:\s*\{\}\)/g, ',');
+}
+
+describe('every tool that returns structuredContent puts its answer in it', () => {
+  it('sweeps a real set of tool files, so an empty sweep cannot pass', () => {
+    assert.ok(toolFiles.length >= 8,
+      `expected at least 8 tracked tool files, found ${toolFiles.length} — the scope is wrong and every `
+      + 'assertion below is meaningless until it is fixed');
+    assert.ok(toolFiles.some(f => f.endsWith('help.ts')), 'help.ts must be in scope — it is the one that broke');
+    assert.ok(toolFiles.some(f => f.endsWith('search.ts')), 'search.ts must be in scope');
+  });
+
+  it('no structuredContent is built from metadata keys alone', () => {
+    const offenders = [];
+    for (const file of toolFiles) {
+      const raw = readFileSync(file, 'utf8');
+      const rawLines = raw.split(/\r?\n/);
+      const trueLine = (text) => {
+        const needle = text.trim();
+        let at = rawLines.findIndex(l => l.trim() === needle);
+        // Fall back to a substring hit: a stripped line can differ from the raw one by a trailing comment.
+        if (at === -1) at = rawLines.findIndex(l => needle.length > 12 && l.includes(needle.slice(0, 40)));
+        if (at === -1) at = rawLines.findIndex(l => l.includes('structuredContent:'));
+        return at === -1 ? '?' : at + 1;
+      };
+      const src = stripComments(raw);
+      // Each `structuredContent: { … }` literal, brace-matched so a nested object does not end it early.
+      const re = /structuredContent:\s*\{/g;
+      let m;
+      while ((m = re.exec(src)) !== null) {
+        let depth = 1, i = m.index + m[0].length;
+        for (; i < src.length && depth > 0; i++) {
+          if (src[i] === '{') depth++;
+          else if (src[i] === '}') depth--;
+        }
+        const literal = flattenSpreads(src.slice(m.index, i));
+        // Top-level keys only: skip anything nested inside a deeper brace.
+        const keys = [];
+        let d = 0;
+        for (const tok of literal.slice(literal.indexOf('{') + 1).split(/([{}])/)) {
+          if (tok === '{') { d++; continue; }
+          if (tok === '}') { d--; continue; }
+          if (d !== 0) continue;
+          /*
+           * BOTH SPELLINGS: `name: value` AND the shorthand `name`.
+           *
+           * The first version of this matched `name:` only, and `{ result, recordType: a['recordType'] }` came
+           * back as `{recordType}` — so a literal that DID carry its payload was reported as metadata-only.
+           * A measurement that shares its subject's blind spot cannot find what the blind spot hides, and here
+           * it manufactured three false findings instead.
+           */
+          // A KEY, never a value. `{ a, b: c }` has keys `a` and `b`; `c` is a value and must not count.
+          // Allowing whitespace BEFORE the identifier was the bug: it let `guide: text,` yield `text`, and
+          // `matched: matchedIds` yield `matchedIds` — a non-metadata name that satisfied the check by
+          // itself, so the sweep stayed green on the very defect it was written for. The delimiter must be
+          // `{` or `,` IMMEDIATELY before (whitespace after it is fine).
+          for (const km of tok.matchAll(/(?:^|[,{])\s*([A-Za-z_][\w]*)\s*(?=[:,}]|$)/g)) keys.push(km[1]);
+          // A spread is handled by FLATTENING it before this loop — see `flattenSpreads`. Treating it as an
+          // opaque payload-bearing token was the first version's escape hatch, and it is what let the pre-fix
+          // `help` pass the shape sweep: its only non-metadata "key" was the spread itself. Mutation-tested.
+          if (/\.\.\.[A-Za-z_]/.test(tok)) keys.push('__object_spread__');   // `...someObject` — opaque, and rare
+        }
+        if (keys.length === 0) continue;                              // a cast or a variable, not a literal
+        const payload = keys.filter(k => !METADATA_ONLY_KEYS.has(k));
+        if (payload.length === 0) {
+          const line = literal.split('\n')[0];
+          offenders.push(`${file}:${trueLine(line)}  keys={${keys.join(', ')}} — metadata only`);
+        }
+      }
+    }
+    assert.deepEqual(offenders, [],
+      'these tools hand a structuredContent-preferring client metadata and no answer, which reads as a thin '
+      + 'successful page rather than a dropped payload:\n  ' + offenders.join('\n  '));
+  });
+
+  it('help carries the guide, and carries the SAME string content does', () => {
+    // Two renderings would be two implementations of the guide — the defect help.ts's own header warns about
+    // for its searched-vs-full paths. So this asserts the identity, not merely the presence.
+    const src = stripComments(readFileSync('server/src/mcp/tools/help.ts', 'utf8'));
+    assert.match(src, /guide: text,/,
+      'help must put the rendered guide in structuredContent, not just the index');
+    assert.match(src, /content: \[\{ type: 'text' as const, text \}\],/,
+      'and the same `text` must still be the prose, so adding the copy cannot break a client reading content');
+  });
+
+  it('the tool schema SAYS which fields carry the guide', () => {
+    // The schema description is what a caller reads while constructing arguments. A caller who had been told
+    // where the prose lives would not have concluded the guide was unreachable.
+    const src = readFileSync('server/src/mcp/tools/help.ts', 'utf8');
+    assert.match(src, /content\[0\]\.text` AND `structuredContent\.guide/,
+      'the description must name both fields — this is the surface that failed to say so');
+  });
+});


### PR DESCRIPTION
## The reported defect was real; the diagnosis was not

Filed from breituai-platform 2026-08-17 §3 as *"help() returns the section index and no section bodies, in BOTH modes"*. Measured 2026-08-19 against code that `git log v3.1.0..HEAD` proves never moved:

| call | `content[0].text` | `structuredContent` |
|---|---|---|
| `help()` | **76,754 chars**, all six bodies | **599 chars** — `restOnly` + `sections` |
| `help(query: "retrieval")` | **4,636 chars**, opens with the body | **653 chars** — same, plus `matched` |

The guide was always complete. **They were reading `structuredContent`, and their own report proves which field:** they described seeing `matched`, and `matched` exists nowhere in the prose. It also explains why both modes looked identical to them — they *are* identical in that field.

## Still ours, and `query` is the precedent

`query` had this exact shape and was fixed — a `structuredContent`-preferring client saw `{count: 25, total: 32}` and not one row, so `results` now goes in both places.

**`help` was overlooked, and the comment beside `query`'s repair is why.** It claimed *"the only tool with that shape — every other structuredContent in this layer carries its own payload"*. True of the eight it described; false of the ninth, which is the tool whose entire job is telling a caller what exists. Two further reported items were raised downstream of the belief that the discovery surface was blind.

`structuredContent.guide` now carries the guide, byte-identical to `content[0].text` — the same string, not a second rendering.

## The gate replaces the claim

`mcp-structured-content-carries-its-payload.test.js` sweeps every tool and refuses a `structuredContent` built from metadata keys alone. A universal claim cannot live in a comment, because a comment is what stops the next person checking.

**It took three corrections, all the measurement sharing its subject's blind spot:**

1. Matching `name:` only → `{ result, recordType: … }` read as `{recordType}`; three innocent tools flagged.
2. Treating `...(x ? {…} : {})` as opaque payload → the escape hatch pre-fix `help` slipped through.
3. Allowing whitespace before a key → `guide: text` yielded `text`, so **the sweep stayed green on the very defect it was written for.**

Each caught by mutation-testing against the pre-fix source. #3 is the one that matters: the first two are loud false positives; #3 was a false pass.

## Verification

Both modes against a running instance: `structuredContent.guide` byte-identical to `content[0].text`, section bodies present for a `structuredContent`-only client. MCP integration **108 pass / 0 fail**, preflight green.

Nothing breaks — `content[0].text` was and remains complete. Corrected on the board at 2026-08-19T0155Z with a `corrects` edge; the correction is partial, every other section of their post stands.