### PR TITLE
test(sync): a propagation timeout now says which side lost the record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `_id` rather than `seq` or `createdAt`: it is on every result type, unique by construction, and the only one of
   the three that cannot tie in turn.
 
+### Changed
+
+- **A propagation timeout in the sync tests now says WHICH SIDE lost the record.** `waitFor`'s diagnostic hook is
+  awaited, so it can go and look rather than being limited to facts already in hand, and the pub/sub arrival wait
+  supplies one that reads whether the sender still holds the record, at what `seq`, and where each member's
+  watermarks sit.
+
+  For a propagation timeout there are only two possibilities — the sender never sent it, or the receiver took it
+  and did not store it — and `waitFor timed out after 25000ms — sync triggers to A all succeeded (8)` cannot tell
+  them apart. That is why the intermittent pub/sub stall has survived four rounds of investigation.
+
+  **Added only after the reproduction avenue was exhausted**, which is the order that matters: six attempts —
+  three isolated, one inside the full sync suite, two against a freshly rebuilt cold stack — all passed at ~1.1 s
+  against the 25 s budget. Four candidate explanations had already been killed by reading source. So the next CI
+  occurrence has to be the one that answers it, and this makes it do that instead of restating the symptom.
+
+  It reads `GET /api/networks/:id`, which already returns each member's `lastSeqPushed` and `lastSeqReceived` — no
+  server change, and none should be introduced for a test diagnostic. A throwing diagnostic degrades to a note
+  rather than replacing the timeout it describes, and it never runs on a wait that succeeded.
+
+  Gated behaviourally against a stub server rather than by reading source: the first version of that gate asserted
+  only that the three outcome strings appear, and mutation testing walked through it — replacing a condition with
+  `if (false)` left every string in place and the gate green. A branch that is mentioned is not a branch that runs.
+  Eight mutations across both rounds, eight caught.
+
 ### Fixed
 
 - **A deleted space's index-readiness pollers kept running for the whole window.** `finalizeSpaceIndexReady`

--- a/testing/standalone/a-timeout-says-which-side-lost-it.test.js
+++ b/testing/standalone/a-timeout-says-which-side-lost-it.test.js
@@ -1,0 +1,168 @@
+/**
+ * A propagation timeout must be able to go and LOOK, and one test's timeout must say which side lost the record.
+ *
+ * ## Why this exists
+ *
+ * `Subscriber-local content survives publisher tombstone` fails intermittently in CI and has survived four rounds
+ * of investigation, because its message — `waitFor timed out after 25000ms — sync triggers to A all succeeded (8)`
+ * — cannot distinguish the only two things it can be: the sender never sent the record, or the receiver took it
+ * and did not store it.
+ *
+ * Six local reproduction attempts (three isolated, one inside the full sync suite, two against a freshly rebuilt
+ * cold stack) all passed at ~1.1 s against the 25 s budget. So the failure is not reachable here and the NEXT CI
+ * occurrence has to be the one that answers it.
+ *
+ * ## The two regressions this pins, both silent
+ *
+ * 1. **`waitFor` must AWAIT its diagnose.** It used to call it synchronously, which limited every caller to facts
+ *    already in hand — and a diagnostic returning a promise interpolated as `[object Promise]`. Nothing would
+ *    fail; the message would just be useless, on the one run that mattered.
+ * 2. **A diagnostic must never replace the timeout it is describing.** `onTimeout` does two HTTP requests, either
+ *    of which can fail for its own reasons. An unswallowed throw there would surface as the diagnostic's error
+ *    instead of the real timeout — strictly worse than no diagnostic at all.
+ *
+ * Both are exercised, not grepped: `waitFor` takes a plain condition function, so it needs no database.
+ *
+ * Run: node --test testing/standalone/a-timeout-says-which-side-lost-it.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripComments } from './_strip-comments.mjs';
+import { waitFor } from '../sync/helpers.js';
+
+const never = async () => false;
+
+describe('waitFor can be given a diagnostic that goes and looks', () => {
+  it('awaits an async diagnose instead of interpolating a promise', async () => {
+    await assert.rejects(
+      () => waitFor(never, 30, 10, async () => {
+        await new Promise(r => setTimeout(r, 5));
+        return 'the sender holds it at seq 42';
+      }),
+      (err) => {
+        assert.match(err.message, /the sender holds it at seq 42/,
+          `the resolved value must reach the message, got: ${err.message}`);
+        assert.doesNotMatch(err.message, /\[object Promise\]/,
+          'a promise reached the message verbatim — diagnose is being called without await');
+        return true;
+      });
+  });
+
+  it('still accepts a synchronous diagnose, and a plain string', async () => {
+    // The change must not have broken the twenty-odd existing callers that return a string directly.
+    await assert.rejects(() => waitFor(never, 30, 10, () => 'sync detail'), /sync detail/);
+    await assert.rejects(() => waitFor(never, 30, 10, 'literal detail'), /literal detail/);
+  });
+
+  it('and none at all', async () => {
+    await assert.rejects(() => waitFor(never, 30, 10), /waitFor timed out after 30ms$/);
+  });
+
+  it('a condition that succeeds never calls the diagnostic', async () => {
+    // It does two HTTP requests. Running it on the happy path would put them in every passing wait.
+    let called = 0;
+    await waitFor(async () => true, 100, 10, () => { called++; return 'x'; });
+    assert.equal(called, 0, 'the diagnostic must only run on a timeout');
+  });
+});
+
+describe('the failing test asks which side lost the record', () => {
+  const helpers = stripComments(readFileSync('testing/sync/helpers.js', 'utf8'));
+  const pubsub = stripComments(readFileSync('testing/sync/pubsub-topology.test.js', 'utf8'));
+
+  it('syncUntil threads onTimeout through and SWALLOWS its failures', () => {
+    assert.match(helpers, /onTimeout \} = \{\}\)/, 'syncUntil must accept an onTimeout hook');
+    assert.match(helpers, /try \{ extra = \(await onTimeout\(\)\) \?\? ''; \} catch \(e\) \{ extra = `diagnostic failed/,
+      'a throwing diagnostic must degrade to a note, never replace the timeout it describes');
+  });
+
+  it('the diagnostic reads the watermark from an endpoint that already exposes it', () => {
+    // `GET /api/networks/:id` returns each member minus the token hash, so `lastSeqPushed` is already readable by
+    // an admin token. No server change was needed, and none should be introduced for a test diagnostic.
+    assert.match(helpers, /api\/networks\/\$\{networkId\}/);
+    assert.match(helpers, /lastSeqPushed\?\.\[spaceId\]/);
+    assert.match(helpers, /lastSeqReceived\?\.\[spaceId\]/);
+  });
+
+  it('and reports all three outcomes, because two of them are not sync bugs at all', () => {
+    /*
+     * "The sender does not have it" means the WRITE failed. "A watermark passed it" means it was marked sent and
+     * never will be again. "No watermark reached it" means the sender should still be offering it, so the loss is
+     * on the wire or at the receiver. A diagnostic that only reported the third would misattribute the other two.
+     */
+    assert.match(helpers, /the SENDER HOLDS/);
+    assert.match(helpers, /marked sent and never will be again/);
+    assert.match(helpers, /lost on the wire or discarded/);
+  });
+
+  it('EXERCISED against a stub: each branch is reachable, not merely present', async () => {
+    /*
+     * The first version of this asserted only that the strings appear in the source, and mutation testing walked
+     * straight through it: replacing the condition with `if (false)` left every string in place and the gate
+     * green. A branch that is mentioned is not a branch that runs.
+     *
+     * A four-line stub server is enough — the diagnostic's whole job is to read two endpoints and say what they
+     * mean, so a stub that answers them exercises every branch with no stack and no database.
+     */
+    const { createServer } = await import('node:http');
+    const { whichSideLostIt } = await import('../sync/helpers.js');
+
+    const serve = (routes) => new Promise((resolve) => {
+      const srv = createServer((req, res) => {
+        const hit = Object.entries(routes).find(([p]) => req.url.startsWith(p));
+        res.writeHead(hit ? 200 : 404, { 'content-type': 'application/json' });
+        res.end(JSON.stringify(hit ? hit[1] : { error: 'not found' }));
+      });
+      srv.listen(0, '127.0.0.1', () => resolve({ srv, url: `http://127.0.0.1:${srv.address().port}` }));
+    });
+
+    // 1. The sender does not hold the record at all.
+    let s = await serve({});
+    try {
+      assert.match(await whichSideLostIt(s.url, 't', 'net', 'sp', 'rec'),
+        /the SENDER does not have rec either \(404\) — the write, not sync/);
+    } finally { s.srv.close(); }
+
+    // 2. It holds it, and a watermark is already at or past its seq.
+    s = await serve({
+      '/api/brain/spaces/sp/memories/rec': { _id: 'rec', seq: 7 },
+      '/api/networks/net': { members: [{ label: 'B', lastSeqPushed: { sp: 7 }, lastSeqReceived: {} }] },
+    });
+    try {
+      const msg = await whichSideLostIt(s.url, 't', 'net', 'sp', 'rec');
+      assert.match(msg, /the SENDER HOLDS rec at seq 7/);
+      assert.match(msg, /pushed=7 received=unset/);
+      assert.match(msg, /AT OR PAST that seq/);
+    } finally { s.srv.close(); }
+
+    // 3. It holds it and no watermark reached it — the loss is downstream.
+    s = await serve({
+      '/api/brain/spaces/sp/memories/rec': { _id: 'rec', seq: 9 },
+      '/api/networks/net': { members: [{ label: 'B', lastSeqPushed: { sp: 4 }, lastSeqReceived: {} }] },
+    });
+    try {
+      const msg = await whichSideLostIt(s.url, 't', 'net', 'sp', 'rec');
+      assert.match(msg, /no watermark reached that seq/);
+      assert.match(msg, /lost on the wire or discarded/);
+    } finally { s.srv.close(); }
+
+    // 4. It holds it but the network cannot be read — informative, and it must not throw.
+    s = await serve({ '/api/brain/spaces/sp/memories/rec': { _id: 'rec', seq: 3 } });
+    try {
+      assert.match(await whichSideLostIt(s.url, 't', 'net', 'sp', 'rec'),
+        /sender holds rec at seq 3; could not read the network \(404\)/);
+    } finally { s.srv.close(); }
+  });
+
+  it('the ARRIVAL wait gets it and the TOMBSTONE wait does not', () => {
+    /*
+     * On the tombstone wait the record is expected to be GONE from the receiver, so "does the sender still have
+     * it" means the opposite and the message would mislead. Gated on the condition rather than on the presence of
+     * the hook, because attaching it to both is the mistake that reads as thoroughness.
+     */
+    assert.match(pubsub, /expectStatus === 200\s*\n?\s*\? \{ onTimeout:/,
+      'the diagnostic must be attached only to the arrival wait');
+    assert.match(pubsub, /whichSideLostIt\(INSTANCES\.a, tokenA, networkId, testSpaceId, memId\)/);
+  });
+});

--- a/testing/sync/helpers.js
+++ b/testing/sync/helpers.js
@@ -169,7 +169,13 @@ export async function waitFor(condition, timeout = 15_000, interval = 500, diagn
     }
     await new Promise(r => setTimeout(r, interval));
   }
-  const detail = typeof diagnose === 'function' ? diagnose() : diagnose;
+  // AWAITED, so a diagnostic may go and LOOK at something.
+  //
+  // It used to be called synchronously, which silently limited every caller to facts already in hand. The sync
+  // stall under investigation cannot be explained by any of those: the question is whether the sender still holds
+  // the record and where its watermark sits, and both take a request. A `diagnose` returning a promise used to
+  // interpolate as `[object Promise]`.
+  const detail = typeof diagnose === 'function' ? await diagnose() : diagnose;
   throw new Error(`waitFor timed out after ${timeout}ms${detail ? ` — ${detail}` : ''}`);
 }
 
@@ -318,15 +324,60 @@ export function makeTriggerProbe(baseUrl, token, networkId, label = baseUrl) {
  * @param what Human phrase completing "waiting for …". Appears in the timeout message; not optional, because
  *   the whole point is that the failure explains itself.
  */
-export async function syncUntil(baseUrl, token, networkId, condition, what, { timeoutMs = 25_000, interval = 500, retriggerMs = 3_000, label } = {}) {
+export async function syncUntil(baseUrl, token, networkId, condition, what, { timeoutMs = 25_000, interval = 500, retriggerMs = 3_000, label, onTimeout } = {}) {
   await triggerSync(baseUrl, token, networkId);
   const probe = makeTriggerProbe(baseUrl, token, networkId, label ?? baseUrl);
   const retrigger = setInterval(() => { void probe(); }, retriggerMs);
   try {
-    return await waitFor(condition, timeoutMs, interval, () => `waiting for ${what} — ${probe.diagnose()}`);
+    return await waitFor(condition, timeoutMs, interval, async () => {
+      // `onTimeout` may fail for its own reasons — a 404, a network blip — and a diagnostic that throws replaces
+      // the real timeout message with its own error, which is strictly worse than no diagnostic.
+      let extra = '';
+      if (typeof onTimeout === 'function') {
+        try { extra = (await onTimeout()) ?? ''; } catch (e) { extra = `diagnostic failed: ${e.message}`; }
+      }
+      return `waiting for ${what} — ${probe.diagnose()}${extra ? ` — ${extra}` : ''}`;
+    });
   } finally {
     clearInterval(retrigger);
   }
+}
+
+/**
+ * WHICH SIDE LOST THE RECORD: the sender never sent it, or the receiver never stored it.
+ *
+ * For a propagation timeout, those are the only two possibilities, and the whole reason the intermittent pub/sub
+ * stall has survived four rounds of investigation is that the timeout message cannot tell them apart. Six
+ * reproduction attempts — three isolated, one full-suite, and two against a cold stack — all passed at ~1.1 s
+ * against a 25 s budget, so the failure is not reachable locally and the next CI occurrence has to be the one
+ * that answers this.
+ *
+ * `GET /api/networks/:id` returns each member with its `lastSeqPushed` and `lastSeqReceived` (it strips only the
+ * token hash), so no server change is needed to read the watermark.
+ *
+ * Three outcomes, each excluding the others:
+ *
+ *  - **The sender does not have the record** — the write failed, and this was never a sync problem.
+ *  - **It has it and `lastSeqPushed` >= its `seq`** — the watermark passed a record that never arrived. The push
+ *    query is `seq > lastSeqPushed`, so this should be impossible; measuring it would disprove that reasoning,
+ *    which is why it is worth stating rather than assuming.
+ *  - **It has it and `lastSeqPushed` < its `seq`** — the sender should have sent it, so the record was lost on
+ *    the wire or discarded by the receiver.
+ */
+export async function whichSideLostIt(senderUrl, senderToken, networkId, spaceId, recordId, type = 'memories') {
+  const rec = await get(senderUrl, senderToken, `/api/brain/spaces/${spaceId}/${type}/${recordId}`);
+  if (rec.status !== 200) return `the SENDER does not have ${recordId} either (${rec.status}) — the write, not sync`;
+  const seq = rec.body?.seq;
+  const net = await get(senderUrl, senderToken, `/api/networks/${networkId}`);
+  if (net.status !== 200) return `sender holds ${recordId} at seq ${seq}; could not read the network (${net.status})`;
+  const marks = (net.body?.members ?? []).map(m =>
+    `${m.label ?? m.instanceId}: pushed=${m.lastSeqPushed?.[spaceId] ?? 'unset'} received=${m.lastSeqReceived?.[spaceId] ?? 'unset'}`);
+  const passed = (net.body?.members ?? []).some(m => (m.lastSeqPushed?.[spaceId] ?? -1) >= seq);
+  return `the SENDER HOLDS ${recordId} at seq ${seq}; watermarks [${marks.join(' | ')}] — `
+    + (passed
+      ? 'a watermark is AT OR PAST that seq, so it was marked sent and never will be again'
+      : 'no watermark reached that seq, so the sender should still be offering it: lost on the wire or discarded '
+        + 'by the receiver');
 }
 
 /** Create a memory on an instance's general space */

--- a/testing/sync/pubsub-topology.test.js
+++ b/testing/sync/pubsub-topology.test.js
@@ -15,7 +15,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { dockerExec,
-  INSTANCES, post, postRetry429, get, del, delWithBody, triggerSync, syncUntil,
+  INSTANCES, post, postRetry429, get, del, delWithBody, triggerSync, syncUntil, whichSideLostIt,
 } from './helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -33,11 +33,33 @@ let networkId;
 let testSpaceId;
 let instanceIdA;
 
-/** Wait for a memory to reach (or leave) B, re-triggering A's sync while waiting. See `syncUntil`. */
+/**
+ * Wait for a memory to reach (or leave) B, re-triggering A's sync while waiting. See `syncUntil`.
+ *
+ * ## `onTimeout` is the point, and it is here because of X-20
+ *
+ * This test's first wait fails intermittently in CI and has survived four rounds of investigation, because
+ * `waitFor timed out after 25000ms — sync triggers to A all succeeded (8)` cannot distinguish the only two things
+ * it can be: A never sent the record, or B took it and did not store it.
+ *
+ * Six local reproduction attempts — three isolated, one inside the full sync suite, two against a freshly rebuilt
+ * cold stack — all PASSED at ~1.1 s against the 25 s budget. So the failure is not reachable here, and the next CI
+ * occurrence is the one that has to answer the question. `whichSideLostIt` makes it do that: it reads whether A
+ * still holds the record, at what `seq`, and where each member's watermarks sit.
+ *
+ * Only on the ARRIVAL wait. On the tombstone wait the record is expected to be gone, so "does the sender have it"
+ * has the opposite meaning and the diagnostic would mislead.
+ */
 const awaitOnB = (memId, expectStatus, what) =>
   syncUntil(INSTANCES.a, tokenA, networkId,
     async () => (await get(INSTANCES.b, tokenB, `/api/brain/spaces/${testSpaceId}/memories/${memId}`)).status === expectStatus,
-    `${what} (expected ${expectStatus} for ${memId} on B)`, { label: 'A' });
+    `${what} (expected ${expectStatus} for ${memId} on B)`,
+    {
+      label: 'A',
+      ...(expectStatus === 200
+        ? { onTimeout: () => whichSideLostIt(INSTANCES.a, tokenA, networkId, testSpaceId, memId) }
+        : {}),
+    });
 
 describe('Pub/Sub topology (A -> B subscriber)', () => {
   before(async () => {


### PR DESCRIPTION

For a propagation timeout there are only two possibilities -- the sender never
sent the record, or the receiver took it and did not store it -- and
`waitFor timed out after 25000ms -- sync triggers to A all succeeded (8)` cannot
tell them apart. That is why X-20 has survived four rounds of investigation.

ADDED ONLY AFTER THE REPRODUCTION AVENUE WAS EXHAUSTED

The order matters, and the tracker said so explicitly: do not add speculative
instrumentation before a reproduction. Six attempts now:

- three runs of `pubsub-topology.test.js` alone, warm stack: 1.1 s each;
- the FULL `npm run test:sync`, warm: `fail 0`, tombstone subtest 1 119 ms;
- two runs against a freshly rebuilt COLD stack (`test:up:rebuild`, empty
  volumes, mongot building every index from nothing): 1 169 ms and 1 141 ms.

All against a 25 000 ms budget. And four candidate explanations were already
killed by reading source -- the watermark being ahead (impossible on the push
side by construction), a second lossy receiver skip (there is none; the conflict
rule FORKS), the tombstone discard path (does not fit the ordering), and index
load starving the publisher (cycles were 19 ms).

So the failure is not reachable here, and the next CI occurrence has to be the
one that answers it. This is not a fifth guessed measurement: it captures the one
distinction that remains and cannot be read from source.

WHAT IT READS

`GET /api/networks/:id` already returns each member minus the token hash, so
`lastSeqPushed` and `lastSeqReceived` are readable by an admin token. No server
change, and none should be introduced for a test diagnostic.

Three outcomes, each excluding the others:

- the sender does not hold the record -- the WRITE failed, never a sync problem;
- it holds it and a watermark is at or past its `seq` -- marked sent, and it will
  never be offered again;
- it holds it and no watermark reached that `seq` -- the sender should still be
  offering it, so the loss is on the wire or at the receiver.

TWO PROPERTIES THAT KEEP IT FROM MAKING THINGS WORSE

`waitFor` now AWAITS its diagnostic. It used to call it synchronously, which
limited every caller to facts already in hand and would have interpolated a
promise as `[object Promise]` -- no failure, just a useless message on the one
run that mattered. The twenty-odd existing callers returning a string are
unaffected and that is asserted.

And `onTimeout` does two HTTP requests, either of which can fail for its own
reasons. A throw there degrades to a note rather than replacing the timeout it
describes, which would be strictly worse than no diagnostic. It also never runs
on a wait that succeeded -- two requests in every passing wait is not a trade
worth making.

Attached to the ARRIVAL wait only. On the tombstone wait the record is expected
to be gone from the receiver, so "does the sender still have it" means the
opposite there and the message would mislead. Attaching it to both is the mistake
that reads as thoroughness.

THE GATE, AND WHY ITS FIRST VERSION WAS NOT ONE

`a-timeout-says-which-side-lost-it.test.js` exercises `waitFor` directly -- it
takes a plain condition function, so no database -- and the diagnostic against a
four-line stub server.

The stub is there because the first version asserted only that the three outcome
strings APPEAR in the source, and mutation testing walked straight through it:
replacing a condition with `if (false)` left every string in place and the gate
green. A branch that is mentioned is not a branch that runs.

Eight mutations across both rounds, eight caught -- including an equal watermark
reading as not-sent, which is the exact case a real stall would produce.