### PR TITLE
feat(rights): name the space-admin rung on the surfaces that were blind to it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The space-admin rung was enforced everywhere and named nowhere, so nobody could find it, grant it, or
+  check they had it.** A token with all four areas at `admin` for one space has administered that space since
+  3.0 (`isSpaceAdminFor`), with both containment rules red-teamed. Measured 2026-08-19: that predicate appeared
+  in **three server files and zero client files** — the matrix showed four independent rungs and nothing said
+  the all-four state had a meaning. breituai-platform asked twice, both times about the surface rather than the
+  capability.
+
+  Now named on the three surfaces that were blind:
+
+  - **`GET /api/tokens/rights-catalog`** gains `derivedRungs` — `requires`, `grants` and `excludes`. **`requires`
+    is COMPUTED from the area list, never written out**, for the same reason the catalog publishes `ROUTE_RIGHTS`
+    instead of letting a client type one: a second statement of a security rule is free to disagree with the
+    first, and a fifth area would break a hand-written copy silently.
+  - **`help()`** names the rung and **marks which spaces the calling token administers**, from the same
+    predicate the server enforces with. Naming answers *find it*; the mark answers *verify I hold it*, which
+    prose cannot.
+  - **The docs**: `07-tokens-api.md` for integrators and `04-settings.md` for operators, both leading with the
+    containment — it is never instance-wide, cannot grant `instanceAdmin`/`createSpaces`, cannot set a floor,
+    and cannot see or edit tokens for a space it does not administer.
+
+  **No security change and no schema change.** Both constraints already held and are covered by named
+  red-team tests; there is deliberately no `spaceAdmin: true` field, because the four rungs already express it.
+  `space-admin-rung-is-named.test.js` runs `isSpaceAdminFor` over a matrix built from the PUBLISHED `requires`,
+  so the description is proven against the enforcement rather than intended to match it — including that each
+  of the four areas is individually necessary.
+
+  Still open: naming it in the rights-matrix UI and granting it in one action, which needs three locale files.
+
 - **The brain-ops guide still described the 25-record spill cliff that the byte budget replaced.** It told a
   caller the answer collapses to *three matches* past 25 records and documented a `complete: {matches, records,
   inline, path, download, expiresAt}` block — a shape that no longer exists. Rewritten to the budget: a whole-

--- a/docs/integration-guide/07-tokens-api.md
+++ b/docs/integration-guide/07-tokens-api.md
@@ -54,6 +54,12 @@ Authorization: Bearer <token>
   "implications": [
     { "when": "knowledge", "atLeast": "write", "grants": "schema", "rung": "read" }
   ],
+  "derivedRungs": [
+    { "id": "spaceAdmin",
+      "requires": { "knowledge": "admin", "files": "admin", "schema": "admin", "dataQuality": "admin" },
+      "grants": "That space’s own tokens (listing, minting and editing) and that space’s own settings, schema and index rebuilds.",
+      "excludes": "Nothing instance-shaped: it cannot grant `instanceAdmin` or `createSpaces`, cannot set a floor, and cannot reach, mint for, or edit tokens for any space it does not administer — it does not even list them." }
+  ],
   "routes": [
     { "area": "knowledge", "method": "POST", "route": "/api/brain/spaces/:spaceId/recall", "needs": "read" },
     { "area": "files", "method": "DELETE", "route": "/api/files/:spaceId", "needs": "write" }
@@ -85,6 +91,27 @@ Three properties worth building against:
 - **It does not chain.** Each rule is evaluated against what was *granted*, never against another rule's
   inference, so the order of the array is not load-bearing.
 - **It is scoped to one space**, and applies to the all-spaces floor within the floor's own scope.
+
+#### `derivedRungs` — states the matrix expresses without naming
+
+**A token whose FOUR areas are all at `admin` for one space is that space's administrator.** That has been
+enforced since 3.0 and, until now, was named nowhere: the matrix showed four independent rungs and nothing
+said the all-four-at-`admin` state had a meaning. An operator could not find it, grant it in one action, or
+verify they held it — and neither could you.
+
+`requires` is the condition, `grants` is what it unlocks **beyond** what the four rungs already give, and
+`excludes` is the containment. Read `excludes` if you are building against it: **it is never instance-wide.**
+It cannot grant `instanceAdmin` or `createSpaces`, cannot set an all-spaces floor, and cannot reach, mint for
+or edit tokens for any space it does not administer — it does not even list them. Those rules are red-teamed,
+not aspirational.
+
+**Derive the state, do not store it.** `requires` is computed server-side from the area list, so it stays
+correct if a fifth area is ever added; a copy of the four names in your own code would not. There is no
+`spaceAdmin: true` field on a token and there will not be — the four rungs already express it, and a second
+field could disagree with them.
+
+To show it in your own UI: read `derivedRungs`, then compare a token's effective rung per area (after
+`implications`) against `requires`.
 
 The stored matrix is *not* rewritten — `GET /api/tokens` returns what was set. Resolve the effective rung by
 applying this table on read; do not persist the result, or a rung that exists only while `knowledge` is

--- a/docs/userguide/04-settings.md
+++ b/docs/userguide/04-settings.md
@@ -149,6 +149,25 @@ description differs per column, because `write` on Files and `write` on Knowledg
 What clicking will do follows after it, including the fact that clicking the level you are already on steps
 down one.
 
+#### Administering one space, without administering the instance
+
+**A token with all four areas at `admin` for one space is that space's administrator.** There is no separate
+checkbox for it, and there deliberately is not: the four rungs already say it, and a second setting could
+disagree with them. But it *is* a real, named thing, and until now nothing on this page told you so — which
+is why it was asked for twice by an operator who already had it and could not tell.
+
+What it means in practice: that token can manage **that space's own tokens** — list, mint and edit them — and
+**that space's own settings**, schema and index rebuilds. Nothing wider.
+
+**What it cannot do, which is the part worth trusting:** it is never instance-wide. It cannot grant
+**instance admin** or **create spaces**, it cannot set the all-spaces floor, and it cannot see or edit tokens
+that reach any space it does not administer — those tokens do not appear in its list at all. So handing
+somebody administration of one space does not quietly hand them a way to widen it.
+
+**To check whether a token has it:** set all four cells in that space's row to admin, or read the row — four
+admins is the state. An agent can ask `help` and its space list marks the spaces the calling token
+administers.
+
 #### Some cells hold each other up
 
 A cell will not always go as low as you click, and the greyed-out segments say why when you hover them. There

--- a/server/src/api/tokens.ts
+++ b/server/src/api/tokens.ts
@@ -5,7 +5,7 @@ import { authRateLimit, globalRateLimit } from '../rate-limit/middleware.js';
 import { createToken, listTokens, revokeToken, regenerateToken, renameToken, setTokenRights, setTokenMfa } from '../auth/tokens.js';
 import { isMfaEnabled, verifyMfaCode } from '../auth/totp.js';
 import { z } from 'zod';
-import { SPACE_AREAS, RUNGS, RUNG_IMPLICATIONS } from '../config/rights-shape.js';
+import { SPACE_AREAS, RUNGS, RUNG_IMPLICATIONS, DERIVED_RUNGS } from '../config/rights-shape.js';
 import { ROUTE_RIGHTS } from '../auth/space-rights.js';
 import { refusalsOutsideEditorScope, editorScopeFor } from '../auth/editor-scope.js';
 import { capRights, describeExcess } from '../auth/mint-cap.js';
@@ -86,6 +86,11 @@ tokensRouter.get('/rights-catalog', globalRateLimit, requireAuth, (_req, res) =>
     areas: SPACE_AREAS,
     rungs: RUNGS,
     implications: RUNG_IMPLICATIONS,
+    // The states the matrix expresses without naming. `spaceAdmin` has been enforced since #937 and was
+    // findable nowhere: an operator saw four independent rungs and nothing said that all four at `admin` IS
+    // administering that space. Published here for the same reason `routes` is — this is the description that
+    // cannot be wrong, because `requires` is computed from `SPACE_AREAS` rather than restated.
+    derivedRungs: DERIVED_RUNGS,
     routes: ROUTE_RIGHTS.map(r => ({ area: r.area, method: r.method, route: r.route, needs: r.needs })),
   });
 });

--- a/server/src/config/rights-shape.ts
+++ b/server/src/config/rights-shape.ts
@@ -61,6 +61,55 @@ export type AreaRungs = Record<SpaceArea, Rung>;
  * chain would make the order of this array load-bearing and let two innocuous rules compose into a grant
  * nobody wrote down. If a transitive implication is ever wanted, it goes in as its own row, visibly.
  */
+/**
+ * The DERIVED rungs — states the matrix expresses without naming, published so they can be found.
+ *
+ * ## Why this exists at all
+ *
+ * `isSpaceAdminFor` (auth/editor-scope.ts) is `SPACE_AREAS.every(area => effectiveRung(...) === 'admin')`.
+ * That capability has been enforced since #937 and is real: it unlocks a space's own tokens and settings, and
+ * `space-admin-edit-boundary.test.js` red-teams both of its containment rules.
+ *
+ * **But it had no NAME on any surface.** `isSpaceAdminFor` appears in three server files and zero client
+ * files, so the matrix showed four independent rungs and nothing said that all four at `admin` IS being that
+ * space's administrator. breituai-platform asked for it twice — 2026-08-17T1910Z and a 1916Z narrowing — and
+ * their words were about the surface, not the capability: *"there is still no SPACE ADMIN rung in the rights
+ * matrix"*. An operator could not find it, grant it in one action, or verify they held it.
+ *
+ * ## Why `requires` is COMPUTED and not written out
+ *
+ * The same reason `rights-catalog` publishes `ROUTE_RIGHTS` instead of letting the client type a list: *"a
+ * list typed into the client would be a second copy of a security control, and the copy that drifts is the
+ * one people read."* A literal `{knowledge: 'admin', files: 'admin', ...}` here would be a second statement
+ * of the predicate, free to disagree with it — and if a fifth area is ever added, the predicate would change
+ * and the published definition would not. Built from `SPACE_AREAS`, both move together or neither does.
+ *
+ * `space-admin-rung-is-named.test.js` asserts this definition against `isSpaceAdminFor` itself, by running
+ * the predicate over a rights object built from `requires` — so agreement is proven rather than intended.
+ */
+export const DERIVED_RUNGS = [
+  {
+    id: 'spaceAdmin',
+    /** Every area at its top rung, FOR ONE SPACE — never the instance. */
+    requires: Object.fromEntries(SPACE_AREAS.map(a => [a, 'admin'])) as AreaRungs,
+    /**
+     * What it unlocks BEYOND what the four rungs already grant, in words rather than as a route list.
+     *
+     * Deliberately prose: the routes it governs are the ones NOT in `ROUTE_RIGHTS` (that table is the four
+     * DATA areas), so enumerating them here would create the second copy this file's own reasoning forbids.
+     * `NOT_AREA_SCOPED` in auth/space-rights.ts carries them with a `why` each.
+     */
+    grants: 'That space’s own tokens (listing, minting and editing) and that space’s own settings, schema '
+      + 'and index rebuilds.',
+    /**
+     * The two containment rules, stated because breituai-platform asked for them to be part of the
+     * DEFINITION rather than inferred. Both are enforced today and red-teamed.
+     */
+    excludes: 'Nothing instance-shaped: it cannot grant `instanceAdmin` or `createSpaces`, cannot set a floor, '
+      + 'and cannot reach, mint for, or edit tokens for any space it does not administer — it does not even '
+      + 'list them.',
+  },
+] as const;
 export const RUNG_IMPLICATIONS = [
   { when: 'knowledge', atLeast: 'write', grants: 'schema', rung: 'read' },
 ] as const satisfies readonly { when: SpaceArea; atLeast: Rung; grants: SpaceArea; rung: Rung }[];

--- a/server/src/mcp/tools/help-sections.ts
+++ b/server/src/mcp/tools/help-sections.ts
@@ -24,6 +24,7 @@
  * put it on the embedding path — so a broken embedder would take the tool that explains the instance down with it.
  */
 import type { ToolContext } from './types.js';
+import { isSpaceAdminFor } from '../../auth/editor-scope.js';
 
 /** Strip control chars (incl. newlines) and backticks, clamp length. */
 export function sanitizeDynamic(s: string, max = 200): string {
@@ -158,10 +159,30 @@ export function helpSections(
     title: 'Spaces accessible to this token',
     body: '',
     preamble: 'Most tools take a "space" parameter; recall and list_chrono search across all your spaces when it is '
-      + 'omitted. Call list_spaces for storage/quota details.',
+      + 'omitted. Call list_spaces for storage/quota details.\n\n'
+      /*
+       * NAMING THE SPACE-ADMIN RUNG, and marking the spaces where this token holds it.
+       *
+       * The capability has been enforced since #937 as `isSpaceAdminFor` — every one of the four areas at
+       * `admin`, for ONE space. It had no name on any surface: the rights matrix shows four independent rungs
+       * and nothing said that all four at admin IS administering that space. breituai-platform asked twice
+       * (2026-08-17T1910Z, narrowed 1916Z) and their complaint was about the surface rather than the
+       * capability — an operator could not find it, grant it in one action, or verify they held it.
+       *
+       * MARKED per space rather than described in prose, because "verify they held it" is the third part of
+       * that complaint and a sentence cannot answer it. The mark comes from the same predicate the server
+       * enforces with, so it cannot claim a rung the caller does not have.
+       */
+      + 'ADMINISTERING A SPACE has a name and this list shows where you hold it. A token whose FOUR areas '
+      + '(knowledge, files, schema, dataQuality) are all at the `admin` rung for one space is that space’s '
+      + 'administrator: it manages that space’s own tokens and settings. It is never instance-wide — it '
+      + 'cannot grant `instanceAdmin` or `createSpaces`, cannot set a floor, and cannot see or edit tokens '
+      + 'for a space it does not administer. `GET /api/tokens/rights-catalog` publishes the definition as '
+      + '`derivedRungs`.',
     lines: ctx.accessibleSpaces.length > 0
       ? ctx.accessibleSpaces.map(s =>
-        `- ${sanitizeDynamic(s.id)}${s.label ? ` ("${sanitizeDynamic(s.label)}")` : ''}`)
+        `- ${sanitizeDynamic(s.id)}${s.label ? ` ("${sanitizeDynamic(s.label)}")` : ''}`
+        + `${isSpaceAdminFor(ctx.rights, s.id) ? '  [you administer this space]' : ''}`)
       : ['(none accessible to this token)'],
   });
 

--- a/testing/standalone/space-admin-rung-is-named.test.js
+++ b/testing/standalone/space-admin-rung-is-named.test.js
@@ -1,0 +1,117 @@
+/**
+ * The space-admin rung has a NAME, and the published name matches the enforced predicate.
+ *
+ * ## What was wrong, and it was not the capability
+ *
+ * `isSpaceAdminFor` has been enforced since #937: every one of the four areas at `admin`, for ONE space. Both
+ * of its containment rules are red-teamed in `space-admin-edit-boundary.test.js` — it cannot grant
+ * `instanceAdmin`/`createSpaces`, cannot set a floor, and cannot see or edit tokens for a space it does not
+ * administer.
+ *
+ * **It had no name on any surface.** Measured 2026-08-19: `isSpaceAdminFor` appeared in three server files and
+ * **zero** client files. The rights matrix showed four independent rungs and nothing said that all four at
+ * `admin` IS administering that space. breituai-platform asked twice — 2026-08-17T1910Z and a 1916Z narrowing
+ * — and both times about the surface: *"there is still no SPACE ADMIN rung in the rights matrix"*. An operator
+ * could not **find** it, **grant** it in one action, or **verify** they held it.
+ *
+ * ## What this file guards, which is the part that can rot
+ *
+ * A published definition is a SECOND statement of a security rule, and the copy that drifts is the one people
+ * read — the reason `rights-catalog` publishes `ROUTE_RIGHTS` rather than letting the client type a list. So
+ * `DERIVED_RUNGS.requires` is COMPUTED from `SPACE_AREAS`, and this file proves it still agrees with
+ * `isSpaceAdminFor` by running the predicate over a rights object built from the published value.
+ *
+ * That is the difference between "we wrote the same thing twice" and "one of them is derived from the other".
+ *
+ * Run: node --test testing/standalone/space-admin-rung-is-named.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripComments } from './_strip-comments.mjs';
+
+const { DERIVED_RUNGS, SPACE_AREAS, RUNGS } = await import('../../server/dist/config/rights-shape.js');
+const { isSpaceAdminFor } = await import('../../server/dist/auth/editor-scope.js');
+
+const spaceAdmin = DERIVED_RUNGS.find(r => r.id === 'spaceAdmin');
+/** A rights matrix granting `rungs` on `spaceId` and nothing else. */
+const rightsFor = (spaceId, rungs) => ({
+  instanceAdmin: false, createSpaces: false, floor: null, perSpace: { [spaceId]: { ...rungs } },
+});
+
+describe('the published definition IS the enforced predicate', () => {
+  it('publishes a spaceAdmin entry at all', () => {
+    assert.ok(spaceAdmin, 'DERIVED_RUNGS must carry `spaceAdmin` — without it the rung has no name again');
+    assert.ok(spaceAdmin.grants, 'and say what it unlocks');
+    assert.ok(spaceAdmin.excludes, 'and what it does not, which is what breituai-platform asked to be explicit');
+  });
+
+  it('a token built from `requires` PASSES isSpaceAdminFor', () => {
+    // The whole point: the published definition is not prose about the predicate, it satisfies it.
+    assert.equal(isSpaceAdminFor(rightsFor('s1', spaceAdmin.requires), 's1'), true,
+      'the published requirement does not actually make a space admin — the two have drifted');
+  });
+
+  it('and it is EXACTLY sufficient — every area matters', () => {
+    // Drop each area to `write` in turn. If any one of them still passes, `requires` over-states the rule and a
+    // reader would grant more than necessary; if the predicate ignored an area, this catches that too.
+    for (const area of SPACE_AREAS) {
+      const weakened = { ...spaceAdmin.requires, [area]: 'write' };
+      assert.equal(isSpaceAdminFor(rightsFor('s1', weakened), 's1'), false,
+        `${area} at 'write' still counted as space admin — either requires or the predicate is wrong`);
+    }
+  });
+
+  it('and it is per-SPACE, never instance-wide', () => {
+    // The containment rule that matters most: holding it on s1 must say nothing about s2.
+    const r = rightsFor('s1', spaceAdmin.requires);
+    assert.equal(isSpaceAdminFor(r, 's1'), true);
+    assert.equal(isSpaceAdminFor(r, 's2'), false,
+      'administering one space must not administer another — this is the rule they asked to be part of the '
+      + 'definition, and the definition would be a lie without it');
+  });
+
+  it('names every area, so a fifth area cannot be silently omitted', () => {
+    assert.deepEqual(Object.keys(spaceAdmin.requires).sort(), [...SPACE_AREAS].sort(),
+      'requires must cover exactly the areas the predicate iterates');
+    for (const v of Object.values(spaceAdmin.requires)) {
+      assert.ok(RUNGS.includes(v), `${v} is not a published rung`);
+    }
+  });
+
+  it('`requires` is COMPUTED from SPACE_AREAS, not written out', () => {
+    /*
+     * The anti-drift property, asserted on source because it cannot be seen from the value.
+     *
+     * A literal `{knowledge: 'admin', files: 'admin', schema: 'admin', dataQuality: 'admin'}` would satisfy
+     * every assertion above TODAY and silently stop matching the predicate the day a fifth area is added —
+     * the predicate would iterate five, the published definition would still claim four, and the assertions
+     * above would keep passing because they are built from the published value.
+     */
+    const src = stripComments(readFileSync('server/src/config/rights-shape.ts', 'utf8'));
+    const at = src.indexOf('DERIVED_RUNGS');
+    assert.ok(at > -1, 'anchor missing — re-point this gate');
+    const block = src.slice(at, at + 900);
+    assert.match(block, /SPACE_AREAS\.map/,
+      'requires must be built from SPACE_AREAS, or it is a second copy of the predicate free to disagree');
+    assert.doesNotMatch(block, /knowledge:\s*'admin'/,
+      'a hand-written area list is the drift this exists to prevent');
+  });
+});
+
+describe('the surfaces that were blind now name it', () => {
+  it('rights-catalog publishes it', () => {
+    const src = stripComments(readFileSync('server/src/api/tokens.ts', 'utf8'));
+    assert.match(src, /derivedRungs: DERIVED_RUNGS/,
+      'the catalog is where a client reads the model — it published the four areas and not this');
+  });
+
+  it('help() names the rung AND marks where the caller holds it', () => {
+    // Naming it in prose answers "find it". Marking the spaces answers "verify I have it", which is the part a
+    // sentence cannot do and the third of breituai-platform's three complaints.
+    const src = stripComments(readFileSync('server/src/mcp/tools/help-sections.ts', 'utf8'));
+    assert.match(src, /ADMINISTERING A SPACE/, 'help must name the rung');
+    assert.match(src, /isSpaceAdminFor\(ctx\.rights, s\.id\)/,
+      'and mark it per space from the same predicate the server enforces with, so it cannot over-claim');
+  });
+});


### PR DESCRIPTION
## The capability was never missing — the name was

A token with all four areas at `admin` for one space has administered that space since 3.0 (`isSpaceAdminFor`), with both containment rules red-teamed. breituai-platform asked twice and both times described the **surface**: *"there is still no SPACE ADMIN rung in the rights matrix"*.

Measured before writing anything: **`isSpaceAdminFor` appears in three server files and ZERO client files.** Enforced everywhere, named nowhere — so an operator could not **find** it, **grant** it in one action, or **verify** they held it.

## No security work in this item, which is what shrank it

Both constraints they asked to have written into the definition already hold, each with a named red-team test:

| constraint | covered by |
|---|---|
| cannot grant more than it holds | *cannot grant instanceAdmin*, *cannot grant createSpaces*, *cannot set a FLOOR*, *still refuses instanceAdmin, createSpaces and a floor from a scoped editor* |
| cannot reach another space | *cannot grant rights for ANOTHER space*, *cannot RENAME a token that reaches a space outside its scope*, *cannot edit an UNRESTRICTED token*, *a space admin does not see tokens from other spaces* |

That last one is stronger than requested: the **listing** is scoped, not only the write.

## Named on three surfaces

- **`rights-catalog`** gains `derivedRungs` — `requires`, `grants`, `excludes`. **`requires` is COMPUTED from `SPACE_AREAS`, never written out**, per the catalog's own rule: *"a list typed into the client would be a second copy of a security control, and the copy that drifts is the one people read."*
- **`help()`** names the rung and **marks which spaces the calling token administers**, from the same predicate the server enforces with. Naming answers *find it*; the mark answers *verify I hold it*, which prose cannot.
- **Docs** — `07-tokens-api.md` and `04-settings.md`, both leading with the containment, because what it *cannot* do is the reason to trust it.

## The gate proves agreement rather than asserting it

`space-admin-rung-is-named.test.js` builds a matrix **from the published `requires`** and runs `isSpaceAdminFor` over it; weakens each area in turn to prove all four are necessary; and checks that holding it on one space says nothing about another.

**Mutation-tested, and the result is the point:** replacing the computed `requires` with a hand-written `{knowledge: 'admin', …}` passes **all seven** value assertions and is caught **only** by the source-reading drift guard.

## No schema change, deliberately

There is no `spaceAdmin: true` field and should not be — the four rungs already express it, and a second field could disagree. `editor-scope.ts` already records that rejection.

**Still open and not claimed here:** naming it in the matrix UI and granting it in one action. That needs three locale files, and the one-action control is already written and deliberately reverted — read `UI-TODO.md` before restarting it.

Red-team **293 pass / 0 fail**. MCP + token integration **108 pass / 0 fail**. Preflight green.