### PR TITLE
chore(testing): a gate may not bound its subject with a magic number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -327,6 +327,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Gates may no longer bound their subject with a magic number.** `src.slice(at, at + 3000)` decides in advance
+  how much of its subject a gate can see; grow the subject and the gate either fails on correct code or passes
+  while checking less than it meant to. A character count also spans different LINES on CRLF than on LF, so a
+  window that fits locally can fall short in CI.
+
+  Three failed in one session, and the cost is not hypothetical:
+
+  - `index-ready-poll.test.js` at `at + 3000` — a new branch pushed its subject out;
+  - `rights-are-explained.test.js` capped a `<thead>` at 1 400 characters — a fifth column took it to 1 770;
+  - `rights-matrix.component.spec.ts` asserted a header count `toBe(4)`.
+
+  **The third is why the Space Admin column was reverted five releases earlier.** It had been built, it worked, and
+  it was thrown away because a count broke — which reads as *"the feature broke the tests"* rather than as *"the
+  test was written wrong"*. The owner had asked five times.
+
+  `testing/standalone/_structural-window.mjs` now holds the three shapes that bound correctly — `bodyOf` (to the
+  next top-level declaration), `between` (to the closing marker, with no cap, because the marker IS the bound), and
+  `bodyOfEndingWith`, which additionally proves the window reached the end of its subject. Three files had
+  hand-rolled the same body-finding loop within hours of each other, which is this codebase's most-produced defect
+  arriving in the test suite instead of the product.
+
+  **A ratchet, not a sweep.** 26 magic windows remain across 19 files, grandfathered in a list that only shrinks —
+  the same shape `no-new-god-files` uses. Rewriting them blind is how a gate quietly starts checking less than it
+  did, because only someone reading a window knows what its real bound is. Four converted here: the three in
+  `result-spill-suppresses-vectors.test.js` and one in `startup-index-wait.test.js`, all four subjects I had just
+  read. One of them was a `doesNotMatch`, where a short window is at its most dangerous — a `return null` past the
+  old 1 800-character cap would have gone unseen, and that is the exact rule whose absence once shipped a truncated
+  answer with nowhere to go.
+
+  Two things are deliberately NOT banned, both because reading them showed they are a different thing wearing the
+  same syntax: `slice(0, N)` truncating a value inside a failure MESSAGE (79 of those, and a 400-line JSON blob in
+  an assertion message helps nobody), and `[\s\S]{0,N}` used as an ADJACENCY bound inside a pattern — *"these two
+  must be near each other"* is a deliberate claim, not a guessed extent. A first draft banned the second and found
+  30 sites; 30 unread sites is exactly the blind sweep this exists to prevent, so they are recorded as an unassessed
+  population rather than a number someone can wave through.
+
+  Six cases, six correct — including a broken pattern reporting "none left", the ratchet slipping upward, and both
+  legitimate shapes staying green.
+
 - **A propagation timeout in the sync tests now says WHICH SIDE lost the record.** `waitFor`'s diagnostic hook is
   awaited, so it can go and look rather than being limited to facts already in hand, and the pub/sub arrival wait
   supplies one that reads whether the sender still holds the record, at what `seq`, and where each member's

--- a/testing/standalone/_structural-window.mjs
+++ b/testing/standalone/_structural-window.mjs
@@ -1,0 +1,88 @@
+/**
+ * Bound a gate's window by STRUCTURE, never by a character count.
+ *
+ * ## What a magic window costs, measured
+ *
+ * A gate that reads `src.slice(at, at + 3000)` has silently decided how much of its subject it can see. Grow the
+ * subject and the window stops covering it — and the gate then either fails on correct code or, worse, passes by
+ * looking at less than it meant to.
+ *
+ * On 2026-08-19 that cost three false failures in one session:
+ *
+ * - `index-ready-poll.test.js` windowed a function body at `at + 3000`; a new branch pushed the statement it
+ *   checks past 3000 characters and it failed on working code.
+ * - `rights-are-explained.test.js` capped a `<thead>` at 1 400 characters; a fifth column took it to 1 770.
+ * - `rights-matrix.component.spec.ts` asserted a header count `toBe(4)`; a fifth column failed it.
+ *
+ * **The third one is why the Space Admin column was reverted five releases earlier.** The owner had asked for it
+ * five times, and each time the obstacle was a test failing on an unrelated addition — which reads as *"the
+ * feature broke the tests"* rather than as *"the test was written wrong"*. His words when it finally shipped:
+ * *"must be noob mistake what you are doing, cant be real that one column creates such problems"*. It was.
+ *
+ * A character count also spans different LINES on CRLF than on LF, so a window that fits locally can fall short in
+ * CI — which is the same failure with a slower feedback loop.
+ *
+ * ## Three copies of this existed before it did
+ *
+ * `optional-index-cannot-fail-a-space.test.js`, `no-polling-a-deleted-space.test.js` and
+ * `index-ready-poll.test.js` each hand-rolled the same body-finding loop within hours of each other. That is the
+ * defect `CLAUDE.md` names as the one this repo produces most — one rule, several implementations — arriving in
+ * the test suite instead of the product.
+ */
+import assert from 'node:assert/strict';
+
+/** A top-level declaration in a TS/JS source: where one subject ends and the next begins. */
+const TOP_LEVEL = /^(?:export\s+)?(?:async\s+function|function|const|class|interface|type|abstract\s+class)\s/;
+
+/**
+ * The body of one named function or const, from its declaration to the next top-level declaration.
+ *
+ * Bounded by what the language actually says, so it cannot fall short as the subject grows. `name` is matched on
+ * the declaration line rather than anywhere in the file, so a call to the function does not become the anchor.
+ *
+ * @param src   the whole source
+ * @param name  the declared name, e.g. `pollVectorIndexReady`
+ * @param label appears in the failure so a broken anchor says which gate to re-point
+ */
+export function bodyOf(src, name, label = name) {
+  const lines = src.split(/\r?\n/);
+  const declared = new RegExp(`^(?:export\\s+)?(?:async\\s+function|function|const|class)\\s+${name}\\b`);
+  const start = lines.findIndex(l => declared.test(l));
+  assert.ok(start > -1, `${label}: no top-level declaration of \`${name}\` — re-anchor this gate`);
+
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (TOP_LEVEL.test(lines[i])) { end = i; break; }
+  }
+  return lines.slice(start, end).join('\n');
+}
+
+/**
+ * The text between an opening marker and its closing marker.
+ *
+ * For markup and for blocks whose end is a literal, like `<thead>` … `</thead>`. **No cap**: the closing marker
+ * IS the bound, which is the whole point — a `[\s\S]{0,1400}?` between the two is a cap wearing a structural
+ * disguise, and it is what failed on the fifth table column.
+ */
+export function between(src, open, close, label = open) {
+  const a = src.indexOf(open);
+  assert.ok(a > -1, `${label}: opening marker \`${open}\` not found — re-anchor this gate`);
+  const b = src.indexOf(close, a + open.length);
+  assert.ok(b > a, `${label}: closing marker \`${close}\` not found after \`${open}\``);
+  return src.slice(a + open.length, b);
+}
+
+/**
+ * A window plus proof it reached the end of its subject.
+ *
+ * The assertion that would have caught all three failures above on the day they were written: a window is only
+ * trustworthy if something at the END of the subject is inside it. Pass the last thing the subject contains, and a
+ * window that ever stops short says so instead of quietly checking less.
+ */
+export function bodyOfEndingWith(src, name, tail, label = name) {
+  const body = bodyOf(src, name, label);
+  assert.ok(body.includes(tail),
+    `${label}: the window does not reach \`${tail}\` — it is not covering all of \`${name}\`, so anything `
+    + 'asserted about the rest of it is being asserted about nothing');
+  return body;
+}

--- a/testing/standalone/gates-bound-their-subject-structurally.test.js
+++ b/testing/standalone/gates-bound-their-subject-structurally.test.js
@@ -1,0 +1,191 @@
+/**
+ * A gate may not bound its subject with a magic number. Ratchet: the grandfathered list only shrinks.
+ *
+ * ## Why this exists, with the cost attached
+ *
+ * `src.slice(at, at + 3000)` decides in advance how much of its subject a gate can see. Grow the subject and the
+ * window stops covering it, and the gate then either fails on correct code or passes while checking less than it
+ * meant to. A character count also spans different LINES on CRLF than on LF, so a window that fits locally can
+ * fall short in CI.
+ *
+ * Three of them failed in one session, 2026-08-19:
+ *
+ * - `index-ready-poll.test.js` at `at + 3000` — a new branch pushed its subject out.
+ * - `rights-are-explained.test.js` capped a `<thead>` at 1 400 characters — a fifth column took it to 1 770.
+ * - `rights-matrix.component.spec.ts` asserted a header count `toBe(4)`.
+ *
+ * **The last one is why the Space Admin column was reverted five releases earlier.** It had been built, it worked,
+ * and it was thrown away because a count broke — which reads as *"the feature broke the tests"* rather than as
+ * *"the test was written wrong"*. The owner had asked five times. His words: *"must be noob mistake what you are
+ * doing, cant be real that one column creates such problems"*.
+ *
+ * ## Why a ratchet and not a sweep
+ *
+ * There are 26 of these, spread over 21 files. Rewriting them blind is how a gate quietly starts checking less than it did — each window
+ * has a subject, and only someone reading it knows what the real bound is. So this refuses NEW ones and lets the
+ * list shrink as they are converted, the same shape `no-new-god-files.test.js` uses for file size.
+ *
+ * ## What is deliberately NOT banned
+ *
+ * `slice(0, N)` for truncating a value inside a failure MESSAGE — 79 of those, and they are correct: a 400-line
+ * JSON blob in an assertion message helps nobody. The banned shape is a window whose start is a FOUND POSITION and
+ * whose end is that position plus a number, because only that shape claims to cover a subject.
+ *
+ * Run: node --test testing/standalone/gates-bound-their-subject-structurally.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, sep } from 'node:path';
+import { stripComments } from './_strip-comments.mjs';
+
+/**
+ * A window whose end is its start plus a constant: `slice(at, at + 400)`.
+ *
+ * Requires the SAME identifier on both sides, which is what distinguishes a window over a subject from an
+ * unrelated pair of offsets — and keeps `slice(0, 300)` message truncation out of scope entirely.
+ */
+const MAGIC_WINDOW = /\.slice\(\s*([A-Za-z_$][\w$]*)\s*,\s*\1\s*\+\s*\d+\s*\)/g;
+
+/*
+ * NOT BANNED HERE, and the reason is the whole discipline of this file: `[\s\S]{0,N}` inside a pattern.
+ *
+ * A first draft banned it and found 30 sites. Reading them showed two different things wearing one syntax:
+ *
+ *   /<thead>([\s\S]{0,1400}?)<\/thead>/          a WINDOW between markers — the cap can only stop it short,
+ *                                                and this is the one that failed on a fifth table column
+ *   /if \(!x\) \{[\s\S]{0,220}?return false;/    an ADJACENCY bound — "these two must be near each other",
+ *                                                which is a deliberate claim, not a guessed extent
+ *
+ * The second is legitimate and there are many of them. Banning both without reading all 30 would be exactly the
+ * blind sweep this ratchet exists to avoid — a gate rewritten without understanding its subject is a gate that
+ * quietly checks less. So this PR takes the unambiguous half, and the 30 are recorded in `QA-TODO.md` as an
+ * unassessed population rather than as a number someone can wave through.
+ */
+
+const ROOTS = ['testing', join('client', 'src')];
+
+function sources(dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    if (name === 'node_modules' || name === 'dist') continue;
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) { sources(p, out); continue; }
+    if (/\.(test|spec)\.(js|mjs|ts)$/.test(p)) out.push(p);
+  }
+  return out;
+}
+
+/**
+ * Files still allowed to carry a magic window, with how many.
+ *
+ * **This list may only shrink.** Converting one means removing or lowering its entry; a file not listed may have
+ * none at all. Counts rather than a bare filename, so a file with three cannot silently gain a fourth.
+ */
+const GRANDFATHERED = new Map([
+  ['testing/standalone/backups-are-not-world-readable.test.js', 1],
+  ['testing/standalone/changelog-entry-is-enforced.test.js', 2],
+  ['testing/standalone/console-redaction-coverage.test.js', 1],
+  ['testing/standalone/credential-bodies-are-strict.test.js', 1],
+  ['testing/standalone/every-token-carries-a-rights-matrix.test.js', 2],
+  ['testing/standalone/face-index-width-is-never-rebuilt.test.js', 1],
+  ['testing/standalone/file-meta-merges-like-the-brain-tools.test.js', 1],
+  ['testing/standalone/mcp-audit-coverage.test.js', 1],
+  ['testing/standalone/meta-precondition.test.js', 1],
+  ['testing/standalone/mint-accepts-rights-capped.test.js', 1],
+  ['testing/standalone/mongo-connect-retry.test.js', 1],
+  ['testing/standalone/no-runtime-model-egress.test.js', 1],
+  ['testing/standalone/notice-coverage.test.js', 1],
+  ['testing/standalone/space-admin-rung-is-named.test.js', 1],
+  ['testing/standalone/ssrf-allow-private-coverage.test.js', 1],
+  ['testing/standalone/sync-dropped-record-is-not-silent.test.js', 1],
+  ['testing/standalone/text-contrast-meets-aa.test.js', 1],
+  ['testing/standalone/toggle-state-is-announced.test.js', 2],
+  ['testing/standalone/vlm-endpoint-egress.test.js', 1],
+]);
+
+/**
+ * THIS FILE is excluded from its own scan.
+ *
+ * It contains the banned shape as a STRING, in the test that proves the pattern still matches — which is the one
+ * assertion stopping this whole gate from silently passing on a regex that broke. A scan flagging its own fixture
+ * would force that proof to be deleted.
+ *
+ * Two files are absent from the list on purpose, having been converted in this change:
+ * `startup-index-wait.test.js` and `result-spill-suppresses-vectors.test.js`. They are the two whose subjects I
+ * had just read, which is the only basis on which a conversion is safe.
+ */
+const SELF = 'gates-bound-their-subject-structurally.test.js';
+
+const found = new Map();
+for (const root of ROOTS) {
+  for (const file of sources(root)) {
+    // Split on the platform separator and rejoin with `/`, so the keys read the same on Windows and in CI. A
+    // grandfathered entry that only matched on one platform would be an allowance nobody could see.
+    const key = file.split(sep).join('/');
+    if (key.endsWith(SELF)) continue;
+    const code = stripComments(readFileSync(file, 'utf8'));
+    const n = [...code.matchAll(MAGIC_WINDOW)].length;
+    if (n > 0) found.set(key, n);
+  }
+}
+
+describe('the scan works before anything is concluded from it', () => {
+  it('walked a real tree', () => {
+    // A scan that matched nothing would report every rule below as satisfied.
+    const files = ROOTS.flatMap(r => sources(r));
+    assert.ok(files.length >= 100, `only found ${files.length} test files — the walk is broken`);
+  });
+
+  it('the pattern still matches the shape it is about', () => {
+    // Proven against a literal, so a regex that silently stopped matching cannot pass as "none left".
+    const sample = 'const body = src.slice(at, at + 1600);';
+    assert.equal([...sample.matchAll(MAGIC_WINDOW)].length, 1, 'MAGIC_WINDOW no longer matches a magic window');
+    // And does NOT match the two shapes that are fine.
+    for (const ok of ['JSON.stringify(b).slice(0, 300)', 'src.slice(start, end)', 'x.slice(a, b + 4)']) {
+      assert.equal([...ok.matchAll(MAGIC_WINDOW)].length, 0, `false positive on: ${ok}`);
+    }
+  });
+});
+
+describe('no NEW magic window', () => {
+  it('every file carrying one is grandfathered, and none has more than its entry', () => {
+    const problems = [];
+    for (const [file, n] of found) {
+      const allowed = GRANDFATHERED.get(file) ?? 0;
+      if (n > allowed) {
+        problems.push(`${file}: ${n} magic window(s), allowed ${allowed}`);
+      }
+    }
+    assert.deepEqual(problems, [],
+      'a gate bounds its subject with a character count. Use `_structural-window.mjs` — `bodyOf`, `between`, or\n'
+      + '`bodyOfEndingWith` — which bound by the next top-level declaration or by the closing marker. A window that\n'
+      + 'can fall short of its subject is a gate that can pass while checking less than it means to.\n'
+      + problems.join('\n'));
+  });
+
+  it('the list only shrinks — an entry that is no longer needed must be removed', () => {
+    /*
+     * The other half of a ratchet. Without this the list is a place numbers go up: someone converts a window,
+     * leaves the entry, and the slot stays open for the next one. `no-new-god-files` reports slack as a note; here
+     * it is a failure, because unlike a file size these go to zero and stay there.
+     */
+    const stale = [];
+    for (const [file, allowed] of GRANDFATHERED) {
+      const actual = found.get(file) ?? 0;
+      if (actual < allowed) stale.push(`${file}: allowed ${allowed}, now has ${actual} — lower or remove it`);
+    }
+    assert.deepEqual(stale, [], 'the grandfathered list is above reality:\n' + stale.join('\n'));
+  });
+
+  it('the total only goes down', () => {
+    /*
+     * A single number, so the direction of travel is visible without diffing a map. It is the sum of the list
+     * above, and the point of stating it separately is that a reviewer can see at a glance whether a change moved
+     * the debt or merely shuffled it between files.
+     */
+    const total = [...found.values()].reduce((a, b) => a + b, 0);
+    const allowed = [...GRANDFATHERED.values()].reduce((a, b) => a + b, 0);
+    assert.ok(total <= allowed,
+      `${total} magic windows across the suite, and the list allows ${allowed}. It may only go down.`);
+  });
+});

--- a/testing/standalone/result-spill-suppresses-vectors.test.js
+++ b/testing/standalone/result-spill-suppresses-vectors.test.js
@@ -20,6 +20,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { stripComments } from './_strip-comments.mjs';
+import { bodyOf } from './_structural-window.mjs';
 
 const {
   suppressEmbeddings, countGraphNodes, SPILL_TTL_DAYS,
@@ -55,9 +56,7 @@ describe('vectors never reach the file', () => {
 
   it('is applied at the write, not left to the caller', () => {
     const src = read('server/src/brain/graph-spill.ts');
-    const at = src.indexOf('export async function spillResultSet');
-    assert.ok(at > -1, 'spillResultSet is gone — re-anchor this gate');
-    const body = src.slice(at, at + 1600);
+    const body = bodyOf(src, 'spillResultSet', 'the vector strip');
     assert.match(body, /JSON\.stringify\(suppressEmbeddings\(\{/,
       'the strip must wrap the whole payload at serialisation, not a field somebody remembered');
   });
@@ -90,8 +89,13 @@ describe('the remainder is written out, with a TTL', () => {
     const src = read('server/src/brain/graph-spill.ts');
     assert.doesNotMatch(src, /SPILL_RECORD_THRESHOLD\s*=/, 'the record threshold must not come back');
     assert.doesNotMatch(src, /SPILL_INLINE_RESULTS\s*=/, 'nor the three-record sample it went with');
-    const at = src.indexOf('export async function spillResultSet');
-    const body = src.slice(at, at + 1800);
+    /*
+     * The window is the WHOLE function, and here that is not tidiness — the assertion below is a
+     * `doesNotMatch`. A window that falls short of its subject passes by looking at less: a `return null` past
+     * the old 1 800-character cap would have gone unseen, and this is the exact rule whose absence shipped a
+     * truncated answer with nowhere to go.
+     */
+    const body = bodyOf(src, 'spillResultSet', 'the no-threshold rule');
     assert.doesNotMatch(body, /return null;/,
       'a spill asked for must be a spill written — a null here is a truncated answer with nowhere to go');
     assert.match(body, /\): Promise<ResultSpill> \{/,
@@ -104,8 +108,7 @@ describe('the remainder is written out, with a TTL', () => {
   it('one-day TTL, through the record machinery', () => {
     assert.equal(SPILL_TTL_DAYS, 1);
     const src = read('server/src/brain/graph-spill.ts');
-    const at = src.indexOf('export async function spillResultSet');
-    assert.match(src.slice(at, at + 1800), /ttlDays: SPILL_TTL_DAYS/,
+    assert.match(bodyOf(src, 'spillResultSet', 'the TTL'), /ttlDays: SPILL_TTL_DAYS/,
       'the file must expire with its record, like the graph spill beside it');
   });
 

--- a/testing/standalone/startup-index-wait.test.js
+++ b/testing/standalone/startup-index-wait.test.js
@@ -27,6 +27,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
+import { bodyOf } from './_structural-window.mjs';
 
 const LIFECYCLE = readFileSync('server/src/spaces/lifecycle.ts', 'utf8');
 const VECTOR = readFileSync('server/src/spaces/vector-index.ts', 'utf8');
@@ -87,9 +88,11 @@ describe('startup does not block on index readiness', () => {
 
   it('the background pass cannot take the process down', () => {
     // It is fire-and-forget; an unhandled rejection in a status-label task must not kill a healthy server.
-    const at = LIFECYCLE.indexOf('async function confirmSpaceIndexesInBackground');
-    assert.ok(at > 0);
-    const fn = LIFECYCLE.slice(at, at + 1200);
+    //
+    // Bounded by the next top-level declaration rather than by `at + 1200`. The function has grown twice since
+    // that number was chosen, and a window that falls short of its subject can only ever check less than it
+    // means to — see `_structural-window.mjs` for the three gates that failed on exactly this in one session.
+    const fn = bodyOf(LIFECYCLE, 'confirmSpaceIndexesInBackground', 'the background pass');
     assert.match(fn, /try \{[\s\S]*?\} catch \(err\) \{/, 'each space must be individually guarded');
   });
 });


### PR DESCRIPTION

`src.slice(at, at + 3000)` decides in advance how much of its subject a gate can
see. Grow the subject and it either fails on correct code or passes while checking
less than it meant to. A character count also spans different LINES on CRLF than
on LF, so a window that fits locally can fall short in CI.

THE COST, WHICH IS NOT HYPOTHETICAL

Three failed in one session, 2026-08-19:

- `index-ready-poll.test.js` at `at + 3000` -- a new branch pushed its subject out;
- `rights-are-explained.test.js` capped a `<thead>` at 1400 characters, and a
  fifth column took it to 1770;
- `rights-matrix.component.spec.ts` asserted a header count `toBe(4)`.

THE THIRD IS WHY THE SPACE ADMIN COLUMN WAS REVERTED FIVE RELEASES EARLIER. It had
been built, it worked, and it was thrown away because a count broke -- which reads
as "the feature broke the tests" rather than as "the test was written wrong". The
owner had asked five times, and when it finally shipped he said: "must be noob
mistake what you are doing, cant be real that one column creates such problems".
He was right, and this is the class of mistake he was pointing at.

THE HELPER, AND THE THREE COPIES THAT PRECEDED IT

`_structural-window.mjs` holds the shapes that bound correctly: `bodyOf` (to the
next top-level declaration), `between` (to the closing marker, with NO cap,
because the marker IS the bound), and `bodyOfEndingWith`, which additionally
proves the window reached the end of its subject -- the assertion that would have
caught all three failures on the day they were written.

Three files had hand-rolled the same body-finding loop within hours of each other.
That is the defect CLAUDE.md names as the one this repo produces most, arriving in
the test suite rather than in the product.

A RATCHET, NOT A SWEEP

26 magic windows remain across 19 files, grandfathered in a list that only
shrinks, the same shape `no-new-god-files` uses. Rewriting them blind is how a
gate quietly starts checking less than it did: only someone reading a window knows
what its real bound is.

Four are converted here -- three in `result-spill-suppresses-vectors.test.js` and
one in `startup-index-wait.test.js` -- and only because those four subjects were
ones I had just read. One is a `doesNotMatch`, where a short window is at its most
dangerous: a `return null` past the old 1800-character cap would have gone unseen,
and that is the exact rule whose absence once shipped a truncated answer with
nowhere to go.

TWO SHAPES DELIBERATELY NOT BANNED

Both because reading them showed a different thing wearing the same syntax.

`slice(0, N)` truncating a value inside a failure MESSAGE: 79 of those, and a
400-line JSON blob in an assertion message helps nobody.

A bounded gap inside a pattern -- "these two tokens must be near each other" is a
deliberate claim, not a guessed extent. A first draft banned it and found 30 sites.
Thirty unread sites is precisely the blind sweep this gate exists to prevent, so
they are recorded in QA-TODO.md as an unassessed population rather than as a
number someone can wave through.

THE GATE CHECKS ITSELF FIRST

It asserts the walk found a real tree and that the pattern still matches the shape
it is about, proven against a literal -- otherwise a regex that silently broke
would report "none left". This file is excluded from its own scan for that reason:
it carries the banned shape as a string, in that proof.

Six cases, six correct: a new window in an unlisted file, a listed file exceeding
its allowance, the ratchet slipping upward, a broken pattern claiming none left,
and both legitimate shapes staying green.