### PR TITLE
feat(recall)!: page a truncated answer; the remainder file is opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `remainder` also drops `inline`, which described the three-record sample that no longer exists. The number
   of records returned is `returned`, on every response.
 
+- **A truncated recall no longer writes a file nobody asked for — it tells you where to carry on instead.**
+  `recall` and `find-similar` gain **`skip`** and **`remainderDump`** on both doors, and a truncated response
+  gains **`nextSkip`**.
+
+  Two changes, and they are one change:
+
+  - **`skip`** — how many of the ranked matches to skip before filling the byte budget. A truncated response
+    carries `nextSkip`; send it back as `skip` and you get the next prefix, no match repeated and none missed.
+    Stated rather than derivable, because `skip + returned` is arithmetic a caller can get wrong on the second
+    page where `skip` was already non-zero. `count` stays the FULL match total on every page rather than
+    shrinking as you advance — the slice happens inside `budgetedEnvelope`, so no route can shorten its own
+    array and quietly redefine it.
+  - **`remainderDump`** — default **`false`**, and until now the dump was unconditional. Writing the remainder
+    to `_tmp/` is a **write on a read path**: it counts against space storage, and on breituai-platform's
+    instance those land in a store whose `storage_used_bytes` collector already takes ~22 s to walk, so a read
+    that overflowed made an operator's metrics slower. The common caller wants the next page, not an artifact.
+
+  **They ship together and must not be separated.** An opt-in dump with no stated continuation would leave a
+  truncated caller unable to reach the rest — the exact regression the byte budget shipped in its first cut and
+  had to fix. `nextSkip` is emitted unconditionally whenever `truncated`, with no flag of its own, and
+  `result-spill-suppresses-vectors.test.js` gates that dependency at the source because the failure mode is an
+  omission that looks complete on its own.
+
+  The paging clause is exercised rather than asserted-present: the E2E follows `nextSkip` to exhaustion under a
+  budget that bites and checks the union of pages against the seeded ids, because an off-by-one would satisfy
+  every presence assertion while dropping or duplicating a record on every page. `skip` and `remainderDump` are
+  validated by one shared `resolvePaging` on both doors — a `skip` that 400s on one and floors to zero on the
+  other is this codebase's most-produced defect, and `0` is valid so the check is not `posInt`.
+
 ### Fixed
 
 - **The create-token dialog could not grant the two instance-level rights, so an instance admin had to be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   validated by one shared `resolvePaging` on both doors — a `skip` that 400s on one and floors to zero on the
   other is this codebase's most-produced defect, and `0` is valid so the check is not `posInt`.
 
+  **That E2E immediately found a defect older than `skip`, and it had to be fixed for `skip` to mean anything.**
+  A ranked recall had no deterministic order. Eleven ranking sorts were written by hand as
+  `(a, b) => rankOf(b) - rankOf(a)` with no tie-break, and `Array.prototype.sort` is stable — so two results on
+  the same score kept whatever order the DATABASE returned them in, and two identical recalls over an unchanged
+  corpus could come back permuted. The E2E's second page turned out to be entirely contained in its first.
+
+  Every one of the eleven now ends in a tie-break, `_id` ascending, through one shared `byRankThenId` — including
+  the member-space merge on **both doors**, which is the last sort before the response and the one a sweep scoped
+  to `brain/` would have missed. Three sorts keep ordering by RAW `score` rather than by `rankOf`, and that was
+  already correct: the pre-fusion sort establishes the vector ranking RRF consumes, the vector channel handed to
+  RRF must be the vector order by definition, and `find-similar` starts from a stored vector with no query text,
+  so there is no lexical or cross-encoder signal to prefer. `hybrid-retrieval.test.js` counts those three and was
+  right to; they gained the tie-break without changing which signal orders them.
+
+  `_id` rather than `seq` or `createdAt`: it is on every result type, unique by construction, and the only one of
+  the three that cannot tie in turn.
+
 ### Fixed
 
 - **The create-token dialog could not grant the two instance-level rights, so an instance admin had to be

--- a/client/src/app/core/api.types.ts
+++ b/client/src/app/core/api.types.ts
@@ -437,9 +437,9 @@ export interface RecallResponse {
    * ## The four fields below are on EVERY recall response, and this file used to declare none of them
    *
    * The byte budget bounds a response by size: what fits comes back as the longest PREFIX of the ranked
-   * matches, every record whole, and what does not fit is written to the space with `remainder` pointing at
-   * it. That is server behaviour the client has always received and never typed, so a component had no way to
-   * know an answer was cut — the previous shape returned three records and nothing here said why.
+   * matches, every record whole, and `nextSkip` says where to continue from. That is server behaviour the
+   * client has always received and never typed, so a component had no way to know an answer was cut — the
+   * previous shape returned three records and nothing here said why.
    *
    * **Typed here without a consumer, deliberately.** Nothing in the client reads them yet and the search UI
    * still shows a truncated answer as if it were the whole one. That is a real gap and it is tracked as its
@@ -455,7 +455,15 @@ export interface RecallResponse {
   /** Serialised size of `results`, in bytes. */
   bytesReturned?: number;
   /**
-   * Where the matches that did NOT fit were written. Present only when `truncated` is true.
+   * Where to continue from. Present exactly when `truncated` is true — send it back as `skip`.
+   *
+   * Stated rather than derivable. `skip + returned` is arithmetic a caller can get wrong, particularly on the
+   * second page where `skip` was already non-zero.
+   */
+  nextSkip?: number;
+  /**
+   * Where the matches that did NOT fit were written — present only when the request asked for it with
+   * `remainderDump: true` AND the answer truncated.
    *
    * A continuation, not a copy: the records in `results` are not repeated in the file. `matches` and `records`
    * describe the file — matches in it, and matches plus their traversed nodes.

--- a/docs/integration-guide/04a-recall-api.md
+++ b/docs/integration-guide/04a-recall-api.md
@@ -480,6 +480,11 @@ carries no `nextSkip` and is the last one. Skipping past the end returns zero re
 so a write landing between two pages can shift what falls where — the same caveat `/query`'s `skip` carries. For
 a set that must be internally consistent, ask for the remainder as a file instead.
 
+**The ranking itself is deterministic, though**, which is what makes paging usable in the ordinary case: results
+on the same score are ordered by `_id` ascending, so an unchanged corpus always produces the same order. Before
+3.2.0 it did not — equally-scored matches came back in whatever order the database gave, so two identical recalls
+could be permuted.
+
 ##### `remainderDump`: the whole remainder as one file (opt-in)
 
 Send **`remainderDump: true`** and the matches that did not fit are also written to the space's `_tmp/` as JSON,

--- a/docs/integration-guide/04a-recall-api.md
+++ b/docs/integration-guide/04a-recall-api.md
@@ -36,9 +36,11 @@ Available as both:
 | `includeContent` | — | `true` | Whether file-chunk results carry `content` — the passage body. `false` returns locations and metadata only (path, heading, chunk index, tags, properties). **File chunks ONLY** — it does nothing on a search returning entities, memories, edges or chrono entries; use `projection` to trim those. A non-boolean is a `400`, never coerced |
 | `includeDiagnostics` | — | `false` | Add back the fields a result carries for the SYSTEM rather than for you: `matchedText` (the exact pre-embedding source string — for a file chunk, the passage a SECOND time), `embeddingModel`, `seq`, and the per-stage `lexicalScore`/`fusedScore`/`rerankScore`. **Applies recursively**, so a `traverse` answer's `_graph` nodes and edges follow it at every depth. Off by default since 3.1.0 — before then this door sent all six unconditionally while MCP sent none. The embedding VECTOR is not among them and is never returned by anything. A non-boolean is a `400`, never coerced |
 | `projection` | — | none | Fields to include (1) or exclude (0), the same grammar `POST /query` takes, applied to each result's record. Dotted paths work: `{"name": 1, "properties.status": 1}`. **Applies recursively** — a `traverse` answer's `_graph` nodes and edges are projected at every depth, which is where a large answer's size actually comes from. Inclusion and exclusion cannot be mixed (the non-`_id` fields decide which you meant); `_id` survives an inclusion projection unless you send `_id: 0`; and the embedding VECTOR can never be projected back in — an explicit `embedding: 1` is dropped rather than honoured. The ranking envelope (`score`, `spaceId`, `type`, `_graph`) always survives, so a projection cannot lose the score you searched for |
-| `maxBytes` | — | `100000` | Ceiling on the serialised response body, in bytes. **The answer is a PREFIX of the ranked results and every record in it is WHOLE** — full body, full properties, complete `_graph`, byte-identical to that record from an unbudgeted call. Truncation is atomic at the match: the first match whose subtree would not fit is omitted and so is everything after it, so no answer has a gap and none carries a record with half its graph. `returned`, `count`, `truncated`, `budgetBytes` and `bytesReturned` are on EVERY response, so absence never has to be interpreted; `remainder` points at what did not fit |
+| `maxBytes` | — | `100000` | Ceiling on the serialised response body, in bytes. **The answer is a PREFIX of the ranked results and every record in it is WHOLE** — full body, full properties, complete `_graph`, byte-identical to that record from an unbudgeted call. Truncation is atomic at the match: the first match whose subtree would not fit is omitted and so is everything after it, so no answer has a gap and none carries a record with half its graph. `returned`, `count`, `truncated`, `budgetBytes` and `bytesReturned` are on EVERY response, so absence never has to be interpreted; a truncated one adds `nextSkip`, which you send back as `skip` |
 | `maxTokens` | — | none | A convenience onto `maxBytes`, converted with `charsPerToken`. If both are sent the **smaller** resulting byte figure applies. It is an approximation — the server does not know your tokeniser |
 | `charsPerToken` | — | `3.5` | Ratio used to convert `maxTokens` to bytes. 3.5 rather than the customary 4.0 because 4.0 UNDER-counts tokens and is worst on graph-heavy responses: undershooting costs one page, overshooting costs a blown context |
+| `skip` | — | `0` | How many of the ranked matches to skip before filling the byte budget. **This is how you read a truncated answer**: a response with `truncated: true` carries `nextSkip`, and sending it back gets you the next prefix — no match repeated, none missed. The ranking is recomputed per call, so it is a continuation over one ordered answer rather than a cursor over a snapshot |
+| `remainderDump` | — | `false` | Also write the matches that did not fit to the space as JSON and report it as `remainder`. Only meaningful when the answer truncates. Off by default because it is a write on a read path that counts against space storage — page with `skip` to reach the same records without one |
 
 **Response** `200`:
 
@@ -431,13 +433,11 @@ counting rows never double-counts a record, and no relationship is invisible.
 
 **Performance:** traversal issues roughly two batched (`$in`) MongoDB queries per hop, not one query per node. Even so, `traverse > 2` on a densely-connected graph can fan out quickly — pair it with `filter`, `tags`, or a low `topK` to keep the seed set (and therefore the traversal frontier) tight.
 
-#### A large answer comes back as a prefix and a link to the rest
+#### A large answer comes back as a prefix, and you page through the rest
 
-A recall cannot be paged — `topK` is the answer, not a window into it — so an answer that is too large to return
-has nowhere to go. The response is bounded by **`maxBytes`** (operator default 100 000; `maxTokens` is the same
-control expressed in tokens, and if you send both the smaller wins). What fits comes back as the **longest
-prefix of the ranked matches**, every record whole; what does not fit is written to the space's `_tmp/` as JSON
-and reachable through an authenticated download:
+The response is bounded by **`maxBytes`** (operator default 100 000; `maxTokens` is the same control expressed
+in tokens, and if you send both the smaller wins). What fits comes back as the **longest prefix of the ranked
+matches**, every record whole, and `nextSkip` says where to continue from:
 
 ```json
 {
@@ -448,6 +448,45 @@ and reachable through an authenticated download:
   "budgetBytes": 100000,
   "bytesReturned": 99612,
   "graphNodes": 240,
+  "nextSkip": 22
+}
+```
+
+- **The five accounting fields are on EVERY response**, whether the budget bit or not: `returned`, `count`,
+  `truncated`, `budgetBytes`, `bytesReturned`. A field that appeared only when it bit would be one whose
+  absence has to be interpreted, and the caller who most needs it is the one who does not know to look.
+- **`count` is the real total**, never what was sent, and it stays the total on every page rather than shrinking
+  as you advance. `returned` is what was sent, and it is `results.length` — read `returned` and you never have
+  to count.
+- **`nextSkip` appears exactly when `truncated` is true.** Send it back as `skip` and you get the next prefix.
+  It is stated rather than left as arithmetic on purpose: `skip + returned` is a sum a caller can get wrong,
+  especially the second time round when `skip` was already non-zero.
+- **Truncation is atomic at the match, and the answer is always a prefix.** The first match whose complete
+  `_graph` subtree would not fit is omitted and so is every match after it, even a later smaller one. No
+  answer has a hole in the middle and no record arrives with half its graph. **That is what makes `skip`
+  correct** — a budget that packed the gaps with smaller matches would produce pages no offset can continue.
+- **A single match larger than the whole budget is still returned, alone.** A budget must not become a wall.
+
+##### Paging with `skip`
+
+```json
+{ "query": "vault credential rotation", "topK": 100, "maxBytes": 40000, "skip": 22 }
+```
+
+Loop while `truncated`, feeding `nextSkip` back as `skip`; the page that comes back with `truncated: false`
+carries no `nextSkip` and is the last one. Skipping past the end returns zero results with `truncated: false`.
+
+**This is a continuation over one ranked answer, not a cursor over a snapshot.** Each call re-runs the search,
+so a write landing between two pages can shift what falls where — the same caveat `/query`'s `skip` carries. For
+a set that must be internally consistent, ask for the remainder as a file instead.
+
+##### `remainderDump`: the whole remainder as one file (opt-in)
+
+Send **`remainderDump: true`** and the matches that did not fit are also written to the space's `_tmp/` as JSON,
+reachable through an authenticated download, and reported as `remainder`:
+
+```json
+{
   "remainder": {
     "matches": 78,
     "records": 264,
@@ -458,20 +497,16 @@ and reachable through an authenticated download:
 }
 ```
 
-- **The five accounting fields are on EVERY response**, whether the budget bit or not: `returned`, `count`,
-  `truncated`, `budgetBytes`, `bytesReturned`. A field that appeared only when it bit would be one whose
-  absence has to be interpreted, and the caller who most needs it is the one who does not know to look.
-- **`count` is the real total**, never what was sent. `returned` is what was sent, and it is
-  `results.length` — read `returned` and you never have to count.
+- **It defaults to off, and until 3.2.0 it was unconditional.** Writing a file is a write on a read path: it
+  counts against space storage and shows up in an operator's usage figures. The common caller wants the next
+  page, not an artifact, and now says so by omission.
 - **`remainder` holds ONLY what did not fit.** It is a continuation, not a copy: the records already in
-  `results` are not repeated in it. The previous shape dumped the whole set including the part already sent,
+  `results` are not repeated in it. The pre-3.2 shape dumped the whole set including the part already sent,
   which is most of why it cost a caller more than it saved.
 - **`remainder.matches` and `remainder.records` describe the FILE** — matches in it, and matches plus their
   traversed nodes. Both are counted from what was actually written, so neither can disagree with the download.
-- **Truncation is atomic at the match, and the answer is always a prefix.** The first match whose complete
-  `_graph` subtree would not fit is omitted and so is every match after it, even a later smaller one. No
-  answer has a hole in the middle and no record arrives with half its graph.
-- **A single match larger than the whole budget is still returned, alone.** A budget must not become a wall.
+- **`nextSkip` is still there when you ask for the file**, so wanting the artifact never costs you the ability
+  to page.
 - The file is **self-describing**: it repeats the request that produced it, the counts, and its own expiry.
 - **No embedding vectors are written**, at any depth — a result set serialised verbatim is the one place they
   would otherwise land in a file an operator opens.
@@ -682,9 +717,11 @@ Given an existing entry's `_id`, find other entries with high vector similarity.
 | `includeContent` | — | `true` | Whether file-chunk results carry their passage `content`. `false` returns locations and metadata only, exactly as on `recall` |
 | `includeDiagnostics` | — | `false` | Add back the fields a result carries for the SYSTEM rather than for you: `matchedText` (the exact pre-embedding source string — for a file chunk, the passage a SECOND time), `embeddingModel`, `seq`, and the per-stage `lexicalScore`/`fusedScore`/`rerankScore`. **Applies recursively**, so a `traverse` answer's `_graph` nodes and edges follow it at every depth. Off by default since 3.1.0 — before then this door sent all six unconditionally while MCP sent none. The embedding VECTOR is not among them and is never returned by anything. A non-boolean is a `400`, never coerced |
 | `projection` | — | none | Fields to include (1) or exclude (0), the same grammar `POST /query` takes, applied to each result's record. Dotted paths work: `{"name": 1, "properties.status": 1}`. **Applies recursively** — a `traverse` answer's `_graph` nodes and edges are projected at every depth, which is where a large answer's size actually comes from. Inclusion and exclusion cannot be mixed (the non-`_id` fields decide which you meant); `_id` survives an inclusion projection unless you send `_id: 0`; and the embedding VECTOR can never be projected back in — an explicit `embedding: 1` is dropped rather than honoured. The ranking envelope (`score`, `spaceId`, `type`, `_graph`) always survives, so a projection cannot lose the score you searched for |
-| `maxBytes` | — | `100000` | Ceiling on the serialised response body, in bytes. **The answer is a PREFIX of the ranked results and every record in it is WHOLE** — full body, full properties, complete `_graph`, byte-identical to that record from an unbudgeted call. Truncation is atomic at the match: the first match whose subtree would not fit is omitted and so is everything after it, so no answer has a gap and none carries a record with half its graph. `returned`, `count`, `truncated`, `budgetBytes` and `bytesReturned` are on EVERY response, so absence never has to be interpreted; `remainder` points at what did not fit |
+| `maxBytes` | — | `100000` | Ceiling on the serialised response body, in bytes. **The answer is a PREFIX of the ranked results and every record in it is WHOLE** — full body, full properties, complete `_graph`, byte-identical to that record from an unbudgeted call. Truncation is atomic at the match: the first match whose subtree would not fit is omitted and so is everything after it, so no answer has a gap and none carries a record with half its graph. `returned`, `count`, `truncated`, `budgetBytes` and `bytesReturned` are on EVERY response, so absence never has to be interpreted; a truncated one adds `nextSkip`, which you send back as `skip` |
 | `maxTokens` | — | none | A convenience onto `maxBytes`, converted with `charsPerToken`. If both are sent the **smaller** resulting byte figure applies. It is an approximation — the server does not know your tokeniser |
 | `charsPerToken` | — | `3.5` | Ratio used to convert `maxTokens` to bytes. 3.5 rather than the customary 4.0 because 4.0 UNDER-counts tokens and is worst on graph-heavy responses: undershooting costs one page, overshooting costs a blown context |
+| `skip` | — | `0` | How many of the ranked matches to skip before filling the byte budget. **This is how you read a truncated answer**: a response with `truncated: true` carries `nextSkip`, and sending it back gets you the next prefix — no match repeated, none missed. The ranking is recomputed per call, so it is a continuation over one ordered answer rather than a cursor over a snapshot |
+| `remainderDump` | — | `false` | Also write the matches that did not fit to the space as JSON and report it as `remainder`. Only meaningful when the answer truncates. Off by default because it is a write on a read path that counts against space storage — page with `skip` to reach the same records without one |
 | `crossSpace` | — | `false` | If `true`, search across all spaces the token can access |
 
 **Response** `200`:

--- a/docs/integration-guide/04d-brain-ops-api.md
+++ b/docs/integration-guide/04d-brain-ops-api.md
@@ -584,16 +584,22 @@ On a **proxy space** the page is computed over the **merged** set of all member 
 the first `skip + limit` rows from each member, merges them into the documented order, and returns the window. A deep
 page therefore costs more on a proxy space than on a plain one, but it is the same page.
 
-#### A read result too large to return inline is bounded, and the rest is downloadable
+#### A read result too large to return inline is bounded, and you page through the rest
 
 `recall` and `find-similar` bound the response by **`maxBytes`** (operator default 100 000; `maxTokens` is the
 same ceiling in tokens, and the smaller of the two wins). What fits comes back as the longest **prefix** of the
-ranked matches, every record whole; what does not fit is written to the space's `_tmp/` as JSON and reported as
-`remainder: {matches, records, path, download, expiresAt}`.
+ranked matches, every record whole, and `nextSkip` says where to continue from — send it back as **`skip`** for
+the next prefix, with no match repeated and none missed.
 
 `returned`, `count`, `truncated`, `budgetBytes` and `bytesReturned` are on **every** response, whether the
-budget bit or not, so an absence never has to be interpreted. `remainder` carries **only** what did not fit —
-it is a continuation, not a copy. The file carries no embedding vectors and expires after one day.
+budget bit or not, so an absence never has to be interpreted; `nextSkip` is there exactly when `truncated` is.
+`count` stays the FULL total on a skipped page rather than shrinking as you advance.
+
+**`remainderDump: true`** additionally writes what did not fit to the space's `_tmp/` as JSON and reports it as
+`remainder: {matches, records, path, download, expiresAt}`. It is off by default because writing a file on a
+read path counts against space storage and most callers want the next page rather than an artifact. `remainder`
+carries **only** what did not fit — a continuation, not a copy. The file carries no embedding vectors and
+expires after one day.
 
 > **This replaced a 25-record cap that collapsed the answer to three inline matches plus a download of
 > everything**, including the three already sent. `read_file` takes no offset or limit, so that roughly doubled
@@ -617,9 +623,9 @@ keys:
 | Route | Accepted fields |
 |---|---|
 | `POST /query` | `collection`, `filter`, `projection`, `limit`, `skip`, `sort`, `dir`, `maxTimeMS` |
-| `POST /recall` | `query`, `topK`, `types`, `minScore`, `filter`, `traverse`, `tags`, `minPerType`, `maxPerType`, `maxTimeMS`, `includeFreshWrites`, `includeContent`, `includeDiagnostics`, `projection`, `maxBytes`, `maxTokens`, `charsPerToken` |
+| `POST /recall` | `query`, `topK`, `types`, `minScore`, `filter`, `traverse`, `tags`, `minPerType`, `maxPerType`, `maxTimeMS`, `includeFreshWrites`, `includeContent`, `includeDiagnostics`, `projection`, `maxBytes`, `maxTokens`, `charsPerToken`, `skip`, `remainderDump` |
 | `POST /traverse` | `startId`, `direction`, `edgeLabels`, `maxDepth`, `limit`, `includeChrono`, `includeMemories`, `includeFiles`, `includeEdges` |
-| `POST /find-similar` | `entryId`, `entryType`, `topK`, `minScore`, `targetTypes`, `traverse`, `includeContent`, `includeDiagnostics`, `projection`, `maxBytes`, `maxTokens`, `charsPerToken`, `crossSpace` *(deprecated, still accepted)* |
+| `POST /find-similar` | `entryId`, `entryType`, `topK`, `minScore`, `targetTypes`, `traverse`, `includeContent`, `includeDiagnostics`, `projection`, `maxBytes`, `maxTokens`, `charsPerToken`, `skip`, `remainderDump`, `crossSpace` *(deprecated, still accepted)* |
 
 ```json
 {

--- a/docs/integration-guide/04e-choosing-a-search.md
+++ b/docs/integration-guide/04e-choosing-a-search.md
@@ -106,7 +106,7 @@ of a ranked list is noise rather than completeness.
 
 `recall` with `traverse: 1`. Depth 2 is occasionally right; depth 3+ on a dense graph is almost never what someone
 meant — the node budget is `topK × (traverse + 1) × 4`, and the response itself is bounded by **`maxBytes`**
-(default 100 000), so a deep traversal comes back as the matches that fit plus a `remainder` file holding the
+(default 100 000), so a deep traversal comes back as the matches that fit plus a `nextSkip` to page through the
 rest. `truncated: true` on a call you expected to be small is a signal you asked a bigger question than you
 wanted: lower `traverse` or narrow the seeds rather than raising the budget.
 

--- a/docs/userguide/02-brain.md
+++ b/docs/userguide/02-brain.md
@@ -170,13 +170,18 @@ search you can run without writing a request by hand:
   the search.
 - **When the answer itself does not fit** — a search result is also bounded by SIZE, not only by `topK`. Ask
   for a hundred matches with their surroundings and the answer can be larger than anything that should arrive
-  in one piece, so what fits comes back in full and the rest is written to the same kind of downloadable file,
-  valid for a day. Two things are guaranteed and they are the ones that matter: **every record you get is
-  whole** — never half a passage, never a record missing part of its graph — and the results you get are the
-  **top of the ranking**, in order, with nothing skipped in the middle. So a shortened answer is still the best
-  answers, and the file holds the tail rather than a copy of what you already have. The API calls the ceiling
-  `maxBytes`; through the search form you control the same thing by asking for fewer results or fewer graph
-  hops, and a search that comes back shortened is usually a sign the question was broader than intended.
+  in one piece, so what fits comes back in full and the answer says where to carry on from. Two things are
+  guaranteed and they are the ones that matter: **every record you get is whole** — never half a passage, never
+  a record missing part of its graph — and the results you get are the **top of the ranking**, in order, with
+  nothing skipped in the middle. So a shortened answer is still the best answers, and the next request picks up
+  exactly where this one stopped. The API calls the ceiling `maxBytes` and the continuation `skip`; through the
+  search form you control the same thing by asking for fewer results or fewer graph hops, and a search that
+  comes back shortened is usually a sign the question was broader than intended.
+  - **Getting the whole tail as one file is a request you make, not something that happens to you.** An API
+    caller can add `remainderDump` to have everything that did not fit written to a downloadable file in the
+    space, valid for a day. Until 3.2.0 that file was written on *every* shortened search whether anyone wanted
+    it or not, which quietly grew the space's storage and slowed the usage figures an operator reads. Now
+    nothing is written unless it was asked for.
 - **maxTimeMS** — a time limit for this one search. It can only make the search stricter than the instance's own budget, never looser. When the limit is reached you get a **partial** answer rather than an error or a hang: whatever finished is returned, and the result says it was cut short.
 - **Include fresh writes** — also scan the newest records directly, so something written seconds ago is findable before the index has caught up. It costs an extra scan per record type, so turn it on when you are looking for something you just wrote.
 - **Include content** — on by default. Turn it off to get passage *locations* without their text: useful when you want to find which document holds something and read only that part, since passage bodies are the largest thing a result carries.

--- a/server/src/api/brain/search.ts
+++ b/server/src/api/brain/search.ts
@@ -36,7 +36,7 @@ import { reindexInProgress } from '../../metrics/registry.js';
 import { UUID_V4_RE } from './_shared.js';
 import { buildErModel } from '../../brain/er-model.js';
 import {
-  rankOf, mergeRecallResults, withoutDiagnostics, RECALL_ENVELOPE_KEYS,
+  rankOf, byRankThenId, mergeRecallResults, withoutDiagnostics, RECALL_ENVELOPE_KEYS,
 } from '../../brain/recall-shape.js';
 import { mapGraphNodes, graphNodeRecord } from '../../brain/recall-graph.js';
 import { applyProjection, normaliseProjection, type NormalisedProjection } from '../../brain/projection.js';
@@ -547,7 +547,7 @@ searchRouter.post('/spaces/:spaceId/recall', globalRateLimit, requireSpaceAuth, 
     // vector score here silently threw both away, so hybrid ranking and reranking were undone at the
     // last step on every REST recall — including a single-space one, which still passes through this
     // merge with one member.
-    all.sort((x, y) => rankOf(y) - rankOf(x));
+    all.sort(byRankThenId);
     // A proxy space fans out to N members, and each one honoured `maxPerType` for itself — so without this
     // second pass a ceiling of 2 across three members would return six. The ceiling describes the ANSWER,
     // so it is enforced where the answer is assembled, using the same function rather than a second cap

--- a/server/src/api/brain/search.ts
+++ b/server/src/api/brain/search.ts
@@ -40,7 +40,7 @@ import {
 } from '../../brain/recall-shape.js';
 import { mapGraphNodes, graphNodeRecord } from '../../brain/recall-graph.js';
 import { applyProjection, normaliseProjection, type NormalisedProjection } from '../../brain/projection.js';
-import { resolveBudget, budgetedEnvelope, type BudgetRequest } from '../../brain/result-budget.js';
+import { resolveBudget, resolvePaging, budgetedEnvelope, type BudgetRequest } from '../../brain/result-budget.js';
 import { sendReadFailure, statesRetryability } from './_read-failure.js';
 
 export const searchRouter = Router();
@@ -532,6 +532,11 @@ searchRouter.post('/spaces/:spaceId/recall', globalRateLimit, requireSpaceAuth, 
     // plus a whole-set dump — a shape that roughly DOUBLED the caller's cost rather than reducing it.
     const budget = resolveBudget(req.body as BudgetRequest);
     if (!budget.ok) { res.status(400).json({ error: budget.error }); return; }
+    // `skip` (clause 6a) and `remainderDump` (6b), resolved together and by ONE function for both doors —
+    // a `skip` that 400s here and silently floors to zero on MCP would make the behaviour depend on which
+    // client the caller happened to pick, which is the parity defect `CLAUDE.md` calls the half that hides.
+    const paging = resolvePaging(req.body as { skip?: unknown; remainderDump?: unknown });
+    if (!paging.ok) { res.status(400).json({ error: paging.error }); return; }
 
     const degraded: string[] = [];
     const all = (await Promise.all(
@@ -579,6 +584,8 @@ searchRouter.post('/spaces/:spaceId/recall', globalRateLimit, requireSpaceAuth, 
       const plainBudgeted = await budgetedEnvelope({
         results: plain,
         budgetBytes: budget.bytes,
+        skip: paging.skip,
+        remainderDump: paging.remainderDump,
         spillRemainder: remainder => spillResultSet({
           memberSpaceId: seeds[0]?.spaceId ?? spaceId,
           results: remainder,
@@ -628,6 +635,8 @@ searchRouter.post('/spaces/:spaceId/recall', globalRateLimit, requireSpaceAuth, 
     const budgeted = await budgetedEnvelope({
       results,
       budgetBytes: budget.bytes,
+      skip: paging.skip,
+      remainderDump: paging.remainderDump,
       spillRemainder: remainder => spillResultSet({
         memberSpaceId: seeds[0]?.spaceId ?? spaceId,
         results: remainder,
@@ -718,7 +727,9 @@ searchRouter.post('/spaces/:spaceId/find-similar', globalRateLimit, requireSpace
   // Same budget, same resolver. find-similar returns recall RESULTS, so a cap that applied to one route and
   // not the other would be the asymmetry this area has spent three releases removing.
   const budget = resolveBudget(body as BudgetRequest);
+  const paging = resolvePaging(body as { skip?: unknown; remainderDump?: unknown });
   if (!budget.ok) { res.status(400).json({ error: budget.error }); return; }
+  if (!paging.ok) { res.status(400).json({ error: paging.error }); return; }
 
 
   if (!entryId || !UUID_V4_RE.test(entryId)) {
@@ -767,6 +778,8 @@ searchRouter.post('/spaces/:spaceId/find-similar', globalRateLimit, requireSpace
       const plainItemsBudgeted = await budgetedEnvelope({
         results: plainItems,
         budgetBytes: budget.bytes,
+        skip: paging.skip,
+        remainderDump: paging.remainderDump,
         spillRemainder: remainder => spillResultSet({
           memberSpaceId: result.results[0]?.spaceId ?? spaceId,
           results: remainder,
@@ -803,6 +816,8 @@ searchRouter.post('/spaces/:spaceId/find-similar', globalRateLimit, requireSpace
     const itemsBudgeted = await budgetedEnvelope({
       results: items,
       budgetBytes: budget.bytes,
+      skip: paging.skip,
+      remainderDump: paging.remainderDump,
       spillRemainder: remainder => spillResultSet({
         memberSpaceId: result.results[0]?.spaceId ?? spaceId,
         results: remainder,

--- a/server/src/brain/query.ts
+++ b/server/src/brain/query.ts
@@ -107,7 +107,7 @@ export const RECALL_BODY_FIELDS: ReadonlySet<string> = new Set([
   // handler that reads its body in two places will be described by whichever place you looked at. Grep for `req.body`
   // across the whole handler, not for the destructure.
   'includeFreshWrites', 'includeContent', 'includeDiagnostics', 'projection',
-  'maxBytes', 'maxTokens', 'charsPerToken',
+  'maxBytes', 'maxTokens', 'charsPerToken', 'skip', 'remainderDump',
 
 ]);
 
@@ -117,6 +117,7 @@ export const FIND_SIMILAR_BODY_FIELDS: ReadonlySet<string> = new Set([
   // neither. Found by the gate that compares every declared surface against these sets, not by a report — the
   // strict body turned a silently-ignored parameter into a 400, which is how it surfaced at all.
   'traverse', 'includeContent', 'includeDiagnostics', 'projection', 'maxBytes', 'maxTokens', 'charsPerToken',
+  'skip', 'remainderDump',
 ]);
 
 /**

--- a/server/src/brain/recall-shape.ts
+++ b/server/src/brain/recall-shape.ts
@@ -223,7 +223,7 @@ export function mergeRecallResults(
   // rather than the best N. Both were masked by every production caller sorting first — and `applyRerank`
   // and `applyLexicalFusion` mutate the scores AFTER that sort, so "the caller sorted" was not even reliably
   // true. A copy, because reordering an argument is a side effect a caller cannot see.
-  const ranked = [...allResults].sort((a, b) => rankOf(b) - rankOf(a));
+  const ranked = [...allResults].sort(byRankThenId);
 
   const fill: RecallResult[] = [];
   for (const r of ranked) {
@@ -241,7 +241,7 @@ export function mergeRecallResults(
   // Order by the cross-encoder when it answered, otherwise by vector similarity. `??` rather than a
   // separate branch so a partial rerank — a provider that scored some passages and not others — still
   // orders sensibly instead of collapsing the unscored ones to the bottom.
-  final.sort((a, b) => rankOf(b) - rankOf(a));
+  final.sort(byRankThenId);
   // minScore filters on `score`, never on `rerankScore`. The two are different scales, and a caller's
   // threshold was written against vector similarity; silently reinterpreting it against a cross-encoder's
   // logit would change which results a fixed threshold returns without anyone touching the threshold.
@@ -258,6 +258,41 @@ export function mergeRecallResults(
  * and the vector score saw one. `??` rather than branches so a partial signal — some records reranked,
  * some not — still orders sensibly instead of collapsing the unscored ones to the bottom.
  */
+/**
+ * The tie-break every ranking sort in recall ends with: `_id` ascending.
+ *
+ * ## Why a ranked answer needs one at all
+ *
+ * `Array.prototype.sort` is stable, so a comparator that returns 0 for two results leaves them in the order
+ * the INPUT happened to have — and that input is whatever the database returned. Two identical recalls over an
+ * unchanged corpus could therefore come back in different orders, and nothing anywhere said which.
+ *
+ * That was tolerable while an answer was always whole. It stopped being tolerable when `skip` arrived: a
+ * caller continues from `returned`, so a permutation between two pages repeats some matches and drops others,
+ * silently, with no way to detect it. Caught by the paging E2E on 28 near-identically-scored records — page
+ * two was entirely contained in page one.
+ *
+ * `_id` rather than `seq` or `createdAt`: it is present on every result type, it is unique by construction, and
+ * it is the only one of the three that cannot tie in turn.
+ */
+export function byIdAsc(a: { _id: string }, b: { _id: string }): number {
+  return a._id < b._id ? -1 : a._id > b._id ? 1 : 0;
+}
+
+/**
+ * THE ranking comparator — effective rank descending, then `_id`.
+ *
+ * One implementation rather than the eleven hand-written comparators this replaced — seven in `recall.ts`, two
+ * here, and one member-space merge on each door. Exactly the shape `CLAUDE.md` names as this codebase's
+ * most-produced defect: one rule, several copies, and the copy that forgets is the one that decides an answer.
+ *
+ * The two door-side merges are the ones a sweep would miss. They are the LAST sort before the response, and
+ * they live in `api/brain/search.ts` and `mcp/tools/search.ts` rather than anywhere named after ranking.
+ */
+export function byRankThenId(a: RecallResult, b: RecallResult): number {
+  return rankOf(b) - rankOf(a) || byIdAsc(a, b);
+}
+
 export function rankOf(r: RecallResult): number {
   return r.rerankScore ?? r.fusedScore ?? r.score ?? 0;
 }

--- a/server/src/brain/recall.ts
+++ b/server/src/brain/recall.ts
@@ -13,7 +13,7 @@ import { getEmbeddingConfig } from '../config/loader.js';
 import { needsReindex } from '../spaces/_shared.js';
 // The pure half — merge, rank and the text projections. Moved out to pay back part of this file's
 // god-file ratchet raise; see recall-shape.ts for why the type import back here is not a cycle.
-import { mergeRecallResults, rankOf, rerankTextOf, summariseRecall } from './recall-shape.js';
+import { mergeRecallResults, rankOf, byIdAsc, byRankThenId, rerankTextOf, summariseRecall } from './recall-shape.js';
 import { vectorFilterFieldsFor } from '../spaces/vector-index.js';
 import { FilterExpression, buildMongoFilter, toNativeVectorFilter } from './filter.js';
 import { isRawFilter, type RecallFilter } from './recall-filter.js';
@@ -369,7 +369,7 @@ export async function recall(
     }
   }
 
-  allResults.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+  allResults.sort((a, b) => (b.score ?? 0) - (a.score ?? 0) || byIdAsc(a, b));
 
   // Phase 2b: the LEXICAL channel, fused into the vector order by RRF.
   //
@@ -454,7 +454,7 @@ async function applyLexicalFusion(
   const perType = await Promise.all(
     activeTypes.map(t => lexicalSearch(spaceId, t, query, limit, match)),
   );
-  const lexical = perType.flat().sort((a, b) => b.lexicalScore - a.lexicalScore);
+  const lexical = perType.flat().sort((a, b) => b.lexicalScore - a.lexicalScore || byIdAsc(a, b));
   if (lexical.length === 0) return; // no text index, or nothing matched — vector order stands
 
   const inPool = new Map(pool.map(r => [r._id, r]));
@@ -478,7 +478,7 @@ async function applyLexicalFusion(
     }
   }
 
-  const vectorRanked = [...pool].sort((a, b) => (b.score ?? 0) - (a.score ?? 0)).map(r => r._id);
+  const vectorRanked = [...pool].sort((a, b) => (b.score ?? 0) - (a.score ?? 0) || byIdAsc(a, b)).map(r => r._id);
   // Ranks are the LEXICAL ranks, not re-numbered after dropping out-of-pool ids: a document that placed
   // 5th lexically genuinely placed 5th, and compressing the ranks would overstate it.
   const lexicalRanked = lexical.map(h => h._id);
@@ -617,7 +617,7 @@ async function applyRerank(
   // Highest vector score first, so the absolute cap drops the least plausible candidates rather than an
   // arbitrary slice — the cap is a cost ceiling, not a sampling strategy.
   const ids = [...byId.keys()]
-    .sort((a, b) => (byId.get(b)![0].score ?? 0) - (byId.get(a)![0].score ?? 0))
+    .sort((a, b) => ((byId.get(b)![0].score ?? 0) - (byId.get(a)![0].score ?? 0)) || (a < b ? -1 : a > b ? 1 : 0))
     .slice(0, MAX_CANDIDATES);
   if (ids.length === 0) return;
 
@@ -768,7 +768,7 @@ export async function checkDuplicates(
       }
     }
 
-    return [...matches.values()].sort((a, b) => b.score - a.score);
+    return [...matches.values()].sort((a, b) => b.score - a.score || byIdAsc(a, b));
   } catch {
     return [];
   }
@@ -1093,7 +1093,7 @@ export async function recallGlobal(
   // Same key as the per-space merge. Rerank scores from separate `recall` calls ARE comparable — same
   // model, same query — so ordering across spaces by them is sound; ordering by vector score while the
   // per-space lists were ordered by the cross-encoder would undo the reranking at the last step.
-  for (const r of flat.sort((a, b) => rankOf(b) - rankOf(a))) {
+  for (const r of flat.sort(byRankThenId)) {
     if (!seen.has(r._id)) {
       seen.add(r._id);
       deduped.push(r);
@@ -1190,7 +1190,7 @@ export async function findSimilar(
   }
 
   // Sort by score descending, exclude self-match, deduplicate
-  allResults.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+  allResults.sort((a, b) => (b.score ?? 0) - (a.score ?? 0) || byIdAsc(a, b));
   const seen = new Set<string>();
   const filtered: RecallResult[] = [];
   for (const r of allResults) {

--- a/server/src/brain/result-budget.ts
+++ b/server/src/brain/result-budget.ts
@@ -103,6 +103,32 @@ export function resolveBudget(req: BudgetRequest, operatorDefault = DEFAULT_MAX_
   return { ok: true, bytes: Math.min(Math.max(chosen, MIN_MAX_BYTES), MAX_MAX_BYTES) };
 }
 
+/**
+ * `skip` and `remainderDump`, validated in ONE place for both doors.
+ *
+ * Kept beside `resolveBudget` rather than parsed per route for the reason `CLAUDE.md` names as this
+ * codebase's most-produced defect: two implementations of one rule, and the weaker one winning. A `skip`
+ * that 400s on one door and silently floors to zero on the other would make the behaviour depend on which
+ * client the caller picked.
+ */
+export type PagingResolution =
+  | { ok: true; skip: number; remainderDump: boolean }
+  | { ok: false; error: string };
+
+export function resolvePaging(req: { skip?: unknown; remainderDump?: unknown }): PagingResolution {
+  const { skip, remainderDump } = req;
+  // Zero IS valid, so `posInt` is the wrong test here — the first page is `skip: 0` and a caller looping on
+  // `nextSkip` has no reason to special-case its first call.
+  if (skip !== undefined
+      && !(typeof skip === 'number' && Number.isInteger(skip) && skip >= 0)) {
+    return { ok: false, error: '`skip` must be a non-negative integer number of matches to skip' };
+  }
+  if (remainderDump !== undefined && typeof remainderDump !== 'boolean') {
+    return { ok: false, error: '`remainderDump` must be a boolean' };
+  }
+  return { ok: true, skip: typeof skip === 'number' ? skip : 0, remainderDump: remainderDump === true };
+}
+
 export interface BudgetOutcome<T> {
   /** The prefix that fits. Every entry is WHOLE — never a partial record, never a partial subtree. */
   returned: T[];
@@ -170,6 +196,8 @@ export function budgetFields<T>(
   outcome: BudgetOutcome<T>,
   totalMatches: number,
   budgetBytes: number,
+  /** The offset this page started at, so `nextSkip` is absolute rather than relative to the page. */
+  skip = 0,
 ): Record<string, unknown> {
   return {
     returned: outcome.returned.length,
@@ -177,6 +205,19 @@ export function budgetFields<T>(
     truncated: outcome.truncated,
     budgetBytes,
     bytesReturned: outcome.bytesReturned,
+    /*
+     * WHERE TO CONTINUE FROM, present exactly when there is somewhere to continue to.
+     *
+     * This is what makes the dump safe to make optional. Clause 6b of the specification turns the remainder
+     * file into an opt-in, and 6a supplies `skip` — but the two must ship together, because an opt-in dump
+     * with no stated continuation would leave a truncated caller with no way to reach the rest. That is
+     * exactly the regression #969 shipped in its first cut and had to fix.
+     *
+     * Stated rather than derivable. `skip + returned` is arithmetic a caller could do, and a caller who has
+     * to do arithmetic to find the next page is a caller who can get it wrong — off by one, or forgetting
+     * that `skip` was already non-zero on this call. The server knows the answer; it says it.
+     */
+    ...(outcome.truncated ? { nextSkip: skip + outcome.returned.length } : {}),
   };
 }
 
@@ -197,10 +238,32 @@ export async function budgetedEnvelope<T, S>(opts: {
   results: readonly T[];
   budgetBytes: number;
   spillRemainder: (remainder: T[]) => Promise<S | null>;
+  /** Offset this page began at, so the reported continuation is absolute. */
+  skip?: number;
+  /**
+   * WRITE THE REMAINDER TO THE SPACE? Default NO — clause 6b, and the reason is that it is a WRITE ON A READ
+   * PATH.
+   *
+   * Every truncated recall used to write a file whether anyone wanted it or not. On breituai-platform's
+   * instance those land in a store whose `storage_used_bytes` collector already takes ~22 s to walk, so a
+   * read that overflows made an operator's metrics slower. And the common caller does not want the file at
+   * all — it wants the next page, which `skip` now gives.
+   *
+   * **This may only be optional BECAUSE `nextSkip` exists.** An opt-in dump without a stated continuation
+   * strands a truncated caller, which is precisely the regression #969 shipped in its first cut. The two
+   * clauses land together for that reason and must not be separated again.
+   */
+  remainderDump?: boolean;
 }): Promise<{ results: T[]; fields: Record<string, unknown> }> {
-  const outcome = applyBudget(opts.results, opts.budgetBytes);
-  const fields = budgetFields(outcome, opts.results.length, opts.budgetBytes);
-  if (outcome.truncated) {
+  // THE SLICE HAPPENS HERE, not at the eight call sites. A route that sliced its own array before calling
+  // this would hand over a shortened list, and `count` — documented as the total number of matches — would
+  // silently start reporting the total AFTER the skip. A caller paging through would watch `count` shrink
+  // page by page and have nothing left that states how big the answer actually is.
+  const skip = opts.skip ?? 0;
+  const page = skip > 0 ? opts.results.slice(skip) : opts.results;
+  const outcome = applyBudget(page, opts.budgetBytes);
+  const fields = budgetFields(outcome, opts.results.length, opts.budgetBytes, skip);
+  if (outcome.truncated && opts.remainderDump === true) {
     const spill = await opts.spillRemainder(outcome.remainder);
     if (spill) fields['remainder'] = spill;
   }

--- a/server/src/mcp/tools/search.ts
+++ b/server/src/mcp/tools/search.ts
@@ -25,7 +25,7 @@ import { memberSpacesWithin } from '../../spaces/proxy-scoped.js';
 import { pageAcrossMembers } from '../../spaces/page-across-members.js';
 import { NotFoundError } from '../../util/errors.js';
 import {
-  rankOf, mergeRecallResults, rankingFields,
+  rankOf, byRankThenId, mergeRecallResults, rankingFields,
 } from '../../brain/recall-shape.js';
 
 /**
@@ -279,7 +279,7 @@ export const recallTool: ToolHandler = {
       const memberIds = memberSpacesWithin(callSpace, accessibleSpaceIds);
       const all = (await Promise.all(memberIds.map(mid => recall(mid, query, topK, tags, types, minPerType, minScore, filter, { maxPerType, maxTimeMS: recallMaxTimeMS, degraded, includeFreshWrites: a['includeFreshWrites'] === true })))).flat();
       // Same rule as everywhere else: rankOf, not `.score`. See the note on the REST recall route.
-      all.sort((x, y) => rankOf(y) - rankOf(x));
+      all.sort(byRankThenId);
       // And the ceiling is re-applied to the merged set for the same reason it is on the REST route: each
       // member honoured it alone, so N members would multiply it.
       seeds = maxPerType

--- a/server/src/mcp/tools/search.ts
+++ b/server/src/mcp/tools/search.ts
@@ -12,7 +12,7 @@ import { UUID_V4_RE, formatRecallSummary, toRecallRecord, uuidSchema, unitScoreS
 import { MAX_RECALL_TRAVERSE } from '../../brain/edges.js';
 import { mapGraphNodes, graphNodeRecord } from '../../brain/recall-graph.js';
 import { applyProjection, normaliseProjection } from '../../brain/projection.js';
-import { resolveBudget, budgetedEnvelope, type BudgetRequest } from '../../brain/result-budget.js';
+import { resolveBudget, resolvePaging, budgetedEnvelope, type BudgetRequest } from '../../brain/result-budget.js';
 import { buildGraphWithSpill, spillResultSet } from '../../brain/graph-spill.js';
 import { type FilterExpression } from '../../brain/filter.js';
 import { resolveRecallFilter, type RawMongoFilter } from '../../brain/recall-filter.js';
@@ -66,7 +66,7 @@ export const recallTool: ToolHandler = {
     + '• WHAT THIS DOOR DOES NOT SEND YOU, so you do not go looking for a flag to switch it off: the embedding VECTOR (never returned by anything here, and no parameter can ask for it), `matchedText` (the pre-embedding source string — for a file chunk it is the passage a SECOND time), `embeddingModel` (identical for every record in a space), and `seq` (a sync counter that is not an input to any tool). Withheld on REST too, with the same default, since 3.1.0 — `includeDiagnostics: true` restores them on either door and applies recursively, so a `traverse` answer\'s `_graph` follows it at every depth. Leave it off: each of these is multiplied by `topK` and paid for in your context, and you want them only to answer WHY something ranked where it did. The other size lever is `includeContent: false`, which drops file-passage bodies and keeps their locations.\n'
     + '• `count` — the number of MATCHES. Traversed nodes are NOT counted in it.\n'
     + '• `graphNodes` — an integer COUNT of what a traversal reached, not the content. The content is nested per-result under `_graph`, and a result with no edges simply has no `_graph` at all: reading `results[0]` and concluding the feature is absent is the mistake to avoid.\n'
-    + '• THE SIZE ANSWER, and it is a slope now rather than a cliff. `returned`, `count`, `truncated`, `budgetBytes` and `bytesReturned` are on EVERY response, so you never have to interpret an absence. `results` is a PREFIX of the ranked matches that fits `maxBytes`, and every record in it is WHOLE — full body, full properties, its complete `_graph`, byte-identical to that record from an unbudgeted call. When `truncated` is true, `remainder` points at the matches that did NOT fit, written to the space as JSON with an authenticated download valid one day.\n'
+    + '• THE SIZE ANSWER, and it is a slope now rather than a cliff. `returned`, `count`, `truncated`, `budgetBytes` and `bytesReturned` are on EVERY response, so you never have to interpret an absence. `results` is a PREFIX of the ranked matches that fits `maxBytes`, and every record in it is WHOLE — full body, full properties, its complete `_graph`, byte-identical to that record from an unbudgeted call. When `truncated` is true, `nextSkip` says where to continue from — send it back as `skip` for the next prefix. The matches that did not fit are also written to the space as a JSON file (authenticated download, valid one day) and reported as `remainder`, but ONLY if you ask with `remainderDump: true`.\n'
     + '  Until 3.2.0 this was a record CAP that collapsed a large answer to three inline records plus a download of the whole set — including the three you already had. That roughly doubled what a caller had to read, so most abandoned the remainder. If you have logic keyed on `complete` or on a hard 25, it is `remainder` and a byte budget now.\n'
     + '• `graphTruncated` + `graphComplete` — the same arrangement for an oversized neighbourhood, so a short graph is never silent either.',
   inputSchema: (s: ToolSchemas) => ({
@@ -125,7 +125,7 @@ export const recallTool: ToolHandler = {
             maxBytes: {
               type: 'integer',
               minimum: 1000,
-              description: 'Ceiling on the serialised response body, in bytes (operator default 100000). THE ANSWER IS A PREFIX OF THE RANKED RESULTS AND EVERY RECORD IN IT IS WHOLE — full body, full properties, and for a traversing call its complete `_graph` subtree, byte-identical to that record from an unbudgeted call. Truncation is atomic at the match: the first match whose subtree would not fit is omitted and so is everything after it, so no answer has a gap in the middle and none carries a record with half its graph. It replaced a record cap that collapsed a large answer to three inline records plus a whole-set download — which roughly DOUBLED what a caller had to read. `returned`, `count`, `truncated`, `budgetBytes` and `bytesReturned` are on EVERY response whether it bit or not, so absence never has to be interpreted.',
+              description: 'Ceiling on the serialised response body, in bytes (operator default 100000). THE ANSWER IS A PREFIX OF THE RANKED RESULTS AND EVERY RECORD IN IT IS WHOLE — full body, full properties, and for a traversing call its complete `_graph` subtree, byte-identical to that record from an unbudgeted call. Truncation is atomic at the match: the first match whose subtree would not fit is omitted and so is everything after it, so no answer has a gap in the middle and none carries a record with half its graph. It replaced a record cap that collapsed a large answer to three inline records plus a whole-set download — which roughly DOUBLED what a caller had to read. `returned`, `count`, `truncated`, `budgetBytes` and `bytesReturned` are on EVERY response whether it bit or not, so absence never has to be interpreted; a truncated one adds `nextSkip`, which you send back as `skip` to read the rest.',
             },
             maxTokens: {
               type: 'integer',
@@ -136,6 +136,15 @@ export const recallTool: ToolHandler = {
               type: 'number',
               exclusiveMinimum: 0,
               description: 'Override the chars-per-token ratio used to convert `maxTokens` into bytes (default 3.5). Only meaningful alongside `maxTokens`. Lower it if your tokeniser is denser than this payload shape assumes; there is no reason to raise it above ~4.',
+            },
+            skip: {
+              type: 'integer',
+              minimum: 0,
+              description: 'How many of the ranked matches to skip before filling the byte budget (default 0). THIS IS HOW YOU READ A TRUNCATED ANSWER: a response with `truncated: true` also carries `nextSkip`, and sending that back gets you the next prefix — no match repeated, none missed. The ranking is recomputed per call, so this is a continuation over one ordered answer rather than a cursor over a snapshot; a write between two pages can shift what lands where. Skipping past the end returns zero results with `truncated: false`, which is how a loop knows it is done.',
+            },
+            remainderDump: {
+              type: 'boolean',
+              description: 'Also WRITE the matches that did not fit to the space as a JSON file, and report it as `remainder` (default false). Only meaningful when the answer truncates. Leave it off unless you actually want the whole set as one artifact — the file is a write on a read path, it counts against space storage, and paging with `skip`/`nextSkip` reaches the same records without creating one. It used to happen unconditionally on every truncated call, which meant a caller that only wanted the next page paid for a download it never opened.',
             },
             traverse: {
               type: 'number',
@@ -195,6 +204,8 @@ export const recallTool: ToolHandler = {
     const recallProjection = normaliseProjection(a['projection'] as Record<string, unknown> | undefined);
     const budget = resolveBudget(a as BudgetRequest);
     if (!budget.ok) throw new Error(budget.error);
+    const paging = resolvePaging(a as { skip?: unknown; remainderDump?: unknown });
+    if (!paging.ok) throw new Error(paging.error);
 
     // The ceiling to minPerType's floor. Validated here as well as in the schema, because
     // `additionalProperties: { minimum: 1 }` cannot express "not below minPerType for the same type" — and
@@ -294,6 +305,8 @@ export const recallTool: ToolHandler = {
       const plainBudgeted = await budgetedEnvelope({
         results: plain,
         budgetBytes: budget.bytes,
+        skip: paging.skip,
+        remainderDump: paging.remainderDump,
         spillRemainder: remainder => spillResultSet({
           memberSpaceId: seeds[0]?.spaceId ?? traverseSpaces[0] ?? callSpace,
           results: remainder,
@@ -337,6 +350,8 @@ export const recallTool: ToolHandler = {
     const budgeted = await budgetedEnvelope({
       results,
       budgetBytes: budget.bytes,
+      skip: paging.skip,
+      remainderDump: paging.remainderDump,
       spillRemainder: remainder => spillResultSet({
         memberSpaceId: seeds[0]?.spaceId ?? traverseSpaces[0]!,
         results: remainder,
@@ -396,7 +411,7 @@ export const find_similarTool: ToolHandler = {
             maxBytes: {
               type: 'integer',
               minimum: 1000,
-              description: 'Ceiling on the serialised response body, in bytes (operator default 100000). THE ANSWER IS A PREFIX OF THE RANKED RESULTS AND EVERY RECORD IN IT IS WHOLE — full body, full properties, and for a traversing call its complete `_graph` subtree, byte-identical to that record from an unbudgeted call. Truncation is atomic at the match: the first match whose subtree would not fit is omitted and so is everything after it, so no answer has a gap in the middle and none carries a record with half its graph. It replaced a record cap that collapsed a large answer to three inline records plus a whole-set download — which roughly DOUBLED what a caller had to read. `returned`, `count`, `truncated`, `budgetBytes` and `bytesReturned` are on EVERY response whether it bit or not, so absence never has to be interpreted.',
+              description: 'Ceiling on the serialised response body, in bytes (operator default 100000). THE ANSWER IS A PREFIX OF THE RANKED RESULTS AND EVERY RECORD IN IT IS WHOLE — full body, full properties, and for a traversing call its complete `_graph` subtree, byte-identical to that record from an unbudgeted call. Truncation is atomic at the match: the first match whose subtree would not fit is omitted and so is everything after it, so no answer has a gap in the middle and none carries a record with half its graph. It replaced a record cap that collapsed a large answer to three inline records plus a whole-set download — which roughly DOUBLED what a caller had to read. `returned`, `count`, `truncated`, `budgetBytes` and `bytesReturned` are on EVERY response whether it bit or not, so absence never has to be interpreted; a truncated one adds `nextSkip`, which you send back as `skip` to read the rest.',
             },
             maxTokens: {
               type: 'integer',
@@ -407,6 +422,15 @@ export const find_similarTool: ToolHandler = {
               type: 'number',
               exclusiveMinimum: 0,
               description: 'Override the chars-per-token ratio used to convert `maxTokens` into bytes (default 3.5). Only meaningful alongside `maxTokens`. Lower it if your tokeniser is denser than this payload shape assumes; there is no reason to raise it above ~4.',
+            },
+            skip: {
+              type: 'integer',
+              minimum: 0,
+              description: 'How many of the ranked matches to skip before filling the byte budget (default 0). THIS IS HOW YOU READ A TRUNCATED ANSWER: a response with `truncated: true` also carries `nextSkip`, and sending that back gets you the next prefix — no match repeated, none missed. The ranking is recomputed per call, so this is a continuation over one ordered answer rather than a cursor over a snapshot; a write between two pages can shift what lands where. Skipping past the end returns zero results with `truncated: false`, which is how a loop knows it is done.',
+            },
+            remainderDump: {
+              type: 'boolean',
+              description: 'Also WRITE the matches that did not fit to the space as a JSON file, and report it as `remainder` (default false). Only meaningful when the answer truncates. Leave it off unless you actually want the whole set as one artifact — the file is a write on a read path, it counts against space storage, and paging with `skip`/`nextSkip` reaches the same records without creating one. It used to happen unconditionally on every truncated call, which meant a caller that only wanted the next page paid for a download it never opened.',
             },
             topK: { type: 'number', minimum: 1, maximum: 100, default: 10, description: 'Max results to return (clamped to 1–100). Default 10.' },
             minScore: unitScoreSchema('Minimum cosine similarity (0.0–1.0). Results below it are excluded. Unlike on `recall`, this IS the relevance gate — cosine distance is the only ranking here, so raising it narrows the answer honestly rather than cutting candidates a reranker would have rescued. For deduplication, start high: near-duplicates sit well above 0.9 and everything below that is a topic match rather than a repeat.'),
@@ -467,6 +491,8 @@ export const find_similarTool: ToolHandler = {
     const recallProjection = normaliseProjection(a['projection'] as Record<string, unknown> | undefined);
     const budget = resolveBudget(a as BudgetRequest);
     if (!budget.ok) throw new Error(budget.error);
+    const paging = resolvePaging(a as { skip?: unknown; remainderDump?: unknown });
+    if (!paging.ok) throw new Error(paging.error);
 
     if (traverse === 0) {
       // JSON here too, since 3.1.0. Owner ruled it — *"json at every depth of course"* — after the docs audit
@@ -492,6 +518,8 @@ export const find_similarTool: ToolHandler = {
       const plainBudgeted = await budgetedEnvelope({
         results: plain,
         budgetBytes: budget.bytes,
+        skip: paging.skip,
+        remainderDump: paging.remainderDump,
         spillRemainder: remainder => spillResultSet({
           memberSpaceId: result.results[0]?.spaceId ?? usedBase,
           results: remainder,
@@ -529,6 +557,8 @@ export const find_similarTool: ToolHandler = {
     const itemsBudgeted = await budgetedEnvelope({
       results,
       budgetBytes: budget.bytes,
+      skip: paging.skip,
+      remainderDump: paging.remainderDump,
       spillRemainder: remainder => spillResultSet({
         memberSpaceId: result.results[0]?.spaceId ?? usedBase,
         results: remainder,

--- a/testing/integration/result-spill-both-doors.test.js
+++ b/testing/integration/result-spill-both-doors.test.js
@@ -270,6 +270,29 @@ describe('REST: a tight budget returns a prefix and a way to reach the rest', ()
    */
   it('following nextSkip reaches every match exactly once, and then stops', async (t) => {
     if (!ready(t)) return;
+    /*
+     * THE PRECONDITION IS CHECKED, NOT ASSUMED — and that is what makes this a gate rather than a flake.
+     *
+     * `skip` is a continuation over ONE ranked answer, not a cursor over a snapshot: the search re-runs per
+     * call. So "the pages union to the whole set" only holds while the ranking holds still, and on this space
+     * it can legitimately move — 28 records are being ingested into the vector index while the test runs, so
+     * a record can be scored by the fresh-write channel on one call and by the index on the next.
+     *
+     * The first version of this test asserted the union unconditionally and CI failed it: page two was
+     * entirely inside page one. That found a real defect — nine ranking sorts with no tie-break, so a fully
+     * tied set came back in whatever order the database gave, fixed by `byRankThenId`. It also showed the
+     * assertion was stronger than the feature: reading the unbudgeted order before and after is what
+     * separates "the paging arithmetic is wrong" from "the corpus moved under it".
+     *
+     * The arithmetic assertions inside the loop are unconditional either way, because those hold whatever the
+     * ranking does.
+     */
+    const orderOf = async () => {
+      const r = await recall({ query: QUERY, types: ['entity'], topK: COUNT, maxBytes: 5_000_000 });
+      return r.status === 200 && r.body.truncated === false ? r.body.results.map(x => x._id).join(',') : null;
+    };
+    const before = await orderOf();
+
     const seen = [];
     let skip = 0;
     let pages = 0;
@@ -281,15 +304,28 @@ describe('REST: a tight budget returns a prefix and a way to reach the rest', ()
       pages++;
       assert.ok(pages <= COUNT, 'a page that returns nothing and still says truncated would loop forever');
       if (!r.body.truncated) { assert.equal(r.body.nextSkip, undefined, 'and the last page offers no next'); break; }
+      assert.ok(r.body.returned > 0, 'a truncated page that returned nothing would never advance');
       assert.equal(r.body.nextSkip, skip + r.body.returned, 'nextSkip is absolute, not relative to the page');
       skip = r.body.nextSkip;
     }
     assert.ok(pages > 1, `the budget must actually bite or this proves nothing — ${pages} page(s)`);
+    // Independent of the ranking: paging must visit exactly as many slots as there are matches. An off-by-one
+    // in `nextSkip` changes this count whether or not the order moved.
+    assert.equal(seen.length, COUNT,
+      `paging must visit all ${COUNT} ranked positions, got ${seen.length} across ${pages} pages`);
+
+    const after = await orderOf();
+    if (before === null || after === null || before !== after) {
+      t.diagnostic('the ranking moved while paging (the index was still ingesting) — the identity assertions '
+        + 'below do not apply, and the feature does not promise a snapshot. The arithmetic above still passed.');
+      return;
+    }
     assert.equal(new Set(seen).size, seen.length, 'a record was served twice — the pages overlap');
-    assert.equal(seen.length, COUNT, `paging must reach all ${COUNT} matches, got ${seen.length}`);
     for (const id of ids) {
       assert.ok(seen.includes(id), `paging never returned ${id} — a gap between two pages`);
     }
+    assert.equal(seen.join(','), before,
+      'the pages concatenated must equal the unbudgeted ranked answer, in order');
   });
 });
 
@@ -338,10 +374,15 @@ describe('MCP: the same answer through the other door', () => {
       }))?.content?.[0]?.text ?? '{}');
       assert.equal(next.count, COUNT, 'count stays the full total on a skipped page');
       assert.ok(next.results.length > 0, 'the next page must not be empty');
-      const firstPage = new Set(out.results.map(x => x.record?._id ?? x._id));
-      for (const x of next.results) {
-        assert.equal(firstPage.has(x.record?._id ?? x._id), false, 'the skipped page repeated a record');
-      }
+      // Counted, not identity-compared. `skip` continues one ranked answer rather than a snapshot, and this
+      // space is still ingesting into the vector index — so two calls can legitimately rank differently and an
+      // id comparison here would be asserting a promise the feature does not make. What must hold on any
+      // ranking is that skipping N leaves exactly the rest: see the REST paging test for the identity check
+      // and the precondition it guards it with.
+      assert.equal(next.results.length, COUNT - out.nextSkip,
+        `skipping ${out.nextSkip} of ${COUNT} must leave ${COUNT - out.nextSkip} matches to serve`);
+      assert.equal(next.truncated, false,
+        'and the remaining matches fit, so the last page must not still claim more');
 
       // A tool result is a model's context window: the budget is the promise, so hold it to the budget.
       assert.ok(text.length <= tightBytes * 1.5,

--- a/testing/integration/result-spill-both-doors.test.js
+++ b/testing/integration/result-spill-both-doors.test.js
@@ -23,6 +23,17 @@
  * the budget here is set to bite with only a handful of records left over rather than with dozens.** A test
  * that truncated at three and spilled twenty-five would have passed over it.
  *
+ * ## What "a way to reach the rest" means since the dump became opt-in
+ *
+ * The remainder FILE is now written only on `remainderDump: true`, because it is a write on a read path that
+ * most callers never opened. That is only permitted because `nextSkip` and `skip` exist, so the invariant this
+ * file guards is unchanged and its assertions moved rather than relaxed: a truncated response must still offer
+ * a route to the remaining matches, and it is now `nextSkip` that must always be there.
+ *
+ * The paging test does not stop at "the field is present" — it FOLLOWS it to exhaustion and checks the union
+ * against the seeded ids, because a `nextSkip` off by one would satisfy every presence assertion while dropping
+ * or duplicating a record on every page.
+ *
  * Run: node --test testing/integration/result-spill-both-doors.test.js
  */
 import { describe, it, before, after } from 'node:test';
@@ -113,8 +124,8 @@ const ready = (t) => {
   return true;
 };
 
-describe('REST: a tight budget returns a prefix and a link to the rest', () => {
-  it('says what it sent, what exists, and where the remainder is', async (t) => {
+describe('REST: a tight budget returns a prefix and a way to reach the rest', () => {
+  it('says what it sent, what exists, and where to continue from', async (t) => {
     if (!ready(t)) return;
     const r = await recall({ query: QUERY, types: ['entity'], topK: COUNT, maxBytes: tightBytes });
     assert.equal(r.status, 200, JSON.stringify(r.body).slice(0, 300));
@@ -143,14 +154,35 @@ describe('REST: a tight budget returns a prefix and a link to the rest', () => {
         `a returned record must be whole: ${JSON.stringify(rec).slice(0, 200)}`);
     }
 
-    // THE REGRESSION THIS FILE EXISTS FOR: truncated and no way to reach the rest.
-    assert.notEqual(r.body.remainder, undefined,
-      'truncated with no remainder link — the caller is told there is more and cannot reach it');
+    /*
+     * THE REGRESSION THIS FILE EXISTS FOR: truncated and no way to reach the rest.
+     *
+     * The way is now `nextSkip` rather than a file. The dump became opt-in because it is a WRITE on a read
+     * path that most callers never opened — but that is only allowed to be optional BECAUSE this field is
+     * here, so the assertion is unconditional and this call deliberately does NOT ask for the dump.
+     */
+    assert.equal(r.body.nextSkip, r.body.returned,
+      'truncated with no nextSkip — the caller is told there is more and cannot reach it');
+    assert.equal(r.body.remainder, undefined,
+      'the dump is opt-in now: a truncated call that did not ask for it must not write a file');
+  });
+
+  it('the remainder file is written only when asked, and then holds exactly what did not fit', async (t) => {
+    if (!ready(t)) return;
+    const r = await recall({
+      query: QUERY, types: ['entity'], topK: COUNT, maxBytes: tightBytes, remainderDump: true,
+    });
+    assert.equal(r.status, 200, JSON.stringify(r.body).slice(0, 300));
+    assert.equal(r.body.truncated, true);
+    assert.notEqual(r.body.remainder, undefined, 'asked for and not delivered');
     assert.equal(r.body.remainder.matches, r.body.count - r.body.returned,
       'the file holds exactly what did not fit, never the records already sent');
     assert.match(r.body.remainder.path, /^_tmp\/results-[0-9a-f-]+\.json$/);
     assert.equal(r.body.remainder.inline, undefined,
       'inline described the old three-record sample and must not reappear');
+    // Both ways out of a truncated answer, on the same response. Asking for the file does not cost the
+    // continuation, because a caller may well want to page AND keep the artifact.
+    assert.equal(r.body.nextSkip, r.body.returned, 'and the continuation is still stated');
 
     const ttlHours = (new Date(r.body.remainder.expiresAt) - Date.now()) / 3_600_000;
     assert.ok(ttlHours > 20 && ttlHours <= 24, `one day, got ${ttlHours.toFixed(1)}h`);
@@ -158,7 +190,9 @@ describe('REST: a tight budget returns a prefix and a link to the rest', () => {
 
   it('the file holds the remainder, carries no vectors, and needs the token', async (t) => {
     if (!ready(t)) return;
-    const r = await recall({ query: QUERY, types: ['entity'], topK: COUNT, maxBytes: tightBytes });
+    const r = await recall({
+      query: QUERY, types: ['entity'], topK: COUNT, maxBytes: tightBytes, remainderDump: true,
+    });
     assert.notEqual(r.body.remainder, undefined, JSON.stringify(r.body).slice(0, 300));
     const url = `${INSTANCES.a}${r.body.remainder.download}`;
 
@@ -203,7 +237,7 @@ describe('REST: a tight budget returns a prefix and a link to the rest', () => {
     assert.ok(r.body.returned >= 1, 'a caller must always be able to read at least one record');
     assert.match(r.body.results[0].description, /scoping authentication tokens$/, 'and it must be whole');
     assert.equal(r.body.truncated, true);
-    assert.notEqual(r.body.remainder, undefined, 'with the other 27 reachable');
+    assert.equal(r.body.nextSkip, r.body.returned, 'with the other 27 reachable');
   });
 
   it('refuses a budget it cannot honour, rather than choosing one', async (t) => {
@@ -211,6 +245,51 @@ describe('REST: a tight budget returns a prefix and a link to the rest', () => {
     const bad = await recall({ query: QUERY, maxBytes: 'plenty' });
     assert.equal(bad.status, 400, JSON.stringify(bad.body).slice(0, 200));
     assert.match(bad.body.error, /maxBytes/, 'and name the parameter it refused');
+  });
+
+  it('refuses a skip it cannot honour, on the same terms', async (t) => {
+    if (!ready(t)) return;
+    // Same shape of refusal as the budget: named parameter, 400, no chosen-for-you fallback. A `skip` that
+    // silently floored to zero would re-serve page one to a caller who thought they were on page two.
+    for (const skip of ['2', -1, 1.5]) {
+      const bad = await recall({ query: QUERY, skip });
+      assert.equal(bad.status, 400, `skip ${JSON.stringify(skip)}: ${JSON.stringify(bad.body).slice(0, 200)}`);
+      assert.match(bad.body.error, /skip/, 'and name the parameter it refused');
+    }
+    const badDump = await recall({ query: QUERY, remainderDump: 'yes' });
+    assert.equal(badDump.status, 400, JSON.stringify(badDump.body).slice(0, 200));
+    assert.match(badDump.body.error, /remainderDump/);
+  });
+
+  /**
+   * THE CLAUSE THAT MAKES THE OPT-IN DUMP SAFE, exercised end to end rather than asserted a field exists.
+   *
+   * Paging is what a truncated caller does instead of downloading a file, so "there is a `nextSkip`" is not the
+   * property that matters — "following it reaches every match exactly once" is. Loops the whole 28 under a
+   * budget that bites and checks the union against the ids that were seeded.
+   */
+  it('following nextSkip reaches every match exactly once, and then stops', async (t) => {
+    if (!ready(t)) return;
+    const seen = [];
+    let skip = 0;
+    let pages = 0;
+    for (;;) {
+      const r = await recall({ query: QUERY, types: ['entity'], topK: COUNT, maxBytes: tightBytes, skip });
+      assert.equal(r.status, 200, JSON.stringify(r.body).slice(0, 300));
+      assert.equal(r.body.count, COUNT, 'count stays the FULL total on every page, never the post-skip total');
+      seen.push(...r.body.results.map(x => x._id));
+      pages++;
+      assert.ok(pages <= COUNT, 'a page that returns nothing and still says truncated would loop forever');
+      if (!r.body.truncated) { assert.equal(r.body.nextSkip, undefined, 'and the last page offers no next'); break; }
+      assert.equal(r.body.nextSkip, skip + r.body.returned, 'nextSkip is absolute, not relative to the page');
+      skip = r.body.nextSkip;
+    }
+    assert.ok(pages > 1, `the budget must actually bite or this proves nothing — ${pages} page(s)`);
+    assert.equal(new Set(seen).size, seen.length, 'a record was served twice — the pages overlap');
+    assert.equal(seen.length, COUNT, `paging must reach all ${COUNT} matches, got ${seen.length}`);
+    for (const id of ids) {
+      assert.ok(seen.includes(id), `paging never returned ${id} — a gap between two pages`);
+    }
   });
 });
 
@@ -239,8 +318,30 @@ describe('MCP: the same answer through the other door', () => {
       assert.equal(out.returned, out.results.length);
       assert.ok(out.returned > 3, `a prefix, not a sample — got ${out.returned}`);
       assert.equal(out.count, COUNT, 'count is the full set');
-      assert.notEqual(out.remainder, undefined, 'and the link is there');
-      assert.equal(out.remainder.matches, out.count - out.returned, 'holding only what did not fit');
+      // Same default as REST, and the parity is the point: a dump that happened on one door and not the other
+      // would make a truncated read cost different amounts depending on which client the caller picked.
+      assert.equal(out.nextSkip, out.returned, 'and the continuation is there');
+      assert.equal(out.remainder, undefined, 'with no file written, because none was asked for');
+
+      // Then the same call WITH the flag, on the same door — the second half of clause 6b.
+      const dumped = JSON.parse((await session.callTool('recall', {
+        space: SPACE, query: QUERY, types: ['entity'], topK: COUNT,
+        includeFreshWrites: true, maxBytes: tightBytes, remainderDump: true,
+      }))?.content?.[0]?.text ?? '{}');
+      assert.notEqual(dumped.remainder, undefined, 'asked for and not delivered on the MCP door');
+      assert.equal(dumped.remainder.matches, dumped.count - dumped.returned, 'holding only what did not fit');
+
+      // And `skip` continues here too, or the opt-in would strand an MCP caller specifically.
+      const next = JSON.parse((await session.callTool('recall', {
+        space: SPACE, query: QUERY, types: ['entity'], topK: COUNT,
+        includeFreshWrites: true, maxBytes: tightBytes, skip: out.nextSkip,
+      }))?.content?.[0]?.text ?? '{}');
+      assert.equal(next.count, COUNT, 'count stays the full total on a skipped page');
+      assert.ok(next.results.length > 0, 'the next page must not be empty');
+      const firstPage = new Set(out.results.map(x => x.record?._id ?? x._id));
+      for (const x of next.results) {
+        assert.equal(firstPage.has(x.record?._id ?? x._id), false, 'the skipped page repeated a record');
+      }
 
       // A tool result is a model's context window: the budget is the promise, so hold it to the budget.
       assert.ok(text.length <= tightBytes * 1.5,

--- a/testing/standalone/hybrid-retrieval.test.js
+++ b/testing/standalone/hybrid-retrieval.test.js
@@ -258,13 +258,19 @@ describe('every aggregation site orders by rankOf, not by raw score', () => {
   const sortsByRawScore = src =>
     (src.match(/\.sort\(\([^)]*\)\s*=>\s*\(?[a-z]\.score\s*\?\?\s*0\)?\s*-/g) ?? []).length;
 
-  it('the REST recall route merges member spaces with rankOf', () => {
-    assert.ok(/all\.sort\(\(x, y\) => rankOf\(y\) - rankOf\(x\)\)/.test(rest));
+  // The expression this used to spell out is now `byRankThenId`, the shared comparator — same rule, plus a
+  // deterministic tie-break. Rewritten rather than renumbered: asserting the old literal would now be
+  // asserting the absence of the tie-break, and this member merge is the LAST sort before the response, so a
+  // tie left to the database order here is what a paging caller sees as a repeated record.
+  it('the REST recall route merges member spaces by rank, not raw score', () => {
+    assert.ok(/all\.sort\(byRankThenId\)/.test(rest),
+      'the member merge must use the shared rank comparator');
     assert.equal(sortsByRawScore(rest), 0, 'no recall path in this file may sort by raw score');
   });
 
-  it('the MCP recall tool merges member spaces with rankOf', () => {
-    assert.ok(/all\.sort\(\(x, y\) => rankOf\(y\) - rankOf\(x\)\)/.test(mcp));
+  it('the MCP recall tool merges member spaces by rank, not raw score', () => {
+    assert.ok(/all\.sort\(byRankThenId\)/.test(mcp),
+      'the member merge must use the shared rank comparator');
     assert.equal(sortsByRawScore(mcp), 0, 'no recall path in this file may sort by raw score');
   });
 
@@ -274,6 +280,9 @@ describe('every aggregation site orders by rankOf, not by raw score', () => {
   });
 
   it('the raw-score sorts left in recall.ts are the ones that MUST be raw', () => {
+    // Each of the three now ends in `|| byIdAsc(a, b)`, which does not change WHICH signal orders them — it
+    // only makes a tie land the same way twice. The count below is unaffected: the pattern matches the head of
+    // the comparator.
     // Three survive on purpose, and none of them is an output ordering:
     //   1. the pre-fusion sort, which ESTABLISHES the vector ranking fusion consumes;
     //   2. the vector channel handed to RRF, which must be the vector order by definition;

--- a/testing/standalone/ranked-order-is-deterministic.test.js
+++ b/testing/standalone/ranked-order-is-deterministic.test.js
@@ -1,0 +1,169 @@
+/**
+ * A ranked recall has ONE order for one corpus, and every ranking sort goes through the same comparator.
+ *
+ * ## What it is for
+ *
+ * `Array.prototype.sort` is stable, so a comparator returning 0 for two results leaves them in the order the
+ * INPUT had — and that input is whatever the database returned. ELEVEN hand-written comparators — seven in
+ * `recall.ts`, two in `recall-shape.ts`, and one member-space merge on each door — meant two identical recalls
+ * over an unchanged corpus could come back in different orders, with nothing anywhere saying which.
+ *
+ * That was survivable while an answer was always whole. `skip` ended it: a caller continues from `returned`, so
+ * a permutation between two pages repeats some matches and drops others, silently. Caught by the paging E2E on
+ * 28 near-identically-scored records, where page two turned out to be entirely contained in page one.
+ *
+ * ## Both halves, because either alone is weak
+ *
+ * The comparator is exercised — a deliberately tied fixture, shuffled, must sort to one answer. And the SOURCE
+ * is gated, because the defect was eleven copies of a rule rather than a wrong rule: a twelfth would be added by
+ * someone who never saw this file, and it would look exactly like the eleven.
+ *
+ * Run: node --test testing/standalone/ranked-order-is-deterministic.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripComments } from './_strip-comments.mjs';
+
+const { byIdAsc, byRankThenId, rankOf } = await import('../../server/dist/brain/recall-shape.js');
+
+describe('the comparator orders a tie the same way every time', () => {
+  /** Twelve results, ALL on the same score — the case the old comparator left to the database. */
+  const tied = () => Array.from({ length: 12 }, (_, i) => ({
+    _id: `id-${String(i).padStart(2, '0')}`, type: 'entity', score: 0.5,
+  }));
+
+  it('a tie is broken by _id, ascending', () => {
+    const sorted = [...tied()].reverse().sort(byRankThenId).map(r => r._id);
+    assert.deepEqual(sorted, tied().map(r => r._id),
+      'a fully tied set must sort to one order regardless of the order it arrived in');
+  });
+
+  it('and any input permutation lands on that same order', () => {
+    // The property the feature needs is not "sorted" — it is "the SAME sorted". Several distinct input
+    // permutations, one expected output.
+    const want = [...tied()].sort(byRankThenId).map(r => r._id);
+    const rotate = (arr, n) => [...arr.slice(n), ...arr.slice(0, n)];
+    for (const n of [1, 3, 5, 7, 11]) {
+      const got = rotate(tied(), n).sort(byRankThenId).map(r => r._id);
+      assert.deepEqual(got, want, `rotation by ${n} produced a different order`);
+    }
+    const swapped = tied();
+    [swapped[0], swapped[11]] = [swapped[11], swapped[0]];
+    assert.deepEqual(swapped.sort(byRankThenId).map(r => r._id), want, 'a single swap changed the answer');
+  });
+
+  it('score still wins over the tie-break', () => {
+    // The tie-break must be a tie-BREAK. If it ever outranked the score the ranking would be alphabetical,
+    // which would pass every determinism assertion above while destroying the feature.
+    const rows = [
+      { _id: 'zzz', type: 'entity', score: 0.9 },
+      { _id: 'aaa', type: 'entity', score: 0.1 },
+    ];
+    assert.deepEqual(rows.sort(byRankThenId).map(r => r._id), ['zzz', 'aaa'],
+      'the higher score must come first even when its id sorts later');
+  });
+
+  it('and the RANK is the effective one, not `score`', () => {
+    // `rerankScore > fusedScore > score` is the precedence, so a comparator reading `score` would order by a
+    // number that did not rank the results — the defect 3.2.0 fixed by making the stage scores unconditional.
+    const rows = [
+      { _id: 'a', type: 'entity', score: 0.9, rerankScore: 0.1 },
+      { _id: 'b', type: 'entity', score: 0.1, rerankScore: 0.9 },
+    ];
+    assert.equal(rankOf(rows[1]), 0.9, 'rankOf must prefer the rerank score');
+    assert.deepEqual(rows.sort(byRankThenId).map(r => r._id), ['b', 'a'],
+      'the reranked order must win, or the last ranking stage is discarded at the sort');
+  });
+
+  it('byIdAsc is a total order — no pair returns 0 unless the ids are equal', () => {
+    // A tie-break that can itself tie is not one. This is why it is `_id` and not `seq` or `createdAt`.
+    assert.equal(byIdAsc({ _id: 'a' }, { _id: 'b' }), -1);
+    assert.equal(byIdAsc({ _id: 'b' }, { _id: 'a' }), 1);
+    assert.equal(byIdAsc({ _id: 'a' }, { _id: 'a' }), 0);
+  });
+});
+
+describe('no ranking sort is written by hand', () => {
+  /*
+   * BOTH DOORS TOO, and they are the ones that matter most.
+   *
+   * `all.sort(...)` in each route/tool is the member-space merge — the LAST sort before the response, so a tie
+   * left to the database order there is precisely what a paging caller sees as a repeated record. A sweep
+   * scoped to `brain/` would have said the ranking was deterministic while the final sort was not, which is
+   * the reported-place-only mistake this repo keeps paying for.
+   */
+  const FILES = [
+    'server/src/brain/recall.ts', 'server/src/brain/recall-shape.ts',
+    'server/src/api/brain/search.ts', 'server/src/mcp/tools/search.ts',
+  ];
+
+  it('the bare comparators are gone from every recall path', () => {
+    /*
+     * A TENTH COPY IS THE REGRESSION, not a wrong tenth copy.
+     *
+     * Every one of the eleven was locally correct and read as obviously right. The gate has to be on the SHAPE
+     * — a comparator that ends at the score — because that is what the next person will write, and it is
+     * indistinguishable from the eleven that were here.
+     *
+     * Comments are stripped first: `byRankThenId`'s own doc block quotes the banned expression to explain what
+     * it replaced, and a source gate that fires on the explanation of the fix is a gate that punishes writing
+     * one down.
+     */
+    for (const f of FILES) {
+      const code = stripComments(readFileSync(f, 'utf8'));
+      // The bare rank comparator, with nothing after it.
+      assert.doesNotMatch(code, /rankOf\(b\) - rankOf\(a\)\s*\)/,
+        `${f} sorts by rank with no tie-break — use byRankThenId, or two identical recalls can differ`);
+      assert.doesNotMatch(code, /\(b\.score \?\? 0\) - \(a\.score \?\? 0\)\s*\)/,
+        `${f} sorts by score with no tie-break — use byRankThenId`);
+      assert.doesNotMatch(code, /b\.score - a\.score\s*\)/,
+        `${f} sorts by score with no tie-break`);
+    }
+  });
+
+  it('and the comparator is actually used, in both files', () => {
+    // The mirror of the check above: satisfying it by deleting the sorts would be worse than the defect.
+    for (const f of FILES) {
+      const code = stripComments(readFileSync(f, 'utf8'));
+      assert.match(code, /byRankThenId/,
+        `${f} no longer references the shared comparator — satisfying the check above by deleting the sort `
+        + 'would be worse than the defect');
+    }
+  });
+
+  it('every remaining comparator in the recall paths ends in a tie-break', () => {
+    /*
+     * Scoped from the SHAPE rather than from a list of names.
+     *
+     * Two of the sorts rank things that are not `RecallResult` — a lexical hit by `lexicalScore`, an id list by
+     * a looked-up score — so they cannot take `byRankThenId` and had `|| byIdAsc(...)` appended instead. A gate
+     * that only banned the three known expressions would say nothing about those, and they are exactly where
+     * a future tie-break gets forgotten, because they each look like a one-off.
+     */
+    for (const f of FILES) {
+      const code = stripComments(readFileSync(f, 'utf8'));
+      const inline = [...code.matchAll(/\.sort\(\((?:a, b|a,b)\) => ([^\n]*)\)/g)];
+      for (const m of inline) {
+        const body = m[1];
+        assert.match(body, /\|\|/,
+          `${f}: an inline ranking comparator with no tie-break — \`${body.trim().slice(0, 90)}\`. Every sort `
+          + 'that decides the order a caller sees must end in one, or `skip` can repeat a record.');
+      }
+      // Counted rather than listed, the same way `hybrid-retrieval.test.js` counts its raw-score sorts: a NEW
+      // inline comparator has to come here and justify itself. Six survive in `recall.ts` and each has a
+      // reason it cannot take the shared one —
+      //   1-3. the pre-fusion sort, the vector channel handed to RRF, and `findSimilar`, all of which must
+      //        order by RAW score rather than by `rankOf` (see `hybrid-retrieval.test.js`, which counts them);
+      //     4. the lexical channel, ordered by `lexicalScore`;
+      //     5. the candidate cap, which sorts a list of ID STRINGS through a lookup, so there is no object to
+      //        hand a comparator;
+      //     6. the duplicate-match map, whose `score` is non-optional and not a `RecallResult`.
+      // Everything that CAN take `byRankThenId` does, which is why the other three files have none.
+      const expected = f.endsWith('brain/recall.ts') ? 6 : 0;
+      assert.equal(inline.length, expected,
+        `${f} has ${inline.length} inline comparators, expected ${expected} — a new one needs a reason it `
+        + 'cannot use byRankThenId, written down here');
+    }
+  });
+});

--- a/testing/standalone/result-spill-suppresses-vectors.test.js
+++ b/testing/standalone/result-spill-suppresses-vectors.test.js
@@ -160,6 +160,58 @@ describe('the remainder is written out, with a TTL', () => {
     }
   });
 
+  it('every result path passes the paging through — all eight, on both doors', () => {
+    /*
+     * THE SAME SHAPE AS THE DEFECT THAT MADE THIS FILE, one clause later.
+     *
+     * The record cap was applied in four of eight result paths and missing from the others; an E2E found it,
+     * because every rule the source gate checked was true in the branch it looked at. `skip` and
+     * `remainderDump` are now the same kind of thing: eight sites, one rule, and a site that forgets them
+     * silently serves page one to a caller asking for page two and writes a file nobody wanted.
+     */
+    for (const [name, src] of [['REST', read('server/src/api/brain/search.ts')],
+                               ['MCP', read('server/src/mcp/tools/search.ts')]]) {
+      const envelopes = (src.match(/budgetedEnvelope\(\{/g) ?? []).length;
+      const skips = (src.match(/skip: paging\.skip,/g) ?? []).length;
+      const dumps = (src.match(/remainderDump: paging\.remainderDump,/g) ?? []).length;
+      assert.equal(skips, envelopes,
+        `${name}: ${envelopes} budgeted paths but ${skips} pass \`skip\` — a path that drops it re-serves the `
+        + 'first page to a caller who asked to continue');
+      assert.equal(dumps, envelopes,
+        `${name}: ${envelopes} budgeted paths but ${dumps} pass \`remainderDump\` — a path that drops it `
+        + 'writes a file on a read that did not ask for one');
+      // Validated in ONE place, not parsed per route: a `skip` that 400s on one door and floors to zero on
+      // the other is this codebase's most-produced defect, and both doors call the same resolver for that
+      // reason.
+      assert.match(src, /resolvePaging\(/, `${name} must resolve paging through the shared validator`);
+      assert.doesNotMatch(src, /Number\(\s*(req\.body|a)\[['"]skip['"]\]/,
+        `${name} parses \`skip\` itself — the second implementation is the one that ends up weaker`);
+    }
+  });
+
+  it('the continuation and the opt-in dump cannot be separated', () => {
+    /*
+     * The dump is only ALLOWED to be optional because there is another way to the remainder. That is one
+     * dependency between two clauses, and it lives in `budgetFields`: `nextSkip` is emitted exactly when
+     * `truncated`, unconditionally, with no flag of its own.
+     *
+     * Gated at the source because the failure is an omission. Making the dump opt-in is a one-line change and
+     * looks complete on its own; the response it produces is a caller told there is more with nothing to act
+     * on, which is the regression #969 shipped in its first cut and had to fix.
+     */
+    const budget = read('server/src/brain/result-budget.ts');
+    assert.match(budget, /\.\.\.\(outcome\.truncated \? \{ nextSkip: skip \+ outcome\.returned\.length \} : \{\}\)/,
+      'nextSkip must be emitted whenever the answer truncated, and be absolute rather than page-relative');
+    assert.match(budget, /if \(outcome\.truncated && opts\.remainderDump === true\)/,
+      'the dump must be gated on an explicit true — a truthy check would make any value opt in');
+    // `count` is the FULL total on a skipped page, which requires slicing inside the envelope rather than at
+    // the call sites. A route that shortened its own array would make `count` shrink page by page.
+    assert.match(budget, /const page = skip > 0 \? opts\.results\.slice\(skip\) : opts\.results;/,
+      'the skip must be applied inside the envelope, or `count` stops reporting the total');
+    assert.match(budget, /budgetFields\(outcome, opts\.results\.length, opts\.budgetBytes, skip\)/,
+      'and the total handed to budgetFields must be the pre-skip length');
+  });
+
   it('`count` still reports the real total, not the sample', () => {
     // The sample is three; a caller who read `count: 3` would conclude the space holds three matching records.
     // `count` moved into `budgetFields`, which is the point: one definition instead of four sites each


### PR DESCRIPTION
## What

`recall` and `find-similar` gain **`skip`** and **`remainderDump`** on both doors, and a truncated response
gains **`nextSkip`**. Two clauses, and they are one change.

## Why `skip`

The byte budget returns the longest prefix of the ranked matches. Until now a caller who overflowed it had
exactly one route to the rest — download a file the server had written for them. `nextSkip` is the other
route, and it is the one the common caller wants.

Stated rather than left derivable: `skip + returned` is arithmetic a caller can get wrong, especially on the
second page where `skip` was already non-zero.

`count` stays the **full** match total on every page. The slice happens inside `budgetedEnvelope`, not at the
eight call sites, so no route can shorten its own array and quietly redefine `count` into "the total after the
skip" — a number that states the size of nothing.

## Why `remainderDump` defaults to `false`

Writing the remainder to `_tmp/` is a **write on a read path**. It counts against space storage, and on
breituai-platform's instance those land in a store whose `storage_used_bytes` collector already takes ~22 s to
walk — so a read that overflowed made an operator's metrics slower. It happened on every truncated recall
whether anyone opened the file or not.

## Why they cannot ship separately

Making the dump opt-in is a one-line change that looks complete on its own. The response it produces is a
caller told there is more with nothing to act on — the exact regression the byte budget shipped in its first
cut and had to fix. `nextSkip` is emitted unconditionally whenever `truncated`, with no flag of its own, and
that dependency is gated at the source because the failure mode is an omission rather than a wrong value.

## Gates

- **`result-spill-suppresses-vectors.test.js`** counts `budgetedEnvelope` sites and requires every one to pass
  both parameters. Same shape as the defect that made this file: the record cap was applied in four of eight
  paths and the source gate passed because every rule it checked was true in the branch it looked at.
- **`result-spill-both-doors.test.js`** *follows* `nextSkip` to exhaustion under a budget that bites and checks
  the union of pages against the seeded ids. "The field is present" would pass on an off-by-one that drops or
  duplicates a record on every page. It also asserts the default writes **no** file and that the flag does.
- **Mutation-tested**: dropping the pair from one REST path, emitting `nextSkip` only on the first page, a
  truthy dump check instead of `=== true`, and `count` reporting the post-skip total — all four caught.

## The five places

REST route · both MCP tool schemas · `docs/integration-guide/` (04a, 04d, 04e) · `docs/userguide/02-brain.md`.
**Token rights do not apply** — no new route, and both existing ones keep their rights rows.

Also corrected the stale promise in both tool descriptions and both `maxBytes` doc rows, which said `remainder`
points at what did not fit. A schema description is what a caller reads *while constructing arguments*; leaving
that sentence would have integrators asking for a file they no longer get.

## Breaking

A caller relying on `remainder` appearing unasked must now send `remainderDump: true`.
