### PR TITLE
chore(testing): the 22 magic windows are gone, and two gates were checking the wrong thing

### DIFF
--- a/testing/standalone/_structural-window.mjs
+++ b/testing/standalone/_structural-window.mjs
@@ -86,3 +86,198 @@ export function bodyOfEndingWith(src, name, tail, label = name) {
     + 'asserted about the rest of it is being asserted about nothing');
   return body;
 }
+
+/*
+ * ---------------------------------------------------------------------------------------------------------------
+ * The bounds below were each hand-rolled, or replaced by a character count, in at least one gate.
+ *
+ * `bodyOf` and `between` cover a named declaration and a literal-delimited block. They do not cover the four other
+ * shapes a gate's subject actually takes, and every gate that needed one of those reached for `at + N` instead:
+ *
+ *   - a CALL or a BLOCK found by index, whose end is its matching bracket;
+ *   - the rest of the STATEMENT an anchor sits in;
+ *   - the block an anchor sits INSIDE, which ends before its own opening brace's match;
+ *   - an HTML OPENING TAG, a markdown SECTION, a YAML LIST ITEM.
+ *
+ * Three files had already hand-rolled the bracket walker independently — `client-bodies-match-server.test.js`,
+ * `credential-bodies-are-strict.test.js` and `no-boot-migration-on-synced-data.test.js` — which is the defect
+ * `CLAUDE.md` names as this repo's most frequent, arriving in the test suite. None of the three skips strings or
+ * comments, so a brace inside a string literal or a `// }` silently ends the window early: the same failure as a
+ * magic number, wearing structure's clothes.
+ * ---------------------------------------------------------------------------------------------------------------
+ */
+
+const PAIRS = { '(': ')', '{': '}', '[': ']' };
+
+/**
+ * Walk source from `i`, yielding only positions that are real code — never inside a string, template, regex-free
+ * comment or line comment. Returns the index of the first depth-0 occurrence of any character in `stop`, or -1.
+ *
+ * Written once because every caller below needs the same skipping, and a walker that does not skip is how a `'}'`
+ * in a message ends a window three declarations early.
+ */
+function scanCode(src, i, visit) {
+  let depth = 0;
+  while (i < src.length) {
+    const c = src[i];
+    // Comments first: `//` and `/* */`. A `"` inside a comment must not open a string.
+    if (c === '/' && src[i + 1] === '/') { i = src.indexOf('\n', i); if (i === -1) return src.length; continue; }
+    if (c === '/' && src[i + 1] === '*') { const e = src.indexOf('*/', i + 2); i = e === -1 ? src.length : e + 2; continue; }
+    if (c === '"' || c === "'" || c === '`') {
+      const quote = c;
+      i++;
+      while (i < src.length && src[i] !== quote) i += src[i] === '\\' ? 2 : 1;
+      i++;
+      continue;
+    }
+    const verdict = visit(c, i, depth);
+    if (verdict !== undefined) return verdict;
+    if (PAIRS[c]) depth++;
+    else if (c === ')' || c === '}' || c === ']') depth--;
+    i++;
+  }
+  return -1;
+}
+
+/**
+ * The bracketed group starting at or after `at`, inclusive of both brackets.
+ *
+ * For a call expression (`recordToolCall(...)`) or a block (`if (x) { ... }` — anchor on the `{`). The closing
+ * bracket IS the bound, so the window cannot fall short however much the subject grows.
+ */
+export function balancedFrom(src, at, label = 'balancedFrom') {
+  let open = -1;
+  for (let i = at; i < src.length; i++) if (PAIRS[src[i]]) { open = i; break; }
+  assert.ok(open > -1, `${label}: no bracket at or after index ${at} — re-anchor this gate`);
+  /*
+   * `depth === 1`, not 0: the walker reports each character with the depth it is AT, and a closer is still inside
+   * the group it closes. The opening bracket is seen at 0 and takes the depth to 1, so its own match is the only
+   * closer seen at 1 — every nested one is deeper. Asserted directly in `structural-window-helper.test.js`, because
+   * getting this off by one returns a window that is too SMALL and every gate using it would still pass.
+   */
+  const wanted = PAIRS[src[open]];
+  const close = scanCode(src, open, (c, i, depth) => (depth === 1 && c === wanted ? i : undefined));
+  assert.ok(close > open, `${label}: the group opened at ${open} is never closed — re-anchor this gate`);
+  return src.slice(open, close + 1);
+}
+
+/**
+ * The `{ … }` block that follows `at` — the body of an `if`, a `for`, or a handler.
+ *
+ * `balancedFrom` on the anchor would return the CONDITION, because an `if`'s first bracket is its paren. Spelled out
+ * as its own function because getting it wrong gives a window that looks plausible and contains none of the subject.
+ */
+export function blockAfter(src, at, label = 'blockAfter') {
+  const brace = src.indexOf('{', at);
+  assert.ok(brace > -1, `${label}: no block after index ${at} — re-anchor this gate`);
+  return balancedFrom(src, brace, label);
+}
+
+/** From `at` to the `;` that ends the statement it begins, inclusive. */
+export function statementFrom(src, at, label = 'statementFrom') {
+  const end = scanCode(src, at, (c, i, depth) => (depth === 0 && c === ';' ? i : undefined));
+  assert.ok(end > at, `${label}: no statement terminator after index ${at} — re-anchor this gate`);
+  return src.slice(at, end + 1);
+}
+
+/**
+ * The statement `at` sits in, from its start up to `at`.
+ *
+ * The bound for a question about what CHOOSES something — "is this `fetch` behind a locality test?" — where the
+ * subject is behind the anchor rather than ahead of it. A fixed count backwards is the worst version of a magic
+ * window: it starts in the middle of whatever precedes, so it can read half of the previous statement and none of
+ * the relevant one, and nothing about the result says which happened.
+ *
+ * Boundaries are collected by scanning FORWARD from the start of the file, because that is the only direction in
+ * which a string or a comment can be recognised — walking backwards, a `'` is as likely to close a string as open
+ * one. That costs a pass per call and buys a bound that cannot be fooled by a `;` inside a message.
+ */
+export function statementUpTo(src, at, label = 'statementUpTo') {
+  /*
+   * DEPTH MATTERS, and the first version of this got it wrong in the way that would have mattered:
+   *
+   *     res = endpoint.external
+   *       ? await ssrfSafeFetch(url, init, { allowPrivate: allowPrivateForSlot(endpoint.slot) })
+   *       : await fetch(url, init);
+   *
+   * Taking the nearest `;`, `{` or `}` at any depth makes the closing brace of that OPTIONS OBJECT the boundary, so
+   * the window starts at `) : await ` and contains no `.external` — and the gate reports a correctly-guarded fetch
+   * as unguarded. Only a boundary at the anchor's own nesting level ends its statement.
+   */
+  const marks = [];
+  let depthAt = null;
+  scanCode(src, 0, (c, i, depth) => {
+    if (i >= at) { if (depthAt === null) depthAt = depth; return at; }
+    if (c === ';' || c === '{' || c === '}') marks.push({ c, i, depth });
+    return undefined;
+  });
+  assert.ok(depthAt !== null, `${label}: index ${at} was never reached — it is inside a string or a comment`);
+  const boundary = marks.filter(m =>
+    (m.c === ';' && m.depth === depthAt)
+    || (m.c === '{' && m.depth === depthAt - 1)    // the brace that opened the block we are in
+    || (m.c === '}' && m.depth === depthAt),       // a sibling block that closed before us
+  ).pop();
+  return src.slice(boundary ? boundary.i + 1 : 0, at);
+}
+
+/**
+ * From `at` to the end of the block `at` sits INSIDE — the first `}` reached at negative depth.
+ *
+ * The bound for an anchor in the middle of a branch (`forkDepthRefused++` inside its `if`): the subject is the rest
+ * of that branch, and its end is the brace that closes it rather than a count of what fits today.
+ */
+export function enclosingBlockFrom(src, at, label = 'enclosingBlockFrom') {
+  const end = scanCode(src, at, (c, i, depth) => (c === '}' && depth === 0 ? i : undefined));
+  assert.ok(end > at, `${label}: index ${at} is not inside a block — re-anchor this gate`);
+  return src.slice(at, end);
+}
+
+/** An HTML opening tag at or after `at`, `<` to `>` inclusive — the bound for an assertion about ATTRIBUTES. */
+export function openTagAt(src, at, label = 'openTagAt') {
+  const lt = src.indexOf('<', at);
+  assert.ok(lt > -1, `${label}: no tag at or after index ${at} — re-anchor this gate`);
+  const gt = src.indexOf('>', lt);
+  assert.ok(gt > lt, `${label}: the tag opened at ${lt} is never closed`);
+  return src.slice(lt, gt + 1);
+}
+
+/**
+ * From `at` to the next markdown heading, or the end of the document.
+ *
+ * For prose: the claim and everything said about it, bounded by where the next subject starts. A character count on
+ * markdown is the worst case of all, because prose is edited for readability by people who are not thinking about
+ * a test.
+ */
+export function markdownSectionFrom(src, at, label = 'markdownSectionFrom') {
+  const rest = src.slice(at);
+  const next = /\n#{1,6} /.exec(rest);
+  return next ? rest.slice(0, next.index) : rest;
+}
+
+/**
+ * The YAML list item containing `at`, bounded by the next line at the same indentation or shallower.
+ *
+ * A workflow step. Its end is where the next step begins, which is indentation — not 400 characters, a number that
+ * changes meaning the moment somebody adds a `name:` to the step above.
+ */
+export function yamlItemAt(src, at, label = 'yamlItemAt') {
+  const lines = src.split(/\r?\n/);
+  let idx = 0, seen = 0;
+  for (let i = 0; i < lines.length; i++) {
+    if (seen + lines[i].length >= at) { idx = i; break; }
+    seen += lines[i].length + 1;
+  }
+  // Walk back to the `- ` that opens the item, so an anchor on any line of a step still bounds the whole step.
+  let start = idx;
+  while (start > 0 && !/^\s*- /.test(lines[start])) start--;
+  const indent = /^(\s*)- /.exec(lines[start]);
+  assert.ok(indent, `${label}: index ${at} is not inside a YAML list item — re-anchor this gate`);
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.trim()) continue;
+    const lead = /^\s*/.exec(line)[0].length;
+    if (lead <= indent[1].length) { end = i; break; }
+  }
+  return lines.slice(start, end).join('\n');
+}

--- a/testing/standalone/backups-are-not-world-readable.test.js
+++ b/testing/standalone/backups-are-not-world-readable.test.js
@@ -28,6 +28,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { bodyOf } from './_structural-window.mjs';
 
 const ROOT = process.cwd();
 const read = (p) => readFileSync(join(ROOT, p), 'utf8');
@@ -68,9 +69,7 @@ describe('one definition of "as tight as the state files"', () => {
     assert.match(modes, /chmodSync\(target, mode\)/, 'hardenSync must chmod the target');
     assert.match(modes, /chmod\(target, mode\)/, 'harden must chmod the target');
     for (const fn of ['mkdirPrivateSync', 'mkdirPrivate']) {
-      const at = modes.indexOf(`export ${fn.endsWith('Sync') ? 'function' : 'async function'} ${fn}(`);
-      assert.ok(at > 0, `${fn} is gone`);
-      assert.match(modes.slice(at, at + 260), /harden(Sync)?\(dir, DIR_MODE\)/,
+      assert.match(bodyOf(modes, fn), /harden(Sync)?\(dir, DIR_MODE\)/,
         `${fn} must tighten a directory that already existed, not only one it creates`);
     }
   });

--- a/testing/standalone/changelog-entry-is-enforced.test.js
+++ b/testing/standalone/changelog-entry-is-enforced.test.js
@@ -32,6 +32,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
+import { yamlItemAt, blockAfter } from './_structural-window.mjs';
 
 const SCRIPT_PATH = join('scripts', 'check-changelog.mjs');
 const WORKFLOW_PATH = join('.github', 'workflows', 'ci.yml');
@@ -68,7 +69,9 @@ describe('CI runs the check', () => {
     // check" — a green build for a missing entry, which is worse than not having the check.
     const at = WORKFLOW.indexOf('actions/checkout@v4');
     assert.ok(at > 0, 'the checkout step is gone');
-    const step = WORKFLOW.slice(at, at + 400);
+    // The step is bounded by where the next step begins, which is indentation. A character count here changes
+    // meaning the moment somebody adds a `name:` to the step above it.
+    const step = yamlItemAt(WORKFLOW, at, 'the checkout step');
     assert.match(step, /fetch-depth:\s*0/,
       'actions/checkout needs fetch-depth: 0, or `base...HEAD` has no merge base and the check silently no-ops');
   });
@@ -107,7 +110,7 @@ describe('the check cannot pass vacuously', () => {
   it('a missing [Unreleased] section fails rather than passing', () => {
     const at = CODE.indexOf('if (!range)');
     assert.ok(at > 0, 'the missing-section branch is gone');
-    assert.match(CODE.slice(at, at + 300), /process\.exit\(1\)/,
+    assert.match(blockAfter(CODE, at, 'the missing-section branch'), /process\.exit\(1\)/,
       'no Unreleased section must fail — otherwise deleting the heading disables the check');
   });
 });

--- a/testing/standalone/console-redaction-coverage.test.js
+++ b/testing/standalone/console-redaction-coverage.test.js
@@ -17,6 +17,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { balancedFrom } from './_structural-window.mjs';
 
 const ROOT = 'server/src';
 
@@ -70,9 +71,11 @@ describe('console output cannot bypass the redactor', () => {
     // endpoint) and because a future refactor is most likely to "simplify" them back.
     const src = readFileSync(`${ROOT}/index.ts`, 'utf8');
     for (const handler of ['unhandledRejection', 'uncaughtException']) {
-      const at = src.indexOf(handler);
+      // The whole registration, bounded by the paren that closes it. At 400 characters this covered both handlers
+      // as they are written today, so `uncaughtException` was being checked twice and its own body never bounded.
+      const at = src.indexOf(`process.on('${handler}'`);
       assert.ok(at > 0, `${handler} handler should exist`);
-      const block = src.slice(at, at + 400);
+      const block = balancedFrom(src, at, `the ${handler} handler`);
       assert.ok(block.includes('redactSecrets('), `${handler} must redact before writing to the console`);
     }
   });

--- a/testing/standalone/credential-bodies-are-strict.test.js
+++ b/testing/standalone/credential-bodies-are-strict.test.js
@@ -29,6 +29,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { statementFrom } from './_structural-window.mjs';
 
 const ROOT = process.cwd();
 const SRC = 'server/src/api/tokens.ts';
@@ -43,14 +44,12 @@ function bodySchemas() {
   const re = /const\s+(\w*Body)\s*=\s*z\.object\(\{/g;
   let m;
   while ((m = re.exec(code)) !== null) {
-    // Walk to the matching close of the z.object( call, then read what follows it.
-    let i = re.lastIndex - 1, depth = 1;
-    while (i < code.length && depth > 0) {
-      i++;
-      if (code[i] === '{') depth++;
-      else if (code[i] === '}') depth--;
-    }
-    out.push({ name: m[1], tail: code.slice(i, i + 40) });
+    /*
+     * The whole declaration, to its terminating `;`. Two things were wrong with the version this replaces: the
+     * brace walker counted a `{` or `}` inside a string as nesting, and the 40-character tail meant a comment
+     * between the object and its `.strict()` reported the schema LOOSE. Both are the shared helper's job now.
+     */
+    out.push({ name: m[1], tail: statementFrom(code, m.index, `the ${m[1]} body schema`) });
   }
   return out;
 }
@@ -64,7 +63,19 @@ describe('token route bodies reject unknown keys', () => {
   });
 
   it('every body schema is .strict()', () => {
-    const loose = bodySchemas().filter(s => !/\)\s*\.strict\(\)/.test(s.tail)).map(s => s.name);
+    /*
+     * Anchored to the END of the declaration, which matters more than it looks.
+     *
+     * `.strict()` ANYWHERE in the statement is satisfied by a nested one — and both bodies here nest a
+     * `rights: z.object({…}).strict().optional()`. Mutation testing removed the OUTER `.strict()` from
+     * `CreateTokenBody` and this stayed green, matching the inner one instead: the schema that mints credentials
+     * would have gone back to dropping unknown keys silently with the gate reporting fine.
+     *
+     * The predecessor read 40 characters past the object's closing brace, which happened to exclude the nested
+     * call. That is not a property anyone had chosen — it is why the position is now stated rather than inherited.
+     */
+    const STRICT_AT_END = /\}\)\s*\.strict\(\)\s*;?\s*$/;
+    const loose = bodySchemas().filter(s => !STRICT_AT_END.test(s.tail)).map(s => s.name);
     assert.deepEqual(
       loose,
       [],

--- a/testing/standalone/every-token-carries-a-rights-matrix.test.js
+++ b/testing/standalone/every-token-carries-a-rights-matrix.test.js
@@ -30,6 +30,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { stripComments } from './_strip-comments.mjs';
+import { bodyOf } from './_structural-window.mjs';
 
 const read = p => stripComments(readFileSync(p, 'utf8'));
 const TOKENS = 'server/src/auth/tokens.ts';
@@ -59,9 +60,7 @@ describe('the boot migration is durable', () => {
   const src = read(BOOT);
 
   it('the backfill result is written to disk, not just held in memory', () => {
-    const at = src.indexOf('export function migrateTokenRightsOnBoot');
-    assert.ok(at > -1, 'the boot step is gone — re-anchor this gate');
-    const after = src.slice(at, at + 700);
+    const after = bodyOf(src, 'migrateTokenRightsOnBoot');
     // Both counts, because the boot step does two things now: derive a missing matrix, and repair a malformed
     // one. `if (filled === 0)` alone would return before persisting a repair — the fix would run and be lost.
     assert.match(after, /if \(filled === 0 && repaired === 0\) return 0;/, 'a write only when something changed');
@@ -71,8 +70,9 @@ describe('the boot migration is durable', () => {
   });
 
   it('a failed write retries next boot rather than being reported as done', () => {
-    const at = src.indexOf('export function migrateTokenRightsOnBoot');
-    const after = src.slice(at, at + 900);
+    // Same subject as the test above, and previously a different guess at how much of it to read — 700 there and
+    // 900 here. Two windows on one function is a sign neither was measured.
+    const after = bodyOf(src, 'migrateTokenRightsOnBoot');
     assert.match(after, /catch/, 'a failed persist must not throw at boot');
     assert.match(after, /will retry next boot/i, 'and must say so, like the media-embedding migration beside it');
   });

--- a/testing/standalone/face-index-width-is-never-rebuilt.test.js
+++ b/testing/standalone/face-index-width-is-never-rebuilt.test.js
@@ -27,6 +27,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { balancedFrom, blockAfter } from './_structural-window.mjs';
 
 const ROOT = process.cwd();
 const SRC = 'server/src/spaces/vector-index.ts';
@@ -69,9 +70,14 @@ describe('the face index refuses a width change', () => {
     // Filter-field changes must still apply — refusing those would freeze the index against legitimate
     // edits and quietly break filtered recall for the space.
     const i = code.indexOf('opts.refuseWidthChange');
-    const stmt = code.slice(Math.max(0, i - 120), i + 40);
+    assert.ok(i > -1, 'the refusal guard is gone — re-anchor this gate');
+    /*
+     * The CONDITION, bounded by the paren that closes it — not 120 characters BEFORE the anchor, which is the same
+     * magic window pointing backwards and is missed by the ratchet's pattern because it is written `i - 120`.
+     */
+    const stmt = balancedFrom(code, code.lastIndexOf('if (', i), 'the width-refusal condition');
     assert.match(stmt, /!\s*dimsMatch/, 'the refusal must be conditioned on the WIDTH differing');
-    assert.match(code.slice(i, i + 1400), /filtersMatch/,
+    assert.match(blockAfter(code, i, 'the width-refusal branch'), /filtersMatch/,
       'a refused width change must still let a filter-field change through, at the existing width');
   });
 

--- a/testing/standalone/file-meta-merges-like-the-brain-tools.test.js
+++ b/testing/standalone/file-meta-merges-like-the-brain-tools.test.js
@@ -29,6 +29,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { stripComments } from './_strip-comments.mjs';
+import { blockAfter } from './_structural-window.mjs';
 
 const src = (p) => stripComments(readFileSync(p, 'utf8'));
 
@@ -83,7 +84,7 @@ describe('deleteFields shipped with the merge, not after it', () => {
     const s = src('server/src/files/file-meta.ts');
     const at = s.indexOf('if (deleteFieldsPaths && deleteFieldsPaths.length > 0)');
     assert.ok(at > 0, 'the deleteFields block was not found — the scanner is wrong, not the code');
-    const block = s.slice(at, at + 1600);
+    const block = blockAfter(s, at, 'the deleteFields block');
     for (const f of ['description', 'excerpt', 'tags', 'entityIds', 'chronoIds', 'memoryIds', 'properties']) {
       assert.match(block, new RegExp(`'${f}'`), `${f} is settable but cannot be deleted`);
     }

--- a/testing/standalone/gates-bound-their-subject-structurally.test.js
+++ b/testing/standalone/gates-bound-their-subject-structurally.test.js
@@ -47,6 +47,25 @@ import { stripComments } from './_strip-comments.mjs';
  */
 const MAGIC_WINDOW = /\.slice\(\s*([A-Za-z_$][\w$]*)\s*,\s*\1\s*\+\s*\d+\s*\)/g;
 
+/**
+ * The same defect written BACKWARDS: `src.slice(Math.max(0, at - 400), at)`.
+ *
+ * It was outside the pattern above, so it was never counted and never grandfathered — nine of them across eight
+ * files, none of which the first version of this gate could see. Found while converting the forward population,
+ * which is the argument for widening a ratchet's pattern as soon as its blind spot is known: a rule that reports
+ * zero because it is not looking reads exactly like a rule that is satisfied.
+ *
+ * Backwards is the WORSE half. A window that stops short of its subject going forwards usually breaks the
+ * assertion and goes red; going backwards it silently starts inside the subject, and in this suite the backwards
+ * form is mostly paired with `doesNotMatch` — an absence asserted over less text than intended, which passes.
+ *
+ * A LINE window (`lines.slice(Math.max(0, i - 3), i + 4).join(' ')`) is deliberately NOT matched. Those are
+ * adjacency claims — "a comment within three lines of the call" — where the number IS the rule rather than a guess
+ * at how much of a subject fits. The `.join(` is what separates them, and it is a reliable signal because a
+ * character window has nothing to join.
+ */
+const MAGIC_WINDOW_BACK = /\.slice\(\s*Math\.max\(\s*0\s*,\s*[A-Za-z_$][\w$.]*\s*-\s*\d+\s*\)[^)]*\)(?!\s*\.join\()/g;
+
 /*
  * NOT BANNED HERE, and the reason is the whole discipline of this file: `[\s\S]{0,N}` inside a pattern.
  *
@@ -82,25 +101,55 @@ function sources(dir, out = []) {
  * none at all. Counts rather than a bare filename, so a file with three cannot silently gain a fourth.
  */
 const GRANDFATHERED = new Map([
-  ['testing/standalone/backups-are-not-world-readable.test.js', 1],
-  ['testing/standalone/changelog-entry-is-enforced.test.js', 2],
-  ['testing/standalone/console-redaction-coverage.test.js', 1],
-  ['testing/standalone/credential-bodies-are-strict.test.js', 1],
-  ['testing/standalone/every-token-carries-a-rights-matrix.test.js', 2],
-  ['testing/standalone/face-index-width-is-never-rebuilt.test.js', 1],
-  ['testing/standalone/file-meta-merges-like-the-brain-tools.test.js', 1],
-  ['testing/standalone/mcp-audit-coverage.test.js', 1],
-  ['testing/standalone/meta-precondition.test.js', 1],
-  ['testing/standalone/mint-accepts-rights-capped.test.js', 1],
-  ['testing/standalone/mongo-connect-retry.test.js', 1],
-  ['testing/standalone/no-runtime-model-egress.test.js', 1],
-  ['testing/standalone/notice-coverage.test.js', 1],
-  ['testing/standalone/space-admin-rung-is-named.test.js', 1],
-  ['testing/standalone/ssrf-allow-private-coverage.test.js', 1],
-  ['testing/standalone/sync-dropped-record-is-not-silent.test.js', 1],
+  /*
+   * TWO ENTRIES LEFT, and both are here because the number is not a window at all.
+   *
+   * The other nineteen files are converted. `_structural-window.mjs` grew the four bounds they actually needed —
+   * a bracketed group, a statement, the block an anchor sits inside, and the three markup shapes — and each
+   * conversion was read individually rather than swept, because a window rewritten without understanding its
+   * subject is a gate that quietly checks less.
+   */
+
+  /*
+   * `parseInt(h.slice(i, i + 2), 16)` — reading the red, green and blue bytes out of a hex colour.
+   *
+   * A hex pair is two characters by definition. There is no subject that can grow, so there is nothing for a
+   * structural bound to bound. This is a fixed-width FIELD read wearing the same syntax as a window, and the
+   * distinction matters: converting it would replace a correct expression with a worse one to satisfy a pattern.
+   */
   ['testing/standalone/text-contrast-meets-aa.test.js', 1],
-  ['testing/standalone/toggle-state-is-announced.test.js', 2],
-  ['testing/standalone/vlm-endpoint-egress.test.js', 1],
+
+  /*
+   * `JSON.stringify(src.slice(handlerStart, handlerStart + 90))` — inside an assertion MESSAGE.
+   *
+   * Nothing is asserted about those 90 characters. They are an excerpt shown to whoever reads the failure, so
+   * they can find the handler; the check itself is `checkSites.some(...)` on real indices. A window only needs a
+   * structural bound when something is CHECKED inside it, and a 90-character quote is the right length for a
+   * message where a whole handler body would not be.
+   */
+  ['testing/standalone/meta-precondition.test.js', 1],
+]);
+
+/**
+ * Files still allowed to carry a BACKWARDS character window, with how many.
+ *
+ * Nine sites the pattern could not previously see, recorded rather than converted in the same change: the forward
+ * population was twenty-two, and rewriting thirty-one windows in one commit is the blind sweep this gate exists to
+ * prevent. **This list may only shrink**, on the same terms as the one above.
+ *
+ * Named individually because each has a different subject. `theme-cannot-recolour-facts` reads 1 400 characters of
+ * CSS behind a declaration; `config-key-docs-coverage` reads a doc comment above a key; `index-ready-poll` reads
+ * what precedes a call. Those are three different structural bounds, not one conversion applied nine times.
+ */
+const GRANDFATHERED_BACK = new Map([
+  ['testing/standalone/backups-are-not-world-readable.test.js', 1],
+  ['testing/standalone/config-key-docs-coverage.test.js', 2],
+  ['testing/standalone/index-ready-poll.test.js', 1],
+  ['testing/standalone/infra-managed-locks-every-field.test.js', 1],
+  ['testing/standalone/models-are-attributed.test.js', 1],
+  ['testing/standalone/proxy-fanout-inventory.test.js', 1],
+  ['testing/standalone/swallowed-writes-must-be-visible.test.js', 1],
+  ['testing/standalone/theme-cannot-recolour-facts.test.js', 1],
 ]);
 
 /**
@@ -116,16 +165,25 @@ const GRANDFATHERED = new Map([
  */
 const SELF = 'gates-bound-their-subject-structurally.test.js';
 
+/*
+ * The helper's own spec is excluded too. It contains every banned shape as a FIXTURE — that is what proves the
+ * bounds are correct, and it is the one file where a magic window is the subject rather than a defect.
+ */
+const FIXTURES = 'structural-window-helper.test.js';
+
 const found = new Map();
+const foundBack = new Map();
 for (const root of ROOTS) {
   for (const file of sources(root)) {
     // Split on the platform separator and rejoin with `/`, so the keys read the same on Windows and in CI. A
     // grandfathered entry that only matched on one platform would be an allowance nobody could see.
     const key = file.split(sep).join('/');
-    if (key.endsWith(SELF)) continue;
+    if (key.endsWith(SELF) || key.endsWith(FIXTURES)) continue;
     const code = stripComments(readFileSync(file, 'utf8'));
     const n = [...code.matchAll(MAGIC_WINDOW)].length;
     if (n > 0) found.set(key, n);
+    const back = [...code.matchAll(MAGIC_WINDOW_BACK)].length;
+    if (back > 0) foundBack.set(key, back);
   }
 }
 
@@ -145,6 +203,24 @@ describe('the scan works before anything is concluded from it', () => {
       assert.equal([...ok.matchAll(MAGIC_WINDOW)].length, 0, `false positive on: ${ok}`);
     }
   });
+
+  it('the BACKWARDS pattern matches its shape, and leaves line windows alone', () => {
+    const back = 'const before = src.slice(Math.max(0, at - 400), at);';
+    assert.equal([...back.matchAll(MAGIC_WINDOW_BACK)].length, 1,
+      'MAGIC_WINDOW_BACK no longer matches a backwards window — it would report zero by not looking');
+
+    /*
+     * A line window is an ADJACENCY claim, where the number is the rule. `.join(` is the signal, and asserting the
+     * exclusion here is what stops a future tightening from banning thirty legitimate proximity checks.
+     */
+    for (const ok of [
+      "const near = lines.slice(Math.max(0, i - 3), i + 4).join(' ')",
+      'const around = lines.slice(Math.max(0, i - 6), i + 2).join("\\n")',
+      'src.slice(0, i)',
+    ]) {
+      assert.equal([...ok.matchAll(MAGIC_WINDOW_BACK)].length, 0, `false positive on: ${ok}`);
+    }
+  });
 });
 
 describe('no NEW magic window', () => {
@@ -160,6 +236,24 @@ describe('no NEW magic window', () => {
       'a gate bounds its subject with a character count. Use `_structural-window.mjs` — `bodyOf`, `between`, or\n'
       + '`bodyOfEndingWith` — which bound by the next top-level declaration or by the closing marker. A window that\n'
       + 'can fall short of its subject is a gate that can pass while checking less than it means to.\n'
+      + problems.join('\n'));
+  });
+
+  it('no NEW backwards window either, and that list only shrinks too', () => {
+    // Both directions on one ratchet, so closing the forward half cannot look like closing the problem.
+    const problems = [];
+    for (const [file, n] of foundBack) {
+      const allowed = GRANDFATHERED_BACK.get(file) ?? 0;
+      if (n > allowed) problems.push(`${file}: ${n} backwards window(s), allowed ${allowed}`);
+    }
+    for (const [file, allowed] of GRANDFATHERED_BACK) {
+      const actual = foundBack.get(file) ?? 0;
+      if (actual < allowed) problems.push(`${file}: allowed ${allowed} backwards, now has ${actual} — lower it`);
+    }
+    assert.deepEqual(problems, [],
+      'a gate reads a fixed number of characters BEHIND its anchor. That is the same defect as a forward window\n'
+      + 'and a worse one: it starts inside its subject silently, and it is usually paired with `doesNotMatch`, so\n'
+      + 'an absence gets asserted over less text than intended and passes. Bound it with `_structural-window.mjs`.\n'
       + problems.join('\n'));
   });
 

--- a/testing/standalone/mcp-audit-coverage.test.js
+++ b/testing/standalone/mcp-audit-coverage.test.js
@@ -29,6 +29,7 @@
 import { describe, it, before } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
+import { balancedFrom } from './_structural-window.mjs';
 
 let MCP_TOOL_OPERATIONS, mcpAuditOperation, isMcpReadOperation;
 let ALL_TOOLS;
@@ -111,6 +112,11 @@ describe('MCP audit coverage', () => {
     const src = readFileSync(ROUTER, 'utf8');
     const at = src.indexOf('recordToolCall(name, callSpace');
     assert.ok(at > 0);
-    assert.ok(!/status: 200/.test(src.slice(at, at + 200)), 'status must not be hardcoded to 200');
+    /*
+     * The call expression, bounded by its own closing paren. This is the shape where a magic window is at its most
+     * dangerous: the assertion is that something is ABSENT, so a window falling short passes by looking at less.
+     */
+    const call = balancedFrom(src, at, 'the recordToolCall call');
+    assert.ok(!/status: 200/.test(call), 'status must not be hardcoded to 200');
   });
 });

--- a/testing/standalone/mint-accepts-rights-capped.test.js
+++ b/testing/standalone/mint-accepts-rights-capped.test.js
@@ -21,6 +21,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { statementFrom } from './_structural-window.mjs';
 
 const ROOT = process.cwd();
 const SRC = 'server/src/api/tokens.ts';
@@ -37,8 +38,20 @@ describe('minting with a rights matrix', () => {
   it('the rights object is itself strict', () => {
     // The same defect the body had: an unknown key inside `rights` would be dropped, and a mis-spelled area
     // would mint a token with less than asked for while reporting success.
-    const i = code.indexOf('rights: z.object(');
-    assert.match(code.slice(i, i + 600), /\}\)\.strict\(\)/, 'the nested rights object drops unknown keys');
+    /*
+     * EVERY one of them, not the first. There are two — the create body and the update body — and `indexOf` checked
+     * only the create route. Found by mutation: loosening the create schema left this green, because the update
+     * schema further down still matched. A route that accepts `rights` and silently drops a mis-spelled area is
+     * exactly the defect this file is about, so checking one of the two routes was checking the wrong half as
+     * often as the right one.
+     */
+    const nested = [...code.matchAll(/rights: z\.object\(/g)];
+    assert.ok(nested.length >= 2,
+      `expected the create and update bodies to both declare a nested rights object, found ${nested.length}`);
+    for (const m of nested) {
+      assert.match(statementFrom(code, m.index, 'the nested rights schema'), /\}\)\.strict\(\)/,
+        'a nested rights object accepts unknown keys, so a mis-spelled area mints less than was asked for');
+    }
   });
 
   it('refuses `rights` together with the legacy fields', () => {

--- a/testing/standalone/mongo-connect-retry.test.js
+++ b/testing/standalone/mongo-connect-retry.test.js
@@ -29,6 +29,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
+import { bodyOf } from './_structural-window.mjs';
 
 const SRC = readFileSync('server/src/db/mongo.ts', 'utf8');
 
@@ -124,9 +125,7 @@ describe('the retry loop itself', () => {
   it('closes the failed client before making another', () => {
     // Each MongoClient carries a topology and timers. Looping without closing leaks one per attempt, so
     // a database that is down for the whole budget leaves a pile of live monitors behind.
-    const at = SRC.indexOf('export async function connectMongo');
-    const body = SRC.slice(at, at + 2000);
-    assert.match(body, /await _client\.close\(\)\.catch\(/);
+    assert.match(bodyOf(SRC, 'connectMongo'), /await _client\.close\(\)\.catch\(/);
   });
 
   it('backs off with jitter and a ceiling', () => {

--- a/testing/standalone/no-runtime-model-egress.test.js
+++ b/testing/standalone/no-runtime-model-egress.test.js
@@ -42,6 +42,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { markdownSectionFrom } from './_structural-window.mjs';
 
 const ROOT = process.cwd();
 const read = (p) => readFileSync(join(ROOT, p), 'utf8');
@@ -138,7 +139,9 @@ describe('the claim and its enforcement are documented together', () => {
     const readme = read('README.md');
     const at = readme.indexOf('Works fully offline');
     assert.ok(at > 0, 'the offline claim is gone from the README');
-    assert.match(readme.slice(at, at + 400), /HF_HUB_OFFLINE/,
+    // Prose, bounded by where the next subject starts. A character count on markdown is the worst case of all,
+    // because prose gets re-flowed for readability by people who are not thinking about a test.
+    assert.match(markdownSectionFrom(readme, at), /HF_HUB_OFFLINE/,
       'the claim must say what enforces it, or it is back to being an assertion');
   });
 

--- a/testing/standalone/notice-coverage.test.js
+++ b/testing/standalone/notice-coverage.test.js
@@ -35,6 +35,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
+import { markdownSectionFrom } from './_structural-window.mjs';
 
 const NOTICE = readFileSync('NOTICE', 'utf8');
 const NOTICE_LC = NOTICE.toLowerCase();
@@ -138,7 +139,8 @@ describe('NOTICE covers everything we redistribute', () => {
         // The verb AND the licence it selects. A bare `/elect/i` was too loose to be worth having: it
         // matched the surrounding prose explaining *why* an election is recorded, so deleting the actual
         // election statement left the test green. Caught by mutating the entry.
-        return !/elects?\s+[^.\n]{0,40}(Apache|MIT|MPL|BSD|ISC|GPL)/i.test(NOTICE.slice(at, at + 700));
+        // The entry, bounded by the next `###` — so an entry that grows an explanation is still read whole.
+        return !/elects?\s+[^.\n]{0,40}(Apache|MIT|MPL|BSD|ISC|GPL)/i.test(markdownSectionFrom(NOTICE, at));
       })
       .map(d => `  ${d.name} (${d.license})`);
 

--- a/testing/standalone/space-admin-rung-is-named.test.js
+++ b/testing/standalone/space-admin-rung-is-named.test.js
@@ -29,6 +29,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { stripComments } from './_strip-comments.mjs';
+import { bodyOf } from './_structural-window.mjs';
 
 const { DERIVED_RUNGS, SPACE_AREAS, RUNGS } = await import('../../server/dist/config/rights-shape.js');
 const { isSpaceAdminFor } = await import('../../server/dist/auth/editor-scope.js');
@@ -89,9 +90,7 @@ describe('the published definition IS the enforced predicate', () => {
      * above would keep passing because they are built from the published value.
      */
     const src = stripComments(readFileSync('server/src/config/rights-shape.ts', 'utf8'));
-    const at = src.indexOf('DERIVED_RUNGS');
-    assert.ok(at > -1, 'anchor missing — re-point this gate');
-    const block = src.slice(at, at + 900);
+    const block = bodyOf(src, 'DERIVED_RUNGS');
     assert.match(block, /SPACE_AREAS\.map/,
       'requires must be built from SPACE_AREAS, or it is a second copy of the predicate free to disagree');
     assert.doesNotMatch(block, /knowledge:\s*'admin'/,

--- a/testing/standalone/ssrf-allow-private-coverage.test.js
+++ b/testing/standalone/ssrf-allow-private-coverage.test.js
@@ -26,6 +26,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { bodyOf } from './_structural-window.mjs';
 
 const ROOT = 'server/src';
 /** The guard's own module defines the parameter — it is not a caller. */
@@ -106,9 +107,7 @@ describe('ssrfSafeFetch callers decide allowPrivate deliberately', () => {
     // the one call site where a future "simplification" back to a two-argument call breaks a documented
     // deployment shape rather than merely loosening a convention.
     const src = readFileSync(`${ROOT}/api/media-config.ts`, 'utf8');
-    const at = src.indexOf('export async function probeModelEndpoint');
-    assert.ok(at > 0, 'probeModelEndpoint should exist');
-    const body = src.slice(at, at + 2000);
+    const body = bodyOf(src, 'probeModelEndpoint');
     // Per SLOT, not instance-wide. The probe has to resolve the same permission the inference client will,
     // and those two now differ per endpoint: an operator who kept one slot strict must see that slot's
     // probe refuse, and an operator who widened another must see that one go through.

--- a/testing/standalone/structural-window-helper.test.js
+++ b/testing/standalone/structural-window-helper.test.js
@@ -1,0 +1,258 @@
+/**
+ * The structural-window helper is tested, because twenty gates are about to trust it.
+ *
+ * ## Why this file exists
+ *
+ * `_structural-window.mjs` replaces a character count in twenty gates. A character count fails LOUDLY when it falls
+ * short — the assertion inside it stops matching and the gate goes red on correct code, which is annoying and
+ * visible. A broken *structural* bound fails QUIETLY: it returns a window that is too small, every assertion inside
+ * it still passes on the smaller text, and twenty gates go on reporting green while checking less than they say.
+ *
+ * That is a strictly worse failure than the one being fixed, and it is only worse because nobody would look. So the
+ * helper is asserted directly, on inputs built to break it, before anything depends on it.
+ *
+ * ## The cases that matter
+ *
+ * Not "does it find a brace" — every naive walker does. The three that separate this from the naive versions three
+ * other gates hand-rolled:
+ *
+ *  - a bracket inside a STRING must not count (`'}'`, `"("`, a template literal);
+ *  - a bracket inside a COMMENT must not count (`// }` and the block form);
+ *  - an ESCAPED quote must not end the string it is in (`'it\'s'`), or everything after it is read as code.
+ *
+ * Each of those is a real construct in the files these gates read.
+ *
+ * Run: node --test testing/standalone/structural-window-helper.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  balancedFrom,
+  statementFrom,
+  enclosingBlockFrom,
+  openTagAt,
+  markdownSectionFrom,
+  yamlItemAt,
+  bodyOf,
+  statementUpTo,
+} from './_structural-window.mjs';
+
+describe('balancedFrom — the bound is the matching bracket', () => {
+  it('reads a whole call, including nested brackets', () => {
+    const src = 'const x = call(a, inner(b, c), [1, 2]);\nconst y = 1;';
+    assert.equal(balancedFrom(src, src.indexOf('call(')), '(a, inner(b, c), [1, 2])');
+  });
+
+  it('a closing bracket inside a STRING does not end the window', () => {
+    // The failure mode the three hand-rolled walkers all have. A message containing a brace is ordinary in this
+    // codebase — every assertion failure text is one — so this is not a theoretical input.
+    const src = `assert.ok(x, 'a } and a ) in a message');\nconst next = 1;`;
+    const got = balancedFrom(src, src.indexOf('assert.ok('));
+    assert.ok(got.includes('in a message'), 'the window stopped at a brace inside a string literal');
+    assert.ok(got.endsWith(')'));
+  });
+
+  it('a bracket inside a LINE COMMENT does not end the window', () => {
+    const src = 'fn(\n  a,   // }\n  b,\n);\nconst after = 1;';
+    const got = balancedFrom(src, src.indexOf('fn('));
+    assert.ok(got.includes('b,'), 'the window stopped at a brace inside a comment');
+  });
+
+  it('a bracket inside a BLOCK COMMENT does not end the window', () => {
+    const src = 'fn(\n  a,\n  /* ) and } */\n  b,\n);\nconst after = 1;';
+    const got = balancedFrom(src, src.indexOf('fn('));
+    assert.ok(got.includes('b,'), 'the window stopped at a bracket inside a block comment');
+  });
+
+  it('an ESCAPED quote does not end the string', () => {
+    // If it did, the rest of the file would be scanned as code and the first stray brace would close the window.
+    const src = "fn('it\\'s fine, and a ) here', last);\nconst after = 1;";
+    const got = balancedFrom(src, src.indexOf('fn('));
+    assert.ok(got.includes('last'), 'an escaped quote ended the string and the window closed early');
+  });
+
+  it('a template literal is skipped like any other string', () => {
+    const src = 'fn(`a } and a ) inside`, last);\nconst after = 1;';
+    assert.ok(balancedFrom(src, src.indexOf('fn(')).includes('last'));
+  });
+
+  it('anchors on a BLOCK when pointed at its brace', () => {
+    const src = 'if (!range) {\n  process.exit(1);\n}\nconst after = 1;';
+    const got = balancedFrom(src, src.indexOf('{'));
+    assert.ok(got.startsWith('{') && got.endsWith('}'));
+    assert.ok(got.includes('process.exit(1)'));
+  });
+
+  it('says so rather than returning a short window when the group never closes', () => {
+    // The whole point. An unbounded window must be an error, never a silently smaller subject.
+    assert.throws(() => balancedFrom('fn(a, b', 0), /never closed/);
+    assert.throws(() => balancedFrom('no brackets here', 0), /no bracket/);
+  });
+});
+
+describe('statementFrom — the bound is the terminator', () => {
+  it('reaches the semicolon past nested calls and strings', () => {
+    const src = "const s = z.object({ a: 1 }).strict();\nconst t = 2;";
+    const got = statementFrom(src, src.indexOf('z.object('));
+    assert.ok(got.includes('.strict()'), 'a nested object hid the end of the statement');
+    assert.ok(got.endsWith(';'));
+  });
+
+  it('a semicolon inside a string is not the end', () => {
+    const src = "fn('a ; here');\nconst after = 1;";
+    assert.ok(statementFrom(src, 0).includes('here'));
+  });
+
+  it('a missing terminator is an error, not a short window', () => {
+    assert.throws(() => statementFrom('const x = 1', 0), /no statement terminator/);
+  });
+});
+
+describe('statementUpTo — the bound behind an anchor is where its statement starts', () => {
+  it('THE case that broke the first version: an options object is not a statement boundary', () => {
+    /*
+     * Taking the nearest `;`, `{` or `}` at any depth makes the closing brace of the options object the boundary,
+     * so the window starts at `) : await ` — and the gate that asks "is this fetch behind a locality test?"
+     * answers no about a fetch that plainly is. Found by running the converted gate, not by reasoning.
+     */
+    const src = [
+      '  let res;',
+      '  try {',
+      '    res = endpoint.external',
+      '      ? await ssrfSafeFetch(url, init, { allowPrivate: allowPrivateForSlot(endpoint.slot) })',
+      '      : await fetch(url, init);',
+      '  } catch (err) { throw err; }',
+    ].join('\n');
+    const at = src.lastIndexOf('fetch(url, init)');
+    const got = statementUpTo(src, at);
+    assert.ok(got.includes('endpoint.external'), 'the locality test is outside the window');
+    assert.ok(!got.includes('let res'), 'the window ran back past the start of the statement');
+  });
+
+  it('a preceding statement ends the window', () => {
+    const src = 'const a = 1;\nconst b = choose ? one() : two();';
+    const got = statementUpTo(src, src.indexOf('two()'));
+    assert.ok(got.includes('choose'));
+    assert.ok(!got.includes('const a'), 'the previous statement is inside the window');
+  });
+
+  it('a semicolon inside a nested arrow does not end the outer statement', () => {
+    const src = 'const f = flag\n  ? (x) => { return g(x); }\n  : (x) => h(x);';
+    const got = statementUpTo(src, src.indexOf('h(x)'));
+    assert.ok(got.includes('flag'), 'a nested block ended the statement early');
+  });
+
+  it('a semicolon in a string is not a boundary', () => {
+    const src = "const msg = 'a ; here';\nconst v = flag ? a() : b();";
+    assert.ok(statementUpTo(src, src.indexOf('b()')).includes('flag'));
+  });
+
+  it('grows with the statement, which is the whole point', () => {
+    const base = 'const v = someVeryLongCondition\n  ? a()\n  : b();';
+    const grown = base.replace('someVeryLongCondition', 'someVeryLongCondition /* ' + 'x'.repeat(800) + ' */');
+    assert.ok(statementUpTo(grown, grown.lastIndexOf('b()')).includes('someVeryLongCondition'));
+  });
+});
+
+describe('enclosingBlockFrom — the bound is the brace that closes what you are inside', () => {
+  it('returns the rest of the branch the anchor sits in', () => {
+    const src = 'if (deep) {\n  counter++;\n  log.warn(`DROPPED ${id}`);\n}\nnext();';
+    const got = enclosingBlockFrom(src, src.indexOf('counter++'));
+    assert.ok(got.includes('DROPPED'), 'the rest of the branch was not covered');
+    assert.ok(!got.includes('next()'), 'the window ran past the end of the branch');
+  });
+
+  it('nested blocks inside the branch do not end it early', () => {
+    const src = 'if (a) {\n  if (b) { inner(); }\n  tail();\n}\nafter();';
+    const got = enclosingBlockFrom(src, src.indexOf('if (b)'));
+    assert.ok(got.includes('tail()'), 'a nested block closed the window');
+    assert.ok(!got.includes('after()'));
+  });
+
+  it('a brace in a message does not end the branch', () => {
+    const src = "if (a) {\n  fail('} not real');\n  tail();\n}\nafter();";
+    assert.ok(enclosingBlockFrom(src, src.indexOf('fail(')).includes('tail()'));
+  });
+});
+
+describe('openTagAt — the bound for an assertion about attributes', () => {
+  it('returns exactly the opening tag', () => {
+    const src = '<div class="tabs" role="tablist" aria-label="Brain views">\n  <button>x</button>\n</div>';
+    const got = openTagAt(src, src.indexOf('<div'));
+    assert.ok(got.startsWith('<div') && got.endsWith('>'));
+    assert.ok(got.includes('aria-label'), 'a long attribute list was cut');
+    assert.ok(!got.includes('<button'), 'the window ran into the children');
+  });
+
+  it('an attribute added at the end is still inside the window', () => {
+    // The Space Admin failure in one line: a fifth column pushed the subject past a character count. Here the
+    // subject grows and the bound grows with it.
+    const grown = '<div class="tabs" role="tablist" aria-label="x" data-extra="' + 'y'.repeat(500) + '">';
+    assert.ok(openTagAt(grown, 0).includes('data-extra'));
+  });
+});
+
+describe('markdownSectionFrom — prose is bounded by the next heading', () => {
+  const doc = '# Title\n\nWorks fully offline. Enforced with HF_HUB_OFFLINE=1.\n\n## Next\n\nSomething else.\n';
+
+  it('covers the claim and everything said about it', () => {
+    const got = markdownSectionFrom(doc, doc.indexOf('Works fully offline'));
+    assert.ok(got.includes('HF_HUB_OFFLINE'));
+    assert.ok(!got.includes('Something else'), 'the window ran into the next section');
+  });
+
+  it('a section at the end of the document is not cut', () => {
+    const got = markdownSectionFrom(doc, doc.indexOf('Something else'));
+    assert.ok(got.includes('Something else'));
+  });
+
+  it('grows with the prose', () => {
+    const padded = doc.replace('Enforced', 'Padding. '.repeat(300) + 'Enforced');
+    assert.ok(markdownSectionFrom(padded, padded.indexOf('Works fully offline')).includes('HF_HUB_OFFLINE'));
+  });
+});
+
+describe('yamlItemAt — a workflow step is bounded by the next step', () => {
+  const wf = [
+    'jobs:',
+    '  check:',
+    '    steps:',
+    '      - uses: actions/checkout@v4',
+    '        with:',
+    '          fetch-depth: 0',
+    '      - name: next step',
+    '        run: echo hi',
+  ].join('\n');
+
+  it('covers the whole step, not a count of it', () => {
+    const got = yamlItemAt(wf, wf.indexOf('actions/checkout@v4'));
+    assert.ok(got.includes('fetch-depth: 0'));
+    assert.ok(!got.includes('next step'), 'the window ran into the following step');
+  });
+
+  it('an anchor on a LATER line of the step still bounds the whole step', () => {
+    const got = yamlItemAt(wf, wf.indexOf('fetch-depth'));
+    assert.ok(got.includes('actions/checkout@v4'), 'it did not walk back to the start of the item');
+  });
+
+  it('grows when the step gains keys', () => {
+    const grown = wf.replace('          fetch-depth: 0', '          fetch-depth: 0\n          persist-credentials: false');
+    const got = yamlItemAt(grown, grown.indexOf('actions/checkout@v4'));
+    assert.ok(got.includes('persist-credentials'));
+    assert.ok(!got.includes('next step'));
+  });
+
+  it('a blank line inside a step does not end it', () => {
+    const spaced = wf.replace('        with:', '\n        with:');
+    assert.ok(yamlItemAt(spaced, spaced.indexOf('actions/checkout@v4')).includes('fetch-depth'));
+  });
+});
+
+describe('bodyOf still behaves, since the new code shares its module', () => {
+  it('bounds a declaration by the next one', () => {
+    const src = 'export function a() {\n  return 1;\n}\n\nexport function b() {\n  return 2;\n}\n';
+    const got = bodyOf(src, 'a');
+    assert.ok(got.includes('return 1'));
+    assert.ok(!got.includes('return 2'));
+  });
+});

--- a/testing/standalone/sync-dropped-record-is-not-silent.test.js
+++ b/testing/standalone/sync-dropped-record-is-not-silent.test.js
@@ -31,6 +31,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { stripComments } from './_strip-comments.mjs';
+import { enclosingBlockFrom, balancedFrom, blockAfter } from './_structural-window.mjs';
 
 const receiver = stripComments(readFileSync('server/src/api/sync/docs.ts', 'utf8'));
 const sender = stripComments(readFileSync('server/src/sync/engine.ts', 'utf8'));
@@ -58,7 +59,8 @@ describe('the receiver separates a drop from an already-current skip', () => {
   it('logs the drop, naming the record and saying it will not be retried', () => {
     const at = receiver.indexOf('forkDepthRefused++');
     assert.ok(at > -1, 'anchor missing — re-point this gate');
-    const block = receiver.slice(at, at + 700);
+    // The rest of the branch the counter sits in, bounded by the brace that closes it.
+    const block = enclosingBlockFrom(receiver, at, 'the fork-depth refusal branch');
     assert.match(block, /log\.warn\(/, 'the side that knows WHY must say so');
     assert.match(block, /DROPPED/, 'and say what happened in a word an operator can grep for');
     assert.match(block, /\$\{incoming\._id\}/, 'naming the record — a count alone cannot be investigated');
@@ -121,7 +123,14 @@ describe('the sender reads the body instead of trusting the status', () => {
     // the space. This asserts the advance is unconditional on the refusal, so nobody "fixes" it into a stall.
     const at = sender.indexOf('maxSeqPushed > lastSeqPushed');
     assert.ok(at > -1, 'anchor missing — re-point this gate');
-    const block = sender.slice(Math.max(0, at - 400), at + 400);
+    /*
+     * The condition AND the branch, each bounded by its own closing bracket. The version this replaces read 400
+     * characters either side, which is the worst combination in this file: the assertion is that something is
+     * ABSENT, so a window that falls short passes by looking at less — and the backwards half is written
+     * `at - 400`, a form the magic-window ratchet's pattern does not match.
+     */
+    const block = balancedFrom(sender, sender.lastIndexOf('if (', at), 'the watermark-advance condition')
+      + blockAfter(sender, at, 'the watermark-advance branch');
     assert.doesNotMatch(block, /forkDepthRefused/,
       'the watermark must not be made conditional on a refusal — that trades a visible drop for a dead space');
   });

--- a/testing/standalone/toggle-state-is-announced.test.js
+++ b/testing/standalone/toggle-state-is-announced.test.js
@@ -29,6 +29,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
+import { openTagAt } from './_structural-window.mjs';
 
 /**
  * Known gaps, by path, with the exact number of buttons still missing an ARIA state.
@@ -120,8 +121,11 @@ describe('the groups fixed here stay fixed', () => {
     const at = src.indexOf('<div class="tabs"');
     assert.ok(at > 0, 'the Brain tab strip is gone — re-anchor this gate');
     const strip = src.slice(at, src.indexOf('</div>', at));
-    assert.match(src.slice(at, at + 200), /role="tablist"/, 'the strip must be a tablist');
-    assert.match(src.slice(at, at + 200), /aria-label/, 'a tablist needs a name');
+    // Both are assertions about the opening TAG, so the tag is the bound. At 200 characters an attribute added
+    // ahead of `aria-label` would push it out and fail a correct template — the Space Admin failure exactly.
+    const tag = openTagAt(src, at, 'the Brain tab strip');
+    assert.match(tag, /role="tablist"/, 'the strip must be a tablist');
+    assert.match(tag, /aria-label/, 'a tablist needs a name');
     const tabs = [...strip.matchAll(/<button class="tab"[^>]*>/g)];
     assert.ok(tabs.length >= 5, `expected the tab buttons, found ${tabs.length}`);
     const silent = tabs.filter(m => !/aria-selected/.test(m[0])).length;

--- a/testing/standalone/vlm-endpoint-egress.test.js
+++ b/testing/standalone/vlm-endpoint-egress.test.js
@@ -34,6 +34,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
+import { bodyOf, statementUpTo } from './_structural-window.mjs';
 
 const ENDPOINT_SRC = 'server/src/files/converters/vlm-endpoint.ts';
 const CLIENT_SRC = 'server/src/files/converters/vlm-client.ts';
@@ -133,9 +134,7 @@ describe('egress is guarded whenever the endpoint is not the bundled model', () 
       ['repairMarkdown', 'docRepair'],
       ['reconcileConsensus', 'docVlm'],
     ]) {
-      const at = client.indexOf(`export async function ${fn}`);
-      assert.ok(at > 0, `${fn} should exist`);
-      assert.match(client.slice(at, at + 600), new RegExp(`asEndpoint\\(opts, '${slot}'\\)`),
+      assert.match(bodyOf(client, fn), new RegExp(`asEndpoint\\(opts, '${slot}'\\)`),
         `${fn} must resolve egress under the ${slot} slot`);
     }
   });
@@ -217,7 +216,10 @@ describe('no operator-configurable URL is fetched without the guard', () => {
       const src = strip(readFileSync(f, 'utf8'));
       // `fetch(` but not `ssrfSafeFetch(` / `peerSafeFetch(` / `egressFetch(` / `.fetch(`.
       for (const m of src.matchAll(/(?<![A-Za-z.])fetch\(/g)) {
-        const window = src.slice(Math.max(0, m.index - 220), m.index);
+        // The statement this fetch is chosen inside, bounded by where that statement begins. At 220 characters
+        // backwards the window could start mid-way through the previous statement and miss the ternary that picks
+        // the client — which would report a correctly-guarded fetch as an offender.
+        const window = statementUpTo(src, m.index, `the fetch in ${f}`);
         if (!GUARD_PREDICATES.test(window)) {
           offenders.push(`${f} (line ${src.slice(0, m.index).split('\n').length})`);
         }


### PR DESCRIPTION
chore(testing): the 22 magic windows are gone, and two gates were checking the wrong thing

X-25 shipped its ratchet in #991 with 22 windows grandfathered in. This converts 19 of the
20 files, leaves 2 entries that are documented non-windows, and closes the pattern's own
blind spot.

WHAT A MAGIC WINDOW IS, IN ONE LINE

`src.slice(at, at + 1600)` — a gate reading a fixed number of characters and calling that
its subject. Grow the subject and the window stops covering it.

THE HELPER GREW THE BOUNDS THOSE GATES ACTUALLY NEEDED

`bodyOf` and `between` covered a named declaration and a literal-delimited block. Nothing
covered the four other shapes a subject takes, so every gate that needed one reached for a
number instead:

  balancedFrom        a call or a block, to its matching bracket
  blockAfter          the block belonging to an `if` — its first bracket is the condition
  statementFrom       to the `;` that ends the statement
  statementUpTo       behind an anchor, to where its statement starts
  enclosingBlockFrom  the rest of the branch an anchor sits inside
  openTagAt           an HTML opening tag, for an assertion about attributes
  markdownSectionFrom prose, to the next heading
  yamlItemAt          a workflow step, to the next step at the same indentation

Three files had hand-rolled the bracket walker independently, and none of the three skipped
strings or comments — so a brace inside a message ended the window early. That is the
same failure as a magic number wearing structure's clothes.

THE HELPER HAS ITS OWN SPEC NOW, AND IT EARNED ITS KEEP IMMEDIATELY

A magic window that falls short goes RED: the assertion inside it stops matching. A
structural bound that falls short goes GREEN over less text. The second is strictly worse
and it is worse only because nobody would look — so the bounds are asserted directly, on
inputs built to break them: a bracket in a string, a bracket in a comment, an escaped
quote, a template literal, a subject padded past any plausible count.

It caught `balancedFrom` off by one on its first run. Every caller would have received a
window one bracket too small, and every gate would have kept passing.

MUTATION TESTING FOUND TWO GATES CHECKING THE WRONG THING

Sixteen mutants, one per converted gate, each breaking the thing the gate is about. All
sixteen are killed now. Two were not:

**`credential-bodies-are-strict` accepted a NESTED `.strict()` as proof the outer schema
was strict.** Both token bodies nest a `rights: z.object({…}).strict().optional()`, so
removing the outer `.strict()` from `CreateTokenBody` left the gate green — the schema that
mints credentials back to silently dropping unknown keys, which is the exact defect the file
was written for. This one is a regression the conversion introduced: the old 40-character
tail happened to exclude the nested call. Nobody had chosen that property, which is why the
position is now stated rather than inherited.

**`mint-accepts-rights-capped` checked the first of two `rights: z.object(` declarations.**
There are two — create and update — and `indexOf` found only create. Loosening create left
it green because update still matched. Pre-existing; now every match is checked.

THE PATTERN HAD A BLIND SPOT THE SAME SIZE AS THE PROBLEM

`src.slice(Math.max(0, at - 400), at)` is the same defect pointing backwards, and the
ratchet's pattern never matched it: nine sites across eight files, uncounted and
ungrandfathered. A rule reporting zero because it is not looking reads exactly like a rule
that is satisfied.

Backwards is the worse half. Forwards, a short window usually breaks its assertion; going
backwards it silently starts inside its subject, and here it is mostly paired with
`doesNotMatch` — an absence asserted over less text than intended, which passes.

Now counted and ratcheted in `GRANDFATHERED_BACK`, a list that may only shrink. One of the
nine is converted rather than recorded, because it was actively wrong: a gate asking "is
this bare `fetch` behind a locality test?" read 220 characters backwards, which could start
mid-way through the previous statement and miss the ternary that picks the client.

LINE WINDOWS ARE DELIBERATELY NOT MATCHED, AND THAT IS ASSERTED

`lines.slice(Math.max(0, i - 3), i + 4).join(' ')` is an ADJACENCY claim — "the guard is
near the call" — where the number IS the rule. The `.join(` separates them, and the
exclusion is pinned in the gate so a future tightening cannot quietly ban thirty
legitimate proximity checks.

WHAT IS LEFT, STATED RATHER THAN IMPLIED

Two entries stay in the forward list and neither is a window: a hex-pair read
(`parseInt(h.slice(i, i + 2), 16)` — two characters by definition, nothing can grow), and a
90-character excerpt inside an assertion MESSAGE, where nothing is checked.

`X-25b` is the nine backwards sites. `X-25c` is 30 capped gaps inside regexes that nobody
has read; a sample showed two different things sharing one syntax, and converting the
legitimate half would weaken it. Both are in `QA-TODO.md` with what to do.

No CHANGELOG entry: no product behaviour changes here, and `testing/` is exempt from the
entry gate for that reason.
