### PR TITLE
fix(sync): a dropped record was reported in the same number as "nothing to do"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A sync push could drop a record permanently and report it in the same number as "nothing to do".**
+  `POST /api/sync/batch-upsert` counted two outcomes in one `skipped` integer:
+
+  | outcome | meaning | lossy? |
+  |---|---|---|
+  | `existing.seq >= incoming.seq` | the receiver is already current | **no** — ordinary conflict resolution, and the common case by far |
+  | `depth >= MAX_FORK_DEPTH` (memories) | content diverged at an identical `seq` and the fork chain is at its cap, so the incoming version is discarded | **YES — the record is gone** |
+
+  And `sync/engine.ts` checked only `resp.ok`, never the body — so the pusher advanced `lastSeqPushed` past the
+  discarded record and **never offered it again**. A permanent loss, invisible from both sides: unlogged on the
+  receiver, unread on the sender.
+
+  `forkDepthRefused` is now its own counter, logged at **warn** by the receiver naming the record id and saying
+  it will not be retried, and read and logged by the pusher as well — both ends, because either log may be the
+  only one somebody has. A peer that omits the field reads as zero, and an unparseable body does not fail a push
+  the peer accepted.
+
+  **The watermark still advances, deliberately.** The receiver would refuse the identical record on every future
+  cycle, so holding it back would stall the space's sync rather than deliver anything. **The fix is visibility,
+  not delivery** — the same conclusion the media-worker swallow reached earlier in this cycle.
+
+  **Found while investigating an intermittent sync test, and NOT yet shown to cause it.** The first version of
+  this note called `skipped` a silent-loss path *by construction*; reading the conditions corrected that — most
+  skips are correct and must stay silent, or the one that matters drowns. A gate now pins that asymmetry: the
+  drop is logged, the already-current skip is not.
 - **The MCP `recall` tool refused the raw-MongoDB filter its own description promised and REST delivers.**
   Its `inputSchema` declared the operator-object grammar only — `propertyNames` restricted to the key
   allowlist, and every value required to be an object of `eq`/`ne`/`in`/`exists`/`gt`/`gte`/`lt`/`lte` with

--- a/docs/integration-guide/09-sync-api.md
+++ b/docs/integration-guide/09-sync-api.md
@@ -142,7 +142,31 @@ POST /api/sync/batch-upsert?spaceId=general&networkId=net-uuid
 }
 ```
 
-Each array is capped at 500 items. Response includes per-type counters.
+Each array is capped at 500 items. Response includes per-type counters:
+
+```json
+{ "status": "ok",
+  "memories": { "inserted": 3, "updated": 1, "forked": 0, "skipped": 12, "forkDepthRefused": 0, "tombstoned": 0 },
+  "entities": { "upserted": 5, "skipped": 2, "tombstoned": 0 },
+  "edges":    { "upserted": 0, "skipped": 0, "tombstoned": 0 },
+  "chrono":   { "upserted": 0, "skipped": 0, "tombstoned": 0 } }
+```
+
+**`skipped` is benign and `forkDepthRefused` is not — read the second one.** They were one counter until now,
+which is the whole reason this paragraph exists.
+
+| counter | what happened | did the record land? |
+|---|---|---|
+| `skipped` | the receiver already holds that record at the same `seq` or newer | **nothing was lost** — this is ordinary conflict resolution and is by far the common case |
+| `forkDepthRefused` | memories only: content diverged at an identical `seq` and the record's fork chain is already at its cap, so the incoming version was **discarded** | **no — the record is gone** |
+
+**A `200` therefore does not mean every record was applied.** If you push, read `forkDepthRefused`: a non-zero
+value means those records did not land, and our own sync engine will **not** offer them again — it advances its
+watermark regardless, because the receiver would refuse the identical record on every future cycle and holding
+the watermark back would stall the space instead. Both ends log it; the receiver's log names the record ids.
+
+A peer on an older build omits `forkDepthRefused` entirely, so treat a missing field as zero rather than as an
+error.
 
 ### Tombstones
 

--- a/server/src/api/sync/docs.ts
+++ b/server/src/api/sync/docs.ts
@@ -554,7 +554,9 @@ syncDocsRouter.post('/batch-upsert', syncRateLimit, requireAuth, denyReadOnly, a
     const chrono = plausible(chronoRaw, 'chrono');
 
     // ── Memories ─────────────────────────────────────────────────────────
-    const memStats = { inserted: 0, updated: 0, forked: 0, skipped: 0, tombstoned: 0 };
+    // `skipped` = the peer is already current (benign). `forkDepthRefused` = a record was DROPPED. They were
+    // one counter until 2026-08-19, which is why the lossy one had never been seen.
+    const memStats = { inserted: 0, updated: 0, forked: 0, skipped: 0, forkDepthRefused: 0, tombstoned: 0 };
     for (const incoming of memories) {
       const tomb = await col<TombstoneDoc>(`${spaceId}_tombstones`)
         .findOne(asFilter<TombstoneDoc>({ _id: incoming._id, type: 'memory' })) as TombstoneDoc | null;
@@ -578,7 +580,27 @@ syncDocsRouter.post('/batch-upsert', syncRateLimit, requireAuth, denyReadOnly, a
       } else if (incoming.seq === existing.seq && incoming.fact !== existing.fact) {
         // Cap fork chains to prevent unbounded growth
         const depth = await forkChainDepth(spaceId, incoming._id);
-        if (depth >= MAX_FORK_DEPTH) { memStats.skipped++; continue; }
+        if (depth >= MAX_FORK_DEPTH) {
+          /*
+           * A DROPPED RECORD, and it used to be counted as `skipped` alongside "I already have this".
+           *
+           * Those two outcomes could not be more different. The common `skipped` — `existing.seq >=
+           * incoming.seq` — means the peer is already current: nothing is lost and the sender is right to
+           * advance past it. THIS one means divergent content at the same seq that cannot fork any deeper,
+           * so the incoming version is discarded. Sharing one integer made the lossy case unobservable, and
+           * `sync/engine.ts` reads only `resp.ok` — so the sender advances its watermark past it and never
+           * sends it again.
+           *
+           * Counted apart and logged HERE because this is the side that knows why. It does not change
+           * delivery: holding the watermark back would re-push a record the peer will refuse identically
+           * every cycle. The fix is visibility, exactly as the media-worker swallow was.
+           */
+          memStats.forkDepthRefused++;
+          log.warn(`sync batch-upsert: DROPPED memory ${incoming._id} in '${spaceId}' — divergent content at `
+            + `seq ${incoming.seq} and the fork chain is already ${depth} deep (MAX_FORK_DEPTH=${MAX_FORK_DEPTH}). `
+            + 'The sender will not offer it again. Resolve the fork chain to accept it.');
+          continue;
+        }
 
         const forkSeq = await nextSeq(spaceId);
         const fork: MemoryDoc = {

--- a/server/src/sync/engine.ts
+++ b/server/src/sync/engine.ts
@@ -17,6 +17,7 @@
 
 import { getConfig, saveConfig, saveConfigSoon, getSecrets, getFaceRecognitionConfig } from '../config/loader.js';
 import { boundedJson } from '../util/bounded-read.js';
+import { reportPushRefusals } from './push-refusals.js';
 import { toSafeRelPath } from '../util/paths.js';
 import { col, asFilter, asDoc, asBulk } from '../db/mongo.js';
 import { applyRemoteTombstone, listTombstones } from '../brain/tombstones.js';
@@ -1030,6 +1031,10 @@ async function pushToPeer(
         log.warn(`Batch push ${payloadKey} to ${member.label}: ${resp.status}`);
         break;
       }
+      // A 200 does not mean every record landed: the peer can discard a memory whose fork chain is at its
+      // cap and still answer 200. `sync/push-refusals.ts` says what that costs and why the watermark still
+      // advances anyway.
+      await reportPushRefusals(resp, payloadKey, member.label ?? member.instanceId, spaceId);
       pushed += batch.length;
       for (const doc of batch) {
         const d = doc as MemoryDoc;

--- a/server/src/sync/push-refusals.ts
+++ b/server/src/sync/push-refusals.ts
@@ -1,0 +1,64 @@
+/**
+ * A `200` from a peer does not mean every record landed. This is the part that notices.
+ *
+ * ## What was silent
+ *
+ * `POST /api/sync/batch-upsert` refuses a memory whose content diverges at an identical `seq` once that
+ * record's fork chain is at `MAX_FORK_DEPTH`: the incoming version is discarded and the request still answers
+ * `200`. Until now that was counted in the same `skipped` integer as *"I already hold this record, at the same
+ * seq or newer"* — which is the common case, is correct, and loses nothing.
+ *
+ * One number, two opposite meanings. So the lossy one had never been seen.
+ *
+ * And the pusher checked only `resp.ok`, never the body. It then advanced `lastSeqPushed` past the discarded
+ * record and **never offered it again** — a permanent loss, unreported at both ends.
+ *
+ * ## Why the watermark still advances
+ *
+ * The receiver would refuse the identical record on every future cycle, so holding the watermark back would
+ * stall that space's sync entirely and deliver nothing. **The defect was the silence, not the advance** — the
+ * same conclusion the swallowed media-worker writes reached earlier in this release cycle: the fix is
+ * visibility, not severity.
+ *
+ * ## Why this is its own file
+ *
+ * `no-new-god-files.test.js` freezes `sync/engine.ts` at its current size and says why: *"the failure mode of
+ * a god-file is not its size on any given day — it is that every change lands in the same place because that
+ * is where the code already is. Put the new behaviour beside it rather than inside it."* It refused this
+ * change inside the engine, correctly, so the behaviour lives here and the engine calls it.
+ */
+import { log } from '../util/log.js';
+import { boundedJson } from '../util/bounded-read.js';
+
+/** The per-type counters `batch-upsert` returns. Only the lossy one is named; the rest are not ours to read. */
+type BatchUpsertReply = Record<string, { forkDepthRefused?: number } | undefined> | null;
+
+/**
+ * Report records the peer accepted the request for and then discarded. Never throws.
+ *
+ * **`boundedJson` and not `resp.json()`**: this body comes from a peer, and `resp.json()` would read whatever
+ * it sends into memory with no ceiling. The batch timeout does not help — it bounds duration, not size, and
+ * `upstream-reads-are-bounded.test.js` refuses the unbounded form.
+ *
+ * **Every failure here is swallowed on purpose, and this is the one place that is right.** The push already
+ * succeeded; a peer on an older build sends no such field, and a body that will not parse must not turn a
+ * delivery the peer accepted into a failed one. The cost of being wrong is a missing log line, and the
+ * alternative is failing sync over a diagnostic.
+ */
+export async function reportPushRefusals(
+  resp: Response,
+  payloadKey: string,
+  peerLabel: string,
+  spaceId: string,
+): Promise<void> {
+  try {
+    const body = await boundedJson<BatchUpsertReply>(
+      resp, `batch-upsert ${payloadKey} response from ${peerLabel}`);
+    const refused = body?.[payloadKey]?.forkDepthRefused ?? 0;
+    if (refused > 0) {
+      log.warn(`Batch push ${payloadKey} to ${peerLabel}: ${refused} record(s) DROPPED by the peer `
+        + `(fork chain at its cap) in space '${spaceId}'. They will not be offered again — the peer's log `
+        + 'names the record ids.');
+    }
+  } catch { /* a diagnostic must never fail a push the peer accepted */ }
+}

--- a/testing/standalone/sync-dropped-record-is-not-silent.test.js
+++ b/testing/standalone/sync-dropped-record-is-not-silent.test.js
@@ -1,0 +1,128 @@
+/**
+ * A record the peer DROPS is reported. A record the peer already has is not.
+ *
+ * ## The conflation this pins apart
+ *
+ * `POST /api/sync/batch-upsert` counted two outcomes in one integer:
+ *
+ * | outcome | meaning | lossy? |
+ * |---|---|---|
+ * | `existing.seq >= incoming.seq` | the peer is already current | **no** — the common case, by far |
+ * | `depth >= MAX_FORK_DEPTH` | divergent content at the same seq, fork chain at its cap, record discarded | **YES** |
+ *
+ * Sharing `skipped` made the lossy one unobservable — and `sync/engine.ts` read only `resp.ok`, so the sender
+ * advanced `lastSeqPushed` past the dropped record and never offered it again. A permanent loss, reported by
+ * the same number as "nothing to do".
+ *
+ * **The watermark still advances, deliberately.** The peer would refuse the identical record on every future
+ * cycle, so holding it back would stall the space's sync to no benefit. The defect was the silence, not the
+ * advance — the same conclusion the media-worker swallow reached: *the fix is visibility, not severity*.
+ *
+ * ## Why this asserts on source rather than driving two instances
+ *
+ * Producing a real fork chain at `MAX_FORK_DEPTH` needs two peers, divergent content at an identical seq, and
+ * repeated conflict — a fixture larger than the change. What can be pinned cheaply and precisely is that the
+ * two outcomes no longer share a counter, that the lossy one is logged on BOTH sides, and that the benign one
+ * stayed quiet. A test that made the common case noisy would be worse than the defect.
+ *
+ * Run: node --test testing/standalone/sync-dropped-record-is-not-silent.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripComments } from './_strip-comments.mjs';
+
+const receiver = stripComments(readFileSync('server/src/api/sync/docs.ts', 'utf8'));
+const sender = stripComments(readFileSync('server/src/sync/engine.ts', 'utf8'));
+/*
+ * The reporting lives BESIDE the engine, not in it. `no-new-god-files.test.js` freezes `sync/engine.ts` at its
+ * size and refused this change inside it — *"put the new behaviour beside it rather than inside it"* — so the
+ * engine delegates and this reads both halves.
+ */
+const refusals = stripComments(readFileSync('server/src/sync/push-refusals.ts', 'utf8'));
+
+describe('the receiver separates a drop from an already-current skip', () => {
+  it('counts them apart', () => {
+    assert.match(receiver, /forkDepthRefused: 0/,
+      'the lossy outcome needs its own counter, or it is invisible inside `skipped`');
+    assert.match(receiver, /memStats\.forkDepthRefused\+\+/,
+      'and the MAX_FORK_DEPTH path must increment it');
+  });
+
+  it('no longer counts a dropped record as `skipped`', () => {
+    // The exact line this replaced. If it comes back, the two outcomes are conflated again.
+    assert.doesNotMatch(receiver, /MAX_FORK_DEPTH\s*\)\s*\{\s*memStats\.skipped\+\+/,
+      'a fork-depth refusal must never be counted as an already-current skip');
+  });
+
+  it('logs the drop, naming the record and saying it will not be retried', () => {
+    const at = receiver.indexOf('forkDepthRefused++');
+    assert.ok(at > -1, 'anchor missing — re-point this gate');
+    const block = receiver.slice(at, at + 700);
+    assert.match(block, /log\.warn\(/, 'the side that knows WHY must say so');
+    assert.match(block, /DROPPED/, 'and say what happened in a word an operator can grep for');
+    assert.match(block, /\$\{incoming\._id\}/, 'naming the record — a count alone cannot be investigated');
+    assert.match(block, /not offer it again|will not be offered again|not offered again/i,
+      'and stating the consequence, which is the part that makes it urgent rather than curious');
+  });
+
+  it('leaves the BENIGN skip silent', () => {
+    /*
+     * The common path is `existing.seq >= incoming.seq` — the peer is already current. Logging that would
+     * produce a warn per record per cycle and train an operator to ignore the log entirely, which is how you
+     * lose the DROP message this change exists to make visible.
+     *
+     * The window is LINES around the statement, not a character count. The first version took 900 characters
+     * after `const entStats` and the `skipped++` it was looking for sits further than that — so the anchor
+     * assertion failed and the real check never ran. A character window spans different amounts of code
+     * depending on comment length and line endings; a structural one does not.
+     */
+    const lines = receiver.split(/\r?\n/);
+    const benign = lines
+      .map((l, i) => ({ l, i }))
+      .filter(({ l }) => /(entStats|edgeStats|chronoStats)\.skipped\+\+/.test(l));
+    assert.ok(benign.length >= 3,
+      `expected the already-current skip on entities, edges and chrono; found ${benign.length}`);
+    for (const { l, i } of benign) {
+      const around = lines.slice(Math.max(0, i - 6), i + 2).join('\n');
+      assert.doesNotMatch(around, /log\.warn/,
+        `an already-current skip is correct behaviour and must stay quiet, near: ${l.trim()}`);
+    }
+  });
+});
+
+describe('the sender reads the body instead of trusting the status', () => {
+  it('the engine calls the reporter on every accepted batch', () => {
+    assert.match(sender, /await reportPushRefusals\(resp, payloadKey,/,
+      'the push loop must ask what the peer actually applied, rather than trusting the status');
+  });
+
+  it('the reporter reads the body, BOUNDED, and reports the lossy counter', () => {
+    assert.match(refusals, /boundedJson</,
+      'a peer body must be read with a ceiling — `resp.json()` bounds nothing, and a timeout bounds duration '
+      + 'not size, which is what `upstream-reads-are-bounded.test.js` refuses');
+    assert.doesNotMatch(refusals, /await resp\.json\(\)/, 'and never the unbounded form');
+    assert.match(refusals, /forkDepthRefused/, 'the field it must read');
+    assert.match(refusals, /log\.warn\(/, 'reported from this side too, since either log may be the only one');
+    assert.match(refusals, /DROPPED/, 'in a word an operator can grep for');
+  });
+
+  it('tolerates a peer that does not send the field, and a body that will not parse', () => {
+    // A peer on an older build returns no such key, and an unparseable body from a push the peer ACCEPTED
+    // must not be turned into a push failure. This is the one place swallowing is right: the delivery already
+    // succeeded, so the cost of being wrong here is a missing log line.
+    assert.match(refusals, /\?\?\s*0/, 'a missing field must read as zero, not as undefined arithmetic');
+    assert.match(refusals, /catch\s*\{/, 'and a parse failure must not fail the push');
+    assert.match(refusals, /Promise<void>/, 'it returns nothing, so no caller can be made to branch on it');
+  });
+
+  it('still advances the watermark — the fix is visibility, not delivery', () => {
+    // Holding `lastSeqPushed` back would re-offer a record the peer refuses identically every cycle, stalling
+    // the space. This asserts the advance is unconditional on the refusal, so nobody "fixes" it into a stall.
+    const at = sender.indexOf('maxSeqPushed > lastSeqPushed');
+    assert.ok(at > -1, 'anchor missing — re-point this gate');
+    const block = sender.slice(Math.max(0, at - 400), at + 400);
+    assert.doesNotMatch(block, /forkDepthRefused/,
+      'the watermark must not be made conditional on a refusal — that trades a visible drop for a dead space');
+  });
+});


### PR DESCRIPTION
## Two opposite outcomes, one counter

`POST /api/sync/batch-upsert` counted both of these as `skipped`:

| condition | meaning | lossy? |
|---|---|---|
| `existing.seq >= incoming.seq` | the receiver is already current | **no** — ordinary conflict resolution, the common case by far |
| `depth >= MAX_FORK_DEPTH` | content diverged at an identical `seq`, fork chain at its cap, incoming version discarded | **YES — the record is gone** |

**And the pusher checked only `resp.ok`.** It never read the body, so it advanced `lastSeqPushed` past the discarded record and would never offer it again — unlogged on the receiver, unread on the sender. A permanent loss reported by the same integer as "nothing to do", which is why none had ever been seen.

## What changed, and what deliberately did not

`forkDepthRefused` is now its own counter. The **receiver** logs it at warn, naming the record id and saying it will not be retried — it is the side that knows why. The **pusher** reads it and logs too, because either log may be the only one somebody has.

**The watermark still advances, deliberately.** The receiver would refuse the identical record on every future cycle, so holding it back would stall the space's sync and deliver nothing. The defect was the silence, not the advance.

**The benign skip stays silent.** A warn per already-current record per cycle trains an operator to ignore the log, which is how you lose the message that matters. A gate pins the asymmetry in both directions.

## Two gates refused this and both were right

- `upstream-reads-are-bounded.test.js` rejected `await resp.json()` — the body comes from a **peer**, and a timeout bounds duration, not size. Now `boundedJson`, which was already imported in that very file.
- `no-new-god-files.test.js` freezes `sync/engine.ts` and refused the logic inside it: *"every change lands in the same place because that is where the code already is."* The behaviour is now `sync/push-refusals.ts`; the engine grew by one line.

## Honest scoping

Found while chasing the intermittent `pubsub-topology` timeout (tracked separately). **It is not proven to cause it** — a fork-depth refusal needs divergent content at an identical seq, which that test does not obviously produce — and the tracker says so.

My first write-up called `skipped` a silent-loss path *by construction*. Reading the conditions corrected that to the conflation, which is narrower and actually fixable; the tracker keeps the wrong version visible because it is the tempting reading.

Preflight green. Sync suite **191 pass / 0 fail / 1 skipped**.