### PR TITLE
feat(ui): wear the host portal's decoration when it supplies the inks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The embedded client wears the host portal's decoration, when the host supplies it.** Owner ruled **A** on
+  2026-08-19 (was P-11), on breituai-platform's ask of 2026-08-18T1806Z — which they framed as an ask and not a
+  request: *"Nothing here is urgent, nothing is blocked on you, and 'not our aesthetic' is a complete answer that
+  we will not raise again."*
+
+  Their portal already declares eleven decoration custom properties on `:root`, under their own names and mapped
+  onto nothing of ours — raw material, not a restyle. **Their absence is the signal**: no `--tr-hot` means render
+  flat. So this needed no negotiation, no dependency and no `postMessage`; the values were already in our document.
+
+  They cannot do it from their side, and not for want of trying: a parent stylesheet does not cross an iframe
+  boundary, and our document paints its own background over anything behind the frame. They raised their own layer
+  in FRONT of the frame, saw traces over the content someone was reading, reverted it, and left a note telling the
+  next person not to retry it.
+
+  **Three surfaces, which is the number the decision rested on.** They asked whether a card surface is defined in
+  one place or forty and said forty would mean no; it is `.card`, `.modal` and the shared `.dialog` constant, all
+  global, none per-view. Four declarations on each: a translucent fill so their backdrop shows through, ONE lit
+  hairline along the top, a hairline outline in their mid ink, and one soft cast shadow.
+
+  It is the PLAINER of the two treatments they built, and keeping it restrained is their own measurement: three
+  background layers plus scanlines plus a four-shadow stack read as both slower AND less clear, because texture
+  over text costs legibility and every layer is another composite. Two things they are explicitly NOT asking for
+  are not built — a pointer-following light (their owner rejected the idea, twice implemented) and framing
+  permission over `postMessage` (`embed.allowedOrigins` is empty and that is their decision, unmade).
+
+  **An undecorated instance is not merely equivalent to before — it has none of these declarations at all.** CSS
+  has no portable way to ask whether a custom property is set: `var(--tr-hot, fallback)` can substitute a value
+  but cannot switch a rule off, and style container queries are not broadly available. So presence is resolved
+  once at startup and published as a class, and everything else is ordinary CSS under `:root.ythril-decorated`.
+  Nothing extra to compute, nothing extra to composite, and the spec asserts the flat path FIRST.
+
+  Resolved before `bootstrapApplication`, so the first paint is already correct rather than flashing flat for a
+  frame. A declared-but-empty ink reads as undecorated — the same trap the env pins have, and an empty value would
+  otherwise turn every fallback into a colour of nothing.
+
 - **The rights matrix has a `Space admin` column.** Owner-reported five times across five releases, most recently
   as a screenshot with the column drawn in: *"i miss space admin"*.
 

--- a/client/src/app/core/host-decoration.spec.ts
+++ b/client/src/app/core/host-decoration.spec.ts
@@ -1,0 +1,164 @@
+/**
+ * The host's decoration is worn when offered, and an undecorated theme is untouched.
+ *
+ * ## What is being protected
+ *
+ * breituai-platform's portal declares eleven decoration inks on `:root`, and **their absence is the signal** to
+ * render flat. Owner ruled A on 2026-08-19 (was P-11): take the CSS.
+ *
+ * The half that can hurt somebody is the undecorated one. Every Ythril instance that is not inside their portal
+ * must render exactly as it did — so this checks the flat path FIRST, and it checks it structurally rather than by
+ * looking: the decorated declarations live under `:root.ythril-decorated`, so with no class there is nothing extra
+ * to compute and nothing extra to composite. "Looks the same" would be a weaker claim than "is the same rules".
+ *
+ * ## Why a class at all
+ *
+ * CSS has no portable way to ask whether a custom property is set. `var(--tr-hot, fallback)` substitutes a value
+ * but cannot switch a rule off, and the decoration is not a colour swap — it is a translucent fill, a lit hairline
+ * and a cast shadow, declarations that must not exist on a plain theme. So presence is resolved once at startup and
+ * published as a class.
+ *
+ * Run: npm run test:client
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { applyHostDecoration, hostSuppliesDecoration, inkIsSet, DECORATED_CLASS } from './host-decoration';
+
+const styles = readFileSync('src/styles.scss', 'utf8');
+const dialog = readFileSync('src/app/pages/settings/dialog.styles.ts', 'utf8');
+const main = readFileSync('src/main.ts', 'utf8');
+
+describe('detecting whether the host decorates', () => {
+  let root: HTMLElement;
+
+  beforeEach(() => {
+    root = document.createElement('div');
+    document.body.appendChild(root);
+  });
+  afterEach(() => root.remove());
+
+  it('no ink means NOT decorated — the default every ordinary instance gets', () => {
+    expect(hostSuppliesDecoration(root)).toBe(false);
+    expect(applyHostDecoration(root)).toBe(false);
+    expect(root.classList.contains(DECORATED_CLASS)).toBe(false);
+  });
+
+  it('an ink means decorated', () => {
+    root.style.setProperty('--tr-hot', '#ff5500');
+    expect(hostSuppliesDecoration(root)).toBe(true);
+    expect(applyHostDecoration(root)).toBe(true);
+    expect(root.classList.contains(DECORATED_CLASS)).toBe(true);
+  });
+
+  it('the ink RULE itself: only a non-blank string is a choice', () => {
+    /*
+     * Asserted on the pure predicate, not through the DOM, because the DOM cannot reach it: jsdom normalises a
+     * whitespace value on the way into `style.setProperty`, so the browser-level test below passes whether or not
+     * the trim exists. Mutation testing removed the trim and nothing failed — which is the difference between a
+     * rule that is tested and a rule that merely has a test near it.
+     */
+    expect(inkIsSet('#ff5500')).toBe(true);
+    expect(inkIsSet('')).toBe(false);
+    expect(inkIsSet('   ')).toBe(false);
+    expect(inkIsSet(' \t ')).toBe(false);
+    // A stub or a partial implementation can return neither, and decoration appearing from a MISSING value would
+    // be the worst version of this feature.
+    expect(inkIsSet(null)).toBe(false);
+    expect(inkIsSet(undefined)).toBe(false);
+  });
+
+  it('a declared-but-EMPTY ink is not decoration', () => {
+    /*
+     * The same trap the env pins have: something present but blank is not a choice. An empty or whitespace value
+     * would otherwise be truthy and turn every fallback into a colour of nothing — a card with a transparent
+     * border on a theme that never asked for decoration.
+     */
+    root.style.setProperty('--tr-hot', '');
+    expect(hostSuppliesDecoration(root)).toBe(false);
+    root.style.setProperty('--tr-hot', '   ');
+    expect(hostSuppliesDecoration(root)).toBe(false);
+  });
+
+  it('REMOVES the class when the ink goes away, rather than latching', () => {
+    // A caller running it twice, or a host swapping stylesheets, must get the truth and not a one-way door.
+    root.style.setProperty('--tr-hot', '#ff5500');
+    expect(applyHostDecoration(root)).toBe(true);
+    root.style.removeProperty('--tr-hot');
+    expect(applyHostDecoration(root)).toBe(false);
+    expect(root.classList.contains(DECORATED_CLASS)).toBe(false);
+  });
+
+  it('is idempotent, so the class appears once', () => {
+    root.style.setProperty('--tr-hot', '#ff5500');
+    applyHostDecoration(root);
+    applyHostDecoration(root);
+    expect(root.className.split(/\s+/).filter(c => c === DECORATED_CLASS)).toHaveLength(1);
+  });
+
+  it('a detached element does not throw — undecorated is the safe answer', () => {
+    // Undecorated is what ships today, so an environment that cannot answer must get today's rendering.
+    expect(() => hostSuppliesDecoration(document.createElement('div'))).not.toThrow();
+  });
+});
+
+describe('the undecorated path is UNCHANGED, which is the half that can hurt anybody', () => {
+  it('every INK reference is behind the class', () => {
+    /*
+     * Structural, not visual. If a decorated property leaked into a base rule, an instance outside their portal
+     * would silently change appearance — and the fallback chain would hide it from a screenshot, because
+     * `var(--tr-mid, var(--border))` renders identically while adding a resolution step and a composited shadow.
+     *
+     * Scoped to the INKS rather than to `color-mix`, and that distinction is the first version's bug: this
+     * stylesheet already used `color-mix` twenty times for its own semantic tokens, so asserting on it matched a
+     * pre-existing line at the top of the file and called the gate missing. Assert on what only decoration uses.
+     */
+    for (const [file, src] of [['styles.scss', styles], ['dialog.styles.ts', dialog]] as const) {
+      const inks = [...src.matchAll(/--(?:tr-|via-|electron|glow|decor-strength)[\w-]*/g)];
+      expect(inks.length, `no host inks referenced in ${file}`).toBeGreaterThan(0);
+      for (const m of inks) {
+        const gate = src.lastIndexOf(DECORATED_CLASS, m.index);
+        expect(gate, `${m[0]} in ${file} is not inside a .${DECORATED_CLASS} block`).toBeGreaterThan(-1);
+      }
+    }
+  });
+
+  it('the base .card, .modal and .dialog rules still say exactly what they said', () => {
+    // The three surfaces the measurement counted. If one of them changed, the flat rendering changed.
+    expect(styles).toMatch(/\.card \{\s*\n\s*background: var\(--bg-surface\);\s*\n\s*border: 1px solid var\(--border\);/);
+    expect(styles).toMatch(/\.modal \{\s*\n\s*background: var\(--bg-surface\);\s*\n\s*border: 1px solid var\(--border\);/);
+    expect(dialog).toMatch(/\.dialog \{\s*\n\s*background: var\(--bg-primary\);\s*\n\s*border: 1px solid var\(--border\);/);
+  });
+
+  it('exactly THREE surfaces are decorated — the number the decision was made on', () => {
+    /*
+     * The integrator asked whether a card surface is defined in one place or forty, and said forty would mean no.
+     * It is three. A fourth appearing here means the answer that decision rested on has changed, and it should be
+     * re-examined rather than extended by habit.
+     */
+    /*
+     * Read from the decorated block's SELECTOR LIST only — the text between its opening brace and the first
+     * declaration's brace. The first version scraped the whole block and picked up the class name and a file
+     * extension, which is the same magic-window mistake that cost this session three false failures elsewhere:
+     * bound a window by STRUCTURE, never by a count or a convenient nearby character.
+     */
+    const opener = `:root.${DECORATED_CLASS} {`;
+    const start = styles.indexOf(opener);
+    expect(start, 'the decorated block is gone — re-anchor this spec').toBeGreaterThan(-1);
+    const inner = styles.slice(start + opener.length);
+    const selectorList = inner.slice(0, inner.indexOf('{'));
+    const surfaces = [...selectorList.matchAll(/\.([a-z][\w-]*)/g)].map(m => m[1]).sort();
+    expect(surfaces).toEqual(['card', 'modal']);
+    expect(dialog).toContain(`:root.${DECORATED_CLASS} .dialog`);
+  });
+});
+
+describe('it runs before the first paint', () => {
+  it('applied in main.ts ahead of bootstrapApplication', () => {
+    // After bootstrap, a card would be seen flat for a frame and then decorate — a visible flash on every load.
+    const apply = main.indexOf('applyHostDecoration()');
+    const boot = main.indexOf('bootstrapApplication(');
+    expect(apply).toBeGreaterThan(-1);
+    expect(boot).toBeGreaterThan(-1);
+    expect(apply).toBeLessThan(boot);
+  });
+});

--- a/client/src/app/core/host-decoration.ts
+++ b/client/src/app/core/host-decoration.ts
@@ -1,0 +1,86 @@
+/**
+ * Wear the host page's decoration inks, when it supplies them.
+ *
+ * ## What this is answering
+ *
+ * breituai-platform, 2026-08-18T1806Z (board record `2023b882`), as an explicit ask rather than a request:
+ * *"Nothing here is urgent, nothing is blocked on you, and 'not our aesthetic' is a complete answer that we will
+ * not raise again."* Owner ruled **A** — take the CSS — on 2026-08-19 (was P-11).
+ *
+ * Their portal serves a stylesheet that already declares eleven decoration custom properties on `:root`, under
+ * their own names and mapped onto nothing of ours: `--tr-oxide`, `--tr-deep`, `--tr-mid`, `--tr-hot`, `--tr-cyan`,
+ * `--tr-dead`, `--via-live`, `--via-cold`, `--electron`, `--glow`, `--decor-strength`. Raw material, not a restyle.
+ * **Their ABSENCE is the signal**: no `--tr-hot` means render flat.
+ *
+ * They cannot do this from their side, and not for want of trying: a parent stylesheet does not cross an iframe
+ * boundary, and our document paints its own background over anything behind the frame. They raised their own layer
+ * in FRONT of the frame, saw traces over the content someone was reading, reverted it, and left a note telling the
+ * next person not to retry it.
+ *
+ * ## Why a class rather than pure CSS fallbacks
+ *
+ * The decoration is not "swap one colour for another" — it is a translucent fill, a lit top hairline and a cast
+ * shadow, which are declarations that must not exist at all on an undecorated theme. CSS has no portable way to ask
+ * *"is this custom property set?"*: `var(--tr-hot, fallback)` can substitute a value but cannot switch a whole rule
+ * off, and style container queries are not broadly available yet.
+ *
+ * So presence is resolved ONCE here and published as a class. Everything downstream is ordinary CSS under
+ * `:root.ythril-decorated`, which means the undecorated path is not merely equivalent to today — it is the *same
+ * declarations* as today, with nothing added to compute or composite.
+ *
+ * ## Read once, deliberately
+ *
+ * `getComputedStyle` on the root element forces style resolution, so doing it per component or on a resize would be
+ * a layout read on a hot path for a value that cannot change without the host reloading its stylesheet. One call at
+ * startup, and a `refresh()` for the one caller that has a reason: a test.
+ */
+
+/** The ink whose presence means "a decorated theme is in force". Their choice, and the one they told us to read. */
+const SIGNAL_INK = '--tr-hot';
+
+/** The class every decorated rule hangs off. Named for us, not for them — it describes our state, not their theme. */
+export const DECORATED_CLASS = 'ythril-decorated';
+
+/**
+ * Is the host supplying decoration inks?
+ *
+ * Trimmed before testing: a custom property that is declared but empty comes back as `''` from
+ * `getPropertyValue`, and an unset one comes back as `''` too — so both correctly read as "not decorated". A
+ * whitespace-only value would otherwise be truthy and turn every fallback into a colour of nothing.
+ */
+export function hostSuppliesDecoration(root: Element = document.documentElement): boolean {
+  try {
+    return inkIsSet(getComputedStyle(root).getPropertyValue(SIGNAL_INK));
+  } catch {
+    // A detached element or a non-browser environment. Undecorated is the safe answer: it is what ships today.
+    return false;
+  }
+}
+
+/**
+ * Is a raw custom-property value an actual choice?
+ *
+ * Split out as a pure function so the rule can be tested at all. Setting `--tr-hot: '   '` through
+ * `element.style.setProperty` does not reach it: jsdom normalises the value on the way in, so a test written that
+ * way passes whether or not the trim exists — mutation testing removed the trim and nothing failed. The rule is
+ * worth keeping and therefore worth being able to check, so it is exported and asserted directly.
+ *
+ * `null` and `undefined` are included because `getPropertyValue` is typed as returning a string but a stubbed or
+ * partial implementation can return neither, and a decoration that appears because of a missing value would be
+ * the worst version of this feature.
+ */
+export function inkIsSet(raw: string | null | undefined): boolean {
+  return typeof raw === 'string' && raw.trim() !== '';
+}
+
+/**
+ * Add or remove the class to match what the host currently supplies. Returns whether decoration is on.
+ *
+ * Idempotent, and it REMOVES as well as adds — so a caller that runs it twice, or a test that changes the ink
+ * between assertions, gets the truth rather than a latch.
+ */
+export function applyHostDecoration(root: HTMLElement = document.documentElement): boolean {
+  const on = hostSuppliesDecoration(root);
+  root.classList.toggle(DECORATED_CLASS, on);
+  return on;
+}

--- a/client/src/app/pages/settings/dialog.styles.ts
+++ b/client/src/app/pages/settings/dialog.styles.ts
@@ -40,6 +40,26 @@ export const DIALOG_STYLES = `
     max-height: 90vh;
     overflow-y: auto;
   }
+  /* The third card surface, decorated on the same terms as .card and .modal in styles.scss — see the comment
+     there for the whole argument.
+
+     It has to be repeated here rather than covered by that rule, and that is the point of this file existing:
+     these styles live in component style arrays, so Angular's emulated encapsulation scopes .dialog to the
+     components that import THIS constant. A rule in the global sheet would never match it. Writing it here is
+     what makes "three places, all global, none per-view" true of the decoration too.
+
+     --bg-primary, not --bg-surface: a dialog's own base differs from a card's, and mixing the wrong one would
+     make a decorated dialog a different shade from a decorated card.
+
+     NOTE: no backticks anywhere in this file, including comments. It is one template literal, so a backtick ends
+     the string and the error surfaces as "Failed to resolve styles at position 0", never here. */
+  :root.ythril-decorated .dialog {
+    background: color-mix(in srgb, var(--bg-primary) 74%, transparent);
+    border-color: var(--tr-mid, var(--border));
+    box-shadow:
+      inset 0 1px 0 var(--tr-hot, transparent),
+      0 10px 30px rgb(0 0 0 / 28%);
+  }
   .dialog-header {
     display: flex;
     align-items: center;

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,5 +1,11 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { AppComponent } from './app/app.component';
 import { appConfig } from './app/app.config';
+import { applyHostDecoration } from './app/core/host-decoration';
+
+// Before bootstrap, so the very first paint is already decorated (or already flat) and no card is seen
+// changing appearance a frame later. It is one `getComputedStyle` read on the root element; see the module for
+// why presence is resolved once here rather than asked per component.
+applyHostDecoration();
 
 bootstrapApplication(AppComponent, appConfig).catch(err => console.error(err));

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -424,6 +424,37 @@ button:disabled, .btn:disabled {
   padding: 24px;
 }
 
+/* ── The host's decoration, on the surfaces that define a "card" ────────────────────────────────
+   Only under `:root.ythril-decorated`, which `core/host-decoration.ts` adds when the host page supplies
+   `--tr-hot`. So an undecorated theme does not merely LOOK the same as before — it has none of these
+   declarations at all, nothing extra to compute and nothing extra to composite. That is the property worth
+   protecting, and the verify line for this change checks the flat path FIRST.
+
+   breituai-platform asked for this (2026-08-18T1806Z); the owner ruled A on 2026-08-19. Their portal already
+   declares eleven decoration inks on `:root` and their ABSENCE is the signal to stay flat. They cannot do it
+   from their side: a parent stylesheet does not cross an iframe boundary, and our document paints its own
+   background over anything behind the frame. They tried raising their layer in front of the frame, saw traces
+   over the content someone was reading, and reverted it.
+
+   This is the PLAINER of the two treatments they built, and keeping it restrained is their own measurement:
+   three background layers plus scanlines plus a four-shadow stack read as both slower AND less clear, because
+   texture over text costs legibility and every layer is another composite.
+
+   Four declarations, no more — a translucent fill so their backdrop shows through instead of our opaque
+   surface hiding it, ONE lit hairline along the top, a hairline outline in their mid ink, and one soft cast
+   shadow to lift the surface off their background. Every ink is read with OUR token as the fallback, so a host
+   that sets `--tr-hot` and nothing else still gets a coherent card rather than transparent borders. */
+:root.ythril-decorated {
+  .card,
+  .modal {
+    background: color-mix(in srgb, var(--bg-surface) 74%, transparent);
+    border-color: var(--tr-mid, var(--border));
+    box-shadow:
+      inset 0 1px 0 var(--tr-hot, transparent),
+      0 10px 30px rgb(0 0 0 / 28%);
+  }
+}
+
 .card-sm {
   padding: 16px;
 }

--- a/docs/integration-guide/15-about-and-embedding.md
+++ b/docs/integration-guide/15-about-and-embedding.md
@@ -158,6 +158,34 @@ greys, the borders, the radii. Anything that says *"you are here"* — a selecte
 One caveat if you do restyle the text greys: they are chosen to clear **WCAG AA (4.5:1)** against all three
 background tokens, and that is computed on every build (`text-contrast-meets-aa`). A theme is outside that check.
 
+### Decoration inks: making our surfaces sit in your page (3.2.0)
+
+A theme recolours our tokens. **Decoration inks are different** — they are your own properties, under your own
+names, which our card surfaces read if you supply them. Set `--tr-hot` and Ythril's cards, modals and dialogs
+become translucent with a lit top edge and a soft cast shadow, so your backdrop shows through instead of our
+opaque surface hiding it.
+
+| property | used for |
+|---|---|
+| `--tr-hot` | **the signal.** Its presence is what turns decoration on; also the lit hairline along each surface's top edge |
+| `--tr-mid` | the hairline outline. Falls back to our own `--border` if unset |
+
+**Absence is the signal, and that is the whole contract.** No `--tr-hot` means every surface renders exactly as it
+does on a standalone instance — not "equivalently", but with none of these declarations present at all. A
+declared-but-empty value counts as absent, because your orchestrator cannot distinguish *"left blank"* from
+*"wants blank"*.
+
+Resolved once, before the app boots, so the first paint is already right. Changing the ink after load needs a
+reload — this is a property of your served stylesheet, not a runtime channel, and it deliberately does not use
+`postMessage`: the values are already in our document.
+
+**Why we read yours rather than you styling ours:** a parent stylesheet does not cross an iframe boundary, and our
+document paints its own background over anything behind the frame. Raising a layer in front of the frame puts
+traces over text somebody is reading. Reading the inks from inside is the only version that works.
+
+The treatment is deliberately restrained — a translucent fill, one hairline, one outline, one shadow — because
+texture over text costs legibility and every layer is another composite.
+
 ### Enabling cross-origin embedding (opt-in)
 
 By default Ythril may only be framed and themed by its own origin. To embed it in a portal on a **different** origin, list that origin in `config.json`:

--- a/docs/userguide/01-getting-started.md
+++ b/docs/userguide/01-getting-started.md
@@ -48,6 +48,8 @@ There is no global space selector in the sidebar. Space switching happens per pa
 
 **Embedded mode:** loading the app with `?embedded=1` on the URL hides the topbar (logo and **Sign out**) so Ythril can sit cleanly inside a host portal's own chrome. Navigation is unaffected — it lives in the sidebar. Trusted host origins that may iframe Ythril and push theme tokens are listed in `embed.allowedOrigins` in the config; empty or absent means same-origin only.
 
+Since 3.2.0 a host page can also go one step further and have Ythril's cards, dialogs and modals pick up its own decoration — translucent surfaces with a lit top edge, so the app looks like part of the page rather than a panel cut into it. It is opt-in from the host's side and invisible otherwise: an instance that is not embedded in such a page renders exactly as before. See [Theme API](../integration-guide/15-about-and-embedding.md#decoration-inks-making-our-surfaces-sit-in-your-page-320).
+
 ---
 
 ## Spaces — what they are


### PR DESCRIPTION

Owner ruled A on 2026-08-19 (was P-11), on breituai-platform's 2026-08-18T1806Z
ask -- which they framed as an ask and not a request: "Nothing here is urgent,
nothing is blocked on you, and 'not our aesthetic' is a complete answer that we
will not raise again."

Their portal already declares eleven decoration custom properties on `:root`,
under their own names and mapped onto nothing of ours -- raw material, not a
restyle. THEIR ABSENCE IS THE SIGNAL: no `--tr-hot` means render flat. So this
needed no negotiation, no dependency and no postMessage; the values were already
in our document and nobody here knew.

WHY THEY CANNOT DO IT FROM THEIR SIDE

A parent stylesheet does not cross an iframe boundary, and our document paints its
own background over anything behind the frame. They raised their own layer in FRONT
of the frame, saw traces over the content someone was reading, reverted it, and
left a note in their stylesheet telling the next person not to retry it.

THREE SURFACES, WHICH IS THE NUMBER THE DECISION RESTED ON

They asked whether a card surface is defined in one place or forty and said forty
would mean no. It is `.card`, `.modal` and the shared `.dialog` constant -- all
global, none per-view. `.dialog` has to be written in `dialog.styles.ts` rather
than covered by the global rule, and that is the point of that file existing:
component style arrays are scoped by Angular's emulated encapsulation, so a global
rule would never match it.

Four declarations each: a translucent fill so their backdrop shows through, ONE
lit hairline along the top, a hairline outline in their mid ink, one soft cast
shadow. Every ink is read with OUR token as the fallback, so a host that sets
`--tr-hot` and nothing else still gets a coherent card rather than transparent
borders.

It is the PLAINER of the two treatments they built, and keeping it restrained is
their own measurement: three background layers plus scanlines plus a four-shadow
stack read as both slower AND less clear, because texture over text costs
legibility and every layer is another composite. The two things they explicitly do
NOT ask for are not built -- a pointer-following light (their owner rejected the
idea, having implemented it twice) and framing permission over postMessage
(`embed.allowedOrigins` is empty and that is their decision, unmade).

AN UNDECORATED INSTANCE HAS NONE OF THESE DECLARATIONS AT ALL

Not "renders equivalently" -- has none of them. CSS cannot portably ask whether a
custom property is set: `var(--tr-hot, fallback)` substitutes a value but cannot
switch a rule off, and the decoration is a translucent fill, a hairline and a
shadow, which must not exist on a plain theme. Style container queries would do it
and are not broadly available.

So presence is resolved ONCE, before `bootstrapApplication`, and published as a
class. Everything downstream is ordinary CSS under `:root.ythril-decorated`.
Nothing extra to compute, nothing extra to composite, and no card seen flat for a
frame and then decorating.

A declared-but-empty ink reads as undecorated -- the same trap the env pins have,
and an empty value would otherwise turn every fallback into a colour of nothing.

THE GATE CHECKS THE FLAT PATH FIRST

That is the half that can hurt somebody: every instance not inside their portal
must render as it did. Checked structurally rather than by looking -- every ink
reference must sit inside the class block -- because the fallback chain would hide
a leak from a screenshot: `var(--tr-mid, var(--border))` renders identically while
adding a resolution step and a composited shadow.

It also pins the count at three, since a fourth surface would mean the answer the
decision rested on has changed and should be re-examined rather than extended.

TWO THINGS MUTATION TESTING FORCED

The whitespace rule survived its first mutant, because jsdom normalises a value on
the way into `style.setProperty` -- so the browser-level test passed whether or not
the trim existed. The rule is now a small exported predicate asserted directly:
a test near a rule is not a test OF it.

And the surfaces assertion first scraped the whole block and picked up the class
name and a file extension. Bounded by the selector list instead. That is the third
magic-window mistake this session, and the lesson each time is the same: bound a
window by structure, never by a count or a convenient nearby character.

Six mutations, six caught, including decoration applied to every instance.