### PR TITLE
fix(indexes): stop polling the readiness of a deleted space's indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A deleted space's index-readiness pollers kept running for the whole window.** `finalizeSpaceIndexReady`
+  already knew about a space vanishing mid-build and handled it at the WRITE — *"space was deleted while its
+  indexes built"* — but the polling before the write did not. So a space deleted during its own build kept up to
+  six pollers alive, each issuing a `listSearchIndexes` every second, until the window expired: 60 s off the boot
+  path and **600 s on it**, three spaces at a time.
+
+  Measured in CI on 2026-08-19: twelve consecutive 60-second give-ups for two `gov-…` spaces, every one reporting
+  `index not present (saw: none)` — which is what an empty catalogue looks like once the collections are gone.
+
+  This is also the case the terminal-absence guard added alongside it deliberately does NOT cover. That one
+  requires the backend to have listed OTHER indexes on the collection, so it can distinguish "not there" from
+  "not asked yet"; an empty listing stays ambiguous. A missing SPACE settles it outright.
+
+  Two details are load-bearing. An unreadable config reads as **"the space still exists"** — `getConfig()` throws
+  before the first successful load, and index builds run in that window, so the opposite default would have made
+  the fix abandon healthy builds during early boot and do it at `debug` level. And the check `return`s rather than
+  `continue`s, which would have turned a one-second poll into a spin.
+
+  The gate additionally pins the ORDERING this depends on: `createSpace` builds a space's indexes before pushing
+  it into config, which is only compatible with this check because that build passes `waitForVectorReady: false`
+  and therefore never polls. It sweeps every `initSpace` caller across both files that have one — a sweep scoped
+  to `spaces/lifecycle.ts` would have reported the set complete while missing `app.ts`.
+
+  Five mutations, five caught, including both wrong defaults and both reorderings.
 - **The search page showed a shortened answer as if it were the whole one.** The server has reported `truncated`
   since the result spill shipped and the client never read it — so a hundred-match search could render a handful
   of records with nothing anywhere on the page explaining why. Under the old record cap that was three records

--- a/server/src/spaces/vector-index.ts
+++ b/server/src/spaces/vector-index.ts
@@ -398,6 +398,18 @@ async function indexServes(
  */
 const ABSENT_IS_TERMINAL_AFTER = 15;
 
+/**
+ * Is this space still in the configuration?
+ *
+ * Reads the in-memory config, so it costs nothing per poll iteration. **A throw means "cannot tell", and that
+ * must read as `true`** — `getConfig()` throws before the first successful load, and a poll running during early
+ * boot must not conclude its space was deleted and abandon a build that is fine.
+ */
+function spaceStillExists(spaceId: string): boolean {
+  try { return getConfig().spaces.some(s => s.id === spaceId); }
+  catch { return true; }
+}
+
 /** Poll a single vector-search index for READY status, up to ~60 seconds.
  *  Returns true once READY, false if it never became READY in the window. */
 export async function pollVectorIndexReady(
@@ -414,6 +426,31 @@ export async function pollVectorIndexReady(
 
   for (let attempt = 0; attempt < attempts; attempt++) {
     await new Promise(r => setTimeout(r, 1000));
+    /*
+     * THE SPACE IS GONE — stop, rather than waiting out the window for indexes nobody will ever create.
+     *
+     * `finalizeSpaceIndexReady` already knows about this case and handles it at the WRITE: *"space was deleted
+     * while its indexes built"*. The polling that precedes the write did not, so a space deleted early in its
+     * own build kept up to six pollers alive, each issuing a `listSearchIndexes` every second, for the whole
+     * window — 600 s of it on the boot path, three spaces at a time.
+     *
+     * Measured in CI on 2026-08-19: twelve consecutive 60-second give-ups for two `gov-…` spaces, every one
+     * reporting `index not present (saw: none)`, which is what an empty catalogue looks like after the
+     * collections have been dropped.
+     *
+     * It is also the case the terminal-absence guard below deliberately does NOT cover: that one requires the
+     * backend to have listed OTHER indexes on this collection, so it can tell "not there" from "not asked yet".
+     * An empty listing stays ambiguous — unless the space itself is gone, which settles it outright.
+     *
+     * Safe against creation, checked rather than assumed: `createSpace` builds indexes BEFORE pushing the space
+     * into config, but passes `waitForVectorReady: false`, so it never reaches this poll. Every path that does
+     * poll — `initSpace` at boot, `initSpace('general')`, `finalizeSpaceIndexReady` — runs with the space
+     * already committed.
+     */
+    if (!spaceStillExists(spaceId)) {
+      log.debug(`Vector search index ${indexName}: space '${spaceId}' no longer exists — abandoning the poll`);
+      return false;
+    }
     try {
       // List ALL indexes and match by name, rather than `listSearchIndexes(indexName)`.
       //

--- a/testing/standalone/no-polling-a-deleted-space.test.js
+++ b/testing/standalone/no-polling-a-deleted-space.test.js
@@ -1,0 +1,134 @@
+/**
+ * The index-readiness poll stops when its space is deleted, and the ordering that makes that safe is pinned.
+ *
+ * ## What was wasted
+ *
+ * `finalizeSpaceIndexReady` already knows about a space vanishing mid-build and handles it at the WRITE — *"space
+ * was deleted while its indexes built"*. The polling before the write did not, so a deleted space kept up to six
+ * pollers alive, each issuing a `listSearchIndexes` every second, for the whole window: 60 s off the boot path
+ * and **600 s on it**, three spaces at a time.
+ *
+ * Measured in CI on 2026-08-19: twelve consecutive 60-second give-ups for two `gov-…` spaces, every one reporting
+ * `index not present (saw: none)` — which is what an empty catalogue looks like once the collections are gone.
+ *
+ * It is also precisely the case the terminal-absence guard does NOT cover. That one requires the backend to have
+ * listed OTHER indexes on the collection, so it can tell "not there" from "not asked yet"; an empty listing stays
+ * ambiguous. A missing SPACE settles it outright, which is why this is a separate check rather than a loosening
+ * of that one.
+ *
+ * ## The ordering half, which is the part that could break silently
+ *
+ * `createSpace` builds a space's indexes BEFORE pushing it into config — deliberately, so a space always has a
+ * backing database. That is only compatible with this check because it passes `waitForVectorReady: false`, so the
+ * creation path never reaches the poll. **If someone reorders that, or drops the flag, this fix would start
+ * abandoning legitimate builds** and the symptom would be a space stuck at `building` with nothing logged above
+ * debug. So the ordering is asserted here, next to the thing that depends on it.
+ *
+ * Run: node --test testing/standalone/no-polling-a-deleted-space.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripComments } from './_strip-comments.mjs';
+
+const vector = stripComments(readFileSync('server/src/spaces/vector-index.ts', 'utf8'));
+const lifecycle = stripComments(readFileSync('server/src/spaces/lifecycle.ts', 'utf8'));
+
+/** One exported function's body, bounded structurally — never by a character count. */
+function bodyOf(src, name) {
+  const lines = src.split(/\r?\n/);
+  const start = lines.findIndex(l => l.includes(`export async function ${name}(`));
+  assert.ok(start > -1, `${name} is gone — re-anchor this gate`);
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^export (async function|function|const) /.test(lines[i])) { end = i; break; }
+  }
+  return lines.slice(start, end).join('\n');
+}
+
+describe('the poll abandons a space that no longer exists', () => {
+  const body = bodyOf(vector, 'pollVectorIndexReady');
+
+  it('checks inside the loop, so it fires on every attempt rather than once', () => {
+    // Once, before the loop, would only catch a space already deleted when the poll started — not the case that
+    // costs anything, which is a space deleted DURING its own build.
+    const loop = body.indexOf('for (let attempt = 0;');
+    const check = body.indexOf('if (!spaceStillExists(spaceId))');
+    assert.ok(loop > -1, 'the poll loop is gone — re-anchor this gate');
+    assert.ok(check > loop, 'the existence check must be inside the attempt loop');
+  });
+
+  it('and BEFORE the listing, so a gone space costs no round trip at all', () => {
+    const check = body.indexOf('if (!spaceStillExists(spaceId))');
+    const listing = body.indexOf('await coll.listSearchIndexes()');
+    assert.ok(listing > -1, 're-anchor: the listing call moved');
+    assert.ok(check < listing, 'checking after the listing would still pay for the query it exists to avoid');
+  });
+
+  it('abandons rather than continues — a `continue` would spin at full speed', () => {
+    assert.match(body, /if \(!spaceStillExists\(spaceId\)\) \{[\s\S]{0,220}?return false;/,
+      'the check must return, not continue');
+  });
+
+  it('CANNOT TELL reads as "still exists", or early boot abandons its own builds', () => {
+    /*
+     * `getConfig()` throws before the first successful load, and index builds can run in that window. A `catch`
+     * returning `false` would make every such poll conclude its space was deleted — the fix causing the outage
+     * it was written to prevent, and quietly, since the log line is `debug`.
+     */
+    assert.match(vector, /function spaceStillExists\(spaceId: string\): boolean \{[\s\S]{0,200}?catch \{ return true; \}/,
+      'an unreadable config must read as "the space still exists"');
+  });
+});
+
+describe('the creation ordering this check depends on', () => {
+  it('createSpace builds indexes WITHOUT waiting, before it commits the space', () => {
+    /*
+     * The precondition, asserted next to the thing that relies on it. Indexes are built before the config push so
+     * a space always has a backing database; that is fine only because the build does not poll. Flip the flag and
+     * the poll would run against a space that is not in config yet, see it missing, and abandon a healthy build.
+     */
+    const call = lifecycle.indexOf("await initSpace(opts.id, { waitForVectorReady: false });");
+    const push = lifecycle.indexOf('cfg.spaces.push(space);');
+    assert.ok(call > -1, 'createSpace no longer builds indexes with waitForVectorReady: false — READ THE GATE '
+      + 'DOC: the readiness poll now abandons a space that is not in config, so a waiting build here would be '
+      + 'abandoned before the space is committed');
+    assert.ok(push > call, 'the config push must still come after the index build');
+  });
+
+  it('and finalizeSpaceIndexReady is kicked off only AFTER the commit', () => {
+    // That one DOES poll, so it must never start before the space is visible in config.
+    const push = lifecycle.indexOf('cfg.spaces.push(space);');
+    const finalize = lifecycle.indexOf('void finalizeSpaceIndexReady(opts.id);');
+    assert.ok(finalize > push, 'the polling finalizer must start after the space is committed');
+  });
+
+  it('every initSpace caller that POLLS already has its space in config', () => {
+    /*
+     * The callers taking the default `waitForVectorReady: true` do poll, so each must run against a committed
+     * space. Counted rather than described: a new default-true caller placed before a config push is the way this
+     * fix breaks, and it would look entirely reasonable at the call site.
+     *
+     * SWEPT ACROSS BOTH FILES that call it, not just this one. `app.ts` has a default-true caller too, and a gate
+     * scoped to `lifecycle.ts` would have reported the set complete while missing it — which is the
+     * one-file-sweep mistake, not a detail.
+     *
+     * Matches with a newline in them are the FUNCTION DECLARATION's own parameter list, which spans lines. The
+     * first version of this assertion counted that as a caller.
+     */
+    const app = stripComments(readFileSync('server/src/app.ts', 'utf8'));
+    const callers = [lifecycle, app]
+      .flatMap(src => [...src.matchAll(/initSpace\((?![^)]*waitForVectorReady)[^)]*\)/g)].map(m => m[0]))
+      .filter(m => !m.includes('\n'));
+    assert.deepEqual(callers.sort(), ["initSpace('general')", 'initSpace(space.id)'],
+      'a new initSpace caller relies on the default (waitForVectorReady: true) and therefore POLLS — confirm its '
+      + 'space is in config first, then add it here');
+
+    // `initSpace('general')` sits after the built-in space is pushed and saved.
+    assert.ok(lifecycle.indexOf("await initSpace('general');") > lifecycle.indexOf("id: 'general',"));
+    // `app.ts` iterates the RELOADED config, so its space is committed by construction.
+    const iterates = app.indexOf('for (const space of newCfg.spaces)');
+    assert.ok(iterates > -1 && app.indexOf('await initSpace(space.id);') > iterates,
+      'the app.ts caller must still be iterating spaces read from config');
+  });
+});


### PR DESCRIPTION
## What

`finalizeSpaceIndexReady` already knew about a space vanishing mid-build and handled it **at the write** — *"space
was deleted while its indexes built"*. The polling that precedes the write did not.

So a space deleted during its own build kept up to six pollers alive, each issuing a `listSearchIndexes` **every
second**, until the window expired: 60 s off the boot path and **600 s on it**, three spaces at a time.

## Measured, not supposed

CI run `32208527782` attempt 1, container logs: **twelve consecutive 60-second give-ups** across two `gov-…`
spaces, every one reporting `index not present (saw: none)` — exactly what an empty catalogue looks like once the
collections have been dropped.

## Why this is a separate check, not a loosening of #981's

The terminal-absence guard from #981 requires the backend to have listed **other** indexes on the same
collection, so it can tell *"not there"* from *"not asked yet"*. That condition is deliberate and it does **not**
fire here: with the collections gone the listing is empty, which stays ambiguous on its own. A missing *space*
settles it outright.

## Two load-bearing details

- **An unreadable config reads as "the space still exists."** `getConfig()` throws before the first successful
  load and index builds run in that window, so the opposite default would have made this fix abandon healthy
  builds during early boot — at `debug` level, so silently. The `catch { return true }` is the whole safety of it.
- **It `return`s rather than `continue`s.** A `continue` would turn a one-second-per-attempt poll into a spin.

## The ordering the safety argument rests on, gated next to it

`createSpace` builds a space's indexes **before** pushing it into config, so a space always has a backing
database. That is only compatible with this check because the build passes `waitForVectorReady: false` and
therefore never reaches the poll. Reorder it, or drop the flag, and this fix would start abandoning legitimate
builds with nothing above `debug` to say so.

The gate pins that, and sweeps every `initSpace` caller across **both** files that have one — a sweep scoped to
`spaces/lifecycle.ts` would have reported the set complete while missing `app.ts`, whose caller takes the polling
default.

**Five mutations, five caught:** the pre-fix state, both wrong defaults, `continue` instead of `return`, and both
reorderings of `createSpace`.

## Also in this commit — tracker only, no code

- **X-20's fourth negative reproduction.** `npm run test:sync` end to end on the warm stack: `fail 0`, and the
  tombstone subtest took 1 119 ms against 1 112 ms isolated. Suite context is not the trigger, which was the
  cheapest remaining hypothesis. Warm is the common factor across all four attempts; a cold stack is what is left.
- **X-22 closed by measurement.** Native `$rankFusion` is **58% / 19% / 3% slower** than our own RRF at 500 / 5 000
  / 20 000 records — because our two channels already run concurrently, so the round trip it would have saved was
  never being paid. Same formula and same constant (`1/(60 + rank)`) on both sides, and `$text` *can* sit in a
  sub-pipeline, so this was the small change and it still lost. Numbers in `_REFERENCE.md` so nobody re-proposes
  it on the next release announcement.
