### PR TITLE
docs(brain-ops): the spill section still described the cliff the byte budget removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The brain-ops guide still described the 25-record spill cliff that the byte budget replaced.** It told a
+  caller the answer collapses to *three matches* past 25 records and documented a `complete: {matches, records,
+  inline, path, download, expiresAt}` block — a shape that no longer exists. Rewritten to the budget: a whole-
+  record prefix bounded by `maxBytes`, the five always-present accounting fields, and `remainder` carrying only
+  what did not fit.
+
+  **Found by a targeted staleness sweep rather than by a gate, and that is the point.** `release:gate` passes
+  on this page — it checks that documented things exist and existing things are documented, and every noun in
+  that paragraph existed. A sentence that is about a real feature and describes it WRONGLY is invisible to a
+  coverage check, which is why the docs lens greps for the vocabulary a change made obsolete instead.
 - **A sync push could drop a record permanently and report it in the same number as "nothing to do".**
   `POST /api/sync/batch-upsert` counted two outcomes in one `skipped` integer:
 

--- a/docs/integration-guide/04d-brain-ops-api.md
+++ b/docs/integration-guide/04d-brain-ops-api.md
@@ -584,12 +584,21 @@ On a **proxy space** the page is computed over the **merged** set of all member 
 the first `skip + limit` rows from each member, merges them into the documented order, and returns the window. A deep
 page therefore costs more on a proxy space than on a plain one, but it is the same page.
 
-#### A read result too large to return inline is downloadable
+#### A read result too large to return inline is bounded, and the rest is downloadable
 
-`recall` and `find-similar` write the **whole result set** to the space's `_tmp/` as JSON once it passes 25
-records (matches plus traversed nodes), and return three matches as a sample with `truncated: true` and a
-`complete: {matches, records, inline, path, download, expiresAt}` block. `count` still reports the real total.
-The file carries no embedding vectors and expires after one day.
+`recall` and `find-similar` bound the response by **`maxBytes`** (operator default 100 000; `maxTokens` is the
+same ceiling in tokens, and the smaller of the two wins). What fits comes back as the longest **prefix** of the
+ranked matches, every record whole; what does not fit is written to the space's `_tmp/` as JSON and reported as
+`remainder: {matches, records, path, download, expiresAt}`.
+
+`returned`, `count`, `truncated`, `budgetBytes` and `bytesReturned` are on **every** response, whether the
+budget bit or not, so an absence never has to be interpreted. `remainder` carries **only** what did not fit —
+it is a continuation, not a copy. The file carries no embedding vectors and expires after one day.
+
+> **This replaced a 25-record cap that collapsed the answer to three inline matches plus a download of
+> everything**, including the three already sent. `read_file` takes no offset or limit, so that roughly doubled
+> what a caller had to read rather than reducing it. The full reasoning is in
+> [Prefiltered Recall and the byte budget](04a-recall-api.md).
 
 `recall` and `find-similar` with `traverse > 0` cap the traversed nodes they return inline. Past that cap the
 **complete** graph is written to the space's file store under `_tmp/` as JSON, and the response carries


### PR DESCRIPTION
`04d-brain-ops-api.md` told a caller that `recall` and `find-similar` write the whole result set out past **25 records** and return **three matches** as a sample, with a `complete: {matches, records, inline, path, download, expiresAt}` block.

None of that has been true since #969. The response is bounded by `maxBytes`, comes back as a whole-record **prefix**, carries five always-present accounting fields, and reports `remainder` — which holds only what did *not* fit, and has no `inline` key.

## Why no gate caught it

`release:gate` passes on this page, and correctly: it checks that documented things **exist** and that existing things **are documented**. Every noun in that paragraph exists. A sentence that is *about* a real feature and describes it **wrongly** is invisible to a coverage check.

That distinction is already written down in `_TODO-ORDERED.md` §4: *"the gate is the FLOOR, not the audit — the audit is whether what is written is still TRUE, which no coverage check can see."*

## How it was found, and what else was checked

Grepped `docs/` for the vocabulary the change made obsolete — `three matches`, `complete.inline`, `25 records`. The other four of tonight's changes swept clean:

- no stale `400` claim for `recall` / `query` / `find-similar`
- nothing claiming the embedding vector is returned
- nothing misplacing `help`'s guide

Docs-only. `release:gate` passes, `lint:docs` clean, 167 docs tests green.