### PR TITLE
chore(todo): the decisions page holds only what is still undecided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -642,6 +642,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`npm run todo:check` now holds the owner's DECISIONS page to open decisions only.** It had reached 312 lines
+  with SEVEN entries filed as open questions already decided — five of them shipped — because the file sat on the
+  checker's exemption list. That exemption's stated reason, *"indexed by outcome rather than queued"*, described a
+  version of the file that held outcomes; they moved to `_REFERENCE.md` and the exemption stayed. So one unchecked
+  page accumulated resolved history for weeks while every checked page stayed clean.
+
+  The damage is not the length. **One settled row makes every other row less believable**, so the reader has to
+  re-check all of them to find out which still count.
+
+  Two rules, in `scripts/parked-decisions-rules.mjs` so they are pure and fixture-testable — `todo/` is gitignored
+  and absent in CI, so a rule that only read those files could never be shown to fail, which is the same reasoning
+  that extracted `matchIndexReference`. A section heading may not announce a resolution, and no decision may be
+  both filed as open and recorded as decided. The second is the one that bites: a coverage check can only see that
+  something is mentioned, while drift needs the second copy compared.
+
+  **Both false positives are part of the rule, not omissions.** `## P-10 — six tags shipped with no GitHub`
+  `Release` is a real, open entry — "shipped" describes the tags, not the decision — and live entries say "fixed"
+  and "reverted" in their prose. The first version fired on that heading. A gate that trips on a live item's
+  wording teaches people to word entries around the gate instead of writing what they mean.
+
+  **A third rule was needed within the hour, because the first cleanup still missed one.** P-10 had been ruled by
+  the owner and said `CLOSED` in its own text, and it stayed on the page. Neither rule could see it: the heading
+  scan skips `P-N` titles and never reads bodies, and the cross-check needs a reference row nobody had written.
+  **The ruling was in the body — the one place nothing looked.** And the manual pass missed it for a worse reason:
+  each entry was verified by asking whether the code had shipped, and this ruling was *do nothing*, so the six
+  absent GitHub Releases were the IMPLEMENTED OUTCOME and read as evidence the question was open. **An absence
+  cannot tell "not done" from "deliberately not done"; only the ruling can.**
+
+  So `rulingsLeftOnThePage` matches SHOUTED markers — `RULED`, `CLOSED`, `OVERRIDDEN`, or "Owner ruled" —
+  case-sensitively, because that is how this repo writes a ruling and not how it writes prose. It attributes each
+  marker to the entry it sits under, reports an entry once however many markers it carries, and ignores the page
+  preamble, which legitimately says that decided items live elsewhere.
+
+  Eleven mutations across the three rules, eleven caught. A twelfth was dropped as an equivalent
+  mutant with the reason recorded rather than chased: on CRLF text `split('
+')` and `split(/?
+/)` yield arrays
+  of the same length, and the call reads `.length`.
+
 - **`excludeFromVectorSearch` is now `suppressEmbeddings`, which is what the two tiers below it were already
   called.** One switch had two names: the per-record flag said `excludeFromVectorSearch` while a type schema
   and the space both said `suppressEmbeddings`, and `record > schema > space` resolved between them. Nothing

--- a/scripts/parked-decisions-rules.mjs
+++ b/scripts/parked-decisions-rules.mjs
@@ -1,0 +1,104 @@
+/**
+ * The two rules that keep the DECISIONS page a list of what the owner still has to decide.
+ *
+ * ## Why they are here rather than inline in `todo-consistency.mjs`
+ *
+ * The same reason `todo-index-match.mjs` exists: `todo/` is gitignored and absent in CI, so a rule that reads
+ * those files directly is untestable and would sit in the repo unable to fail. These are pure — text in, findings
+ * out — so `parked-decisions-rules.test.js` can prove they discriminate using fixtures.
+ *
+ * ## What went wrong that they prevent
+ *
+ * Owner, 2026-08-19, opening the page: *"why are there so many items? remove everything thats already done. i
+ * only want to see what i have todo — hence 'todo'"*. It was 312 lines, and SEVEN entries filed as open questions
+ * were decided; five of those had already shipped.
+ *
+ * It rotted because it was on `todo-consistency.mjs`'s `NOT_A_QUEUE` exemption list, whose stated reason —
+ * "indexed by outcome rather than queued" — described a file that held outcomes. The outcomes moved to
+ * `_REFERENCE.md` and the exemption stayed, so an unchecked page accumulated history for weeks while every
+ * checked page stayed clean.
+ *
+ * **The damage is not the length.** One settled row makes every other row less believable, so the owner has to
+ * re-read all of them to find out which still count.
+ */
+
+/**
+ * Section headings that announce a RESOLUTION on a page that should hold none.
+ *
+ * ## Two false positives designed out, and both are the reason this is not a keyword ban
+ *
+ * - **Body text is never read.** A live decision legitimately says "fixed" and "reverted" in its own prose: P-10
+ *   opens with *"the current release is fixed; the backlog is the question"*, and P-7 records an approach that was
+ *   tried and reverted. Scanning the body fires on both.
+ * - **Entry titles are skipped.** `## P-10 — six tags SHIPPED with no GitHub Release` says what happened to the
+ *   tags, not to the decision. The first version of this check failed on exactly that, which is the
+ *   rule-versus-one-spelling mistake: an outcome word in a title says nothing about whether the question is
+ *   answered.
+ *
+ * So it looks only at headings that are NOT a `P-N` entry — which is where the rot actually lived, as whole
+ * sections of resolved history (`## Answered`, `## ANSWERED 2026-08-08`, `## Also owner-scoped`). A decided `P-N`
+ * left in place is caught by `decidedButStillFiled` instead, on evidence rather than on wording.
+ */
+export function resolvedHeadings(src) {
+  const re = /^#{2,3}[ \t]+(?!P-\d)(?=.*\b(?:answered|resolved|closed|decided|shipped|done)\b).*$/gim;
+  return [...src.matchAll(re)].map(m => ({
+    heading: m[0].trim(),
+    line: src.slice(0, m.index).split(/\r?\n/).length,
+  }));
+}
+
+/**
+ * Decisions that are on the parked page AND recorded as decided in the reference.
+ *
+ * **This is the check that actually bites**, and the reason it exists as well as the heading scan: a coverage rule
+ * can only see that something is mentioned, while drift needs the second copy compared. Every decided item is a
+ * row in `_REFERENCE.md`'s table keyed by its `P-` number, so a number in both files is decided-but-still-filed —
+ * precisely the state the owner found, and it needs no judgement about wording to detect.
+ */
+export function decidedButStillFiled(parkedSrc, referenceSrc) {
+  const decided = new Set([...referenceSrc.matchAll(/^\|[ \t]*(P-\d+)[ \t]*\|/gim)].map(m => m[1]));
+  const filed = new Set([...parkedSrc.matchAll(/^#{2,3}[ \t]+(P-\d+)\b/gim)].map(m => m[1]));
+  return [...filed].filter(id => decided.has(id)).sort();
+}
+
+/**
+ * Entries whose own body records that they were RULED, and which are therefore not open.
+ *
+ * ## The gap this closes, found the same day the other two were written
+ *
+ * P-10 survived the first cleanup. It had been ruled by the owner on 2026-08-17 — *"P-10 no backfill, only newset
+ * is interesting"* — and said **CLOSED** in its own text, and it still sat on the page as an open decision.
+ *
+ * Neither existing rule could see it. `resolvedHeadings` deliberately skips `P-N` titles and never reads bodies,
+ * because a title saying "six tags shipped" is about the tags; `decidedButStillFiled` needs a row in the reference
+ * table, and nobody had written one. **The ruling was in the body, which was the one place nothing looked.**
+ *
+ * And my own manual check missed it for a worse reason: I verified each entry by asking whether the code had
+ * shipped. P-10's ruling was *do nothing*, so the six missing Releases were the IMPLEMENTED OUTCOME and I read
+ * them as evidence the question was still open. An absence cannot distinguish "not done" from "deliberately not
+ * done"; only the ruling can.
+ *
+ * ## Why markers and not outcome words
+ *
+ * Scanning bodies for words like "fixed" or "closed" is what the heading rule was narrowed to avoid — P-11 ends
+ * with *"this genuinely closes it"* about an option it is offering, and P-7 records an approach that was reverted.
+ * So this matches only SHOUTED markers, which is how this repo writes a ruling and not how it writes prose:
+ * `RULED`, `CLOSED`, `OVERRIDDEN`, or the phrase "Owner ruled". Case-sensitive, deliberately.
+ */
+export function rulingsLeftOnThePage(parkedSrc) {
+  const lines = parkedSrc.split(/\r?\n/);
+  const out = [];
+  let entry = null;
+  for (let i = 0; i < lines.length; i++) {
+    const heading = /^#{2,3}[ \t]+(P-\d+)\b/.exec(lines[i]);
+    if (heading) { entry = heading[1]; continue; }
+    // A marker before any entry heading belongs to the page preamble, which legitimately explains that decided
+    // items live elsewhere.
+    if (!entry) continue;
+    const marker = /\b(RULED|CLOSED|OVERRIDDEN)\b|Owner ruled/.exec(lines[i]);
+    if (marker && !out.some(o => o.id === entry)) {
+      out.push({ id: entry, marker: marker[0], line: i + 1 });
+    }
+  }
+  return out;
+}

--- a/scripts/todo-consistency.mjs
+++ b/scripts/todo-consistency.mjs
@@ -31,6 +31,7 @@ import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { matchIndexReference } from './todo-index-match.mjs';
+import { resolvedHeadings, decidedButStillFiled, rulingsLeftOnThePage } from './parked-decisions-rules.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const TODO = join(ROOT, 'todo');
@@ -58,7 +59,14 @@ const NOT_A_QUEUE = new Map([
   ['_AUDIT-LENSES.md', 'a catalogue of review methods, not a list of work'],
   ['_THE_LOOP.md', 'the process description itself'],
   ['_CRYPTO-INVENTORY.md', 'a fact sheet kept for reference; its subject is closed'],
-  ['_PARKED-DECISIONS.md', 'owner decisions, indexed by outcome rather than queued'],
+  // Exempt from the QUEUE rules — its items are decisions, not work, so they have no verify line and are not in
+  // the ordered index. It is NOT unchecked: rule 5 holds it to open-decisions-only.
+  //
+  // The old reason read "indexed by outcome rather than queued", which described a file that held outcomes. They
+  // moved to `_REFERENCE.md` and the exemption stayed, so this page accumulated resolved history for weeks while
+  // every checked page stayed clean — until the owner opened it and found seven settled items filed as open. An
+  // exemption's stated reason is load-bearing: it is what the next person checks before adding a rule.
+  ['_PARKED-DECISIONS.md', 'owner DECISIONS, not work — no verify line, not in the ordered index (see rule 5)'],
   ['_DEPRECATIONS.md', 'a removal checklist keyed to a future major, not the current queue'],
   ['_CLA-BOT-SETUP.md', 'setup instructions'],
   ['_NEXT-PR-PLAN.md', 'the working plan for the PR in flight; cleared on push'],
@@ -282,6 +290,50 @@ console.log(`\n${YELLOW}todo/ consistency${R}  ${DIM}(owner rules 2026-08-02 and
       console.log(`${GREEN}  ✓${R} ${PLAN} describes work that is still ahead`);
     }
   }
+}
+
+// ── rule 5: the DECISIONS page lists only what the owner still has to decide
+//
+// Owner, 2026-08-19, reading it: *"why are there so many items? remove everything thats already done. i only
+// want to see what i have todo — hence 'todo'"*. It was 312 lines, and SEVEN entries filed as open questions were
+// decided — five of them already shipped.
+//
+// The two rules live in `parked-decisions-rules.mjs`, pure and fixture-tested, for the same reason
+// `matchIndexReference` does: `todo/` is gitignored and absent in CI, so a rule that only reads those files
+// directly can never be shown to fail. See that file for what each one refuses and which false positives were
+// designed out of it.
+{
+  const PARKED = '_PARKED-DECISIONS.md';
+  const REF = '_REFERENCE.md';
+  let clean = true;
+  if (files.includes(PARKED)) {
+    const src = readFileSync(join(TODO, PARKED), 'utf8');
+
+    for (const { heading, line } of resolvedHeadings(src)) {
+      fail(`${PARKED}:${line} has a section announcing a resolution — "${heading.slice(0, 70)}". This page is what `
+        + 'the owner still has to DECIDE. Record the outcome in `_REFERENCE.md` under Decisions already made.');
+      clean = false;
+    }
+
+    for (const { id, marker, line } of rulingsLeftOnThePage(src)) {
+      fail(`${PARKED}:${line} — ${id} records its own ruling ("${marker}"), so it is not an open decision. Move `
+        + 'the outcome to `_REFERENCE.md`. A ruling of "do nothing" leaves no code to find, which is exactly how '
+        + 'this one survived a manual pass that checked whether anything had shipped.');
+      clean = false;
+    }
+
+    if (files.includes(REF)) {
+      const both = decidedButStillFiled(src, readFileSync(join(TODO, REF), 'utf8'));
+      for (const id of both) {
+        fail(`${PARKED} still carries ${id}, which ${REF} records as DECIDED. One of the two is wrong, and a `
+          + 'settled row on the decisions page makes every other row less believable.');
+        clean = false;
+      }
+    }
+  }
+  console.log(clean
+    ? `${GREEN}  ✓${R} the decisions page holds only what is still undecided`
+    : `${RED}  ✗${R} the decisions page carries settled items`);
 }
 
 // ── the exemption list must not rot

--- a/testing/standalone/parked-decisions-rules.test.js
+++ b/testing/standalone/parked-decisions-rules.test.js
@@ -1,0 +1,225 @@
+/**
+ * The DECISIONS page check can actually FAIL, and it does not fire on a live decision's wording.
+ *
+ * ## What happened
+ *
+ * Owner, 2026-08-19, opening `todo/_PARKED-DECISIONS.md`: *"why are there so many items? remove everything thats
+ * already done. i only want to see what i have todo — hence 'todo'"*. It was 312 lines, and **seven** entries
+ * filed as open questions were already decided; five of those had shipped.
+ *
+ * It rotted because the file was on `todo-consistency.mjs`'s `NOT_A_QUEUE` exemption list, whose stated reason —
+ * *"indexed by outcome rather than queued"* — described a version of the file that held outcomes. The outcomes
+ * moved to `_REFERENCE.md` and the exemption stayed, so an unchecked page accumulated resolved history for weeks
+ * while every checked page stayed clean.
+ *
+ * **The damage is not the length.** One settled row makes every other row less believable, so the owner has to
+ * re-read all of them to find out which still count.
+ *
+ * ## Why fixtures, and not the real folder
+ *
+ * `todo/` is gitignored and absent in CI, so a test that read it would skip in the only place it runs
+ * automatically — which is not a test. The same reasoning that put `matchIndexReference` in its own module put
+ * these two rules in `parked-decisions-rules.mjs`: they are pure, so the fixtures below are the whole subject.
+ *
+ * ## The half that is easy to get wrong
+ *
+ * Both false-positive cases matter as much as the failures. A live decision legitimately contains outcome words —
+ * `## P-10 — six tags SHIPPED with no GitHub Release` is a real, open entry — and a check that fired on it would
+ * teach the next person to word entries around the gate instead of writing what they mean. The first version of
+ * this rule failed on exactly that heading.
+ *
+ * Run: node --test testing/standalone/parked-decisions-rules.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolvedHeadings, decidedButStillFiled, rulingsLeftOnThePage } from '../../scripts/parked-decisions-rules.mjs';
+
+const lines = (...xs) => xs.join('\n');
+
+describe('a section announcing a resolution is caught', () => {
+  it('catches the four shapes the page had actually reached', () => {
+    // Every one of these was on the page when the owner found it.
+    for (const heading of [
+      '## Answered — resolved reasoning lives in `_REFERENCE.md`, not here',
+      '## ANSWERED 2026-08-08 — moved to the queue',
+      '### Closed 2026-08-04 by the owner',
+      '## Decided: the export notice',
+    ]) {
+      const found = resolvedHeadings(lines('# Your decisions', '', heading, '', 'body'));
+      assert.equal(found.length, 1, `not caught: ${heading}`);
+      assert.equal(found[0].heading, heading);
+    }
+  });
+
+  it('reports the LINE, so the fix does not need a search', () => {
+    const src = lines('# Your decisions', '', 'intro', '', '## Answered — outcomes', '', 'body');
+    assert.deepEqual(resolvedHeadings(src).map(f => f.line), [5]);
+  });
+
+  it('does NOT fire on a live entry whose TITLE contains an outcome word', () => {
+    /*
+     * `## P-10 — six tags shipped with no GitHub Release` is real and open: "shipped" describes what happened to
+     * the tags, not to the decision. The first version of this rule failed on it, which is the
+     * rule-versus-one-spelling mistake — an outcome word in a title says nothing about whether the question is
+     * answered. A decided `P-N` is caught on evidence instead, by `decidedButStillFiled`.
+     */
+    for (const heading of [
+      '## P-10 — six tags shipped with no GitHub Release, and the page said the project stopped at 2.5.1',
+      '## P-12 — four images shipped with the wrong label: keep them or re-tag?',
+      '## P-13 — should a closed vote still be listed?',
+    ]) {
+      assert.deepEqual(resolvedHeadings(lines(heading, '', 'body')), [], `false positive on: ${heading}`);
+    }
+  });
+
+  it('does NOT fire on body prose, only on headings', () => {
+    // Both of these are real sentences from live entries.
+    const src = lines(
+      '## P-10 — a question',
+      '',
+      '**The current release is fixed; the backlog is the question.**',
+      '',
+      'I converted all twenty pins to presence checks before the test failed; the change is reverted.',
+      'This was answered upstream and then closed, which is why the question is what WE do.',
+    );
+    assert.deepEqual(resolvedHeadings(src), []);
+  });
+
+  it('ignores a level-1 title and deeper sub-headings of an entry', () => {
+    // `# Your decisions` is the page title. `#### …` is inside an entry's own argument, where "the options, with
+    // their real cost" style sub-heads live; neither announces a section of history.
+    assert.deepEqual(resolvedHeadings(lines('# Decisions answered elsewhere', '', 'x')), []);
+    assert.deepEqual(resolvedHeadings(lines('#### What was decided upstream', '', 'x')), []);
+  });
+
+  it('matches case-insensitively and only on whole words', () => {
+    assert.equal(resolvedHeadings('## ANSWERED').length, 1);
+    assert.equal(resolvedHeadings('## answered').length, 1);
+    // "undone" and "disclosed" contain "done" and "closed" as substrings and must not match.
+    assert.deepEqual(resolvedHeadings(lines('## Work undone by the migration', '## Not yet disclosed')), []);
+  });
+});
+
+describe('a decision recorded as decided must not still be filed as open', () => {
+  const REFERENCE = lines(
+    '## Decisions already made',
+    '',
+    '| # | decision | outcome | verified |',
+    '|---|---|---|---|',
+    '| P-4 | space bodies | **A — strict** | gated |',
+    '| P-6 | pre-existing violation | **classify** | shipped |',
+  );
+
+  it('catches the exact state the owner found', () => {
+    const parked = lines('## P-4 — space request bodies: refuse an unknown key?', '', 'Still wondering.');
+    assert.deepEqual(decidedButStillFiled(parked, REFERENCE), ['P-4']);
+  });
+
+  it('catches several at once, sorted, so one run names them all', () => {
+    const parked = lines('## P-6 — a question', '', 'x', '', '## P-4 — another', '', 'y');
+    assert.deepEqual(decidedButStillFiled(parked, REFERENCE), ['P-4', 'P-6']);
+  });
+
+  it('is silent when the page holds only undecided items', () => {
+    const parked = lines('## P-7 — how does an operator pin a field at NOTHING?', '', 'x', '', '## P-11 — taste', '', 'y');
+    assert.deepEqual(decidedButStillFiled(parked, REFERENCE), []);
+  });
+
+  it('reads the reference TABLE, not any mention of the number', () => {
+    /*
+     * The point of comparing two copies rather than checking a mention: `_REFERENCE.md` discusses decisions in
+     * prose all over the file, and a substring search would call every one of them decided. Only a table row keyed
+     * by the number is the record.
+     */
+    const prose = lines('## Some history', '', 'P-4 was argued at length and the reasoning is worth keeping.');
+    const parked = lines('## P-4 — still open', '', 'x');
+    assert.deepEqual(decidedButStillFiled(parked, prose), [],
+      'prose mentioning P-4 must not count as a decided record');
+  });
+
+  it('and the parked side must be a HEADING, not a cross-reference', () => {
+    // An entry may legitimately point at a decided one — "unlike P-4, this is not a breaking change" — without
+    // being that decision.
+    const parked = lines('## P-7 — a question', '', 'Unlike P-4, this one is not breaking.');
+    assert.deepEqual(decidedButStillFiled(parked, REFERENCE), []);
+  });
+
+  it('survives CRLF, which is what this repo checks out on Windows', () => {
+    const parked = ['## P-4 — a question', '', 'x'].join('\r\n');
+    const ref = REFERENCE.split('\n').join('\r\n');
+    assert.deepEqual(decidedButStillFiled(parked, ref), ['P-4']);
+
+    const found = resolvedHeadings(['# Title', '', 'intro', '', '## Answered', '', 'x'].join('\r\n'));
+    assert.equal(found.length, 1);
+    // The heading must come back TRIMMED of the carriage return, or the reported text ends mid-line in a terminal.
+    assert.equal(found[0].heading, '## Answered');
+    assert.equal(found[0].line, 5, 'the line number must be the same on CRLF as on LF');
+  });
+});
+
+describe('an entry that records its own ruling is not an open decision', () => {
+  const entry = (...body) => ['## P-10 — six tags shipped with no GitHub Release', '', ...body].join('\n');
+
+  it('catches the exact entry that survived the manual cleanup', () => {
+    /*
+     * P-10 had been ruled by the owner and said CLOSED in its own text, and it still sat on the page. Neither
+     * other rule could see it: the heading scan skips `P-N` titles and never reads bodies, and the cross-check
+     * needs a reference row nobody had written. The ruling was in the body — the one place nothing looked.
+     *
+     * And the manual pass missed it for a worse reason: each entry was verified by asking whether the code had
+     * shipped, and this ruling was "do nothing", so the six missing Releases were the IMPLEMENTED OUTCOME and read
+     * as evidence the question was open. An absence cannot tell "not done" from "deliberately not done".
+     */
+    const found = rulingsLeftOnThePage(entry(
+      '**RULED B ON 2026-08-17: no backfill.** Owner: *"P-10 no backfill, only newset is interesting."*',
+    ));
+    assert.deepEqual(found.map(f => ({ id: f.id, marker: f.marker })), [{ id: 'P-10', marker: 'RULED' }]);
+    assert.equal(found[0].line, 3);
+  });
+
+  it('catches every marker shape, and reports each entry once', () => {
+    for (const [body, marker] of [
+      ['**CLOSED**; the mechanism is fixed in #965.', 'CLOSED'],
+      ['Owner ruled A on 2026-08-01.', 'Owner ruled'],
+      ['My recommendation was OVERRIDDEN.', 'OVERRIDDEN'],
+    ]) {
+      assert.deepEqual(rulingsLeftOnThePage(entry(body)).map(f => f.marker), [marker], `missed: ${body}`);
+    }
+    // Two markers in one entry is still one finding — a repeated complaint about one row is noise.
+    assert.equal(rulingsLeftOnThePage(entry('**RULED B.**', 'x', '**CLOSED**.')).length, 1);
+  });
+
+  it('does NOT fire on the prose of a genuinely open entry', () => {
+    /*
+     * The false positives that decide the shape of this rule. P-11 offers an option described as one that
+     * "genuinely closes it"; P-7 records an approach that was reverted. Neither is a ruling, and a rule that fired
+     * on them would teach people to write around it.
+     */
+    for (const body of [
+      'They have committed not to raise it again, so this genuinely closes it.',
+      'I converted all twenty pins to presence checks; the change is reverted.',
+      'Told them it is parked with this recommendation, so this is not a silent park.',
+      'The current release is fixed; the backlog is the question.',
+      'It changes how the product LOOKS to every customer, and the flat path stays byte-identical.',
+    ]) {
+      assert.deepEqual(rulingsLeftOnThePage(entry(body)), [], `false positive on: ${body}`);
+    }
+  });
+
+  it('ignores markers in the page preamble, before any entry', () => {
+    // The header legitimately explains that decided items are recorded elsewhere.
+    const src = ['# Your decisions — two open', '', 'Decisions already CLOSED live in `_REFERENCE.md`.', '',
+      '## P-7 — a real question', '', 'body'].join('\n');
+    assert.deepEqual(rulingsLeftOnThePage(src), []);
+  });
+
+  it('attributes a marker to the entry it is under, not the first one', () => {
+    const src = ['## P-7 — open', '', 'body', '', '## P-11 — also open', '', '**RULED A.**'].join('\n');
+    assert.deepEqual(rulingsLeftOnThePage(src).map(f => f.id), ['P-11']);
+  });
+
+  it('and survives CRLF', () => {
+    const src = ['## P-10 — x', '', '**RULED B.**'].join('\r\n');
+    assert.deepEqual(rulingsLeftOnThePage(src).map(f => f.id), ['P-10']);
+  });
+});


### PR DESCRIPTION

Owner, opening `todo/_PARKED-DECISIONS.md`: "why are there so many items? remove
everything thats already done. i only want to see what i have todo - hence
'todo'".

WHAT I FOUND, VERIFIED AGAINST THE CODE RATHER THAN THE FILE

312 lines, and SEVEN of the entries filed as open questions were decided. Five of
those had already SHIPPED, which the page did not know:

- P-4 (strict space request bodies) -- every body is `.strict()` and
  `space-bodies-are-strict.test.js` passes, including the misspelt
  `faceDescriptorDims` case the entry was written about;
- P-5 (does the Dockerfile skip the CUDA download) -- it does, on both stages,
  with the reasoning in a comment. The question was answerable from source;
- P-6 (does a pre-existing schema violation block an unrelated edit) --
  `brain/write-validation.ts` classifies caused / pre-existing / repaired;
- P-9 (`find_similar` changing its response type with a parameter) -- JSON at
  every depth since 3.1.0, on the owner's ruling;
- the CLA bot "account action" -- `cla=SUCCESS` on #980 through #984.

Plus two whole sections of resolved history, and one item I had parked on the
owner myself that turned out to be his instance rebooting.

Three real decisions remain: P-7, P-10, P-11. The page is 123 lines and every row
is a live either/or with a recommendation. Outcomes moved to `_REFERENCE.md` as
one table, one line each.

WHY IT ROTTED, WHICH IS THE PART WORTH FIXING

The file was on `todo-consistency.mjs`'s `NOT_A_QUEUE` exemption list. That
exemption's stated reason -- "indexed by outcome rather than queued" -- described
a version of the file that HELD outcomes. The outcomes moved to `_REFERENCE.md`
and the exemption stayed. So one unchecked page accumulated history for weeks
while every checked page stayed clean.

An exemption's stated reason is load-bearing: it is what the next person reads
before deciding whether a rule is needed. That comment is now rewritten to say
what is exempt (the queue rules) and what is not (rule 5).

THE DAMAGE IS NOT THE LENGTH

One settled row makes every other row less believable, so the reader has to
re-check all of them to find out which still count. That is what turns a decision
list into something you stop opening.

THE RULES, AND WHY THEY ARE THEIR OWN MODULE

`scripts/parked-decisions-rules.mjs`, pure text-in-findings-out, for exactly the
reason `matchIndexReference` was extracted: `todo/` is gitignored and absent in
CI, so a rule that only reads those files can never be shown to fail and would
sit in the repo unable to catch anything.

1. A section heading may not announce a resolution.
2. No decision may be BOTH filed as open and recorded as decided. This is the one
   that bites -- a coverage rule can only see that something is mentioned, while
   drift needs the second copy compared, and a P-number in both files needs no
   judgement about wording.

BOTH FALSE POSITIVES ARE PART OF THE RULE, NOT OMISSIONS

`## P-10 - six tags SHIPPED with no GitHub Release` is a real, open entry:
"shipped" describes the tags, not the decision. My first version failed on it.
And live entries legitimately say "fixed" and "reverted" in their prose -- P-10
opens with "the current release is fixed; the backlog is the question".

So the heading scan skips `P-N` entry titles and never reads the body, and a
decided entry is caught on EVIDENCE instead. A gate that trips on a live item's
wording teaches people to word entries around the gate rather than write what they
mean.

Six mutations, six caught, including both false-positive directions. A seventh was
dropped as an EQUIVALENT mutant with the reason written down rather than chased:
on CRLF text `split('\n')` and `split(/\r?\n/)` produce arrays of the same length,
and the call reads `.length`, so there is no behaviour to catch and an assertion
"killing" it would pin an implementation detail instead of a rule.