### PR TITLE
chore(testing): the backwards windows are gone, and one of them was answering the wrong question

### DIFF
--- a/testing/standalone/_structural-window.mjs
+++ b/testing/standalone/_structural-window.mjs
@@ -204,14 +204,7 @@ export function statementUpTo(src, at, label = 'statementUpTo') {
    * the window starts at `) : await ` and contains no `.external` — and the gate reports a correctly-guarded fetch
    * as unguarded. Only a boundary at the anchor's own nesting level ends its statement.
    */
-  const marks = [];
-  let depthAt = null;
-  scanCode(src, 0, (c, i, depth) => {
-    if (i >= at) { if (depthAt === null) depthAt = depth; return at; }
-    if (c === ';' || c === '{' || c === '}') marks.push({ c, i, depth });
-    return undefined;
-  });
-  assert.ok(depthAt !== null, `${label}: index ${at} was never reached — it is inside a string or a comment`);
+  const { marks, depthAt } = boundariesBefore(src, at, label);
   const boundary = marks.filter(m =>
     (m.c === ';' && m.depth === depthAt)
     || (m.c === '{' && m.depth === depthAt - 1)    // the brace that opened the block we are in
@@ -280,4 +273,174 @@ export function yamlItemAt(src, at, label = 'yamlItemAt') {
     if (lead <= indent[1].length) { end = i; break; }
   }
   return lines.slice(start, end).join('\n');
+}
+
+/*
+ * ---------------------------------------------------------------------------------------------------------------
+ * The bounds the BACKWARDS population needed (X-25b).
+ *
+ * Nine gates read a fixed number of characters behind an anchor. Reading all nine showed they were asking five
+ * different questions, and every one of them has an exact answer that a count only approximates:
+ *
+ *   "is this call inside a try/catch?"                    -> the enclosing block
+ *   "is this fence marked as a response?"                 -> the line above it
+ *   "what does this field's doc comment say?"             -> the comment block above it
+ *   "which NOTICE section mentions this model?"           -> the section around it
+ *   "is this control inside an @if that checks managed?"  -> which enclosing blocks contain it
+ *
+ * The last one is the reason not to have swept these: a backwards character window answers a CONTAINMENT question
+ * with a PROXIMITY measurement, and those are not the same question. A guard that opened and CLOSED above the
+ * control satisfies proximity while containing nothing.
+ * ---------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Every real-code `;`, `{` and `}` before `at`; the bracket depth at `at`; and the stack of `{` still OPEN there.
+ *
+ * THE STACK, NOT THE DEPTH, ANSWERS "WHICH BLOCK AM I IN" — and the difference is not academic. Bracket depth
+ * counts parens too, so an anchor inside `log.info(\`readiness confirmed…\`)` sits two deep rather than one, and
+ * comparing against `depthAt - 1` then looks for a brace at a level where none exists. The gate would have reported
+ * a re-anchoring failure rather than a wrong window, so this one was loud — but it was found by a spec fixture that
+ * anchors inside a string, which is exactly what the real gate does, and not by reasoning about it.
+ *
+ * Depth is kept as well, because `statementUpTo` genuinely does want same-level `;` boundaries.
+ */
+function boundariesBefore(src, at, label) {
+  const marks = [];
+  const open = [];
+  let depthAt = null;
+  scanCode(src, 0, (c, i, depth) => {
+    if (i >= at) { if (depthAt === null) depthAt = depth; return at; }
+    if (c === ';' || c === '{' || c === '}') marks.push({ c, i, depth });
+    if (c === '{') open.push(i);
+    else if (c === '}') open.pop();
+    return undefined;
+  });
+  assert.ok(depthAt !== null, `${label}: index ${at} was never reached — it is inside a string or a comment`);
+  return { marks, depthAt, open };
+}
+
+/** The text from the start of the line containing `brace` up to it — the `if (…)` or `try` that opened the block. */
+function openingLineOf(src, brace) {
+  return src.slice(src.lastIndexOf('\n', brace) + 1, brace);
+}
+
+/**
+ * The whole block `at` sits inside, INCLUDING the line that opens it.
+ *
+ * The bound for "is this guarded?" — a `try {` or an `if (failed.length === 0) {`. The opening LINE is included
+ * deliberately, because the guard is usually the condition rather than the brace: bounding at the brace itself
+ * would answer "what is in the block" while the question was "what let us into it".
+ */
+export function enclosingBlockAround(src, at, label = 'enclosingBlockAround') {
+  const { open } = boundariesBefore(src, at, label);
+  const brace = open[open.length - 1];
+  assert.ok(brace !== undefined, `${label}: index ${at} is not inside a block — re-anchor this gate`);
+  return openingLineOf(src, brace) + balancedFrom(src, brace, label);
+}
+
+/**
+ * Every enclosing block whose opening line matches `opener`, outermost first.
+ *
+ * Answers CONTAINMENT rather than proximity. A block that opened and closed before `at` is not returned, which is
+ * the whole difference: `src.slice(at - 600, at)` cannot tell "the control is inside this guard" from "a guard
+ * happens to be written nearby", and the second one is a false pass on an unguarded control.
+ */
+export function enclosingBlocksMatching(src, at, opener, label = 'enclosingBlocksMatching') {
+  const { open } = boundariesBefore(src, at, label);
+  return open
+    .map(brace => `${openingLineOf(src, brace)}{`)
+    .filter(head => opener.test(head));
+}
+
+/**
+ * An Angular component's inline template — the text inside `template: ` + backtick … backtick.
+ *
+ * Needed because the JS scanner treats a template literal as a STRING and skips it whole, so every `@if (…) {` in
+ * an Angular template is invisible to `enclosingBlocksMatching`. That is correct for reading TypeScript and useless
+ * for reading the markup inside it, which is a different language in the same file.
+ */
+export function angularTemplateOf(src, label = 'angularTemplateOf') {
+  const key = src.indexOf('template:');
+  assert.ok(key > -1, `${label}: no inline template in this component — re-anchor this gate`);
+  const open = src.indexOf('`', key);
+  assert.ok(open > -1, `${label}: template: is not followed by a template literal`);
+  let i = open + 1;
+  while (i < src.length && src[i] !== '`') i += src[i] === '\\' ? 2 : 1;
+  assert.ok(i < src.length, `${label}: the template literal is never closed`);
+  return src.slice(open + 1, i);
+}
+
+/**
+ * Every enclosing MARKUP block whose opening line matches `opener`, outermost first.
+ *
+ * The same containment question as `enclosingBlocksMatching`, over template syntax rather than TypeScript. It skips
+ * `{{ … }}` interpolations and quoted attribute values, because a brace in either is not control flow — an
+ * `[ngModel]="{a: 1}"` would otherwise push a level that never closes and put every later control inside a
+ * phantom block.
+ */
+export function enclosingMarkupBlocksMatching(text, at, opener) {
+  const open = [];
+  let i = 0;
+  while (i < at) {
+    const c = text[i];
+    if (c === '"' || c === "'") {                  // an attribute value: braces in it are data, not structure
+      const quote = c;
+      i++;
+      while (i < at && text[i] !== quote) i++;
+      i++;
+      continue;
+    }
+    if (c === '{' && text[i + 1] === '{') {        // an interpolation, balanced by its own `}}`
+      const end = text.indexOf('}}', i + 2);
+      i = end === -1 ? at : end + 2;
+      continue;
+    }
+    if (c === '{') open.push(i);
+    else if (c === '}') open.pop();
+    i++;
+  }
+  return open
+    .map(brace => `${text.slice(text.lastIndexOf('\n', brace) + 1, brace)}{`)
+    .filter(head => opener.test(head));
+}
+
+/** The last non-empty line before `at` — for a marker whose rule IS "immediately above". */
+export function lineBefore(src, at, label = 'lineBefore') {
+  const lines = src.slice(0, at).split(/\r?\n/);
+  while (lines.length && lines[lines.length - 1].trim() === '') lines.pop();
+  assert.ok(lines.length, `${label}: nothing precedes index ${at} — re-anchor this gate`);
+  return lines[lines.length - 1];
+}
+
+/**
+ * The `/* … *' + '/` comment block immediately above `at`, or `''` when there is none.
+ *
+ * Returns empty rather than throwing: "this field has no doc comment" is a legitimate answer that a gate asserts
+ * ON, and turning it into an exception would make an absent comment indistinguishable from a broken anchor.
+ */
+export function docCommentBefore(src, at, label = 'docCommentBefore') {
+  const close = src.lastIndexOf('*/', at);
+  if (close === -1) return '';
+  // Only if nothing but whitespace separates the comment from the anchor — otherwise it belongs to something else.
+  if (src.slice(close + 2, at).trim() !== '') return '';
+  const open = src.lastIndexOf('/*', close);
+  if (open === -1) return '';
+  return src.slice(open, close + 2);
+}
+
+/**
+ * The markdown section CONTAINING `at` — back to its own heading, forward to the next.
+ *
+ * `markdownSectionFrom` starts at the anchor, which is right when the anchor IS the heading. When the anchor is a
+ * mention somewhere inside a section, the thing being asked about is the section it belongs to, and half of that
+ * is behind the anchor.
+ */
+export function markdownSectionAround(src, at, label = 'markdownSectionAround') {
+  const before = src.slice(0, at);
+  const heads = [...before.matchAll(/^#{1,6} .*$/gm)];
+  const start = heads.length ? heads[heads.length - 1].index : 0;
+  const rest = src.slice(at);
+  const next = /\n#{1,6} /.exec(rest);
+  return src.slice(start, next ? at + next.index : src.length);
 }

--- a/testing/standalone/backups-are-not-world-readable.test.js
+++ b/testing/standalone/backups-are-not-world-readable.test.js
@@ -28,7 +28,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { bodyOf } from './_structural-window.mjs';
+import { bodyOf, enclosingBlockAround } from './_structural-window.mjs';
 
 const ROOT = process.cwd();
 const read = (p) => readFileSync(join(ROOT, p), 'utf8');
@@ -78,8 +78,9 @@ describe('one definition of "as tight as the state files"', () => {
     // Windows and plenty of network shares (SMB, some NFS exports) ignore POSIX modes. Hardening must never turn a
     // working upload or backup into a failed one — the mode is a tightening, not a precondition.
     for (const m of modes.matchAll(/chmod(?:Sync)?\([^)]*\)/g)) {
-      const at = modes.indexOf(m[0]);
-      const around = modes.slice(Math.max(0, at - 140), at + m[0].length + 40);
+      // The block the chmod is IN, including the line that opened it — which is where `try` lives. The version this
+      // replaces read 140 characters behind and 40 ahead, so a `try` one statement further up read as absent.
+      const around = enclosingBlockAround(modes, m.index, `the guard around ${m[0]}`);
       assert.match(around, /try\s*\{|catch/, `${m[0]} is not guarded`);
     }
   });

--- a/testing/standalone/config-key-docs-coverage.test.js
+++ b/testing/standalone/config-key-docs-coverage.test.js
@@ -49,6 +49,7 @@ import assert from 'node:assert/strict';
 import { readFileSync, readdirSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { lineBefore, docCommentBefore } from './_structural-window.mjs';
 
 const ROOT = join(fileURLToPath(new URL('.', import.meta.url)), '..', '..');
 const TYPES = join(ROOT, 'server', 'src', 'config', 'types.ts');
@@ -153,7 +154,9 @@ function configExamples() {
       // its own: `{"tokens": [...]}` is a token-access response AND `tokens` is a real config field, so a response example
       // was reported as three undeclared config keys. The docs mark these unambiguously with a `**Response**` line
       // immediately above the fence, so that marker is what to read.
-      const preamble = src.slice(Math.max(0, m.index - 220), m.index);
+      // "Immediately above the fence" IS the rule, so the bound is the LINE above it rather than 220 characters,
+      // which reaches back over a paragraph and can find a `**Response**` belonging to a different example.
+      const preamble = lineBefore(src, m.index, 'the fence preamble');
       if (/\*\*Response\*\*/i.test(preamble)) continue;
       found.push({ doc: f, parsed });
     }
@@ -222,7 +225,10 @@ describe('every top-level config field is documented', () => {
       assert.ok(at > 0, `${field} should be a top-level Config field (${why})`);
       // Normalised first: a JSDoc comment wraps, so the phrase routinely reads `not\n   * meant to be
       // hand-edited` and a `\s+` between the words does not match the leading asterisk.
-      const comment = src.slice(Math.max(0, at - 700), at).replace(/^\s*\*/gm, ' ').replace(/\s+/g, ' ');
+      // The field's OWN doc comment, bounded by its delimiters. At 700 characters this reached back into the comment
+      // on the field ABOVE, so one field's exemption reason could satisfy its neighbour's.
+      const comment = docCommentBefore(src, at, `${field}'s doc comment`)
+        .replace(/^\s*\*/gm, ' ').replace(/\s+/g, ' ');
       assert.match(comment, /not\s+(meant to be\s+)?hand-edited/i,
         `${field} is exempted as machine-managed, so its declaration must say it is not hand-edited`);
     }

--- a/testing/standalone/gates-bound-their-subject-structurally.test.js
+++ b/testing/standalone/gates-bound-their-subject-structurally.test.js
@@ -45,7 +45,16 @@ import { stripComments } from './_strip-comments.mjs';
  * Requires the SAME identifier on both sides, which is what distinguishes a window over a subject from an
  * unrelated pair of offsets — and keeps `slice(0, 300)` message truncation out of scope entirely.
  */
-const MAGIC_WINDOW = /\.slice\(\s*([A-Za-z_$][\w$]*)\s*,\s*\1\s*\+\s*\d+\s*\)/g;
+/**
+ * A forward window: `src.slice(at, at + 1600)`, and now also `src.slice(f(x), f(x) + 900)`.
+ *
+ * The capture was a bare IDENTIFIER, which missed the form with the anchor inlined —
+ * `src.slice(src.indexOf('async function indexServes'), src.indexOf('async function indexServes') + 900)`, found in
+ * a file that already carried a comment explaining why character counts are wrong. Widened to any repeated
+ * expression up to 80 characters with no comma in it. The backreference matches literally, so the two halves still
+ * have to be the same text — which is what makes this a window rather than an ordinary two-index slice.
+ */
+const MAGIC_WINDOW = /\.slice\(\s*([^,()]{1,80}?(?:\([^()]{0,60}\))?)\s*,\s*\1\s*\+\s*\d+\s*\)/g;
 
 /**
  * The same defect written BACKWARDS: `src.slice(Math.max(0, at - 400), at)`.
@@ -120,6 +129,16 @@ const GRANDFATHERED = new Map([
   ['testing/standalone/text-contrast-meets-aa.test.js', 1],
 
   /*
+   * `parseInt(bits.slice(i * 8, i * 8 + 8), 2)` — reading one byte out of a bit string.
+   *
+   * The same class as the hex pair above and found by the same widening: eight bits is what a byte IS. Both are
+   * fixed-width FIELD reads, and the fact that two of the three surviving entries are this shape is the argument for
+   * keeping the exemptions rather than contorting the pattern to exclude them — a pattern that tries to tell a field
+   * read from a window by its arithmetic will get it wrong in the other direction eventually.
+   */
+  ['testing/red-team-tests/auth-surface-hardening.test.js', 1],
+
+  /*
    * `JSON.stringify(src.slice(handlerStart, handlerStart + 90))` — inside an assertion MESSAGE.
    *
    * Nothing is asserted about those 90 characters. They are an excerpt shown to whoever reads the failure, so
@@ -142,14 +161,15 @@ const GRANDFATHERED = new Map([
  * what precedes a call. Those are three different structural bounds, not one conversion applied nine times.
  */
 const GRANDFATHERED_BACK = new Map([
-  ['testing/standalone/backups-are-not-world-readable.test.js', 1],
-  ['testing/standalone/config-key-docs-coverage.test.js', 2],
-  ['testing/standalone/index-ready-poll.test.js', 1],
-  ['testing/standalone/infra-managed-locks-every-field.test.js', 1],
-  ['testing/standalone/models-are-attributed.test.js', 1],
-  ['testing/standalone/proxy-fanout-inventory.test.js', 1],
-  ['testing/standalone/swallowed-writes-must-be-visible.test.js', 1],
-  ['testing/standalone/theme-cannot-recolour-facts.test.js', 1],
+  /*
+   * EMPTY. All nine are converted, and the list stays here rather than being deleted because an empty ratchet is the
+   * thing that keeps it empty — remove the map and the check goes with it.
+   *
+   * Reading the nine showed they were asking five different questions, which is why they were not swept: an
+   * enclosing block, the line above, the doc comment above, the section around, and — the one that mattered — which
+   * blocks CONTAIN the anchor. That last one was answering a containment question with a proximity measurement, so a
+   * guard that opened and closed above a form control counted as guarding it.
+   */
 ]);
 
 /**
@@ -198,8 +218,24 @@ describe('the scan works before anything is concluded from it', () => {
     // Proven against a literal, so a regex that silently stopped matching cannot pass as "none left".
     const sample = 'const body = src.slice(at, at + 1600);';
     assert.equal([...sample.matchAll(MAGIC_WINDOW)].length, 1, 'MAGIC_WINDOW no longer matches a magic window');
-    // And does NOT match the two shapes that are fine.
-    for (const ok of ['JSON.stringify(b).slice(0, 300)', 'src.slice(start, end)', 'x.slice(a, b + 4)']) {
+
+    /*
+     * The INLINED-ANCHOR form, which the identifier-only capture could not see. Pinned as its own case because it is
+     * how the widening was earned: three of these were sitting in the suite, one of them in a file that already
+     * carried a comment about why character counts are wrong.
+     */
+    const inlined = "const fn = src.slice(src.indexOf('function f'), src.indexOf('function f') + 900);";
+    assert.equal([...inlined.matchAll(MAGIC_WINDOW)].length, 1,
+      'MAGIC_WINDOW no longer matches a window whose anchor is written out twice');
+
+    // And does NOT match the shapes that are fine.
+    for (const ok of [
+      'JSON.stringify(b).slice(0, 300)',
+      'src.slice(start, end)',
+      'x.slice(a, b + 4)',
+      // Two DIFFERENT expressions is an ordinary slice, not a window — the backreference is what separates them.
+      "s.slice(s.indexOf('a'), s.indexOf('b') + 4)",
+    ]) {
       assert.equal([...ok.matchAll(MAGIC_WINDOW)].length, 0, `false positive on: ${ok}`);
     }
   });

--- a/testing/standalone/index-ready-poll.test.js
+++ b/testing/standalone/index-ready-poll.test.js
@@ -30,6 +30,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { enclosingBlockAround, bodyOfEndingWith, bodyOf } from './_structural-window.mjs';
 
 const ROOT = 'server/src';
 
@@ -73,21 +74,18 @@ describe('search-index listing is never name-filtered', () => {
 
   it('the poll matches by name and accepts queryable as ready', () => {
     const src = readFileSync(`${ROOT}/spaces/vector-index.ts`, 'utf8');
-    const at = src.indexOf('export async function pollVectorIndexReady');
-    assert.ok(at > 0);
-    // Bounded STRUCTURALLY — the whole function, to the next top-level export — rather than by `at + 3000`.
-    // A character window spans different lines on CRLF than on LF, and it silently shrinks whenever the
-    // function grows: adding the terminal-absence branch pushed the statement below past 3000 characters and
-    // this assertion started failing on code that was correct. A window that can look at less than it means
-    // to is a window that can pass on less than it means to.
-    const srcLines = src.split(/\r?\n/);
-    const start = srcLines.findIndex(l => l.includes('export async function pollVectorIndexReady'));
-    let end = srcLines.length;
-    for (let i = start + 1; i < srcLines.length; i++) {
-      if (/^export (async function|function|const) /.test(srcLines[i])) { end = i; break; }
-    }
-    const body = srcLines.slice(start, end).join('\n');
-    assert.ok(body.includes('gave up after'), 'the window must reach the end of the function');
+    /*
+     * Bounded STRUCTURALLY — the whole function, to the next top-level declaration — rather than by `at + 3000`.
+     * A character window spans different lines on CRLF than on LF, and it silently shrinks whenever the function
+     * grows: adding the terminal-absence branch pushed the statement below past 3000 characters and this assertion
+     * started failing on code that was correct.
+     *
+     * This is now the SHARED bound. The loop that used to sit here was one of three independent hand-rolls of it,
+     * written within hours of each other, which is what `_structural-window.mjs` was extracted for. `bodyOf` alone
+     * would do; `bodyOfEndingWith` also carries the "the window reached the end of its subject" assertion that used
+     * to be spelled out below, and having it inside the helper means every caller gets it.
+     */
+    const body = bodyOfEndingWith(src, 'pollVectorIndexReady', 'gave up after');
     assert.match(body, /all\.find\(i => i\.name === indexName\)/);
     // `queryable` is the property recall actually depends on; a mongot reporting it without a READY
     // status would otherwise poll forever.
@@ -135,7 +133,9 @@ describe('search-index listing is never name-filtered', () => {
     // is what recall depends on, and it is Verify's philosophy applied one layer down — send one real
     // request rather than infer from a status field.
     const src = readFileSync(`${ROOT}/spaces/vector-index.ts`, 'utf8');
-    const fn = src.slice(src.indexOf('async function indexServes'), src.indexOf('async function indexServes') + 900);
+    // `indexOf(…) + 900` is the same magic window with the anchor inlined, and the ratchet's pattern did not match
+    // it because the pattern required a bare identifier on both sides. Widened, and this is the bound it wanted.
+    const fn = bodyOf(src, 'indexServes');
     assert.match(fn, /\$vectorSearch/, 'the probe must be a real vector query');
     assert.match(fn, /index: indexName/, 'against the index being polled, by name');
     assert.match(fn, /limit: 1/, 'and cheap — this is a liveness question, not a search');
@@ -161,7 +161,9 @@ describe('search-index listing is never name-filtered', () => {
       .replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
     const at = src.indexOf('readiness confirmed for all');
     assert.ok(at > 0, 'the summary line should still exist for the all-good case');
-    const before = src.slice(Math.max(0, at - 400), at);
+    // The branch the summary sits in, INCLUDING the line that opened it — the condition is the whole subject here,
+    // and it lives outside the braces. A count backwards could start inside the block and miss it.
+    const before = enclosingBlockAround(src, at, 'the all-good summary branch');
     assert.match(before, /failed\.length === 0/,
       'the success wording must be conditional on nothing having failed');
     assert.match(src, /did not reach ready for \$\{failed\.length\}/,

--- a/testing/standalone/infra-managed-locks-every-field.test.js
+++ b/testing/standalone/infra-managed-locks-every-field.test.js
@@ -30,12 +30,18 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { execSync } from 'node:child_process';
+import { angularTemplateOf, enclosingMarkupBlocksMatching } from './_structural-window.mjs';
 
 const files = execSync('git ls-files "client/src/app/pages/settings/media-processing/*.component.ts"',
   { encoding: 'utf8' }).trim().split('\n').filter(f => f && !f.endsWith('.spec.ts'));
 
 /** Every `<input>`, `<select>` and `<textarea>` that is bound to a model — i.e. that a person can change. */
-function boundControls(src) {
+function boundControls(componentSrc) {
+  /*
+   * The TEMPLATE, not the component file. The containment walk below reads markup braces, and the JS scanner in
+   * `_structural-window.mjs` treats the whole template literal as a string and skips it — so run it on the markup.
+   */
+  const src = angularTemplateOf(componentSrc);
   const out = [];
   for (const m of src.matchAll(/<(input|select|textarea)\b[\s\S]{0,400}?(?:\/>|<\/(?:select|textarea)>)/g)) {
     const block = m[0];
@@ -44,10 +50,25 @@ function boundControls(src) {
     // inside `@if (!(s.faceLocked('personEntityTypes') || s.managed))` — it does not RENDER when managed, which
     // is a stronger lock than a disabled attribute. A gate that understood only `[disabled]` reported that as a
     // defect, and following it would have meant adding a redundant binding to correct code.
-    const before = src.slice(Math.max(0, m.index - 600), m.index);
-    // `[^)]*` would stop at the first `)`, and these conditions contain their own — `s.faceLocked('…')` closes
-    // before `managed` is reached, so the guard read as absent on a control that has one.
-    if (/@if\s*\([\s\S]{0,120}?\bmanaged\b[\s\S]{0,300}$/.test(before)) continue;
+    /*
+     * CONTAINMENT, not proximity — and this is the one conversion in this batch that fixes a real hole rather than
+     * merely stating the bound properly.
+     *
+     * `src.slice(m.index - 600, m.index)` asks "is there a managed guard NEARBY". The question is "is this control
+     * INSIDE one". A guard that opened and closed above the control satisfies the first and contains nothing, so an
+     * unguarded control 600 characters below a closed `@if` read as locked. The walk below keeps a brace stack, so
+     * only a guard still OPEN at this control counts.
+     *
+     * It reads MARKUP braces rather than TypeScript ones, and that distinction is not cosmetic: the JS scanner in
+     * `_structural-window.mjs` treats a template literal as a string and skips it whole, so on a component file it
+     * finds no `@if` at all and reported this correctly-guarded picker as unguarded. Two languages in one file need
+     * two walks.
+     *
+     * It also drops the `[\s\S]{0,120}?` gap: the whole opening line is returned, so a condition containing its own
+     * parens — `s.faceLocked('personEntityTypes') || s.managed` — cannot be cut short of `managed`.
+     */
+    const guards = enclosingMarkupBlocksMatching(src, m.index, /@if\s*\(/);
+    if (guards.some(g => /\bmanaged\b/.test(g))) continue;
     const id = /id="([^"]+)"/.exec(block)?.[1]
       ?? /\[\(ngModel\)\]="([^"]+)"/.exec(block)?.[1]
       ?? '(unnamed)';

--- a/testing/standalone/lexical-introduction.test.js
+++ b/testing/standalone/lexical-introduction.test.js
@@ -28,6 +28,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
+import { bodyOf } from './_structural-window.mjs';
 
 const SRC = 'server/src/brain/vector-score.ts';
 const RECALL_SRC = 'server/src/brain/recall.ts';
@@ -219,7 +220,7 @@ describe('the fresh-write scan cannot take the index half down with it', () => {
 describe('introduction is gated on evidence', () => {
   const strip = s => s.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
   const src = strip(readFileSync(RECALL_SRC, 'utf8'));
-  const fn = src.slice(src.indexOf('async function introduceLexicalOnly'), src.indexOf('async function introduceLexicalOnly') + 3000);
+  const fn = bodyOf(src, 'introduceLexicalOnly');
 
   it('the function exists and is reached from fusion', () => {
     assert.ok(fn.length > 100, 'introduceLexicalOnly should exist');

--- a/testing/standalone/models-are-attributed.test.js
+++ b/testing/standalone/models-are-attributed.test.js
@@ -30,6 +30,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { markdownSectionAround } from './_structural-window.mjs';
 
 const ROOT = process.cwd();
 const read = (p) => readFileSync(join(ROOT, p), 'utf8');
@@ -116,7 +117,10 @@ describe('every model baked into an image is attributed', () => {
         const short = model.split('/')[1];
         const at = notice.indexOf(short);
         if (at < 0) { missing.push(`${model} (from ${f}) — no mention in NOTICE`); continue; }
-        const section = notice.slice(Math.max(0, at - 400), at + 900);
+        // The NOTICE section the mention BELONGS to, heading to heading. The licence line usually sits above the
+        // mention, so a forward-only bound misses it; 400 characters backwards could instead reach into the
+        // PREVIOUS entry and read somebody else's licence as this model's, which is the worse direction to be wrong.
+        const section = markdownSectionAround(notice, at, `the NOTICE entry for ${short}`);
         if (!/Licen[cs]e:/i.test(section)) missing.push(`${model} (from ${f}) — mentioned but no licence stated`);
       }
     }

--- a/testing/standalone/proxy-fanout-inventory.test.js
+++ b/testing/standalone/proxy-fanout-inventory.test.js
@@ -37,6 +37,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { execSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { enclosingBlocksMatching } from './_structural-window.mjs';
 
 /**
  * Read fan-outs, by file, with the count in that file.
@@ -214,8 +215,16 @@ function callSites() {
     // counted. A sweep that only matches calls is blind to exactly the indirection that makes a fan-out hard to
     // follow, which is the wrong way round.
     for (const m of src.matchAll(/(?<![.\w])resolveMemberSpaces(?!\s*\()/g)) {
-      const before = src.slice(Math.max(0, m.index - 200), m.index);
-      if (/import\s*\{[^}]*$/.test(before)) continue;   // the import statement itself is not a use
+      /*
+       * "Is this name inside an `import { … }` clause?" is a CONTAINMENT question, so it is answered by the brace
+       * stack rather than by reading backwards. 200 characters was a guess that fails on a long import list.
+       *
+       * `statementUpTo` was the wrong tool and said so loudly: it treats `{` as a statement boundary, which is right
+       * for a block and wrong for an import clause, so the window began after the brace and no longer contained the
+       * word `import`. Six files were then reported as by-reference fan-outs on the strength of their import line.
+       */
+      const enclosing = enclosingBlocksMatching(src, m.index, /^\s*import\s/);
+      if (enclosing.length) continue;   // the import statement itself is not a use
       out.push({ file: f, arg: 'BY-REFERENCE' });
     }
   }

--- a/testing/standalone/retry-jitter.test.js
+++ b/testing/standalone/retry-jitter.test.js
@@ -16,6 +16,7 @@
 import { describe, it, before } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
+import { bodyOf } from './_structural-window.mjs';
 
 let withJitter;
 before(async () => { ({ withJitter } = await import('../../server/dist/util/backoff.js')); });
@@ -61,7 +62,7 @@ describe('both retry queues use it', () => {
     assert.match(src, /withJitter\(/, 'media retries must be jittered');
     // Pin it to the scheduling function specifically — importing the helper and not using it here
     // would leave the herd intact.
-    const fn = src.slice(src.indexOf('function nextClaimableAfter'), src.indexOf('function nextClaimableAfter') + 400);
+    const fn = bodyOf(src, 'nextClaimableAfter');
     assert.match(fn, /withJitter\(delay\)/);
   });
 

--- a/testing/standalone/structural-window-helper.test.js
+++ b/testing/standalone/structural-window-helper.test.js
@@ -35,6 +35,11 @@ import {
   yamlItemAt,
   bodyOf,
   statementUpTo,
+  enclosingBlockAround,
+  enclosingBlocksMatching,
+  lineBefore,
+  docCommentBefore,
+  markdownSectionAround,
 } from './_structural-window.mjs';
 
 describe('balancedFrom — the bound is the matching bracket', () => {
@@ -245,6 +250,133 @@ describe('yamlItemAt — a workflow step is bounded by the next step', () => {
   it('a blank line inside a step does not end it', () => {
     const spaced = wf.replace('        with:', '\n        with:');
     assert.ok(yamlItemAt(spaced, spaced.indexOf('actions/checkout@v4')).includes('fetch-depth'));
+  });
+});
+
+describe('enclosingBlockAround — the block you are in, plus the line that let you in', () => {
+  it('includes the CONDITION, not just the braces', () => {
+    // The question is "what guarded this?", and the guard is the condition. Bounding at the brace would answer a
+    // different question and answer it correctly, which is the worst kind of wrong.
+    const src = 'fn();\nif (failed.length === 0) {\n  log.info("readiness confirmed for all");\n}\nafter();';
+    const got = enclosingBlockAround(src, src.indexOf('readiness confirmed'));
+    assert.ok(got.includes('failed.length === 0'), 'the condition is outside the window');
+    assert.ok(!got.includes('after()'), 'the window ran past the block');
+    assert.ok(!got.includes('fn()'), 'the window ran back past the block');
+  });
+
+  it('finds a try/catch wrapping a call', () => {
+    const src = 'a();\ntry {\n  chmodSync(target, mode);\n} catch { /* best effort */ }\nb();';
+    const got = enclosingBlockAround(src, src.indexOf('chmodSync'));
+    assert.ok(/try\s*\{/.test(got), 'the try is outside the window');
+  });
+
+  it('a nested block does not become the answer', () => {
+    const src = 'if (outer) {\n  if (inner) { x(); }\n  target();\n}\n';
+    const got = enclosingBlockAround(src, src.indexOf('target()'));
+    assert.ok(got.includes('outer'), 'it picked a sibling block instead of the enclosing one');
+  });
+
+  it('grows with the block, which a count cannot', () => {
+    const pad = '  filler();\n'.repeat(200);
+    const src = `if (guardCondition) {\n${pad}  target();\n}\n`;
+    assert.ok(enclosingBlockAround(src, src.indexOf('target()')).includes('guardCondition'));
+  });
+});
+
+describe('enclosingBlocksMatching — containment, which is NOT proximity', () => {
+  const OPENER = /@if\s*\(/;
+
+  it('THE case a backwards window gets wrong: a guard that already CLOSED does not count', () => {
+    /*
+     * This is why the nine backwards windows were not swept blind. `src.slice(at - 600, at)` finds the text of a
+     * guard that opened and closed above the control and calls the control guarded. It is not — the guard contains
+     * nothing. A proximity measurement cannot answer a containment question, and here the false answer is "this
+     * form control is locked when the instance is managed" about one that is not.
+     */
+    const src = [
+      '@if (!(s.faceLocked("x") || s.managed)) {',
+      '  <input id="guarded" [(ngModel)]="a" />',
+      '}',
+      '<input id="exposed" [(ngModel)]="b" />',
+    ].join('\n');
+
+    const guarded = enclosingBlocksMatching(src, src.indexOf('id="guarded"'), OPENER);
+    assert.equal(guarded.length, 1, 'the control inside the guard was not seen as contained');
+    assert.match(guarded[0], /managed/);
+
+    const exposed = enclosingBlocksMatching(src, src.indexOf('id="exposed"'), OPENER);
+    assert.deepEqual(exposed, [], 'a guard that closed above the control was counted as containing it');
+  });
+
+  it('reports nesting outermost first', () => {
+    const src = '@if (a) {\n  @if (b) {\n    <input id="deep" />\n  }\n}';
+    const got = enclosingBlocksMatching(src, src.indexOf('id="deep"'), OPENER);
+    assert.equal(got.length, 2);
+    assert.match(got[0], /\(a\)/);
+    assert.match(got[1], /\(b\)/);
+  });
+
+  it('a condition containing its own parens is not truncated', () => {
+    // `[^)]*` stopped at the first `)`, so `s.faceLocked('…')` closed before `managed` was reached and the guard
+    // read as absent. The whole opening line is returned, so there is nothing to truncate.
+    const src = '@if (!(s.faceLocked("personEntityTypes") || s.managed)) {\n  <input id="x" />\n}';
+    const got = enclosingBlocksMatching(src, src.indexOf('id="x"'), OPENER);
+    assert.equal(got.length, 1);
+    assert.ok(got[0].includes('managed'), 'the condition was cut at an inner paren');
+  });
+});
+
+describe('lineBefore — for a marker whose rule is literally "immediately above"', () => {
+  it('returns the last non-empty line, skipping blanks', () => {
+    const doc = '**Response**\n\n```json\n{"tokens": []}\n```\n';
+    assert.equal(lineBefore(doc, doc.indexOf('```json')), '**Response**');
+  });
+
+  it('does not reach past it to an earlier marker', () => {
+    const doc = '**Response**\n\nSome prose.\n\n```json\n{}\n```\n';
+    assert.equal(lineBefore(doc, doc.indexOf('```json')), 'Some prose.');
+  });
+});
+
+describe('docCommentBefore — the comment block above a declaration', () => {
+  const src = '/** Machine-managed: not meant to be hand-edited. */\n  sync?: SyncConfig;\n';
+
+  it('returns the comment', () => {
+    const got = docCommentBefore(src, src.indexOf('sync?:'));
+    assert.ok(got.includes('hand-edited'));
+    assert.ok(got.startsWith('/*') && got.endsWith('*/'));
+  });
+
+  it('returns EMPTY when code separates the comment from the anchor', () => {
+    // An absent doc comment is an answer a gate asserts on. Throwing would make it look like a broken anchor.
+    const other = '/** About something else. */\nconst x = 1;\n  sync?: SyncConfig;\n';
+    assert.equal(docCommentBefore(other, other.indexOf('sync?:')), '');
+  });
+
+  it('returns EMPTY when there is no comment at all', () => {
+    assert.equal(docCommentBefore('  sync?: SyncConfig;\n', 2), '');
+  });
+
+  it('grows with the comment', () => {
+    const grown = src.replace('Machine-managed', 'Machine-managed. ' + 'More prose. '.repeat(200));
+    assert.ok(docCommentBefore(grown, grown.indexOf('sync?:')).includes('hand-edited'));
+  });
+});
+
+describe('markdownSectionAround — the section a MENTION belongs to', () => {
+  const notice = '## A\n\nLicence: MIT\n\nwhisper-small is bundled.\n\n## B\n\nNo licence here.\n';
+
+  it('reaches backwards to the section heading, which is where the licence is', () => {
+    // The half `markdownSectionFrom` cannot see: the model is mentioned after the licence line, so bounding
+    // forward from the mention finds nothing and reports an attributed model as unattributed.
+    const got = markdownSectionAround(notice, notice.indexOf('whisper-small'));
+    assert.ok(/Licen[cs]e:/.test(got), 'the licence above the mention is outside the window');
+    assert.ok(!got.includes('No licence here'), 'the window ran into the next section');
+  });
+
+  it('does not leak the PREVIOUS section in', () => {
+    const got = markdownSectionAround(notice, notice.indexOf('No licence here'));
+    assert.ok(!/Licen[cs]e: MIT/.test(got), 'a licence from another section would be read as this one\'s');
   });
 });
 

--- a/testing/standalone/swallowed-writes-must-be-visible.test.js
+++ b/testing/standalone/swallowed-writes-must-be-visible.test.js
@@ -26,6 +26,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
+import { statementUpTo } from './_structural-window.mjs';
 
 const FILE = 'server/src/files/media/worker.ts';
 const src = readFileSync(FILE, 'utf8');
@@ -79,7 +80,13 @@ describe('the media worker never loses a write in silence', () => {
     // fix was visibility, not severity, and a later "tidy-up" that promotes these to throws would be a
     // regression dressed as rigour.
     const describeAt = src.indexOf('described but the metadata write failed');
-    const window = src.slice(Math.max(0, describeAt - 400), describeAt);
+    assert.ok(describeAt > -1, 'the log line is gone — re-anchor this gate');
+    /*
+     * The statement the log line is IN, bounded by where that statement begins. This is the shape where a backwards
+     * count is at its most dangerous: the assertion is that a rethrow is ABSENT, so a window starting too late reads
+     * less text and passes. Here it would pass on exactly the regression it exists to catch.
+     */
+    const window = statementUpTo(src, describeAt, 'the describe-write handler');
     assert.doesNotMatch(window, /\.catch\(\s*\(\s*err[^)]*\)\s*=>\s*\{\s*throw/,
       'the describe write must not rethrow — that re-pays for a model call that already succeeded');
   });

--- a/testing/standalone/sync-waits-retrigger-and-diagnose.test.js
+++ b/testing/standalone/sync-waits-retrigger-and-diagnose.test.js
@@ -43,6 +43,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
+import { balancedFrom } from './_structural-window.mjs';
 
 const ROOT = process.cwd();
 
@@ -75,8 +76,13 @@ function bareWaits(src) {
   const re = /await triggerSync\([^)]*\);(?:[^\n]*\n){0,6}?[^\n]*await waitFor\(/g;
   let n = 0, m;
   while ((m = re.exec(src)) !== null) {
-    const seg = src.slice(m.index + m[0].length, m.index + m[0].length + 800);
-    const args = /\}\s*(,[^;]*)?\);/.exec(seg)?.[1] ?? '';
+    /*
+     * The `waitFor(` CALL, bounded by the paren that closes it. At 800 characters a long predicate pushed the
+     * argument list out of the window, so `diagnose` read as absent and a correctly-written wait was counted as bare
+     * — and this gate's whole output is that count.
+     */
+    const call = balancedFrom(src, m.index + m[0].length - 1, 'the waitFor call');
+    const args = /\}\s*(,[\s\S]*)?\)$/.exec(call)?.[1] ?? '';
     if (!/diagnose/.test(args)) n++;
   }
   return n;

--- a/testing/standalone/theme-cannot-recolour-facts.test.js
+++ b/testing/standalone/theme-cannot-recolour-facts.test.js
@@ -35,6 +35,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { docCommentBefore } from './_structural-window.mjs';
 
 const CSS = readFileSync(join('client', 'src', 'styles.scss'), 'utf8');
 const DOC = readFileSync(join('docs', 'integration-guide', '15-about-and-embedding.md'), 'utf8');
@@ -52,7 +53,10 @@ describe('the semantic tokens exist and are grouped as such', () => {
   it('the block still explains the rule at the point of declaration', () => {
     // The comment is what stops the next person "tidying up" by pointing a pill at --accent again.
     const at = CSS.indexOf('--state-active:');
-    const around = CSS.slice(Math.max(0, at - 1400), at);
+    assert.ok(at > -1, 'the token is gone — re-anchor this gate');
+    // The comment block above the declaration, bounded by its own delimiters rather than by 1 400 characters of
+    // whatever happens to precede it — which on a stylesheet is other rules, and any of them may say "theme".
+    const around = docCommentBefore(CSS, at, 'the semantic-state note');
     assert.match(around, /theme/i, 'the declaration should carry the identity-vs-facts note');
     assert.match(around, /SEMANTIC STATE NEVER DOES|must not move|does not own facts/i,
       'the rule must be stated where the tokens are declared');


### PR DESCRIPTION
chore(testing): the backwards windows are gone, and one of them was answering the wrong question

X-25b: nine gates read a fixed number of characters BEHIND an anchor. All nine converted,
the ratchet's second list is at zero, and its pattern no longer has the blind spot that
hid three more.

THE ONE THAT WAS ACTUALLY WRONG, NOT MERELY LOOSE

`infra-managed-locks-every-field.test.js` asks whether a form control is inside an
`@if` that checks `managed`, and answered it by reading 600 characters backwards.

That measures PROXIMITY. The question is CONTAINMENT. A guard that opened and CLOSED
above the control satisfies proximity and contains nothing — so an unguarded control
sitting below a closed guard read as locked, on the page whose entire job is refusing
edits when the instance is infra-managed.

`enclosingMarkupBlocksMatching` walks a brace stack, so only a guard still open at the
control counts.

That conversion then reported a control the old window had passed, and it was a second
bug in my own conversion rather than a finding: the JS scanner treats an Angular
template literal as a STRING and skips it whole, so on a component file it found no
`@if` at all and called a correctly-guarded picker unguarded. Two languages in one file
need two walks — hence `angularTemplateOf` and a markup-brace variant beside the
TypeScript one.

WHY THE OTHER EIGHT WERE NOT SWEPT

Reading them showed five different questions, each with an exact answer a count only
approximates:

  is this chmod inside a try/catch?           -> enclosingBlockAround
  is this fence marked as a response?         -> lineBefore
  what does this field's doc comment say?     -> docCommentBefore
  which NOTICE section mentions this model?   -> markdownSectionAround
  is this reference the import itself?        -> enclosingBlocksMatching

Converting all nine identically would have fixed the wording and kept the bug.

`enclosingBlockAround` includes the LINE that opens the block, not just the braces,
because the guard is usually the condition: `if (failed.length === 0) {` is the subject
when the question is what let us in.

THE PATTERN HAD A SECOND BLIND SPOT

The ratchet matched `slice(at, at + N)` only with a bare identifier, so it never saw
`slice(f(x), f(x) + N)`. Three of those were sitting in the suite — one in a file that
already carried a comment explaining why character counts are the wrong axis. A rule
reporting zero because it is not looking reads exactly like a rule that is satisfied.
Widened to any repeated expression; the backreference is still what separates a window
from an ordinary two-index slice, and that distinction is pinned.

THE HELPER CAUGHT ITS OWN BUG AGAIN

A spec fixture that anchors inside a string literal — which is what the real
`index-ready-poll` gate does — showed that bracket DEPTH is the wrong measure for "which
block am I in": parens count too, so an anchor inside `log.info(\`…\`)` sits two deep
rather than one. Replaced with a brace stack, which is what the question actually is.

`statementUpTo` was also the wrong tool in one place and said so loudly: it treats `{` as
a statement boundary, which is right for a block and wrong for an `import { … }` clause,
so six files were briefly reported as by-reference proxy fan-outs on the strength of
their import line. That is containment too.

MUTATION TESTED, AND TWO OF MINE WERE AIMED WRONG

Eleven mutants, all killed. Two survived the first pass because I broke the first
occurrence of a string rather than the one the gate reads — the licence line of a
different NOTICE entry, and a log message the gate uses only as an anchor. Worth saying
because "the mutant lived" and "my mutation missed" look identical until you read the
subject.

Three windows remain in the forward list and none is a window: two fixed-width FIELD
reads (a hex pair, a byte out of a bit string) and a 90-character excerpt inside an
assertion message where nothing is checked.

WHAT IS LEFT

`X-25c` — 30 capped gaps inside regexes, unread. A sample showed two different things
sharing one syntax, and converting the legitimate half would weaken it.

No CHANGELOG entry: no product behaviour changes, and `testing/` is exempt from the entry
gate for that reason.
