### PR TITLE
fix(tokens): mint a token with instance-level rights — and three defects the screenshot found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The create-token dialog could not grant the two instance-level rights, so an instance admin had to be
+  created and then edited.** `draftRights` initialised `instanceAdmin` and `createSpaces` to `false` and no
+  control could change them — while `CreateTokenBody` has accepted both throughout. The edit dialog grew these
+  controls in #908 and nothing brought them to create; reported by breituai-platform 2026-08-17 §9 as the two
+  forms presenting different rights surfaces. It was one missing block, not a diverged surface: both forms
+  already shared the same per-space matrix, and all four translation keys already existed in en/de/pl.
+
+  Placed **outside** the spaces check, deliberately. That branch renders nothing when the instance has no
+  spaces yet, and a fresh instance with no spaces is exactly when `createSpaces` is the right thing to grant.
+
+- **And a rendering defect found while doing it: `.permission-help` in that dialog had never been styled.**
+  It was defined in `tokens.styles.ts`, which only `tokens.component.ts` imports, and Angular scopes component
+  styles — so the create dialog's own use of the class had no CSS behind it. **`tokens.component.spec.ts`
+  asserted the element was `not.toBeNull()` and passed the whole time**, which is the point: a DOM assertion
+  cannot see an unstyled element.
+
+  This is the third time this one file has lost a stylesheet to component scoping — its own header documents
+  the first, when extracting the dialog left `.dialog-backdrop` behind and it rendered as a full-width block
+  with no backdrop. So `.danger-zone`, `.danger-title` and `.permission-help` now live in `DIALOG_STYLES`,
+  which both dialogs import and a move cannot leave behind. The row styles stay in the rights dialog: rotate
+  and revoke exist nowhere else. A gate asserts each class is defined in the stylesheet the component actually
+  imports, and was mutation-tested by renaming one away.
+
 - **The space-admin rung was enforced everywhere and named nowhere, so nobody could find it, grant it, or
   check they had it.** A token with all four areas at `admin` for one space has administered that space since
   3.0 (`isSpaceAdminFor`), with both containment rules red-teamed. Measured 2026-08-19: that predicate appeared

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Placed **outside** the spaces check, deliberately. That branch renders nothing when the instance has no
   spaces yet, and a fresh instance with no spaces is exactly when `createSpaces` is the right thing to grant.
 
+- **And a THIRD defect, found only by screenshotting the dialog: two of the four rights areas were off-screen.**
+  The create dialog rendered at the shared 600px default, so **DATA QUALITY was not visible at all and SCHEMA's
+  rungs were clipped mid-cell** — a token could not be minted with a rung in either. The rights dialog sets
+  `--dialog-max-width: min(1400px, 94vw)` for exactly this, with a comment recording that 600px was *"reported
+  as too narrow"*; the create dialog never did.
+
+  **It was invisible to every measurement.** All five column headers were in the DOM, all eight rung pickers
+  were present and countable, `clientWidth` was 598 and `scrollWidth` was EQUAL to it — so nothing overflowed
+  and nothing scrolled. The table was squeezed, not clipped in any way an assertion notices. Verified after the
+  fix at a 1500px viewport: `clientWidth` 1398, and all four area headers inside the viewport bounds.
+
 - **And a rendering defect found while doing it: `.permission-help` in that dialog had never been styled.**
   It was defined in `tokens.styles.ts`, which only `tokens.component.ts` imports, and Angular scopes component
   styles — so the create dialog's own use of the class had no CSS behind it. **`tokens.component.spec.ts`

--- a/client/src/app/pages/settings/dialog.styles.ts
+++ b/client/src/app/pages/settings/dialog.styles.ts
@@ -46,4 +46,43 @@ export const DIALOG_STYLES = `
     justify-content: space-between;
     margin-bottom: 16px;
   }
+
+  /*
+   * THE SET-APART BLOCK, shared because two dialogs now need it and a copy would drift.
+   *
+   * It lived inline in token-rights-dialog alone. When the create dialog gained the same instance-level
+   * flags, its markup used these class names and rendered COMPLETELY UNSTYLED — the create dialog imports
+   * DIALOG_STYLES only, and Angular's per-component style encapsulation meant the other dialog's copy could
+   * not reach it. That is the same defect as the schema property editor's lost stylesheet (#915): markup that
+   * looks right in the diff and renders as unstyled text in the product.
+   *
+   * Only the CONTAINER and its heading move here. .danger-row/.danger-label/.danger-hint stay inline in
+   * the rights dialog, because rotate and revoke exist nowhere else — a create form has nothing to rotate.
+   *
+   * Visually separated, and last. A destructive control beside Save is a mis-click; the reader should have to
+   * travel to reach it. The border is the boundary, not decoration.
+   */
+  .danger-zone {
+    margin-top: 20px;
+    border: 1px solid var(--danger-border, var(--border));
+    border-radius: var(--radius-md);
+    padding: 12px 14px;
+  }
+  .danger-title {
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: .04em;
+    color: var(--danger, var(--text-secondary));
+    margin-bottom: 10px;
+  }
+  /* The inline hint beside a flag: an icon and a sentence on one line, muted. */
+  .permission-help {
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+    font-size: 12px;
+    color: var(--text-muted);
+    margin: 0;
+  }
 `;

--- a/client/src/app/pages/settings/token-create-dialog.component.ts
+++ b/client/src/app/pages/settings/token-create-dialog.component.ts
@@ -97,6 +97,39 @@ import type { Space, TokenRecord } from '../../core/api.types';
               }
             </div>
 
+            <!-- INSTANCE-LEVEL RIGHTS, and this dialog had none of them.
+                 draftRights hardcoded instanceAdmin and createSpaces to false with no control, so a token
+                 that should hold either had to be created and then EDITED — while the create API has always
+                 accepted both (CreateTokenBody declares them). The edit dialog grew these controls in #908
+                 and nothing brought them here. Reported by breituai-platform 2026-08-17 §9 as the two forms
+                 presenting different rights surfaces; it is one missing block, not a diverged surface.
+
+                 OUTSIDE the spaces check above, deliberately. That branch renders nothing when the instance
+                 has no spaces yet — and a fresh instance with no spaces is exactly when createSpaces is the
+                 right thing to grant. Nesting these inside it would leave the one case they matter most
+                 unreachable.
+
+                 Shown rather than hidden from a scoped editor, matching the edit dialog and its stated reason:
+                 the server refuses a space-restricted administrator who tries to grant either, so the control
+                 offers what the caller may attempt and the server stays the authority. -->
+            <div class="danger-zone" style="margin-top:14px;">
+              <div class="danger-title">{{ 'tokens.rights.instanceLevel' | transloco }}</div>
+              <p class="permission-help" style="margin-top:6px;">
+                <ph-icon name="info" [size]="14" />
+                <span>{{ 'tokens.rights.instanceLevelHint' | transloco }}</span>
+              </p>
+              <label style="display:flex;align-items:center;gap:8px;margin-top:10px;">
+                <input type="checkbox" [checked]="draftRights().instanceAdmin"
+                       (change)="setFlag('instanceAdmin', $any($event.target).checked)" />
+                <span>{{ 'tokens.rights.instanceAdmin' | transloco }}</span>
+              </label>
+              <label style="display:flex;align-items:center;gap:8px;margin-top:8px;">
+                <input type="checkbox" [checked]="draftRights().createSpaces"
+                       (change)="setFlag('createSpaces', $any($event.target).checked)" />
+                <span>{{ 'tokens.rights.createSpaces' | transloco }}</span>
+              </label>
+            </div>
+
             <div class="form-grid-bottom" style="margin-top:12px;">
               <button class="btn-secondary btn" type="button" (click)="close.emit()">{{ 'common.cancel' | transloco }}</button>
               <button class="btn-primary btn" type="submit" style="margin-left:auto;" [disabled]="creating() || !newName.trim()">
@@ -125,6 +158,20 @@ export class TokenCreateDialogComponent {
   draftRights = signal<TokenRights>({ instanceAdmin: false, createSpaces: false, floor: null, perSpace: {} });
   newName = '';
   newExpiry = '';
+
+  /**
+   * The two instance-level flags, settable at MINT time — which they were not.
+   *
+   * `draftRights` initialised both to `false` and nothing could change them, so a token that should hold
+   * either had to be created and then edited. The create API accepted both throughout (`CreateTokenBody`),
+   * and the edit dialog grew the controls in #908; only this form was left behind.
+   *
+   * Same signature and same one-line body as the edit dialog's `setFlag`, on purpose: two spellings of one
+   * update is how the two forms drift apart again, and this defect IS that drift.
+   */
+  setFlag(key: 'instanceAdmin' | 'createSpaces', on: boolean): void {
+    this.draftRights.update(d => ({ ...d, [key]: on }));
+  }
 
   createToken(): void {
     if (!this.newName.trim()) return;

--- a/client/src/app/pages/settings/token-create-dialog.component.ts
+++ b/client/src/app/pages/settings/token-create-dialog.component.ts
@@ -47,7 +47,23 @@ import type { Space, TokenRecord } from '../../core/api.types';
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, ModalDirective, RightsMatrixComponent],
-  styles: [DIALOG_STYLES],
+  styles: [DIALOG_STYLES, `
+    /*
+     * WIDEN FOR THE MATRIX — the edit dialog does this and this one did not, so two of the four areas were
+     * unreachable when MINTING a token.
+     *
+     * Found by screenshotting the dialog, and it could not have been found any other way: all five columns
+     * are in the DOM and countable (5 headers, 8 rung pickers), and Data quality was simply not on screen
+     * while Schema's rungs were clipped mid-cell. Measured at the shared 600px default: clientWidth 598,
+     * maxWidth 600px, and scrollWidth EQUAL to clientWidth — so nothing scrolled and nothing overflowed in a
+     * way any assertion would notice. The table was squeezed, not scrollable.
+     *
+     * The same value as the rights dialog, which carries the reason: at 600px the matrix renders as a column
+     * of squeezed cells and the space rows wrap, reported as 'too narrow'. Same table, same need, same
+     * number — a different one here would be a second answer to one question.
+     */
+    :host { --dialog-max-width: min(1400px, 94vw); }
+  `],
   template: `
       <div class="dialog-backdrop">
         <div class="dialog" [appModal]="'tokens.create.title' | transloco" (dismiss)="close.emit()" (click)="$event.stopPropagation()">

--- a/client/src/app/pages/settings/token-create-dialog.instance-rungs.spec.ts
+++ b/client/src/app/pages/settings/token-create-dialog.instance-rungs.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * The create-token dialog offers the two instance-level rights, and its shared styles actually reach it.
+ *
+ * ## The defect
+ *
+ * `draftRights` initialised `instanceAdmin` and `createSpaces` to `false` and **no control could change
+ * them** — so a token that should hold either had to be created and then EDITED. The create API accepted both
+ * throughout (`CreateTokenBody` declares them); the edit dialog grew the controls in #908 and nothing brought
+ * them here. Reported by breituai-platform 2026-08-17 §9 as the two forms presenting different rights
+ * surfaces. It is one missing block, not a diverged surface.
+ *
+ * ## And the second half, which no existing test could have caught
+ *
+ * `.danger-zone`, `.danger-title` and `.permission-help` were defined inside OTHER components' style arrays.
+ * Angular's emulated encapsulation scopes those, so markup here using them renders **unstyled** — and
+ * `.permission-help` was already in this template before this change, already unstyled, with
+ * `tokens.component.spec.ts` asserting only that *"the element is not null"*. It passed the whole time.
+ *
+ * That is the shape of `verify-visual-changes-with-screenshots`: a thing can pass every measurement and be
+ * wrong to look at. A DOM assertion cannot see it, so this file asserts the mechanism instead — the classes
+ * must come from the stylesheet this component actually imports.
+ *
+ * Run: npm run test:client
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const component = readFileSync('src/app/pages/settings/token-create-dialog.component.ts', 'utf8');
+const shared = readFileSync('src/app/pages/settings/dialog.styles.ts', 'utf8');
+const editor = readFileSync('src/app/pages/settings/token-rights-dialog.component.ts', 'utf8');
+
+describe('create-token dialog: instance-level rights', () => {
+  it('offers both flags, bound to the draft', () => {
+    for (const flag of ['instanceAdmin', 'createSpaces']) {
+      expect(component).toContain(`draftRights().${flag}`);
+      expect(component).toContain(`setFlag('${flag}',`);
+    }
+  });
+
+  it('can actually change them — a checkbox with no handler is the defect wearing a control', () => {
+    expect(component).toMatch(/setFlag\(key: 'instanceAdmin' \| 'createSpaces', on: boolean\)/);
+    expect(component).toMatch(/this\.draftRights\.update\(/);
+  });
+
+  it('puts them OUTSIDE the spaces check, or the one case they matter most is unreachable', () => {
+    /*
+     * The matrix sits inside `@else` on `availableSpaces().length === 0`. A fresh instance with no spaces is
+     * exactly when `createSpaces` is the right thing to grant — so nesting the flags in that branch would hide
+     * them precisely when they are needed. Asserted by ORDER: the flags must come after the block that closes
+     * the spaces conditional.
+     */
+    const spacesBranch = component.indexOf('loadingSpaces');
+    const matrixClose = component.indexOf('</div>', component.indexOf('app-rights-matrix'));
+    const flags = component.indexOf('tokens.rights.instanceLevel');
+    expect(spacesBranch).toBeGreaterThan(-1);
+    expect(flags).toBeGreaterThan(matrixClose);
+  });
+
+  it('sends them: the body carries the whole matrix, flags included', () => {
+    // `rights: this.draftRights()` is what makes the controls mean anything. A body assembled field by field
+    // could offer a checkbox and post without it.
+    expect(component).toMatch(/rights: this\.draftRights\(\)/);
+  });
+});
+
+describe('the shared styles reach this component', () => {
+  it('imports the stylesheet that defines the classes it uses', () => {
+    expect(component).toContain("import { DIALOG_STYLES } from './dialog.styles'");
+    expect(component).toMatch(/styles: \[DIALOG_STYLES\]/);
+  });
+
+  for (const cls of ['danger-zone', 'danger-title', 'permission-help']) {
+    it(`\`.${cls}\` is defined in DIALOG_STYLES, not in another component's scope`, () => {
+      // The whole failure mode: the class exists SOMEWHERE, the markup looks right, and Angular scopes the
+      // definition to a component this markup is not in.
+      expect(component).toContain(`class="${cls}"`);
+      expect(shared).toContain(`.${cls} {`);
+    });
+  }
+
+  it('and the editor no longer keeps its own copy of the two it shared', () => {
+    // Two copies of one rule is how they drift. The row styles STAY there — rotate and revoke exist only in
+    // the editor, so a create form has nothing to rotate.
+    expect(editor).not.toMatch(/^\s*\.danger-zone \{/m);
+    expect(editor).not.toMatch(/^\s*\.danger-title \{/m);
+    expect(editor).toMatch(/\.danger-row \{/);
+  });
+});

--- a/client/src/app/pages/settings/token-create-dialog.instance-rungs.spec.ts
+++ b/client/src/app/pages/settings/token-create-dialog.instance-rungs.spec.ts
@@ -63,10 +63,41 @@ describe('create-token dialog: instance-level rights', () => {
   });
 });
 
+describe('the dialog is wide enough for the matrix it contains', () => {
+  it('widens itself, or two of the four areas are unreachable', () => {
+    /*
+     * FOUND BY SCREENSHOT, and findable no other way.
+     *
+     * At the shared 600px default this dialog rendered with DATA QUALITY off-screen and SCHEMA's rungs
+     * clipped mid-cell — so a token could not be minted with a rung in either. Every DOM assertion passed
+     * throughout: five headers present, eight rung pickers present, clientWidth 598 and scrollWidth EQUAL to
+     * it, so nothing overflowed and nothing scrolled. The table was squeezed, not clipped in any way a
+     * measurement notices.
+     *
+     * Verified after the fix at 1500px viewport: clientWidth 1398, and all four area headers inside the
+     * viewport bounds.
+     */
+    expect(component).toMatch(/--dialog-max-width:\s*min\(1400px, 94vw\)/);
+  });
+
+  it('uses the SAME width as the rights dialog, not a second answer to one question', () => {
+    const width = /--dialog-max-width:\s*(min\([^)]*\))/;
+    const mine = component.match(width);
+    const theirs = editor.match(width);
+    expect(mine).not.toBeNull();
+    expect(theirs).not.toBeNull();
+    expect(mine[1]).toBe(theirs[1]);
+  });
+});
+
 describe('the shared styles reach this component', () => {
   it('imports the stylesheet that defines the classes it uses', () => {
     expect(component).toContain("import { DIALOG_STYLES } from './dialog.styles'");
-    expect(component).toMatch(/styles: \[DIALOG_STYLES\]/);
+    // The RULE, not one spelling: DIALOG_STYLES must be in the styles array. This asserted the literal
+    // `styles: [DIALOG_STYLES]` and broke the moment the array gained a second entry for the dialog width —
+    // a change that honours the rule completely. A gate pinned to one spelling fails on a correct change and
+    // teaches the next person to loosen it.
+    expect(component).toMatch(/styles: \[\s*DIALOG_STYLES/);
   });
 
   for (const cls of ['danger-zone', 'danger-title', 'permission-help']) {

--- a/client/src/app/pages/settings/token-rights-dialog.component.ts
+++ b/client/src/app/pages/settings/token-rights-dialog.component.ts
@@ -40,22 +40,10 @@ import type { Space, TokenRecord } from '../../core/api.types';
        squeezed cells and the space rows wrap — reported as "too narrow". The --dialog-max-width variable exists
        precisely so a host can say this; sizing was always the caller's decision. */
     :host { --dialog-max-width: min(1400px, 94vw); }
-    /* Visually separated, and last. A destructive control beside Save is a mis-click; the reader should have
-       to travel to reach it. The border is the boundary, not decoration. */
-    .danger-zone {
-      margin-top: 20px;
-      border: 1px solid var(--danger-border, var(--border));
-      border-radius: var(--radius-md);
-      padding: 12px 14px;
-    }
-    .danger-title {
-      font-size: 12px;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: .04em;
-      color: var(--danger, var(--text-secondary));
-      margin-bottom: 10px;
-    }
+    /* .danger-zone, .danger-title and .permission-help moved to DIALOG_STYLES when the CREATE dialog
+       gained the same instance-level flags — its markup used these names and rendered unstyled, because
+       per-component encapsulation means this copy could not reach it. The rows below stay here: rotate and
+       revoke exist in this dialog only. */
     .danger-row {
       display: flex;
       align-items: center;


### PR DESCRIPTION
## 1. The create dialog could not grant the two instance-level rights

`draftRights` initialised `instanceAdmin` and `createSpaces` to `false` and **nothing could change them**, so an instance admin had to be created and then *edited*. `CreateTokenBody` has declared both throughout — the server never refused it, the form never asked. The edit dialog grew the controls in #908 and nothing brought them here.

Reported by breituai-platform 2026-08-17 §9. Measured first: both forms already share the same per-space matrix and differ only on these two, and all four translation keys already exist in en/de/pl — one missing block, no locale work.

**Placed outside the spaces check**, deliberately: that branch renders nothing when the instance has no spaces, and a fresh instance with no spaces is exactly when `createSpaces` is the right grant.

## 2. `.permission-help` in that dialog had never been styled

Defined in `tokens.styles.ts`, imported only by `tokens.component.ts`, and Angular scopes component styles — so the create dialog's own pre-existing use of the class had no CSS behind it. Not global, no `::ng-deep`.

**`tokens.component.spec.ts` asserted the element was `not.toBeNull()` and passed the whole time.** `.danger-zone`, `.danger-title` and `.permission-help` now live in `DIALOG_STYLES`, which both dialogs import. Row styles stay in the rights dialog — rotate and revoke exist nowhere else.

**Third time this file has lost a stylesheet to component scoping**; its own header documents the first.

## 3. Two of the four rights areas were OFF-SCREEN

Found only by screenshotting it. At the shared 600px default, **DATA QUALITY was not visible and SCHEMA's rungs were clipped mid-cell** — a token could not be minted with a rung in either.

**Invisible to every measurement:** five headers in the DOM, eight rung pickers present and countable, `clientWidth` 598 with `scrollWidth` *equal* to it. Nothing overflowed, nothing scrolled; the table was squeezed. The rights dialog sets `--dialog-max-width: min(1400px, 94vw)` for exactly this, its comment recording 600px as *"reported as too narrow"*. Create never did.

Verified after, at a 1500px viewport: `clientWidth` 1398, all four area headers inside the viewport.

## Gates

`token-create-dialog.instance-rungs.spec.ts` (11 tests): both flags bound **and handled**, the outside-the-spaces ordering, the body still carrying the whole matrix, each class defined in the stylesheet this component imports, the same width as the rights dialog, and the editor no longer holding a duplicate copy.

Mutation-tested by renaming `.permission-help` in `DIALOG_STYLES` away — only that assertion fails.

Client suite **1141 pass / 0 fail** before the new file; preflight green.