### PR TITLE
fix(mcp): recall refused the raw-Mongo filter its own description promised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The MCP `recall` tool refused the raw-MongoDB filter its own description promised and REST delivers.**
+  Its `inputSchema` declared the operator-object grammar only — `propertyNames` restricted to the key
+  allowlist, and every value required to be an object of `eq`/`ne`/`in`/`exists`/`gt`/`gte`/`lt`/`lte` with
+  `additionalProperties: false`. **The dispatcher validates arguments before the handler runs**, so that was a
+  hard refusal the resolver never got to answer.
+
+  Measured on one instance, one space, the same instant, with breituai-platform's own filter from
+  2026-08-17 §10:
+
+  ```
+  filter { type: 'message', 'properties.readBy': { $not: { $regex: 'ythril' } } }
+    REST  POST /recall  ->  200, returns the record
+    MCP   recall        ->  isError: /filter/type: must be object;
+                                     /filter/properties.readBy: unexpected property '$not'
+  ```
+
+  **Two refusals in one filter, and both are the schema being narrower than the server**: a bare
+  `type: 'message'` is valid raw-Mongo equality, and `$not` is on the allowlist `query` takes. The 3.0.0
+  notice promised the raw grammar and the tool description repeated it, so a caller who read either was told
+  they had something the schema refused.
+
+  The schema is now `type: 'object'` plus its description, exactly as `query`'s filter has always been
+  declared, and `resolveRecallFilter` is the only gate — it already accepts either grammar, refuses a MIXED
+  one, and enforces the key allowlist RECURSIVELY so `$or` cannot smuggle a key past it. **Widening the
+  grammar did not widen the keys:** an out-of-allowlist key and a mixed filter are still refused, now
+  identically on both doors.
+
+  `RECALL_FILTER_KEY_PATTERN` is DELETED rather than left unreferenced. Its own comment admitted it *"mirrors
+  `ALLOWED_FILTER_KEY_PREFIXES` (brain/filter.ts)"* — one allowlist, two encodings, free to drift, and the
+  schema-side copy is the one that drifted narrow.
+
+  `recall-filter-parity-both-doors.test.js` sends nine filters to both doors and compares the verdicts,
+  asserting the expected verdict as well as the agreement — two doors agreeing on the WRONG answer would
+  satisfy an agreement-only test, and before this fix they agreed on refusing all four raw cases.
+
 - **`help`'s `structuredContent` was an index with no guide in it, so a client that reads that field found the
   discovery tool empty.** It now carries `guide`, byte-identical to `content[0].text`.
 

--- a/docs/integration-guide/04a-recall-api.md
+++ b/docs/integration-guide/04a-recall-api.md
@@ -534,6 +534,16 @@ That exists because the operator-object form cannot express an OR at any length,
 }
 ```
 
+> **AND ON BOTH DOORS, which it was not until now.** REST accepted the raw grammar from the day it shipped;
+> the MCP `recall` tool's `inputSchema` still declared the operator-object form only, so the dispatcher —
+> which validates arguments *before* the handler runs — refused a raw filter that REST answered `200` for.
+> Measured on one instance, one space, the same instant, with a filter an integrator had reported:
+> `{type: 'message', 'properties.readBy': {$not: {$regex: 'ythril'}}}` → REST `200`, MCP
+> `/filter/type: must be object; /filter/properties.readBy: unexpected property '$not'`.
+>
+> Both doors now accept and refuse the same filters, including the refusals: an out-of-allowlist key and a
+> MIXED filter fail identically on each. `recall-filter-parity-both-doors.test.js` drives both and compares.
+
 Three rules apply to both grammars:
 
 - **A filter that MIXES them is a `400`** naming the offending keys, rather than one half quietly winning.

--- a/server/src/mcp/tools/search.ts
+++ b/server/src/mcp/tools/search.ts
@@ -8,7 +8,7 @@
  */
 
 import type { ToolHandler, ToolContext, ToolResult, ToolSchemas } from './types.js';
-import { UUID_V4_RE, formatRecallSummary, toRecallRecord, uuidSchema, unitScoreSchema, QUERY_FILTER_OPERATORS, RECALL_FILTER_KEY_PATTERN } from './shared.js';
+import { UUID_V4_RE, formatRecallSummary, toRecallRecord, uuidSchema, unitScoreSchema, QUERY_FILTER_OPERATORS } from './shared.js';
 import { MAX_RECALL_TRAVERSE } from '../../brain/edges.js';
 import { mapGraphNodes, graphNodeRecord } from '../../brain/recall-graph.js';
 import { applyProjection, normaliseProjection } from '../../brain/projection.js';
@@ -146,21 +146,34 @@ export const recallTool: ToolHandler = {
             filter: {
               type: 'object',
               description: 'Optional property filter, in EITHER of two grammars. RAW MONGODB is accepted — the same operators `query` takes (`$or`, `$and`, `$not`, `$nor`, `$in`, `$regex`, `$elemMatch`, comparisons) nested to depth 8 — and so is the older one-operator-object-per-key form (`{"properties.status": {"eq": "x"}}`), which is ANDed across keys. A filter MIXING both is refused rather than resolved. Keys are allowlisted either way, including inside `$or`. A raw filter takes the exhaustive path (it cannot become a native index pre-filter), which is slower and returns the same records. **`topK` is filled from records that SATISFY the filter** — it is never applied to an already-truncated shortlist, so a filtered recall cannot silently miss a matching record. Two mechanisms deliver that: `tags`, `type`, `name`, `status`, `label` and schema-DECLARED `properties.<key>` with eq/in/gt/gte/lt/lte are pushed into the vector index as a native pre-filter, restricting the search to the matching subset; an undeclared `properties.*`, or `exists`/`ne`, falls back to scoring the whole space exhaustively and filtering after — slower, same results, still nothing dropped by `topK`. Declare a heavily-filtered property in the space schema to keep it on the fast path. Keys must use dot-notation and start with "properties.", "tags", "type", "name", "status", or "label" (any other key is rejected). Each value is an operator object with one or more of: eq, ne, in (array), exists (boolean), gt, gte, lt, lte. Example: { "properties.status": { "eq": "accepted" }, "properties.count": { "gt": 10 } }. Records not matching ALL filter conditions are excluded.',
-              propertyNames: { pattern: RECALL_FILTER_KEY_PATTERN },
-              additionalProperties: {
-                type: 'object',
-                additionalProperties: false,
-                properties: {
-                  eq: { description: 'Exact equality.' },
-                  ne: { description: 'Not equal.' },
-                  in: { type: 'array', description: 'Value is in array (any-of for tags).' },
-                  exists: { type: 'boolean', description: 'Property is present.' },
-                  gt: { type: 'number', description: 'Greater than.' },
-                  gte: { type: 'number', description: 'Greater than or equal.' },
-                  lt: { type: 'number', description: 'Less than.' },
-                  lte: { type: 'number', description: 'Less than or equal.' },
-                },
-              },
+              /*
+               * NO STRUCTURAL CONSTRAINT HERE, and that is the fix rather than an omission.
+               *
+               * This declared `propertyNames: { pattern: RECALL_FILTER_KEY_PATTERN }` plus an
+               * `additionalProperties` requiring every value to be an operator object of
+               * eq/ne/in/exists/gt/gte/lt/lte with `additionalProperties: false`. So the schema accepted the
+               * LEGACY grammar and nothing else — while the description two lines above promised raw MongoDB,
+               * and REST delivers it.
+               *
+               * Measured on one instance, one space, the same instant, with breituai-platform's own filter
+               * `{type: 'message', 'properties.readBy': {$not: {$regex: 'ythril'}}}`:
+               *
+               *     REST  POST /recall  ->  200, returns the record
+               *     MCP   recall        ->  isError: /filter/type: must be object;
+               *                                      /filter/properties.readBy: unexpected property '$not'
+               *
+               * TWO refusals in one filter, and both are the schema being narrower than the server: a bare
+               * `type: 'message'` is valid raw-Mongo equality, and `$not` is on the allowlist `query` takes.
+               *
+               * **The dispatcher validates arguments BEFORE the handler runs**, so a schema stricter than the
+               * resolver is not a hint — it is a hard refusal the resolver never gets to answer. That is why
+               * relaxing the schema is the whole fix: `resolveRecallFilter` already accepts either grammar,
+               * refuses a MIXED one, and enforces the key allowlist RECURSIVELY so `$or` cannot smuggle a key
+               * past it. Its errors are better than the schema's, because it knows which grammar you meant.
+               *
+               * `query`'s own filter is declared exactly this way — `type: 'object'` and a description — for
+               * exactly this reason. Two tools, one grammar, and this was the copy that constrained it.
+               */
             },
           },
           required: ['query'],

--- a/server/src/mcp/tools/shared.ts
+++ b/server/src/mcp/tools/shared.ts
@@ -191,12 +191,18 @@ export const QUERY_FILTER_OPERATORS = [
   '$exists', '$type', '$regex', '$options', '$all', '$elemMatch', '$size', '$mod',
 ] as const;
 
-/**
- * `propertyNames` pattern for the recall filter's keys — mirrors `ALLOWED_FILTER_KEY_PREFIXES`
- * (brain/filter.ts): `properties.<path>`, or exactly `tags`/`type`/`name`/`status`/`label` (optionally
- * dot-suffixed). Encodes the injection-prevention allowlist so agents see which keys are legal.
+/*
+ * `RECALL_FILTER_KEY_PATTERN` WAS HERE AND IS DELETED, not merely left unreferenced.
+ *
+ * It was a `propertyNames` pattern for the recall filter's keys, and its own comment carried the admission:
+ * *"mirrors `ALLOWED_FILTER_KEY_PREFIXES` (brain/filter.ts)"*. One allowlist, two encodings, free to disagree
+ * — and they did. The pattern also refused `$or`/`$and`/`$not` as keys, so a schema written to document the
+ * legal keys ended up rejecting the raw-Mongo grammar the same tool's description promises and REST delivers.
+ *
+ * The resolver (`brain/recall-filter.ts`) enforces the allowlist RECURSIVELY, in either grammar, and is now
+ * the only copy. Do not reintroduce a schema-side mirror: the dispatcher validates arguments before the
+ * handler runs, so a mirror that drifts narrow becomes a refusal the resolver never gets to answer.
  */
-export const RECALL_FILTER_KEY_PATTERN = '^(properties\\..+|(tags|type|name|status|label)(\\..+)?)$';
 
 /** Format a RecallResult as a single human-readable summary line. */
 export function formatRecallSummary(r: RecallResult): string {

--- a/testing/integration/recall-filter-parity-both-doors.test.js
+++ b/testing/integration/recall-filter-parity-both-doors.test.js
@@ -1,0 +1,161 @@
+/**
+ * The SAME recall filter is accepted, or refused, identically on both doors.
+ *
+ * ## Why this test and not another capability check
+ *
+ * `mcp-rest-parity.test.js` gates the capability half — does the tool exist for the route. `CLAUDE.md` says
+ * the other half is the one that hides:
+ *
+ * > **Parameters count too, and this is the half that hides.** A capability present on both surfaces still
+ * > violates the rule if one door accepts less.
+ *
+ * And it names this exact defect as the example. It was real. Measured on one instance, one space, the same
+ * instant, with breituai-platform's own filter from 2026-08-17 §10:
+ *
+ *     filter { type: 'message', 'properties.readBy': { $not: { $regex: 'ythril' } } }
+ *
+ *     REST  POST /recall  ->  200, returns the record
+ *     MCP   recall        ->  isError: /filter/type: must be object;
+ *                                      /filter/properties.readBy: unexpected property '$not'
+ *
+ * Two refusals in one filter, both the MCP `inputSchema` being narrower than the server: a bare
+ * `type: 'message'` is valid raw-Mongo equality, and `$not` is on the allowlist `query` takes. Meanwhile the
+ * tool's own description promised raw MongoDB. **The 3.0.0 notice promised it too**, so a caller who read
+ * either was told they had something the schema refused.
+ *
+ * A source-reading gate could not have caught this: the description was right, the resolver was right, and the
+ * two disagreed only when a real filter met the dispatcher. So the test drives both doors.
+ *
+ * Run: node --test testing/integration/recall-filter-parity-both-doors.test.js
+ */
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
+import { INSTANCES, post } from '../sync/helpers.js';
+import { openMcpSession } from '../sync/mcp-session.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
+const RUN = Date.now();
+const SPACE = `filter-parity-${RUN}`;
+
+let token;
+let seeded = false;
+
+before(async () => {
+  token = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim();
+  const created = await post(INSTANCES.a, token, '/api/spaces', { id: SPACE, label: `Filter parity ${RUN}` });
+  assert.equal(created.status, 201, JSON.stringify(created.body));
+  const r = await post(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/entities`, {
+    name: `parity-note-${RUN}`,
+    type: 'message',
+    description: 'A board note about retrieval, for the parity filter to match.',
+    properties: { readBy: 'breituai-platform', status: 'open' },
+    tags: ['parity'],
+    waitForEmbedding: true,
+  });
+  seeded = r.status === 201;
+});
+
+after(async () => {
+  await fetch(`${INSTANCES.a}/api/spaces/${SPACE}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ confirm: true }),
+  }).catch(() => {});
+});
+
+/** REST: did this filter produce an answer, or a refusal? */
+async function viaRest(filter) {
+  const r = await post(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/recall`,
+    { query: 'board note about retrieval', filter, includeFreshWrites: true, topK: 10 });
+  return { accepted: r.status === 200, detail: r.status === 200 ? '' : JSON.stringify(r.body).slice(0, 200) };
+}
+
+/** MCP: the same question through the other door. `isError` is this transport's refusal. */
+async function viaMcp(filter) {
+  const session = await openMcpSession(token);
+  try {
+    const res = await session.callTool('recall', {
+      space: SPACE, query: 'board note about retrieval', filter, includeFreshWrites: true, topK: 10,
+    });
+    const text = res?.content?.[0]?.text ?? '';
+    return { accepted: !res?.isError, detail: res?.isError ? text.slice(0, 200) : '' };
+  } finally {
+    session.close();
+  }
+}
+
+/**
+ * Every filter here is sent to BOTH doors and the two verdicts compared.
+ *
+ * `expected` is asserted as well as the agreement, because two doors that agree on the WRONG answer would
+ * satisfy an agreement-only test — and the raw-Mongo cases were refused on both doors before the grammar was
+ * widened, so agreement alone would have passed then too.
+ */
+const CASES = [
+  {
+    what: "breituai-platform's own filter — the reported case, verbatim",
+    filter: { type: 'message', 'properties.readBy': { $not: { $regex: 'ythril' } } },
+    expected: true,
+  },
+  { what: 'raw $or across allowlisted keys',
+    filter: { $or: [{ type: 'message' }, { 'properties.status': 'open' }] }, expected: true },
+  { what: 'raw $and with a nested $in',
+    filter: { $and: [{ type: { $in: ['message', 'note'] } }, { 'properties.status': 'open' }] }, expected: true },
+  { what: 'raw equality on a bare string value',
+    filter: { type: 'message' }, expected: true },
+  { what: 'the LEGACY grammar, which must keep working',
+    filter: { 'properties.status': { eq: 'open' } }, expected: true },
+  { what: 'legacy grammar with two keys, ANDed',
+    filter: { type: { eq: 'message' }, 'properties.status': { eq: 'open' } }, expected: true },
+
+  // ── Refusals. Both doors must refuse these, and for the same reason. ────────────────────────────────────
+  { what: 'a key outside the allowlist — the injection guard, which widening must NOT have loosened',
+    filter: { $or: [{ spaceId: 'other-space' }] }, expected: false },
+  { what: 'a key outside the allowlist at the top level',
+    filter: { _id: 'anything' }, expected: false },
+  { what: 'a MIXED filter — raw and legacy together, which is a caller believing two things',
+    filter: { $or: [{ type: 'message' }], 'properties.status': { eq: 'open' } }, expected: false },
+];
+
+describe('recall filter: both doors accept and refuse the same things', () => {
+  for (const { what, filter, expected } of CASES) {
+    it(`${expected ? 'accepts' : 'refuses'}: ${what}`, async (t) => {
+      if (!seeded) return t.skip('seed write unavailable');
+      const [rest, mcp] = await Promise.all([viaRest(filter), viaMcp(filter)]);
+
+      assert.equal(rest.accepted, expected,
+        `REST should ${expected ? 'accept' : 'refuse'} ${JSON.stringify(filter)} — got ${rest.detail}`);
+      assert.equal(mcp.accepted, expected,
+        `MCP should ${expected ? 'accept' : 'refuse'} ${JSON.stringify(filter)} — got ${mcp.detail}`);
+      // The agreement, stated separately so a failure says which half moved rather than only that one did.
+      assert.equal(rest.accepted, mcp.accepted,
+        `the two doors disagree about ${JSON.stringify(filter)}: REST ${rest.accepted ? 'accepted' : 'refused'}, `
+        + `MCP ${mcp.accepted ? 'accepted' : 'refused'} — this is the parity defect CLAUDE.md calls the half `
+        + `that hides. REST said "${rest.detail}", MCP said "${mcp.detail}"`);
+    });
+  }
+
+  it('and the raw filter actually MATCHES, so acceptance is not an empty answer', async (t) => {
+    if (!seeded) return t.skip('seed write unavailable');
+    // A filter that is accepted and matches nothing would satisfy every assertion above while proving the
+    // grammar reaches no records. `$not` on a value that is present is the reported shape, and the seeded
+    // record's `readBy` is "breituai-platform" — so `$not /ythril/` must return it.
+    const r = await post(INSTANCES.a, token, `/api/brain/spaces/${SPACE}/recall`, {
+      query: 'board note about retrieval', includeFreshWrites: true, topK: 10,
+      filter: { type: 'message', 'properties.readBy': { $not: { $regex: 'ythril' } } },
+    });
+    assert.equal(r.status, 200, JSON.stringify(r.body).slice(0, 200));
+    assert.ok(r.body.results.length >= 1,
+      'the raw filter must reach the seeded record — an accepted filter returning nothing proves nothing');
+    // By NAME, not by `type`. On a REST recall result `type` is the KNOWLEDGE type — `entity` — and the
+    // entity's own `type` field (`message`, the thing the filter matched on) is shadowed by it in the flat
+    // envelope. Asserting `type === 'message'` here failed while the filter was working perfectly, which is
+    // the assertion being wrong rather than the product.
+    assert.equal(r.body.results[0].name, `parity-note-${RUN}`,
+      'and it must be the record the filter selected, not merely some record');
+  });
+});

--- a/testing/standalone/mcp-args-validation.test.js
+++ b/testing/standalone/mcp-args-validation.test.js
@@ -38,6 +38,12 @@ describe('MCP args enforcement — breaking rejections', () => {
     if (needle) assert.ok(err.toLowerCase().includes(needle), `${name}: "${err}" should mention ${needle}`);
   };
 
+  /** The counterpart, for a rule that deliberately moved OUT of this layer. */
+  const accepts = (name, args) => {
+    const err = v.validate(tool(name), args);
+    assert.equal(err, null, `${name}: expected the validator to ACCEPT ${JSON.stringify(args)}, got "${err}"`);
+  };
+
   it('rejects an unknown property (additionalProperties:false)', () => {
     rejects('recall', { query: 'x', bogus: 1 }, 'bogus');
   });
@@ -56,11 +62,30 @@ describe('MCP args enforcement — breaking rejections', () => {
   it('rejects a bad collection enum (query.collection)', () => {
     rejects('query', { space: 'general', collection: 'widgets', filter: {} });
   });
-  it('rejects a recall filter key outside the allowlist (propertyNames)', () => {
-    rejects('recall', { query: 'x', filter: { evil: { eq: 1 } } });
-  });
-  it('rejects a recall filter operator outside the allowed set', () => {
-    rejects('recall', { query: 'x', filter: { tags: { regex: 'x' } } });
+  it('does NOT reject a recall filter at the validator — the resolver owns that, in either grammar', () => {
+    /*
+     * Two tests were here: `rejects('recall', {filter: {evil: {eq: 1}}})` for an out-of-allowlist key, and
+     * `rejects('recall', {filter: {tags: {regex: 'x'}}})` for an operator outside the set. Both asserted the
+     * VALIDATOR refused, via a `propertyNames` pattern and an operator-object `additionalProperties`.
+     *
+     * **Those constraints made the tool refuse the raw-MongoDB grammar its own description promised and REST
+     * delivers**, because this validator runs BEFORE the handler. Measured on one instance, one instant:
+     * `{type: 'message', 'properties.readBy': {$not: {$regex: 'ythril'}}}` → REST 200, MCP
+     * `/filter/type: must be object; /filter/properties.readBy: unexpected property '$not'`.
+     *
+     * **The refusals themselves have not gone anywhere** — `resolveRecallFilter` enforces the key allowlist
+     * recursively (including inside `$or`) and refuses a MIXED filter, and it is now the only copy of that
+     * rule. `recall-filter-parity-both-doors.test.js` proves both doors accept and refuse the same nine
+     * filters against a live instance, which is the layer where this can actually be observed.
+     *
+     * This test is not a note that something was deleted: it FAILS if a structural constraint comes back,
+     * which is the only way to keep the two doors from diverging again.
+     */
+    accepts('recall', { query: 'x', filter: { $or: [{ type: 'message' }, { 'properties.status': 'open' }] } });
+    accepts('recall', { query: 'x', filter: { 'properties.readBy': { $not: { $regex: 'ythril' } } } });
+    accepts('recall', { query: 'x', filter: { type: 'message' } });
+    // The legacy grammar still passes the validator too — widening accepted more, never less.
+    accepts('recall', { query: 'x', filter: { 'properties.status': { eq: 'open' } } });
   });
   it('rejects a non-UUID entryId (pattern)', () => {
     rejects('find_similar', { entryId: 'not-a-uuid', entryType: 'entity' });

--- a/testing/standalone/mcp-tool-schemas.test.js
+++ b/testing/standalone/mcp-tool-schemas.test.js
@@ -81,13 +81,34 @@ describe('MCP tool schemas — high-value enrichments', () => {
     assert.equal(l.default, 20);
   });
 
-  it('recall.filter encodes the key allowlist via propertyNames, and traverse/minScore carry bounds', () => {
+  it('recall.filter carries NO structural constraint, and traverse/minScore still carry bounds', () => {
+    /*
+     * THIS ASSERTION IS INVERTED FROM WHAT IT WAS, deliberately. It used to require
+     * `filter.propertyNames.pattern` and check the key allowlist through it.
+     *
+     * That pattern refused `$or`/`$and`/`$not` as keys and required every value to be an operator object, so
+     * the MCP tool rejected the raw-MongoDB grammar that its own description promised and REST delivers.
+     * **The dispatcher validates arguments before the handler runs**, so it was a hard refusal the resolver
+     * never got to answer. Measured: `{type: 'message', 'properties.readBy': {$not: {$regex: 'ythril'}}}` →
+     * REST 200, MCP `/filter/type: must be object; /filter/properties.readBy: unexpected property '$not'`.
+     *
+     * The key allowlist is NOT gone — `resolveRecallFilter` enforces it recursively, in either grammar, and is
+     * now the only copy. `query`'s filter has always been declared this way for the same reason.
+     *
+     * So this now guards the fix rather than the defect: reinstating a structural constraint here would
+     * re-break parity, and this fails if anyone does. The behavioural half — which filters are accepted and
+     * which refused, on BOTH doors — is `recall-filter-parity-both-doors.test.js`.
+     */
     const recall = schemaOf('recall');
-    const pat = recall.properties.filter.propertyNames.pattern;
-    const re = new RegExp(pat);
-    assert.ok(re.test('properties.status'), 'properties.* keys allowed');
-    assert.ok(re.test('tags'), 'tags key allowed');
-    assert.ok(!re.test('evil'), 'arbitrary keys rejected by the pattern');
+    const filter = recall.properties.filter;
+    assert.equal(filter.type, 'object', 'filter is still an object');
+    assert.equal(filter.propertyNames, undefined,
+      'a propertyNames pattern refuses $or/$and/$not as keys — that is what broke parity');
+    assert.equal(filter.additionalProperties, undefined,
+      'an additionalProperties operator-object shape refuses raw Mongo values, including a bare string');
+    assert.match(filter.description, /RAW MONGODB is accepted/,
+      'and the description must keep saying so, since it is what a caller reads while building arguments');
+
     assert.equal(recall.properties.traverse.minimum, 0);
     assert.equal(recall.properties.traverse.maximum, 5);
     assert.equal(recall.properties.minScore.minimum, 0);


### PR DESCRIPTION
## Measured on both doors, one instance, one space, the same instant

With breituai-platform's own filter from their 2026-08-17 §10:

```
filter { type: 'message', 'properties.readBy': { $not: { $regex: 'ythril' } } }

  REST  POST /recall  ->  200, returns the record
  MCP   recall        ->  isError: /filter/type: must be object;
                                   /filter/properties.readBy: unexpected property '$not'
```

**Two refusals in one filter, and both are the MCP `inputSchema` being narrower than the server.** A bare `type: 'message'` is valid raw-Mongo equality, and `$not` is on the allowlist `query` takes. The description two lines above promised raw MongoDB; so did the 3.0.0 notice.

**The dispatcher validates arguments BEFORE the handler runs**, so this was not a stale hint — it was a hard refusal the resolver never got to answer.

## The fix is deletion, because the second copy was the defect

`filter` is now `type: 'object'` plus its description, exactly how `query`'s filter has always been declared. `resolveRecallFilter` is the only gate: either grammar, refuses a MIXED one, and enforces the key allowlist **recursively** so `$or` cannot smuggle a key past it.

**Widening the grammar did not widen the keys** — an out-of-allowlist key and a mixed filter are still refused, now identically on both doors.

`RECALL_FILTER_KEY_PATTERN` is deleted, not left unreferenced. Its own comment admitted it *"mirrors `ALLOWED_FILTER_KEY_PREFIXES` (brain/filter.ts)"* — one allowlist, two encodings, and the schema-side copy is the one that drifted narrow.

## The test drives both doors, because nothing else could catch this

The description was right, the resolver was right, and they disagreed only when a real filter met the dispatcher. `recall-filter-parity-both-doors.test.js` sends nine filters to both doors — six accepted, three refused — and asserts the **expected** verdict as well as the agreement, because two doors agreeing on the wrong answer would satisfy an agreement-only test.

**Mutation-tested:** with the old schema restored, exactly the four raw-Mongo cases fail and the legacy and refusal cases still pass. It also asserts the accepted filter actually *matches* the seeded record — an accepted filter reaching nothing would prove the grammar useless.

## Two standalone tests rewritten, not deleted

Both pinned the old mechanism by name while the rule they protect still holds one layer down. They now assert the validator **accepts** the raw grammar (failing if a structural constraint returns) and that the schema carries no `propertyNames`, keeping the traverse/minScore bounds untouched.

## One correction to my own work

The parity test first asserted `results[0].type === 'message'` and failed while the filter worked perfectly: on a flat REST recall result `type` is the *knowledge* type, which shadows the entity's own. It asserts the name now.

Preflight green, 118 MCP/parity integration tests pass.