### PR TITLE
feat(recall)!: the per-stage scores are the ordering, not a diagnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
+- **The three per-stage scores are the ORDERING, and they were hidden behind a flag whose purpose is removing
+  cost.** `lexicalScore`, `fusedScore` and `rerankScore` now come back on **every** recall and find-similar
+  result, on **both** doors, each present only when that stage ran. `includeDiagnostics` no longer governs
+  them — it covers `matchedText`, `embeddingModel` and `seq`, which is what it was for.
+
+  breituai-platform 2026-08-17T1549Z, correcting their own 1540Z, and the argument is ours turned around
+  correctly: we said the six bundled fields are not where a large response comes from — the bodies are. **Three
+  floats per result are not a cost.** Bundling a passage-sized field with three numbers under one switch was
+  the actual error.
+
+  **And `score` is not the number that ranked the result.** Precedence in a fused recall is
+  `rerankScore > fusedScore > score`, so on any instance with a cross-encoder the value in the response did not
+  decide the position in the response, and the value that did was unavailable. Their reranker has been live
+  since 2026-08-03. It compounds with our own documented behaviour: **`minScore` filters on `score` alone**,
+  never on the fused or rerank ordering — so a caller could threshold on a number that did not order the
+  results while being unable to see the one that did.
+
+  **MCP had never sent them at all**, so that door gained them rather than merely un-gating them. An absent
+  score still means the stage did not run; that contract is unchanged.
+
+  `RECALL_DIAGNOSTIC_FIELDS` — the union of both groups — is DELETED rather than left unreferenced. It was the
+  strip list for both doors, which is exactly what made the ordering conditional; with the ranking half
+  unconditional, a name that reads like "the withheld set" and is not one would be worse than no name. The
+  strip sites take `RECALL_RECORD_DIAGNOSTICS`, and `rankingFields` emits the scores with no flag to pass.
+
+  Two assertions in `both-doors-same-recall-content.test.js` were rewritten rather than renumbered: one
+  required all six fields absent by default, which is now requiring the defect. It splits into *record
+  diagnostics absent* and *ranking scores present*, and the graph walk additionally asserts a traversed node
+  carries **no** ranking score — it was never ranked, so a score there would be a number with nothing behind
+  it.
 - **A failure of the store answered `400`, telling every caller the fault was theirs. It is now `503` and says
   `retryable`.** Two parties reported the same defect from opposite sides within thirty hours, and the second
   report is what priced it.

--- a/docs/integration-guide/04-brain-api.md
+++ b/docs/integration-guide/04-brain-api.md
@@ -718,16 +718,17 @@ What you *can* control:
 |---|---|---|
 | `projection` | `POST /query`, **and recall / find-similar** | any field you do not name. On recall it applies recursively, so a `traverse` answer's `_graph` is projected at every depth |
 | `includeContent: false` | recall, find-similar | file-passage **bodies**, keeping path, heading, chunk index, tags and properties |
-| `includeDiagnostics: false` *(the default)* | recall, find-similar | `matchedText`, `embeddingModel`, `seq` and the per-stage scores — **recursively**, so a `traverse` answer's `_graph` follows it at every depth |
+| `includeDiagnostics: false` *(the default)* | recall, find-similar | `matchedText`, `embeddingModel` and `seq` — **recursively**, so a `traverse` answer's `_graph` follows it at every depth. **NOT the per-stage scores** — see below |
 | `includeDiagnostics` *(query string, default off)* | the **list** routes — entities, memories, edges, chrono | `matchedText` and `embeddingModel`. **`seq` is NOT dropped here**, unlike on recall: it is the `If-Match` value, and withholding it would take away conditional writes. Send `?includeDiagnostics=true` to get the two fields back |
 
 A projection is worth reaching for rather than skipping: a bare query over a dozen records with full
 descriptions and properties is the cheapest way to overrun a token budget, and naming the four fields you
 actually branch on turns that into a page you can read.
 
-**REST and MCP return the same recall content.** Until 3.1.0 they did not: REST sent `matchedText`,
-`embeddingModel`, `seq` and the per-stage scores unconditionally while MCP sent none of them, and neither
-door said so. All six are now off by default on both, and `includeDiagnostics: true` restores them on both.
+**The per-stage scores always come back on both doors and no parameter removes them — they are the ORDERING.** See [the recall API page](04a-recall-api.md#the-per-stage-scores-are-the-ordering).
+**REST and MCP return the same recall content.** Until 3.1.0 they did not: REST sent all six unconditionally
+while MCP sent none. Now the three RECORD fields are off by default on both (`includeDiagnostics: true`
+restores them) and the three SCORES are on by default on both — which MCP had never sent at all.
 
 What still differs is the **shape**, deliberately, because each is natural to its transport: a REST result is
 flat — record fields beside `score` — while an MCP result nests them under `record`. The *field set* a caller

--- a/docs/integration-guide/04a-recall-api.md
+++ b/docs/integration-guide/04a-recall-api.md
@@ -151,6 +151,25 @@ unavailable, and **none of them can fail a search** — a stage that cannot answ
 **Ordering precedence is `rerankScore` → `fusedScore` → `score`** — the order of how much each signal
 actually knows.
 
+#### The per-stage scores are the ORDERING
+
+`lexicalScore`, `fusedScore` and `rerankScore` are on **every** recall and find-similar result, on **both**
+doors, each present only when that stage actually ran. **No parameter removes them**, and
+`includeDiagnostics` does not govern them — that flag covers `matchedText`, `embeddingModel` and `seq`.
+
+**Read the highest one present to know why a result placed where it did.** Precedence is
+`rerankScore > fusedScore > score`, so on an instance with a cross-encoder configured, `score` — plain vector
+similarity — is *not* the number that ordered the answer. Combined with the section below, where `minScore`
+filters on `score` alone, a caller could previously threshold on one number while a different one decided the
+positions, and could not read the second.
+
+They sat behind `includeDiagnostics` until now. That flag exists to remove COST, and three floats per result
+are not a cost — `matchedText` is, which is why it stayed behind the flag and these did not. MCP had never
+sent them at all, so that door gained them rather than merely un-gating them.
+
+An absent score means that stage did not run: no reranker configured, no lexical channel for that query.
+That was always the contract; what changed is that you no longer have to ask.
+
 #### `minScore` always filters on `score`
 
 This is deliberate and worth being explicit about: `minScore` is a **vector-similarity** floor and stays

--- a/server/src/api/brain/search.ts
+++ b/server/src/api/brain/search.ts
@@ -502,8 +502,13 @@ searchRouter.post('/spaces/:spaceId/recall', globalRateLimit, requireSpaceAuth, 
     }
     const safeIncludeContent = includeContentRaw !== false;
 
-    // `includeDiagnostics` (default FALSE) restores the six fields a recall result carries for the system
-    // rather than for the caller: `matchedText`, `embeddingModel`, `seq`, and the three per-stage scores.
+    // `includeDiagnostics` (default FALSE) restores the three RECORD fields a recall result carries for the
+    // system rather than for the caller: `matchedText`, `embeddingModel` and `seq`.
+    //
+    // IT NO LONGER GOVERNS THE PER-STAGE SCORES. `lexicalScore`/`fusedScore`/`rerankScore` are unconditional
+    // on both doors: precedence in a fused recall is `rerankScore > fusedScore > score`, so gating them meant
+    // the number that DECIDED a result's position was the one a caller could not read — while `minScore`
+    // filters on `score` alone. Three floats are not a cost and do not belong behind a cost flag.
     //
     // This door used to return all six unconditionally while MCP returned none, and neither said so. Owner
     // ruled 2026-08-16 that the two surfaces match and that the fields are off by default on both — so this

--- a/server/src/brain/recall-graph.ts
+++ b/server/src/brain/recall-graph.ts
@@ -39,7 +39,7 @@
  */
 import type { EdgeDoc, EntityDoc } from '../config/types.js';
 import { type SeedTraverseNeighbor } from './edges.js';
-import { RECALL_DIAGNOSTIC_FIELDS, NEVER_RETURNED_FIELDS } from './recall-shape.js';
+import { RECALL_RECORD_DIAGNOSTICS, NEVER_RETURNED_FIELDS } from './recall-shape.js';
 import { applyProjection, type NormalisedProjection } from './projection.js';
 
 /**
@@ -157,7 +157,11 @@ function stripDiag<T extends object>(doc: T, include: boolean): T {
   // `NEVER_RETURNED_FIELDS` is dropped on BOTH branches — `includeDiagnostics` restores diagnostics,
   // never the vector, and an early return here would have made it an opt-in to a 768-float array.
   const out = { ...doc } as Record<string, unknown>;
-  const drop = include ? NEVER_RETURNED_FIELDS : [...RECALL_DIAGNOSTIC_FIELDS, ...NEVER_RETURNED_FIELDS];
+  // `RECALL_RECORD_DIAGNOSTICS`, not the old union that also held the three ranking scores. Nothing observable
+  // changes HERE — a traversed node was never ranked, so it never had a `lexicalScore` to strip — but naming
+  // the record set is what stops this line silently becoming the one place that still hides an ordering score
+  // if a future change ever attaches one to a node.
+  const drop = include ? NEVER_RETURNED_FIELDS : [...RECALL_RECORD_DIAGNOSTICS, ...NEVER_RETURNED_FIELDS];
   for (const k of drop) delete out[k];
   return out as T;
 }

--- a/server/src/brain/recall-shape.ts
+++ b/server/src/brain/recall-shape.ts
@@ -48,12 +48,45 @@ import type { RecallResult, RecallKnowledgeType } from './recall.js';
  */
 export const RECALL_RECORD_DIAGNOSTICS = ['matchedText', 'embeddingModel', 'seq'] as const;
 
-/** The per-stage ranking scores: why this result placed where it did. Beside `score`, never inside `record`. */
+/**
+ * The per-stage ranking scores. **RETURNED BY DEFAULT, on both doors — they are the ORDERING, not payload.**
+ *
+ * ## Why they left the `includeDiagnostics` bundle
+ *
+ * breituai-platform 2026-08-17T1549Z, correcting their own 1540Z, and the argument is mine turned around
+ * correctly. I wrote that the six bundled fields are not where a large response comes from — the bodies are.
+ * **Three floats per result are not a cost, so they do not belong behind a flag whose purpose is removing
+ * cost.** Bundling a passage-sized field with three numbers under one switch was the actual error.
+ *
+ * ## And `score` is not the number that ranked the result
+ *
+ * Precedence in a fused recall is `rerankScore > fusedScore > score`. So on any instance with a cross-encoder,
+ * the value in the response did not decide the position in the response, and the value that did was
+ * unavailable. Their reranker has been live since 2026-08-03, which makes `rerankScore` the operative number
+ * on every recall they make.
+ *
+ * It compounds with our own documented behaviour: `minScore` filters on `score` ALONE, never on the fused or
+ * rerank ordering. A caller could threshold on a number that did not order the results while being unable to
+ * see the one that did. Either half alone is survivable.
+ *
+ * ## Absent still means "that stage did not run"
+ *
+ * These are emitted only when present, so an instance with no reranker returns no `rerankScore` and a
+ * lexical-free query returns no `lexicalScore`. That was already the contract and it is unchanged — what
+ * changed is that a caller no longer has to ask.
+ *
+ * Beside `score`, never inside `record`: a score describes how the result RANKED, not what the record is.
+ */
 export const RECALL_RANKING_DIAGNOSTICS = ['lexicalScore', 'fusedScore', 'rerankScore'] as const;
 
-/** Both groups, for the flat REST shape and for anything asserting on the whole set. */
-export const RECALL_DIAGNOSTIC_FIELDS: readonly string[] =
-  [...RECALL_RECORD_DIAGNOSTICS, ...RECALL_RANKING_DIAGNOSTICS];
+/*
+ * `RECALL_DIAGNOSTIC_FIELDS` WAS HERE — the union of both groups — AND IS DELETED.
+ *
+ * It was the strip list for both doors, which is precisely what made the ordering scores conditional. With
+ * the ranking half now unconditional, a union constant has no caller that should want it: a stripper wants
+ * `RECALL_RECORD_DIAGNOSTICS`, and a test asserting on "the six that used to be bundled" can spread the two
+ * itself and say why. Keeping it would leave a name that reads like the withheld set and is not one.
+ */
 
 /**
  * Stripped always, restorable by nothing — deliberately NOT part of `RECALL_DIAGNOSTIC_FIELDS`.
@@ -90,12 +123,32 @@ export function diagnosticFields(
  * the traverse builder and to the audit outcome, and deleting a field in place would change what those saw.
  */
 export function withoutDiagnostics<T extends object>(results: T[], include: boolean): T[] {
-  if (include) return results;
-  return results.map(r => {
+  // `RECALL_RECORD_DIAGNOSTICS` and NOT the old union: the three ranking scores are the ORDERING and are now
+  // unconditional, so stripping them here is what made the number that ranked a result unavailable to the
+  // caller who wanted to know why it ranked there. The vector is still removed either way.
+  if (include) return results.map(r => {
     const out = { ...r } as Record<string, unknown>;
-    for (const k of [...RECALL_DIAGNOSTIC_FIELDS, ...NEVER_RETURNED_FIELDS]) delete out[k];
+    for (const k of NEVER_RETURNED_FIELDS) delete out[k];
     return out as T;
   });
+  return results.map(r => {
+    const out = { ...r } as Record<string, unknown>;
+    for (const k of [...RECALL_RECORD_DIAGNOSTICS, ...NEVER_RETURNED_FIELDS]) delete out[k];
+    return out as T;
+  });
+}
+
+/**
+ * The ranking scores a result actually carries — always, and only the ones whose stage ran.
+ *
+ * Separate from `diagnosticFields` because that helper takes an `include` flag, and passing it a literal
+ * `true` at four call sites would read as "this is still conditional, we just always say yes". It is not
+ * conditional: there is no parameter that removes these, by design.
+ */
+export function rankingFields(src: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const k of RECALL_RANKING_DIAGNOSTICS) if (src[k] !== undefined) out[k] = src[k];
+  return out;
 }
 
 /**

--- a/server/src/mcp/tools/help-sections.ts
+++ b/server/src/mcp/tools/help-sections.ts
@@ -109,13 +109,21 @@ What you CAN control, and where:
   the part you decided you need. Passage bodies are by far the largest thing a
   result carries.
 - recall -> includeDiagnostics, and you almost never want it. Off by default on
-  BOTH doors since 3.1.0, it adds back the six fields a result carries for the
+  BOTH doors, it adds back the three RECORD fields a result carries for the
   system: matchedText (the pre-embedding source string -- for a file chunk, the
   passage a second time), embeddingModel (identical for every record in a
-  space), seq (a sync counter that is not an input to any tool), and the
-  per-stage lexical/fused/rerank scores. It is RECURSIVE: a traverse answer's
-  _graph nodes and edges follow it at every depth. Turn it on to work out why
-  something ranked where it did, then turn it off.
+  space), and seq (a sync counter that is not an input to any tool). It is
+  RECURSIVE: a traverse answer's _graph nodes and edges follow it at every
+  depth. Turn it on to see WHICH TEXT was embedded, then turn it off.
+
+THE PER-STAGE SCORES ARE NOT BEHIND THAT FLAG, and this is worth knowing before
+you try to switch them on. lexicalScore, fusedScore and rerankScore come back on
+EVERY recall, on both doors, each present only when that stage ran. They are the
+ORDERING: score is vector similarity, precedence in a fused recall is
+rerankScore > fusedScore > score, and minScore filters on score ALONE -- so on an
+instance with a reranker configured, the number that decided a result's position
+is rerankScore and the number you can threshold on is a different one. Read the
+highest of the three that is present to know why something placed where it did.
 - The other read tools return a formatted summary line per record rather than a
   document. list_chrono and find_entities_by_name cost you an id, a name and a
   type whatever the record holds, so there is nothing to trim.

--- a/server/src/mcp/tools/search.ts
+++ b/server/src/mcp/tools/search.ts
@@ -25,7 +25,7 @@ import { memberSpacesWithin } from '../../spaces/proxy-scoped.js';
 import { pageAcrossMembers } from '../../spaces/page-across-members.js';
 import { NotFoundError } from '../../util/errors.js';
 import {
-  rankOf, mergeRecallResults, diagnosticFields, RECALL_RANKING_DIAGNOSTICS,
+  rankOf, mergeRecallResults, rankingFields,
 } from '../../brain/recall-shape.js';
 
 /**
@@ -63,7 +63,7 @@ export const recallTool: ToolHandler = {
   description: 'Search all knowledge types (memories, entities, edges, chrono entries, files) by MEANING and by exact tokens: a semantic vector ranking is fused with a lexical (BM25) ranking, so identifiers such as article numbers or form ids rank even though their embeddings carry little meaning. A cross-encoder refines the top candidates when the operator has configured one. Searches the specified space if provided, otherwise across all accessible spaces.\n\n'
     + 'THE RESPONSE, because knowing the parameters is only half of it:\n'
     + '• `results` — the ranked matches. Each carries `_id`, its name/fact/title, type, tags, properties, `spaceId`, timestamps and `score` (vector similarity).\n'
-    + '• WHAT THIS DOOR DOES NOT SEND YOU, so you do not go looking for a flag to switch it off: the embedding VECTOR (never returned by anything here, and no parameter can ask for it), `matchedText` (the pre-embedding source string — for a file chunk it is the passage a SECOND time), `embeddingModel` (identical for every record in a space), `seq` (a sync counter that is not an input to any tool), and the per-stage `lexicalScore`/`fusedScore`/`rerankScore`. All six are withheld on REST too, with the same default, since 3.1.0 — `includeDiagnostics: true` restores them on either door and applies recursively, so a `traverse` answer\'s `_graph` follows it at every depth. Leave it off: each of these is multiplied by `topK` and paid for in your context, and you want them only to answer WHY something ranked where it did. The other size lever is `includeContent: false`, which drops file-passage bodies and keeps their locations.\n'
+    + '• WHAT THIS DOOR DOES NOT SEND YOU, so you do not go looking for a flag to switch it off: the embedding VECTOR (never returned by anything here, and no parameter can ask for it), `matchedText` (the pre-embedding source string — for a file chunk it is the passage a SECOND time), `embeddingModel` (identical for every record in a space), and `seq` (a sync counter that is not an input to any tool). Withheld on REST too, with the same default, since 3.1.0 — `includeDiagnostics: true` restores them on either door and applies recursively, so a `traverse` answer\'s `_graph` follows it at every depth. Leave it off: each of these is multiplied by `topK` and paid for in your context, and you want them only to answer WHY something ranked where it did. The other size lever is `includeContent: false`, which drops file-passage bodies and keeps their locations.\n'
     + '• `count` — the number of MATCHES. Traversed nodes are NOT counted in it.\n'
     + '• `graphNodes` — an integer COUNT of what a traversal reached, not the content. The content is nested per-result under `_graph`, and a result with no edges simply has no `_graph` at all: reading `results[0]` and concluding the feature is absent is the mistake to avoid.\n'
     + '• THE SIZE ANSWER, and it is a slope now rather than a cliff. `returned`, `count`, `truncated`, `budgetBytes` and `bytesReturned` are on EVERY response, so you never have to interpret an absence. `results` is a PREFIX of the ranked matches that fits `maxBytes`, and every record in it is WHOLE — full body, full properties, its complete `_graph`, byte-identical to that record from an unbudgeted call. When `truncated` is true, `remainder` points at the matches that did NOT fit, written to the space as JSON with an authenticated download valid one day.\n'
@@ -116,7 +116,7 @@ export const recallTool: ToolHandler = {
             includeDiagnostics: {
               type: 'boolean',
               default: false,
-              description: 'Add back the fields a result carries for the SYSTEM rather than for you (default false, and false is what you want almost always). On the record: `matchedText` — the exact pre-embedding source string, which for a file chunk is the heading plus the passage, so the passage a SECOND time; `embeddingModel`, identical for every record in a space; and `seq`, a sync counter that is not an input to any tool. Beside `score`: the per-stage `lexicalScore`, `fusedScore` and `rerankScore`, each present only if that stage ran. Turn it on to answer WHY something ranked where it did — which text was embedded, which stage promoted it — then turn it off, because every one of these is multiplied by `topK` and paid for in your context. REST takes the same parameter with the same default; before 3.1.0 REST sent all six unconditionally and this door sent none, which is the asymmetry it closes.',
+              description: 'Add back the three RECORD fields a result carries for the SYSTEM rather than for you (default false, and false is what you want almost always): `matchedText` — the exact pre-embedding source string, which for a file chunk is the heading plus the passage, so the passage a SECOND time; `embeddingModel`, identical for every record in a space; and `seq`, a sync counter that is not an input to any tool. Turn it on to see WHICH TEXT was embedded, then turn it off — `matchedText` especially is multiplied by `topK` and paid for in your context. REST takes the same parameter with the same default. **THIS NO LONGER GOVERNS THE PER-STAGE SCORES.** `lexicalScore`, `fusedScore` and `rerankScore` come back on EVERY recall, on both doors, each present only if that stage ran — because they are the ORDERING, not payload. `score` is vector similarity, and precedence in a fused recall is `rerankScore > fusedScore > score`, so on an instance with a reranker the number that decided a result’s position was previously the one you could not see. Three floats are not a cost, so they do not belong behind a flag whose purpose is removing cost.',
             },
             projection: {
               type: 'object',
@@ -286,8 +286,7 @@ export const recallTool: ToolHandler = {
       // alone, which meant the plainest large call was the one that returned everything.
       const plain = seeds.map(r => ({
         score: r.score,
-        ...diagnosticFields(r as unknown as Record<string, unknown>,
-          RECALL_RANKING_DIAGNOSTICS, includeDiagnostics),
+        ...rankingFields(r as unknown as Record<string, unknown>),
         spaceId: r.spaceId,
         type: r.type,
         record: applyProjection(toRecallRecord(r, { includeContent, includeDiagnostics }), recallProjection),
@@ -327,8 +326,7 @@ export const recallTool: ToolHandler = {
       const nested = mapGraphNodes(graph.bySeed.get(r._id), graphNodeRecord, includeDiagnostics, recallProjection);
       return {
         score: r.score,
-        ...diagnosticFields(r as unknown as Record<string, unknown>,
-          RECALL_RANKING_DIAGNOSTICS, includeDiagnostics),
+        ...rankingFields(r as unknown as Record<string, unknown>),
         spaceId: r.spaceId, type: r.type,
         record: applyProjection(toRecallRecord(r, { includeContent, includeDiagnostics }), recallProjection),
         ...(nested ? { _graph: nested } : {}),
@@ -389,7 +387,7 @@ export const find_similarTool: ToolHandler = {
             includeDiagnostics: {
               type: 'boolean',
               default: false,
-              description: 'Add back the fields a result carries for the SYSTEM rather than for you (default false, and false is what you want almost always). On the record: `matchedText` — the exact pre-embedding source string, which for a file chunk is the heading plus the passage, so the passage a SECOND time; `embeddingModel`, identical for every record in a space; and `seq`, a sync counter that is not an input to any tool. Beside `score`: the per-stage `lexicalScore`, `fusedScore` and `rerankScore`, each present only if that stage ran. Turn it on to answer WHY something ranked where it did — which text was embedded, which stage promoted it — then turn it off, because every one of these is multiplied by `topK` and paid for in your context. REST takes the same parameter with the same default; before 3.1.0 REST sent all six unconditionally and this door sent none, which is the asymmetry it closes.',
+              description: 'Add back the three RECORD fields a result carries for the SYSTEM rather than for you (default false, and false is what you want almost always): `matchedText` — the exact pre-embedding source string, which for a file chunk is the heading plus the passage, so the passage a SECOND time; `embeddingModel`, identical for every record in a space; and `seq`, a sync counter that is not an input to any tool. Turn it on to see WHICH TEXT was embedded, then turn it off — `matchedText` especially is multiplied by `topK` and paid for in your context. REST takes the same parameter with the same default. **THIS NO LONGER GOVERNS THE PER-STAGE SCORES.** `lexicalScore`, `fusedScore` and `rerankScore` come back on EVERY recall, on both doors, each present only if that stage ran — because they are the ORDERING, not payload. `score` is vector similarity, and precedence in a fused recall is `rerankScore > fusedScore > score`, so on an instance with a reranker the number that decided a result’s position was previously the one you could not see. Three floats are not a cost, so they do not belong behind a flag whose purpose is removing cost.',
             },
             projection: {
               type: 'object',
@@ -486,8 +484,7 @@ export const find_similarTool: ToolHandler = {
       // specific entry and the answer names it back.
       const plain = result.results.map(r => ({
         score: r.score,
-        ...diagnosticFields(r as unknown as Record<string, unknown>,
-          RECALL_RANKING_DIAGNOSTICS, includeDiagnostics),
+        ...rankingFields(r as unknown as Record<string, unknown>),
         spaceId: r.spaceId,
         type: r.type,
         record: applyProjection(toRecallRecord(r, { includeContent, includeDiagnostics }), recallProjection),
@@ -523,8 +520,7 @@ export const find_similarTool: ToolHandler = {
       const nested = mapGraphNodes(graph.bySeed.get(r._id), graphNodeRecord, includeDiagnostics, recallProjection);
       return {
         score: r.score,
-        ...diagnosticFields(r as unknown as Record<string, unknown>,
-          RECALL_RANKING_DIAGNOSTICS, includeDiagnostics),
+        ...rankingFields(r as unknown as Record<string, unknown>),
         spaceId: r.spaceId, type: r.type,
         record: applyProjection(toRecallRecord(r, { includeContent, includeDiagnostics }), recallProjection),
         ...(nested ? { _graph: nested } : {}),

--- a/testing/standalone/both-doors-same-recall-content.test.js
+++ b/testing/standalone/both-doors-same-recall-content.test.js
@@ -35,12 +35,12 @@ import { describe, it, before } from 'node:test';
 import assert from 'node:assert/strict';
 
 let mapGraphNodes, graphNodeRecord, toRecallRecord, withoutDiagnostics;
-let RECALL_DIAGNOSTIC_FIELDS, RECALL_RANKING_DIAGNOSTICS, diagnosticFields;
+let RECALL_RECORD_DIAGNOSTICS, RECALL_RANKING_DIAGNOSTICS, rankingFields;
 before(async () => {
   ({ mapGraphNodes, graphNodeRecord } = await import('../../server/dist/brain/recall-graph.js'));
   ({ toRecallRecord } = await import('../../server/dist/mcp/tools/shared.js'));
   ({
-    withoutDiagnostics, RECALL_DIAGNOSTIC_FIELDS, RECALL_RANKING_DIAGNOSTICS, diagnosticFields,
+    withoutDiagnostics, RECALL_RECORD_DIAGNOSTICS, RECALL_RANKING_DIAGNOSTICS, rankingFields,
   } = await import('../../server/dist/brain/recall-shape.js'));
 });
 
@@ -86,7 +86,9 @@ const restResult = (diag) => {
 /** The MCP result: envelope plus `record`, same graph. */
 const mcpResult = (diag) => ({
   score: seed().score,
-  ...diagnosticFields(seed(), RECALL_RANKING_DIAGNOSTICS, diag),
+  // Unconditional, mirroring the product: the ranking scores left the `includeDiagnostics` bundle
+  // because they are the ORDERING, not payload. `rankingFields` has no flag to pass.
+  ...rankingFields(seed()),
   spaceId: seed().spaceId,
   type: seed().type,
   record: toRecallRecord(seed(), { includeDiagnostics: diag }),
@@ -133,11 +135,33 @@ for (const diag of [false, true]) {
 }
 
 describe('the default withholds the system fields, everywhere', () => {
-  it('no diagnostic survives at the result level on either door', () => {
+  it('no RECORD diagnostic survives at the result level on either door', () => {
+    /*
+     * THIS SPLIT IN TWO, deliberately. It used to iterate all six bundled fields and require every one absent.
+     *
+     * The three RANKING scores left that bundle: `score` is not the number that ordered a result once a
+     * reranker runs (`rerankScore > fusedScore > score`), so withholding them meant a caller could threshold on
+     * a number that did not order the answer while being unable to see the one that did. They are now
+     * unconditional on both doors — so requiring their absence would now be requiring the defect.
+     *
+     * What still must be withheld is the three RECORD fields, and that half is unchanged.
+     */
     for (const [door, r] of [['REST', restResult(false)], ['MCP', mcpResult(false)]]) {
       const keys = flatKeys(r);
-      for (const f of RECALL_DIAGNOSTIC_FIELDS) {
+      for (const f of RECALL_RECORD_DIAGNOSTICS) {
         assert.equal(keys.has(f), false, `${door} still returns \`${f}\` by default`);
+      }
+    }
+  });
+
+  it('and every RANKING score that ran DOES survive, on both doors, unasked', () => {
+    // The other half of the split, and the reason for it. A caller must be able to see the number that ordered
+    // the result without setting a flag whose purpose is removing cost — three floats are not a cost.
+    for (const [door, r] of [['REST', restResult(false)], ['MCP', mcpResult(false)]]) {
+      const keys = flatKeys(r);
+      for (const f of RECALL_RANKING_DIAGNOSTICS) {
+        assert.equal(keys.has(f), true,
+          `${door} withholds \`${f}\` by default — that is the ordering, and it is not a diagnostic`);
       }
     }
   });
@@ -148,9 +172,16 @@ describe('the default withholds the system fields, everywhere', () => {
     // leave the larger half of the saving unmade on a traversing call.
     const check = (nodes, door) => {
       for (const n of nodes ?? []) {
-        for (const f of RECALL_DIAGNOSTIC_FIELDS) {
+        for (const f of RECALL_RECORD_DIAGNOSTICS) {
           assert.equal(f in n.node, false, `${door}: _graph node still carries \`${f}\``);
           assert.equal(f in n.edge, false, `${door}: _graph edge still carries \`${f}\``);
+        }
+        // A ranking score has no meaning on a traversed node and must not appear even though the scores are
+        // now unconditional at the RESULT level. A node was never ranked — it is here because the graph
+        // relates it to something that was — so a score on one would be a number with nothing behind it.
+        for (const f of RECALL_RANKING_DIAGNOSTICS) {
+          assert.equal(f in n.node, false, `${door}: _graph node carries \`${f}\`, but it was never ranked`);
+          assert.equal(f in n.edge, false, `${door}: _graph edge carries \`${f}\`, but it was never ranked`);
         }
         check(n._graph, door);
       }


### PR DESCRIPTION
`lexicalScore`, `fusedScore` and `rerankScore` now come back on **every** recall and find-similar result, on **both** doors, each present only when that stage ran. `includeDiagnostics` no longer governs them — it covers `matchedText`, `embeddingModel` and `seq`, which is what it was for.

## The argument is ours, turned around correctly

breituai-platform 2026-08-17T1549Z, correcting their own 1540Z. We had written that the six bundled fields are not where a large response comes from — the bodies are. **Three floats per result are not a cost, so they do not belong behind a flag whose purpose is removing cost.**

## And `score` is not the number that ranked the result

Precedence in a fused recall is `rerankScore > fusedScore > score`. On any instance with a cross-encoder, the value in the response did not decide the position in the response, and the value that did was unavailable. Their reranker has been live since 2026-08-03.

It compounds with our own documented behaviour: **`minScore` filters on `score` alone**, never on the fused or rerank ordering — so a caller could threshold on a number that did not order the results while being unable to read the one that did.

**MCP had never sent them at all**, so that door gained them. Verified on a running instance: both doors return `score`, `lexicalScore` and `fusedScore` unasked, and still withhold `matchedText`/`embeddingModel`.

## The union constant is deleted, not left unreferenced

`RECALL_DIAGNOSTIC_FIELDS` was the strip list for both doors — precisely what made the ordering conditional. A constant that reads like "the withheld set" and is not one is worse than none. Strip sites take `RECALL_RECORD_DIAGNOSTICS`; `rankingFields` emits the scores with no flag to pass — deliberately not `diagnosticFields(..., true)`, which would read as "still conditional, we just always say yes".

## Two assertions rewritten rather than renumbered

`both-doors-same-recall-content.test.js` required all six absent by default, which is **now requiring the defect**. It splits into *record diagnostics absent* and *ranking scores present*.

The graph walk gained the opposite assertion: a traversed node must carry **no** ranking score. It was never ranked — it is there because the graph relates it to something that was — so a score there would be a number with nothing behind it.

## Docs

The full explanation went to `04a-recall-api.md`, beside the `minScore` section it interacts with, because `04-brain-api.md` sat one line under its 900-line cap and the first draft pushed it to 917. `help()` and both schema descriptions corrected — all three said the flag covers six fields.

Standalone **4558 pass / 0 fail**. Recall + MCP integration **165 pass / 0 fail**.