### PR TITLE
fix(sync): a watermark could advance past a record the peer never received

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A sync watermark could advance past a record the peer never received, and then nothing ever sent it again.**
+  `lastSeqPushed` and `lastSeqReceived` are one number per member per space, and each cycle runs **five**
+  independent transfers under it — tombstones plus memories, entities, edges and chrono. Any one can stop early:
+  a non-`2xx` from the peer, or its 50-page cap.
+
+  Both watermarks were set to the **maximum** across those transfers, which is only correct when all of them
+  finished. A memories push that failed at seq 300, in a cycle where the entities push succeeded to seq 500,
+  moved the watermark to 500 — and **the memory at seq 400 was behind it permanently.** Nothing errored at the
+  cycle level, one warn was logged and then discarded, and every later cycle reported success while never
+  sending that record again. The pull side had the same shape, and its tombstone fetch was worse: a non-`ok`
+  response there had no `else` at all — nothing applied, nothing logged, and the watermark moved past the
+  deletions anyway.
+
+  **`docs/sync-protocol.md` already described the correct rule**, in three places: *"if a sync fails mid-way, the
+  watermark is not advanced"*, *"a network drop mid-push persists nothing for that cycle"*, and the page-cap
+  paragraph's *"nothing is lost"*. The engine did not implement it. All three statements were true per transfer
+  and false for the number that actually gates the next cycle.
+
+  The rule is now in one place, `sync/watermark.ts`: a transfer that ran to completion places no limit; one that
+  stopped early limits the advance to the last position it actually delivered; the lowest limit wins; and the
+  watermark never moves backwards.
+
+  **"Never advance when something was truncated" would have been the wrong fix, and this is the part worth
+  keeping.** It livelocks. A transfer that stopped at its page cap has more to give, so the next cycle would
+  re-fetch the same pages and stop in the same place for ever, and a space more than one cap behind could never
+  catch up — trading one lost record for a space that syncs nothing. A limit keeps both properties: nothing is
+  skipped, and a capped transfer still advances by a full page-set per cycle.
+
+  Two details that are load-bearing rather than incidental. The push limit is the last **accepted** seq, not the
+  author-guarded maximum: on a `pubsub` or `braintree` network the push filter is empty and this instance relays
+  every document it holds, so the author-guarded number would let the watermark pass a relayed document the peer
+  never accepted and nothing else was going to send. And the pull records its position **after** the batch
+  upsert, never before — vouching first would promise records that a throw between the two had lost.
+
+  A cycle that held its watermark back now says so and names the transfers, because a watermark quietly staying
+  put reads exactly like a cycle with nothing to do.
+
+  **This is the collection axis of a hypothesis recorded as killed on the author axis.** Both existing author
+  guards are correct and unchanged — they govern *whose* records may move a watermark, never *whether a transfer
+  finished*. It is **not** established as the cause of the intermittent pub/sub propagation stall under
+  investigation: that run's logs contain no truncated transfer at all. The two are tracked separately until one
+  is measured to explain the other.
+
+  Eight mutations, eight caught, including the pre-fix state and both wrong-fix directions.
 - **An unconfigured optional feature was reporting fourteen working spaces as broken, permanently.** Enabling
   face recognition with nothing able to write a face vector — `FACE_RECOGNITION_ENABLED=true`, no
   `faceRecognition.externalModel`, no model files placed under `DATA_ROOT` — made every space report a red

--- a/docs/integration-guide/09-sync-api.md
+++ b/docs/integration-guide/09-sync-api.md
@@ -176,6 +176,7 @@ error.
 **The `sinceSeq` you send is recorded.** The serving instance stores it as `lastSeqServed` for your peer identity and prunes tombstones that every member has pulled past — that is the only retention bound on the collection, because an age-based one would let a long-absent peer resurrect a deleted record. Two consequences for an integrator:
 
 - **Send your real watermark, and never a value higher than what you have applied.** Claiming a position you have not reached lets the other side drop tombstones you still need.
+  - **And a watermark shared across several transfers may only reach where ALL of them are complete.** A cycle that fetches tombstones plus four collections under one `sinceSeq` must limit its next `sinceSeq` to the lowest position among the transfers that stopped early — a non-`2xx`, or a page cap. Taking the maximum instead claims a position the stopped transfer never reached, and its unserved records then sit behind your watermark permanently while every later cycle looks successful. Our own engine had this defect until 3.2.0.
 - **A peer that never pulls tombstones blocks pruning for its spaces** — deliberately, since "has not pulled" and "has caught up" must not look alike.
 
 ### File Sync Artifacts

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -56,7 +56,11 @@ Four high-water marks are kept per member. The first two prevent redundant data 
 | `lastSeqServed[spaceId]` | `Record<string,number>` | Highest `sinceSeq` this peer has pulled **our** tombstones from — its confirmed position in our data ([details](#lastseqserved--the-mirror-watermark-and-why-tombstone-retention-needs-it)) |
 | `lastFileTombstoneAckedAt[spaceId]` | `Record<string,string>` | Newest `deletedAt` among FILE tombstones this peer answered `200` to on a push ([details](#lastfiletombstoneackedat--the-same-bound-for-file-tombstones-from-acknowledgement)) |
 
-All three are stored per member in the config file. After a successful sync they are written through the coalesced asynchronous config flush (`saveConfigSoon`) rather than a blocking synchronous write — sync bookkeeping never stalls the event loop. If a sync fails mid-way, the watermark is not advanced — the next cycle retries from the last safe point, giving at-least-once delivery semantics (re-delivery is harmless: everything is re-derived from `seq`).
+All three are stored per member in the config file. After a successful sync they are written through the coalesced asynchronous config flush (`saveConfigSoon`) rather than a blocking synchronous write — sync bookkeeping never stalls the event loop. If a sync fails mid-way, the watermark is not advanced past the failure — the next cycle retries from the last safe point, giving at-least-once delivery semantics (re-delivery is harmless: everything is re-derived from `seq`).
+
+**One watermark, five transfers, and that is what "the last safe point" has to mean.** A cycle runs five independent transfers under each watermark — tombstones plus memories, entities, edges and chrono — and any one of them can stop early: a non-`2xx` from the peer, or its page cap. **The watermark advances only as far as EVERY transfer in the cycle is complete through.** A transfer that finished places no limit; one that stopped early limits the advance to the last position it actually delivered, and the lowest such limit wins.
+
+Before 3.2.0 both watermarks were set to the *maximum* across the transfers, which is only correct when all of them finished. A memories push that failed at seq 300, in a cycle where the entities push succeeded to seq 500, moved the watermark to 500 — and the memory at seq 400 was behind it permanently, re-sent by nothing, while every later cycle reported success. A held-back cycle now says so in the log, naming which transfers stopped, because a watermark quietly staying put reads exactly like a cycle with nothing to do.
 
 ---
 
@@ -106,6 +110,8 @@ Without `?full=true` the list endpoints return `{_id, seq}` stubs, and the calle
 With `?full=true` the full document payload is embedded in the paginated list response. The pull phase is `ceil(N/200)` requests regardless of how many documents exist.
 
 Pagination is additionally capped at **50 pages per type per cycle** (~10,000 documents). A backlog larger than that is drained across successive cycles — the watermark advances each cycle, so nothing is lost, it just takes more than one cycle to catch up.
+
+Hitting that cap counts as a transfer stopping early (see [watermarks](#watermarks)), so it limits how far the shared watermark may advance — to exactly what this type delivered. That is also why the rule is a *limit* rather than "do not advance at all": a capped type has more to give, and refusing to advance would make it re-fetch the same pages every cycle and never catch up.
 
 **Impact at 100 ms WAN latency:**
 
@@ -200,7 +206,9 @@ Response: `{ status: 'ok', memories: {inserted,updated,forked,skipped,tombstoned
 
 ### `lastSeqPushed` update
 
-After a successful batch push, `lastSeqPushed[spaceId]` is advanced to the highest `seq` **among documents authored by this instance** (`doc.author.instanceId === cfg.instanceId`). The maximum is tracked per acknowledged batch, but persistence happens once after all four collections have pushed — a network drop mid-push persists nothing for that cycle. That is safe, just conservative: the next cycle re-pushes from the old watermark and the upserts are idempotent.
+After a successful batch push, `lastSeqPushed[spaceId]` is advanced to the highest `seq` **among documents authored by this instance** (`doc.author.instanceId === cfg.instanceId`), and never past the point every transfer in the cycle is complete through (see [watermarks](#watermarks)). The maximum is tracked per acknowledged batch and persisted once after all four collections have pushed, so a drop mid-push leaves the watermark at the last position the peer actually accepted. The next cycle re-pushes from there and the upserts are idempotent.
+
+**The limit is the last ACCEPTED seq, not the author-guarded maximum**, and the two answer different questions: the author guard says how far this instance's own records reached, while the accepted position says how far the transfer got at all. On a `pubsub` or `braintree` network the push filter is empty — this instance relays every document it holds — so limiting by the author-guarded number would let the watermark advance past a relayed document the peer never accepted, and nothing else was going to send it.
 
 Relayed docs (received from a third peer and stored locally) are pushed to other members but do **not** advance `lastSeqPushed`. Their seq values belong to the originating instance's counter and could be arbitrarily higher than the local counter, which would incorrectly suppress future pushes of this instance's own work.
 

--- a/server/src/sync/engine.ts
+++ b/server/src/sync/engine.ts
@@ -25,6 +25,8 @@ import { recordFileTombstoneAck, ackedPositionFrom } from './file-tombstone-ack.
 import { recordSyncResult, type SyncCounts } from './history.js';
 import { buildFileManifest } from '../files/manifest.js';
 import { log } from '../util/log.js';
+import { resolveWatermark, truncationWarn, type TransferOutcome } from './watermark.js';
+import { pullTombstones, pushTombstones } from './tombstone-transfer.js';
 import { applyConcludedSpaceRounds } from '../spaces/apply-wipe-round.js';
 import { bumpSeq, isSeqImplausible } from '../util/seq.js';
 import { peerSafeFetch, isPeerUrlAllowed, PEER_TRANSFER_TIMEOUT_MS } from './peer-fetch.js';
@@ -850,42 +852,37 @@ async function pullFromPeer(
   const memberState = freshNet?.members.find(m => m.instanceId === member.instanceId);
   const sinceSeq = memberState?.lastSeqReceived?.[spaceId] ?? 0;
 
-  // Pull tombstones first — so deletions apply before we potentially upsert deleted docs
-  try {
-    const tombsUrl = `${member.url}/api/sync/tombstones?spaceId=${encodeURIComponent(remoteSpaceId)}&networkId=${encodeURIComponent(networkId)}&sinceSeq=${sinceSeq}`;
-    const resp = await peerSafeFetch(tombsUrl, opts());
-    if (resp.ok) {
-      const data = await boundedJson<{ memories?: TombstoneDoc[]; entities?: TombstoneDoc[]; edges?: TombstoneDoc[]; chrono?: TombstoneDoc[] }>(resp, 'sync peer');
-      const all = [...(data.memories ?? []), ...(data.entities ?? []), ...(data.edges ?? []), ...(data.chrono ?? [])];
-      // The peer we pulled from is the authenticated source. Its own tombstones
-      // (issuer === member) are authorised; a tombstone it relays on behalf of a
-      // third author is refused here and applied instead when we sync directly
-      // with that author.
-      for (const t of all) { await applyRemoteTombstone(t, { peerInstanceId: member.instanceId }); }
-    }
-  } catch (err) {
-    log.warn(`pullFromPeer tombstones from ${member.label}: ${err}`);
-  }
+  // Tombstones first, so deletions apply before anything that would re-upsert a deleted doc. Both directions
+  // live in `sync/tombstone-transfer.ts`; its own doc block says why they belong together.
+  const tombstones = await pullTombstones({ member, spaceId, remoteSpaceId, networkId, sinceSeq, requestInit: opts });
 
   // Pull memories — use full=true to return complete docs in a single pass,
   // eliminating the N per-document secondary fetches that would be brutal over WAN.
   let highestSeq = sinceSeq;
   let overallMaxSeq = 0; // Track the highest seq seen across ALL items (used to bump local counter)
 
-  type PullResult = { count: number; highSeq: number; maxSeq: number };
+  type PullResult = { count: number; highSeq: number; maxSeq: number } & TransferOutcome;
   async function pullType<T extends MemoryDoc | EntityDoc | EdgeDoc | ChronoEntry>(
     urlSuffix: string,
   ): Promise<PullResult> {
     let count = 0, highSeq = sinceSeq, maxSeq = 0;
     let cur: string | null = null;
     let pg = 0;
+    // Complete THROUGH here. Pages arrive in ascending seq order, so the highest seq applied is also the
+    // position this transfer is complete up to — which is what a shared watermark needs when it stops early.
+    let deliveredThrough = sinceSeq;
+    let truncated = false;
     do {
       const params = new URLSearchParams({
         spaceId: remoteSpaceId, networkId, sinceSeq: String(sinceSeq), limit: '200', full: 'true',
         ...(cur ? { cursor: cur } : {}),
       });
       const resp = await peerSafeFetch(`${member.url}/api/sync/${urlSuffix}?${params}`, batchOpts());
-      if (!resp.ok) { log.warn(`Pull ${urlSuffix} from ${member.label} returned ${resp.status}`); break; }
+      if (!resp.ok) {
+        truncated = true;
+        log.warn(truncationWarn(`Pull ${urlSuffix} from`, member.label ?? '', spaceId, resp.status, deliveredThrough));
+        break;
+      }
       const { items, nextCursor } = await boundedJson<{
         items: (T | { _id: string; seq: number; deletedAt: string })[]; nextCursor: string | null;
       }>(resp, 'sync peer');
@@ -912,9 +909,20 @@ async function pullFromPeer(
         }
       }
       await batchUpsertBySeq<T>(`${spaceId}_${urlSuffix}`, pageDocs, spaceId);
+      // Only after the page is APPLIED. Recording it before the upsert would vouch for records that a throw
+      // between the two would have lost.
+      if (maxSeq > deliveredThrough) deliveredThrough = maxSeq;
       cur = nextCursor; pg++;
     } while (cur && pg < 50);
-    return { count, highSeq, maxSeq };
+    // The page cap is a truncation too, and it is the one that made "never advance on truncation" the wrong
+    // fix: this transfer genuinely has more to give, so it must keep the ceiling AND keep making progress.
+    // The page cap is a truncation too, and it is why "never advance on truncation" was the wrong fix: this
+    // transfer has more to give, so it must cap the watermark AND keep making progress.
+    if (cur) {
+      truncated = true;
+      log.warn(truncationWarn(`Pull ${urlSuffix} from`, member.label ?? '', spaceId, `${pg}-page cap`, deliveredThrough));
+    }
+    return { count, highSeq, maxSeq, deliveredThrough, truncated };
   }
 
   const memR = await pullType<MemoryDoc>('memories');
@@ -927,7 +935,21 @@ async function pullFromPeer(
   pulledEdges = edgeR.count;
   pulledChrono = chronoR.count;
 
-  highestSeq = Math.max(memR.highSeq, entR.highSeq, edgeR.highSeq, chronoR.highSeq);
+  /*
+   * ONE WATERMARK, FIVE TRANSFERS — so the max is only safe if all five finished.
+   *
+   * `Math.max` across the four types was the old rule, and it moved `lastSeqReceived` to a position a
+   * truncated type had not reached: its unserved records then sat behind the watermark for ever, while every
+   * later cycle reported success. `safeWatermark` lowers the ceiling to whatever the stopped transfers can
+   * actually vouch for. All five are passed, including the tombstones — an omitted transfer places no ceiling,
+   * which makes it exactly the one that gets skipped.
+   */
+  highestSeq = resolveWatermark({
+    direction: 'receive', peerLabel: member.label ?? member.instanceId, spaceId,
+    from: sinceSeq, candidate: Math.max(memR.highSeq, entR.highSeq, edgeR.highSeq, chronoR.highSeq),
+    transfers: { memories: memR, entities: entR, edges: edgeR, chrono: chronoR, tombstones },
+    warn: log.warn,
+  });
   overallMaxSeq = Math.max(memR.maxSeq, entR.maxSeq, edgeR.maxSeq, chronoR.maxSeq);
 
   // Bump the local seq counter so future local writes always get a seq higher
@@ -974,25 +996,8 @@ async function pushToPeer(
   const memberState = freshNet?.members.find(m => m.instanceId === member.instanceId);
   const lastSeqPushed = memberState?.lastSeqPushed?.[spaceId] ?? 0;
 
-  // Push tombstones — only those newer than the last push watermark
-  // Push tombstones — page through all tombstones since the last push watermark.
-  // A hard cap would silently drop deletions after long offline periods.
-  {
-    let tsCursor: number = lastSeqPushed;
-    const tsEndpoint = `${member.url}/api/sync/tombstones?spaceId=${encodeURIComponent(remoteSpaceId)}&networkId=${encodeURIComponent(networkId)}`;
-    while (true) {
-      const page = await listTombstones(spaceId, tsCursor, 500);
-      if (page.length === 0) break;
-      const resp = await peerSafeFetch(tsEndpoint, {
-        ...opts(),
-        method: 'POST',
-        body: JSON.stringify({ tombstones: page }),
-      });
-      if (!resp.ok) { log.warn(`Push tombstones to ${member.label}: ${resp.status}`); break; }
-      tsCursor = page[page.length - 1]!.seq;
-      if (page.length < 500) break;
-    }
-  }
+  // Tombstones first — paged, with no hard cap, since one would silently drop deletions after a long absence.
+  const tombstones = await pushTombstones({ member, spaceId, remoteSpaceId, networkId, lastSeqPushed, requestInit: opts });
 
   // Fetch only docs changed since the last push — read and send in PUSH_BATCH_SIZE
   // chunks directly from MongoDB without loading the whole result set into memory first.
@@ -1012,10 +1017,11 @@ async function pushToPeer(
   async function pushCollection<T extends MemoryDoc | EntityDoc | EdgeDoc | ChronoEntry>(
     collName: string,
     payloadKey: 'memories' | 'entities' | 'edges' | 'chrono',
-  ): Promise<{ pushed: number; maxSeq: number }> {
+  ): Promise<{ pushed: number; maxSeq: number } & TransferOutcome> {
     let pushed = 0;
     let localMaxSeq = lastSeqPushed;
     let seqCursor = lastSeqPushed;
+    let truncated = false;
     while (true) {
       const batch = await col<T>(collName)
         .find(asFilter<T>({ seq: { $gt: seqCursor }, ...ownedFilter }))
@@ -1028,7 +1034,8 @@ async function pushToPeer(
         body: JSON.stringify({ [payloadKey]: batch }),
       });
       if (!resp.ok) {
-        log.warn(`Batch push ${payloadKey} to ${member.label}: ${resp.status}`);
+        truncated = true;
+        log.warn(truncationWarn(`Batch push ${payloadKey} to`, member.label ?? '', spaceId, resp.status, seqCursor));
         break;
       }
       // A 200 does not mean every record landed: the peer can discard a memory whose fork chain is at its
@@ -1043,7 +1050,12 @@ async function pushToPeer(
       seqCursor = (batch[batch.length - 1] as MemoryDoc).seq;
       if (batch.length < PUSH_BATCH_SIZE) break;
     }
-    return { pushed, maxSeq: localMaxSeq };
+    // `deliveredThrough` is `seqCursor` — the last seq the peer ACCEPTED — and not `localMaxSeq`, which is
+    // author-guarded. The two answer different questions: `localMaxSeq` is how far our own records reached,
+    // `seqCursor` is how far this transfer got at all. Capping with the author-guarded number would let the
+    // watermark advance past a foreign doc that was never accepted, which on a pubsub or braintree network
+    // (where `ownedFilter` is empty and we relay everything) is a record only we were going to send.
+    return { pushed, maxSeq: localMaxSeq, deliveredThrough: seqCursor, truncated };
   }
 
   const memP = await pushCollection<MemoryDoc>(`${spaceId}_memories`, 'memories');
@@ -1055,7 +1067,13 @@ async function pushToPeer(
   pushedEntities = entP.pushed;
   pushedEdges = edgeP.pushed;
   pushedChrono = chronoP.pushed;
-  maxSeqPushed = Math.max(memP.maxSeq, entP.maxSeq, edgeP.maxSeq, chronoP.maxSeq);
+  // Same rule as the pull, same function — see `sync/watermark.ts` for why it is not two implementations.
+  maxSeqPushed = resolveWatermark({
+    direction: 'push', peerLabel: member.label ?? member.instanceId, spaceId,
+    from: lastSeqPushed, candidate: Math.max(memP.maxSeq, entP.maxSeq, edgeP.maxSeq, chronoP.maxSeq),
+    transfers: { memories: memP, entities: entP, edges: edgeP, chrono: chronoP, tombstones },
+    warn: log.warn,
+  });
 
   // Persist the push high-water mark so next sync only sends new/changed docs
   if (maxSeqPushed > lastSeqPushed) {

--- a/server/src/sync/tombstone-transfer.ts
+++ b/server/src/sync/tombstone-transfer.ts
@@ -1,0 +1,110 @@
+/**
+ * The tombstone half of a sync cycle — both directions, side by side.
+ *
+ * ## Why it lives here rather than in `engine.ts`
+ *
+ * Pull and push each had their own inline block, twenty lines apart in a thousand-line file, and the two halves of
+ * one protocol phase never got read together. That cost something specific: the pull's `!resp.ok` branch **did not
+ * exist**. A peer answering `503` to a tombstone fetch applied nothing, logged nothing, and the cycle advanced its
+ * watermark past the deletions anyway. The push side had a warn for the same case. One phase, two implementations,
+ * and the weaker one silently won — which `CLAUDE.md` names as the defect this codebase produces most.
+ *
+ * ## Both return a `TransferOutcome`, and that is the point
+ *
+ * Tombstones travel under the SAME `lastSeqReceived` / `lastSeqPushed` as the four document collections. A
+ * deletion that did not transfer, followed by a watermark that moved past it, is a deletion that never propagates
+ * — the record stays alive on the peer for ever and every later cycle reports success. So each direction reports
+ * how far it actually got, and `sync/watermark.ts` limits the shared watermark to it.
+ */
+import { peerSafeFetch } from './peer-fetch.js';
+import { boundedJson } from '../util/bounded-read.js';
+import { applyRemoteTombstone, listTombstones } from '../brain/tombstones.js';
+import { log } from '../util/log.js';
+import type { NetworkMember, TombstoneDoc } from '../config/types.js';
+import type { TransferOutcome } from './watermark.js';
+
+/** Tombstones are paged at 500. A hard cap would silently drop deletions after a long absence, so there is none. */
+const TOMBSTONE_PAGE = 500;
+
+/**
+ * Fetch the peer's tombstones since `sinceSeq` and apply them.
+ *
+ * Called BEFORE the document pull so deletions land before anything that would re-upsert a deleted doc.
+ */
+export async function pullTombstones(opts: {
+  member: NetworkMember;
+  spaceId: string;
+  remoteSpaceId: string;
+  networkId: string;
+  sinceSeq: number;
+  requestInit: () => RequestInit;
+}): Promise<TransferOutcome> {
+  const { member, spaceId, remoteSpaceId, networkId, sinceSeq, requestInit } = opts;
+  const outcome: TransferOutcome = { deliveredThrough: sinceSeq, truncated: false };
+  try {
+    const url = `${member.url}/api/sync/tombstones?spaceId=${encodeURIComponent(remoteSpaceId)}`
+      + `&networkId=${encodeURIComponent(networkId)}&sinceSeq=${sinceSeq}`;
+    const resp = await peerSafeFetch(url, requestInit());
+    if (!resp.ok) {
+      // THE BRANCH THAT DID NOT EXIST. Silence here meant the deletions were skipped and the watermark moved
+      // past them, so the next cycle asked for tombstones newer than ones it had never seen.
+      outcome.truncated = true;
+      log.warn(
+        `Pull tombstones from ${member.label} returned ${resp.status} — holding the receive watermark for `
+        + `space '${spaceId}' at ${sinceSeq} so the deletions are re-requested next cycle.`,
+      );
+      return outcome;
+    }
+    const data = await boundedJson<{
+      memories?: TombstoneDoc[]; entities?: TombstoneDoc[]; edges?: TombstoneDoc[]; chrono?: TombstoneDoc[];
+    }>(resp, 'sync peer');
+    const all = [
+      ...(data.memories ?? []), ...(data.entities ?? []), ...(data.edges ?? []), ...(data.chrono ?? []),
+    ];
+    // The peer we pulled from is the authenticated source. Its own tombstones (issuer === member) are
+    // authorised; a tombstone it relays on behalf of a third author is refused here and applied instead when we
+    // sync directly with that author.
+    for (const t of all) { await applyRemoteTombstone(t, { peerInstanceId: member.instanceId }); }
+  } catch (err) {
+    outcome.truncated = true;
+    log.warn(`pullFromPeer tombstones from ${member.label}: ${err}`);
+  }
+  return outcome;
+}
+
+/** Send our tombstones newer than `lastSeqPushed`, paging until the peer has them all. */
+export async function pushTombstones(opts: {
+  member: NetworkMember;
+  spaceId: string;
+  remoteSpaceId: string;
+  networkId: string;
+  lastSeqPushed: number;
+  requestInit: () => RequestInit;
+}): Promise<TransferOutcome> {
+  const { member, spaceId, remoteSpaceId, networkId, lastSeqPushed, requestInit } = opts;
+  const outcome: TransferOutcome = { deliveredThrough: lastSeqPushed, truncated: false };
+  const endpoint = `${member.url}/api/sync/tombstones?spaceId=${encodeURIComponent(remoteSpaceId)}`
+    + `&networkId=${encodeURIComponent(networkId)}`;
+  let cursor = lastSeqPushed;
+  for (;;) {
+    const page = await listTombstones(spaceId, cursor, TOMBSTONE_PAGE);
+    if (page.length === 0) break;
+    const resp = await peerSafeFetch(endpoint, {
+      ...requestInit(), method: 'POST', body: JSON.stringify({ tombstones: page }),
+    });
+    if (!resp.ok) {
+      // Caps the shared watermark. A tombstone page the peer refused, followed by a watermark that advanced past
+      // it, is a deletion this instance will never send again.
+      outcome.truncated = true;
+      log.warn(
+        `Push tombstones to ${member.label}: ${resp.status} — delivered through seq ${cursor}, so the push `
+        + `watermark for space '${spaceId}' is held there.`,
+      );
+      break;
+    }
+    cursor = page[page.length - 1]!.seq;
+    outcome.deliveredThrough = cursor;
+    if (page.length < TOMBSTONE_PAGE) break;
+  }
+  return outcome;
+}

--- a/server/src/sync/watermark.ts
+++ b/server/src/sync/watermark.ts
@@ -1,0 +1,138 @@
+/**
+ * How far a SHARED watermark may advance when several independent transfers ran beneath it.
+ *
+ * ## The defect this exists to make impossible
+ *
+ * `lastSeqPushed` and `lastSeqReceived` are **one number per member per space**. Each sync cycle runs FIVE
+ * independent transfers under that one number — tombstones plus memories, entities, edges and chrono — and each
+ * of them can stop early on its own: a non-`ok` response from the peer, or a page cap reached.
+ *
+ * Both watermarks were then set to the **maximum** across those transfers. So a memories push that failed at seq
+ * 300, in a cycle where the entities push succeeded to seq 500, moved the watermark to 500 — and the memory at
+ * seq 400 was behind it **for ever**. Nothing errored at the cycle level, nothing was logged past one warn, and
+ * every subsequent cycle reported success while never sending that record again.
+ *
+ * That is the class of bug where a record becomes invisible while every trigger reports having done its job.
+ *
+ * ## Why the author guards do not cover it
+ *
+ * Both watermarks are already author-guarded — the pull advances only for docs authored by the peer, the push
+ * only for docs authored by us — and those guards are correct and load-bearing. But they are about **whose**
+ * records may move the watermark, not about **whether a transfer finished**. A truncated transfer is invisible
+ * to a watermark that summarises it, whoever wrote the records.
+ *
+ * ## Why "do not advance at all when something was truncated" is the WRONG fix
+ *
+ * It livelocks. A type that stopped because it hit its page cap has more to give; refusing to advance means the
+ * next cycle re-fetches the same pages and stops in the same place, for ever, and a space more than one cap
+ * behind can never catch up. The failure mode would be a space that syncs nothing rather than a space that loses
+ * one record — worse, and harder to see.
+ *
+ * ## The rule
+ *
+ * A transfer that RAN TO COMPLETION vouches for everything above the old watermark, so it places no ceiling. A
+ * transfer that stopped early vouches only up to the last position it actually delivered. The watermark may
+ * advance to the lowest such ceiling — every transfer is complete up to there, so nothing is skipped, and a
+ * capped transfer still makes a full page-set of progress each cycle.
+ */
+
+/** What one transfer within a cycle can vouch for. */
+export interface TransferOutcome {
+  /**
+   * The highest seq this transfer is COMPLETE through.
+   *
+   * Only consulted when `truncated`. Transfers page in ascending seq order, so the last position they delivered
+   * is also the position they are complete up to.
+   */
+  deliveredThrough: number;
+  /** True when it stopped before exhausting what the peer had: a non-`ok` response, a throw, or a page cap. */
+  truncated: boolean;
+}
+
+/**
+ * The furthest a shared watermark may move.
+ *
+ * @param from      the watermark's current value; the result is never below it, because a watermark must not
+ *                  go backwards — re-sending is idempotent by seq, but rewinding would re-do unbounded work.
+ * @param candidate what the cycle would have written with no truncation (today: the max across transfers).
+ * @param transfers every transfer that ran under this watermark. **Passing fewer than all of them is the
+ *                  defect**, not a partial fix: an omitted transfer places no ceiling and is exactly the one
+ *                  that gets skipped.
+ */
+export function safeWatermark(
+  from: number,
+  candidate: number,
+  transfers: readonly TransferOutcome[],
+): number {
+  let ceiling = candidate;
+  for (const t of transfers) {
+    if (t.truncated && t.deliveredThrough < ceiling) ceiling = t.deliveredThrough;
+  }
+  return Math.max(from, ceiling);
+}
+
+/**
+ * Did anything stop early? Used only to decide whether the cycle SAYS so.
+ *
+ * A cycle that silently held its watermark back looks identical to a cycle with nothing to do, and the whole
+ * argument of this module is that a caller must not have to infer a truncation.
+ */
+export function truncatedTransfers(
+  transfers: readonly (TransferOutcome & { label: string })[],
+): string[] {
+  return transfers.filter(t => t.truncated).map(t => t.label);
+}
+
+/**
+ * The one sentence a transfer logs when it stops early.
+ *
+ * Here rather than at each of the four `break`s, so every one of them says the same thing: what stopped, how far
+ * it got, and that the watermark is being held rather than advanced. Four hand-written versions of this is how
+ * the pull tombstone branch came to have none at all.
+ */
+export function truncationWarn(
+  what: string, peerLabel: string, spaceId: string, status: string | number, deliveredThrough: number,
+): string {
+  return `${what} ${peerLabel}: ${status} — delivered through seq ${deliveredThrough}, so the watermark for `
+    + `space '${spaceId}' is held there rather than advanced past records that did not transfer.`;
+}
+
+/**
+ * The whole rule for one direction of one cycle: compute the watermark, and say so when it was held back.
+ *
+ * Both call sites use this rather than `safeWatermark` plus their own reporting, for the reason this module
+ * exists at all — the previous version had the max-across-transfers rule written out twice, and the two would
+ * have drifted the moment a sixth transfer arrived. `safeWatermark` stays exported because it is the pure part
+ * and deserves its own tests.
+ *
+ * **Every transfer that ran under this watermark must be passed.** An omitted one places no limit, which makes
+ * it precisely the transfer whose records get skipped.
+ */
+export function resolveWatermark(opts: {
+  /** `'receive'` or `'push'` — appears in the log so the two directions are distinguishable. */
+  direction: 'receive' | 'push';
+  peerLabel: string;
+  spaceId: string;
+  from: number;
+  candidate: number;
+  /**
+   * Every transfer that ran, KEYED BY ITS NAME.
+   *
+   * A record rather than a labelled array so a call site names all five on one line. That is not brevity for
+   * its own sake: the call sites are in a file this change had to shrink, and a five-line spread of
+   * `{ ...x, label: 'x' }` is five chances to mistype a label that only ever appears in a log.
+   */
+  transfers: Readonly<Record<string, TransferOutcome>>;
+  warn: (msg: string) => void;
+}): number {
+  const labelled = Object.entries(opts.transfers).map(([label, t]) => ({ ...t, label }));
+  const at = safeWatermark(opts.from, opts.candidate, labelled);
+  const heldBack = truncatedTransfers(labelled);
+  if (heldBack.length > 0) {
+    opts.warn(
+      `Sync ${opts.direction} from/to ${opts.peerLabel} space '${opts.spaceId}': ${heldBack.join(', ')} stopped `
+      + `early, so the ${opts.direction} watermark advances only to ${at}. The rest is retried next cycle.`,
+    );
+  }
+  return at;
+}

--- a/testing/standalone/one-watermark-four-transfers.test.js
+++ b/testing/standalone/one-watermark-four-transfers.test.js
@@ -1,0 +1,188 @@
+/**
+ * A shared sync watermark may not advance past a transfer that stopped early.
+ *
+ * ## The defect
+ *
+ * `lastSeqPushed` and `lastSeqReceived` are ONE number per member per space, and each cycle runs FIVE
+ * independent transfers under it — tombstones plus memories, entities, edges and chrono. Each can stop early on
+ * its own: a non-`ok` response, a throw, or a page cap.
+ *
+ * Both watermarks were set to the **maximum** across them. So a memories push that failed at seq 300, in a cycle
+ * where entities succeeded to 500, moved the watermark to 500 — and the memory at seq 400 was behind it **for
+ * ever**. Nothing errored at the cycle level and every later cycle reported success while never sending it again.
+ *
+ * ## Why the existing author guards do not cover it
+ *
+ * They are correct and load-bearing, and they are about a different axis. The pull advances only for docs
+ * authored by the peer; the push only for docs authored by us. Neither says anything about whether a transfer
+ * FINISHED. `_REFERENCE.md` records the author-axis hypothesis as killed — this is the collection axis, and it
+ * was alive.
+ *
+ * ## The rule, and the wrong fix it replaces
+ *
+ * "Never advance when something was truncated" **livelocks**: a transfer that stopped at its page cap has more to
+ * give, so the next cycle re-fetches the same pages and stops in the same place for ever, and a space more than
+ * one cap behind can never catch up. That trades losing one record for syncing nothing.
+ *
+ * So: a transfer that ran to completion places no ceiling; one that stopped early vouches only up to what it
+ * delivered; the watermark advances to the lowest such ceiling. Nothing is skipped and a capped transfer still
+ * makes a full page-set of progress per cycle.
+ *
+ * Run: node --test testing/standalone/one-watermark-four-transfers.test.js
+ * (requires a prior `npm run build` in server/)
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripComments } from './_strip-comments.mjs';
+
+const { safeWatermark, truncatedTransfers } = await import('../../server/dist/sync/watermark.js');
+
+/** A transfer that finished everything above the old watermark. */
+const done = () => ({ deliveredThrough: 0, truncated: false });
+/** A transfer that stopped after delivering through `n`. */
+const stopped = (n) => ({ deliveredThrough: n, truncated: true });
+
+describe('the watermark stops at what the slowest stopped transfer can vouch for', () => {
+  it('THE DEFECT: a truncated transfer caps the advance', () => {
+    // The exact case: memories failed at 300, entities finished to 500. The old rule wrote 500 and stranded the
+    // memory at 400.
+    assert.equal(safeWatermark(100, 500, [stopped(300), done(), done(), done(), done()]), 300,
+      'the watermark must not pass a record the peer never served');
+  });
+
+  it('all five complete — the candidate stands, unchanged', () => {
+    // The common case must cost nothing. If this ever returned less than the candidate, sync would crawl.
+    assert.equal(safeWatermark(100, 500, [done(), done(), done(), done(), done()]), 500);
+  });
+
+  it('two truncated — the LOWEST ceiling wins', () => {
+    assert.equal(safeWatermark(100, 500, [stopped(400), done(), stopped(250), done(), done()]), 250,
+      'every transfer must be complete through the result, so the lowest ceiling is the only safe one');
+  });
+
+  it('a truncation ABOVE the candidate cannot raise it', () => {
+    // A ceiling is a maximum, never a target. A transfer that stopped at 900 in a cycle whose highest relevant
+    // seq was 500 must leave the answer at 500 — raising it would invent progress nothing made.
+    assert.equal(safeWatermark(100, 500, [stopped(900), done()]), 500);
+  });
+
+  it('NEVER goes backwards, even when a transfer stopped before the current watermark', () => {
+    /*
+     * The livelock guard, and the one that stops this fix being worse than the defect.
+     *
+     * A transfer that fails on its FIRST page reports `deliveredThrough` at the old watermark, or below it if a
+     * cursor was behind. Letting that rewind the watermark would re-send everything since, every cycle, for as
+     * long as one peer kept refusing — turning one lost record into unbounded repeated work.
+     */
+    assert.equal(safeWatermark(400, 500, [stopped(100), done()]), 400, 'a rewind would re-do unbounded work');
+    assert.equal(safeWatermark(400, 500, [stopped(0)]), 400);
+    assert.equal(safeWatermark(400, 300, [done()]), 400, 'nor may a lower candidate rewind it');
+  });
+
+  it('progress is still made when the page cap truncates', () => {
+    // The reason "never advance on truncation" was rejected. A capped transfer delivered a full page-set, and
+    // the watermark must move to the end of it or the next cycle repeats the same fetch for ever.
+    assert.equal(safeWatermark(0, 10_000, [stopped(10_000), done(), done(), done(), done()]), 10_000,
+      'a capped transfer must still advance by what it delivered');
+    // Two cycles of catching up, each moving forward.
+    assert.equal(safeWatermark(10_000, 20_000, [stopped(20_000), done()]), 20_000);
+  });
+
+  it('an empty transfer list leaves the candidate alone', () => {
+    // Defensive rather than expected: no caller passes none. It must not silently mean "no ceiling is safe".
+    assert.equal(safeWatermark(100, 500, []), 500);
+  });
+
+  it('truncatedTransfers names them, so a held-back cycle is never silent', () => {
+    const names = truncatedTransfers([
+      { ...stopped(1), label: 'memories' }, { ...done(), label: 'entities' },
+      { ...stopped(2), label: 'tombstones' },
+    ]);
+    assert.deepEqual(names, ['memories', 'tombstones']);
+    assert.deepEqual(truncatedTransfers([{ ...done(), label: 'memories' }]), [],
+      'a healthy cycle must produce no message at all');
+  });
+});
+
+describe('every transfer under a shared watermark is passed to the rule', () => {
+  const src = stripComments(readFileSync('server/src/sync/engine.ts', 'utf8'));
+
+  it('both watermarks go through safeWatermark rather than a bare Math.max', () => {
+    /*
+     * THE OMISSION IS THE REGRESSION, and it looks like nothing.
+     *
+     * `Math.max(memR.highSeq, entR.highSeq, edgeR.highSeq, chronoR.highSeq)` reads as obviously right — four
+     * numbers, take the biggest. It is still there, as the CANDIDATE; what must not come back is assigning it
+     * straight to the watermark.
+     */
+    assert.match(src, /highestSeq = resolveWatermark\(\{/, 'the receive watermark must go through the rule');
+    assert.match(src, /maxSeqPushed = resolveWatermark\(\{/, 'and so must the push watermark');
+    assert.doesNotMatch(src, /highestSeq = Math\.max\(/,
+      'the receive watermark is assigned a bare max again — that is the defect verbatim');
+    assert.doesNotMatch(src, /maxSeqPushed = Math\.max\(/,
+      'the push watermark is assigned a bare max again — that is the defect verbatim');
+  });
+
+  it('FIVE transfers on each side, tombstones included', () => {
+    /*
+     * Counted, because an omitted transfer places NO ceiling and is therefore exactly the one that gets
+     * skipped. Tombstones are the one most likely to be left out: they are fetched and sent in their own block,
+     * before the loop over the four collections, and they do not look like "a type".
+     *
+     * They are also the transfer where the loss is worst — a deletion that never propagates, on a pull whose
+     * `!resp.ok` branch used to be completely silent.
+     */
+    const lists = [...src.matchAll(/transfers: \{([^}]*)\}/g)].map(m => m[1]);
+    assert.equal(lists.length, 2, `expected two transfer sets, found ${lists.length}`);
+    for (const list of lists) {
+      const keys = list.split(',').map(x => x.split(':')[0].trim()).filter(Boolean);
+      assert.equal(keys.length, 5, `a cycle passes ${keys.length} transfers, not 5: ${list.trim()}`);
+      for (const k of ['memories', 'entities', 'edges', 'chrono', 'tombstones']) {
+        assert.ok(keys.includes(k), `${k} is missing from a transfer set: ${list.trim()}`);
+      }
+    }
+  });
+
+  it('the pull records its position only AFTER the page is applied', () => {
+    // Vouching before the upsert would promise records that a throw between the two would have lost — the same
+    // class of mistake one layer down.
+    assert.match(src, /await batchUpsertBySeq<T>\([^\n]*\);\s*\n\s*if \(maxSeq > deliveredThrough\) deliveredThrough = maxSeq;/,
+      'deliveredThrough must be advanced after the batch upsert, not before');
+  });
+
+  it('the page cap counts as a truncation', () => {
+    // Easy to miss, because nothing failed. The loop exits with a live cursor and the transfer has more to give.
+    assert.match(src, /if \(cur\) \{\s*\n\s*truncated = true;/,
+      'a live cursor at the page cap must set truncated, or the watermark passes what was not fetched');
+  });
+
+  it('the push caps with the ACCEPTED position, not the author-guarded one', () => {
+    // `localMaxSeq` answers "how far did our own records reach"; `seqCursor` answers "how far did this transfer
+    // get at all". On pubsub and braintree networks `ownedFilter` is empty and we relay foreign docs, so
+    // capping with the author-guarded number would advance past a relayed doc the peer never accepted.
+    assert.match(src, /deliveredThrough: seqCursor, truncated \}/,
+      'the push ceiling must be the last accepted seq');
+    assert.doesNotMatch(src, /deliveredThrough: localMaxSeq/,
+      'the author-guarded max answers a different question and would leave relayed docs strandable');
+  });
+
+  it('a pull tombstone fetch that failed is no longer silent, and both halves live together', () => {
+    /*
+     * The pull had no `else` at all: a non-ok response applied nothing, logged nothing, and the watermark
+     * advanced past the deletions anyway. The push side had a warn for the identical case — one protocol phase,
+     * two implementations, twenty lines apart in a thousand-line file, and the weaker one silently won.
+     *
+     * Both halves now live in `sync/tombstone-transfer.ts` so they cannot be read separately again, which is why
+     * this assertion reads that file rather than the engine.
+     */
+    const ts = stripComments(readFileSync('server/src/sync/tombstone-transfer.ts', 'utf8'));
+    assert.match(ts, /export async function pullTombstones/, 'the pull half must live here');
+    assert.match(ts, /export async function pushTombstones/, 'and so must the push half');
+    assert.equal((ts.match(/outcome\.truncated = true;/g) ?? []).length, 3,
+      'expected three truncation points: the pull non-ok, the pull throw, and the push non-ok');
+    // And the engine must not have grown its own copy back.
+    assert.doesNotMatch(src, /api\/sync\/tombstones\?spaceId=/,
+      'the engine is building a tombstone URL again — that is the second implementation coming back');
+  });
+});


### PR DESCRIPTION
## What

`lastSeqPushed` and `lastSeqReceived` are **one number per member per space**, and each sync cycle runs **five**
independent transfers under it — tombstones plus memories, entities, edges and chrono. Any one can stop early: a
non-`2xx` from the peer, or its 50-page cap.

Both watermarks were set to the **maximum** across those transfers, which is only correct when all of them
finished. A memories push that failed at seq 300, in a cycle where the entities push succeeded to seq 500, moved
the watermark to 500 — and **the memory at seq 400 was behind it permanently.** Nothing errored at the cycle
level, one warn was logged and then discarded, and every later cycle reported success while never sending that
record again.

The pull side had the identical shape. Its tombstone fetch was worse: the `!resp.ok` case had **no `else` at
all** — nothing applied, nothing logged, watermark moved past the deletions anyway. The push side had a warn for
exactly that case. One protocol phase, two implementations, twenty lines apart in a thousand-line file, and the
weaker one silently won.

## The docs already promised this

`docs/sync-protocol.md` claimed it in three places: *"if a sync fails mid-way, the watermark is not advanced"*, *"a
network drop mid-push persists nothing for that cycle"*, and the page-cap paragraph's *"nothing is lost"*. All
three were true **per transfer** and false for the number that actually gates the next cycle. Corrected rather
than deleted — the rule they described is the right one.

## Why "never advance on truncation" is the wrong fix

**It livelocks.** A transfer that stopped at its page cap has more to give, so the next cycle re-fetches the same
pages and stops in the same place, for ever; a space more than one cap behind can never catch up. That trades
losing one record for a space that syncs nothing.

## The rule

A transfer that ran to completion places no limit. One that stopped early limits the advance to the last position
it actually delivered. The lowest limit wins, and the watermark never moves backwards. Nothing is skipped, and a
capped transfer still advances by a full page-set per cycle.

One implementation in `sync/watermark.ts`; both directions call `resolveWatermark`, which also logs when it held
back — a watermark quietly staying put reads exactly like a cycle with nothing to do.

## Two load-bearing details

- **The push limit is the last ACCEPTED seq, not the author-guarded maximum.** They answer different questions.
  On `pubsub`/`braintree` the push filter is empty and this instance relays everything it holds, so the
  author-guarded number would let the watermark pass a relayed doc the peer never accepted — and nothing else was
  going to send it.
- **The pull records its position AFTER the batch upsert.** Vouching first would promise records a throw between
  the two had lost.

## Two extractions, required by a gate that was right

`no-new-god-files.test.js` refused the change — `engine.ts` grew past its freeze — and its instruction is
correct: *put the new behaviour beside it rather than inside it.* So `sync/tombstone-transfer.ts` now holds
**both** tombstone directions (which is what makes the missing-`else` impossible to reintroduce unnoticed) and
`sync/watermark.ts` holds the rule and the message. `engine.ts` ends up **smaller than it started**.

## This is the collection axis of a hypothesis recorded as killed

X-20 killed *"a watermark advances past a record that was never served"* on the **author** axis, correctly — both
author guards are sound and unchanged here. They govern *whose* records may move a watermark, never *whether a
transfer finished*.

## NOT the cause of the pub/sub stall, and saying so is the point

The failing run's container logs contain no `Batch push … to <peer>: <status>` and no `Pull … returned <status>`,
so nothing was truncated in it. What that run **does** show is now recorded in X-20: A ran a cycle every 3 s
throughout the 25 s window, each completing in **~19 ms** against 270 ms for the cycle that delivered — so the
pusher ran, reported success, and found nothing to send. The two stay separate until one is measured to explain
the other.

## Gates

`one-watermark-four-transfers.test.js`. `safeWatermark` is pure, so the rule is **exercised**: the defect case,
all-complete, two-truncated, a limit above the candidate, the no-rewind guard, and progress under the page cap.
Plus the source half — both watermarks through the rule, a bare `Math.max` assignment banned, and the transfer set
**counted at five** including tombstones, because an omitted transfer places no limit and is therefore exactly
the one that gets skipped.

**Eight mutations, eight caught**, including the pre-fix state and both wrong-fix directions (a complete transfer
also capping, which would stall sync; and a watermark allowed to rewind).
