### PR TITLE
feat(embed): granting a portal permission to frame this brain no longer needs shell access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Who may embed this instance is now editable in the admin UI — Settings → Embedding.** `embed.allowedOrigins` has
+  worked since embedding shipped and lived only in `config.json`, so granting a portal permission to frame a brain
+  meant shell access to the server. Asked for by breituai-platform on 2026-08-19T1046Z, and the reason is theirs:
+  *someone runs a brain, someone else wants to use it inside a portal, and the person who must act has to be talked
+  through editing a JSON file on a server* — which in practice means it does not happen and the brain stays in a
+  browser tab. `GET`/`PATCH /api/admin/embed-config`, admin plus MFA on the write, because listing an origin grants
+  framing **and** runtime restyling together and both are ways to impersonate this interface. The same validator as
+  the config-file path, with one deliberate difference: the file DROPS an invalid entry with a warning, and the form
+  **refuses** it and names it back — a form has somebody waiting on an answer, and accepting-then-discarding is how a
+  caller gets told a change worked when it did not. `GET` also reports `invalid`, the stored entries the validator
+  drops, which is the answer when a portal will not frame and the list looks right. No restart, by either route.
 - **The embedded client wears the host portal's decoration, when the host supplies it.** Owner ruled **A** on
   2026-08-19 (was P-11), on breituai-platform's ask of 2026-08-18T1806Z — which they framed as an ask and not a
   request: *"Nothing here is urgent, nothing is blocked on you, and 'not our aesthetic' is a complete answer that

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1942,5 +1942,14 @@
   "tokens.rights.plain.dataQuality.none": "Ihr Agent sieht keine Duplikat- oder Widerspruchsprüfungen.",
   "tokens.rights.plain.dataQuality.read": "Ihr Agent sieht gemeldete Duplikate und Widersprüche, kann sie aber nicht auflösen.",
   "tokens.rights.plain.dataQuality.write": "Ihr Agent kann auflösen, zusammenführen und verwerfen, was die Prüfung meldet.",
-  "tokens.rights.plain.dataQuality.admin": "Ihr Agent kann außerdem Prüfläufe für den ganzen Space starten."
+  "tokens.rights.plain.dataQuality.admin": "Ihr Agent kann außerdem Prüfläufe für den ganzen Space starten.",
+  "nav.embedding": "Einbettung",
+  "embedding.origins.title": "Herkünfte, die diese Instanz einbetten dürfen",
+  "embedding.origins.subtitle": "Ein hier eingetragenes Portal darf Ythril in seiner eigenen Seite anzeigen. Standardmäßig ist nichts erlaubt.",
+  "embedding.origins.warning": "Ein Eintrag gewährt zwei Dinge gleichzeitig: Ythril in einem Rahmen anzuzeigen und es zur Laufzeit neu zu gestalten. Beides lässt sich nutzen, um diese Oberfläche vorzutäuschen. Tragen Sie daher nur Herkünfte ein, die Sie selbst betreiben oder ebenso weit vertrauen.",
+  "embedding.origins.none": "Kein Eintrag vorhanden. Ythril kann nur von sich selbst eingerahmt werden.",
+  "embedding.origins.add": "Herkunft hinzufügen",
+  "embedding.origins.entryLabel": "Erlaubte Herkunft",
+  "embedding.origins.saved": "Gespeichert — sofort aktiv, kein Neustart nötig.",
+  "embedding.origins.hint": "Eine exakte Herkunft pro Zeile: nur Schema, Host und Port, ohne Pfad. https ist erforderlich, außer auf localhost. Platzhalter werden nie akzeptiert. Eine Änderung greift ab der nächsten Anfrage."
 }

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1942,5 +1942,14 @@
   "tokens.rights.plain.dataQuality.none": "Your agent cannot see duplicate or contradiction reviews.",
   "tokens.rights.plain.dataQuality.read": "Your agent can see flagged duplicates and contradictions, and resolve none.",
   "tokens.rights.plain.dataQuality.write": "Your agent can resolve, merge and dismiss what review flags.",
-  "tokens.rights.plain.dataQuality.admin": "Your agent can also start scans across the whole space."
+  "tokens.rights.plain.dataQuality.admin": "Your agent can also start scans across the whole space.",
+  "nav.embedding": "Embedding",
+  "embedding.origins.title": "Origins allowed to embed this instance",
+  "embedding.origins.subtitle": "A portal listed here may show Ythril inside its own page. Nothing is allowed by default.",
+  "embedding.origins.warning": "Listing an origin grants two things together: permission to display Ythril inside a frame, and permission to restyle it at runtime. Both can be used to impersonate this interface, so add only origins you operate or trust to the same degree.",
+  "embedding.origins.none": "No origin is listed. Ythril can only be framed by itself.",
+  "embedding.origins.add": "Add an origin",
+  "embedding.origins.entryLabel": "Allowed origin",
+  "embedding.origins.saved": "Saved — active immediately, no restart.",
+  "embedding.origins.hint": "One exact origin per line: scheme, host and port only, with no path. https is required except on localhost. Wildcards are never accepted. A change takes effect on the next request."
 }

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1942,5 +1942,14 @@
   "tokens.rights.plain.dataQuality.none": "Twój agent nie widzi przeglądów duplikatów ani sprzeczności.",
   "tokens.rights.plain.dataQuality.read": "Twój agent widzi zgłoszone duplikaty i sprzeczności, ale ich nie rozstrzygnie.",
   "tokens.rights.plain.dataQuality.write": "Twój agent może rozstrzygać, scalać i odrzucać to, co zgłasza przegląd.",
-  "tokens.rights.plain.dataQuality.admin": "Twój agent może też uruchamiać skanowanie całej przestrzeni."
+  "tokens.rights.plain.dataQuality.admin": "Twój agent może też uruchamiać skanowanie całej przestrzeni.",
+  "nav.embedding": "Osadzanie",
+  "embedding.origins.title": "Źródła, które mogą osadzić tę instancję",
+  "embedding.origins.subtitle": "Portal wpisany na tę listę może pokazywać Ythril na własnej stronie. Domyślnie nie jest to dozwolone.",
+  "embedding.origins.warning": "Wpis nadaje dwa uprawnienia naraz: wyświetlanie Ythril w ramce oraz zmianę jego wyglądu w czasie działania. Oba można wykorzystać do podszycia się pod ten interfejs, więc dodawaj tylko źródła, którymi sam zarządzasz lub którym ufasz w tym samym stopniu.",
+  "embedding.origins.none": "Brak wpisów. Ythril może być osadzony tylko przez siebie samego.",
+  "embedding.origins.add": "Dodaj źródło",
+  "embedding.origins.entryLabel": "Dozwolone źródło",
+  "embedding.origins.saved": "Zapisano — działa od razu, bez restartu.",
+  "embedding.origins.hint": "Jedno dokładne źródło w wierszu: tylko schemat, host i port, bez ścieżki. https jest wymagane z wyjątkiem localhost. Symbole wieloznaczne nigdy nie są akceptowane. Zmiana działa od następnego żądania."
 }

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -110,6 +110,12 @@ export const routes: Routes = [
               import('./pages/settings/webhooks.component').then(m => m.WebhooksComponent),
           },
           {
+            path: 'embedding',
+            title: 'nav.embedding',
+            loadComponent: () =>
+              import('./pages/settings/embedding.component').then(m => m.EmbeddingComponent),
+          },
+          {
             path: 'about',
             title: 'nav.about',
             loadComponent: () =>

--- a/client/src/app/pages/settings/embedding.component.spec.ts
+++ b/client/src/app/pages/settings/embedding.component.spec.ts
@@ -1,0 +1,164 @@
+/**
+ * The embedding page behaves like a form that tells the truth about what the server did.
+ *
+ * ## What is worth testing here, and what is not
+ *
+ * Not that the origins are valid — the page deliberately does not know. `isValidEmbedOrigin` lives on the server and
+ * is shared with the config-file path, because a copy here would be free to disagree with it and the operator would
+ * be told their origin was bad by code a version behind.
+ *
+ * What IS worth testing is every way this page could lie:
+ *
+ *  - a refused origin that renders like an accepted one, so a save looks like it worked;
+ *  - a stored-but-invalid entry from `config.json` that renders like a valid one, which is the whole answer to
+ *    "why will my portal not frame" and the answer would be hidden;
+ *  - a blank row sent as an origin and refused, when it is really somebody who clicked Add and changed their mind;
+ *  - a red mark left on a row after it has been edited, saying the new text was refused when nothing has checked it.
+ *
+ * Run: npm run test:client
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { getTranslocoModule } from '../../testing/transloco-testing';
+import { EmbeddingComponent } from './embedding.component';
+
+function setup() {
+  TestBed.configureTestingModule({
+    imports: [EmbeddingComponent, getTranslocoModule()],
+    providers: [provideHttpClient(), provideHttpClientTesting()],
+  });
+  const fixture = TestBed.createComponent(EmbeddingComponent);
+  const http = TestBed.inject(HttpTestingController);
+  return { fixture, cmp: fixture.componentInstance, http };
+}
+
+describe('the embedding page', () => {
+  let ctx: ReturnType<typeof setup>;
+
+  beforeEach(() => { ctx = setup(); });
+
+  it('loads the stored list', () => {
+    ctx.http.expectOne('/api/admin/embed-config')
+      .flush({ allowedOrigins: ['https://portal.example.com'], resolved: ['https://portal.example.com'], invalid: [] });
+    expect(ctx.cmp.origins()).toEqual(['https://portal.example.com']);
+    expect(ctx.cmp.rejected()).toEqual([]);
+  });
+
+  it('marks a STORED entry the server already rejects', () => {
+    /*
+     * The diagnostic case. An operator whose portal opens in a tab comes here to find out why, and the answer is
+     * often an entry written by hand into `config.json` that the validator drops. Rendering it identically to a
+     * valid one would hide the only useful thing on the page.
+     */
+    ctx.http.expectOne('/api/admin/embed-config').flush({
+      allowedOrigins: ['https://good.example.com', 'http://bad.example.com'],
+      resolved: ['https://good.example.com'],
+      invalid: ['http://bad.example.com'],
+    });
+    expect(ctx.cmp.rejected()).toEqual(['http://bad.example.com']);
+  });
+
+  it('sends the list and adopts what the server stored', () => {
+    ctx.http.expectOne('/api/admin/embed-config').flush({ allowedOrigins: [], resolved: [], invalid: [] });
+    ctx.cmp.addOrigin();
+    ctx.cmp.setOrigin(0, 'https://portal.example.com/');
+    ctx.cmp.save();
+
+    const req = ctx.http.expectOne(r => r.method === 'PATCH');
+    expect(req.request.body).toEqual({ allowedOrigins: ['https://portal.example.com/'] });
+    // The server normalises, so the page must show the STORED value rather than what was typed — otherwise the
+    // trailing slash stays on screen and an operator comparing it with the portal's origin sees a mismatch.
+    req.flush({ allowedOrigins: ['https://portal.example.com'], resolved: ['https://portal.example.com'] });
+    expect(ctx.cmp.origins()).toEqual(['https://portal.example.com']);
+    expect(ctx.cmp.savedAt()).toBe(true);
+  });
+
+  it('drops blank rows rather than sending them to be refused', () => {
+    // An empty input is somebody who clicked Add and changed their mind. Sending it would produce a 400 about an
+    // origin nobody was trying to add.
+    ctx.http.expectOne('/api/admin/embed-config').flush({ allowedOrigins: [], resolved: [], invalid: [] });
+    ctx.cmp.addOrigin();
+    ctx.cmp.addOrigin();
+    ctx.cmp.setOrigin(0, '  https://portal.example.com  ');
+    ctx.cmp.save();
+
+    const req = ctx.http.expectOne(r => r.method === 'PATCH');
+    expect(req.request.body).toEqual({ allowedOrigins: ['https://portal.example.com'] });
+  });
+
+  it('shows a refusal and marks the row that caused it', () => {
+    ctx.http.expectOne('/api/admin/embed-config').flush({ allowedOrigins: [], resolved: [], invalid: [] });
+    ctx.cmp.addOrigin();
+    ctx.cmp.setOrigin(0, 'https://portal.example.com/app');
+    ctx.cmp.save();
+
+    ctx.http.expectOne(r => r.method === 'PATCH').flush(
+      { error: 'Every entry must be an exact, scheme-qualified origin with no path', invalid: ['https://portal.example.com/app'] },
+      { status: 400, statusText: 'Bad Request' },
+    );
+
+    expect(ctx.cmp.problem()).toMatch(/exact, scheme-qualified/);
+    expect(ctx.cmp.rejected()).toEqual(['https://portal.example.com/app']);
+    // NOT saved. A refusal that left the success note up would be the worst possible reading of this screen.
+    expect(ctx.cmp.savedAt()).toBe(false);
+    expect(ctx.cmp.saving()).toBe(false);
+  });
+
+  it('keeps what the operator typed after a refusal, so it can be corrected', () => {
+    // Clearing the field on refusal would make them retype an origin that is one character wrong.
+    ctx.http.expectOne('/api/admin/embed-config').flush({ allowedOrigins: [], resolved: [], invalid: [] });
+    ctx.cmp.addOrigin();
+    ctx.cmp.setOrigin(0, 'http://portal.example.com');
+    ctx.cmp.save();
+    ctx.http.expectOne(r => r.method === 'PATCH').flush(
+      { error: 'https is required', invalid: ['http://portal.example.com'] },
+      { status: 400, statusText: 'Bad Request' },
+    );
+    expect(ctx.cmp.origins()).toEqual(['http://portal.example.com']);
+  });
+
+  it('clears the red mark when the row is edited', () => {
+    // Leaving it red would assert that the NEW text was refused, which nothing has checked.
+    ctx.http.expectOne('/api/admin/embed-config').flush({
+      allowedOrigins: ['http://bad.example.com'], resolved: [], invalid: ['http://bad.example.com'],
+    });
+    expect(ctx.cmp.rejected()).toEqual(['http://bad.example.com']);
+    ctx.cmp.setOrigin(0, 'https://bad.example.com');
+    expect(ctx.cmp.rejected()).toEqual([]);
+  });
+
+  it('removing a row clears the saved note, so it cannot describe a stale state', () => {
+    ctx.http.expectOne('/api/admin/embed-config').flush({ allowedOrigins: ['https://a.example.com'], resolved: ['https://a.example.com'], invalid: [] });
+    ctx.cmp.save();
+    ctx.http.expectOne(r => r.method === 'PATCH').flush({ allowedOrigins: ['https://a.example.com'], resolved: ['https://a.example.com'] });
+    expect(ctx.cmp.savedAt()).toBe(true);
+    ctx.cmp.removeOrigin(0);
+    expect(ctx.cmp.savedAt()).toBe(false);
+  });
+
+  it('renders the framing-and-restyling warning, in its own callout', () => {
+    /*
+     * Asserted on the ELEMENT, not on the words. The transloco test module resolves every key to the key itself, so
+     * checking the rendered prose for "restyle" tests the harness rather than the page — my first version did that
+     * and failed against a page that renders the warning correctly. The WORDING is pinned where it lives, in
+     * `embed-origins-are-editable.test.js` against the locale files.
+     */
+    ctx.http.expectOne('/api/admin/embed-config').flush({ allowedOrigins: [], resolved: [], invalid: [] });
+    ctx.fixture.detectChanges();
+    const callout = ctx.fixture.nativeElement.querySelector('.danger-note');
+    expect(callout).toBeTruthy();
+    expect(callout.textContent).toContain('embedding.origins.warning');
+    // It must survive a populated list too — a warning that only shows on an empty page is missing when it matters.
+    ctx.cmp.origins.set(['https://portal.example.com']);
+    ctx.fixture.detectChanges();
+    expect(ctx.fixture.nativeElement.querySelector('.danger-note')).toBeTruthy();
+  });
+
+  it('survives a load failure without leaving the page blank and silent', () => {
+    ctx.http.expectOne('/api/admin/embed-config').error(new ProgressEvent('network'));
+    expect(ctx.cmp.problem()).toBeTruthy();
+    expect(ctx.cmp.origins()).toEqual([]);
+  });
+});

--- a/client/src/app/pages/settings/embedding.component.ts
+++ b/client/src/app/pages/settings/embedding.component.ts
@@ -1,0 +1,195 @@
+import { Component, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { TranslocoModule } from '@jsverse/transloco';
+import { HttpClient } from '@angular/common/http';
+import { PhIconComponent } from '../../shared/ph-icon.component';
+import { SettingsCardComponent } from '../../shared/settings-card.component';
+
+/**
+ * Who may frame and restyle this instance.
+ *
+ * ## Why this page exists
+ *
+ * `embed.allowedOrigins` has worked since embedding shipped, and it lived only in `config.json` — so granting a
+ * portal permission to frame a brain meant shell access to the server and a text editor. breituai-platform asked
+ * for this on 2026-08-19, and their case is the one that shape does not serve: **someone runs a brain, someone else
+ * wants to use it inside a portal, and the person who must act has to be talked through editing JSON on a server.**
+ * In practice that does not happen and the brain stays in a browser tab.
+ *
+ * ## The warning is on the page, not only in the guide
+ *
+ * Listing an origin grants two things TOGETHER — framing (a clickjacking primitive) and runtime theming (a
+ * UI-spoofing one) — and it is a deliberate design that they share one list: an origin you trust to render Ythril
+ * inside its chrome is exactly the origin you trust to restyle it. An operator adding a line to a text box has to
+ * be told that, at the moment they do it.
+ *
+ * ## Nothing here validates an origin
+ *
+ * The server does, with the same function the config-file path uses, and a refused entry comes back named. A copy of
+ * that rule here would be the defect this repo produces most — and the weaker copy would be deciding who may frame
+ * the admin UI. What this page must NOT do is drop a bad entry quietly: the operator typed it and is watching, so
+ * the failure is shown rather than absorbed.
+ */
+@Component({
+  selector: 'app-embedding',
+  standalone: true,
+  imports: [FormsModule, TranslocoModule, PhIconComponent, SettingsCardComponent],
+  // NOTE: no backticks anywhere in this template. A backtick inside an inline template terminates the string and
+  // Angular reports `NG1001: Decorator argument must be literal`, pointing at @Component rather than at the line.
+  styles: [`
+    .embed-page { display: flex; flex-direction: column; gap: 16px; }
+    .origins { display: flex; flex-direction: column; gap: 8px; }
+    .origin-row { display: flex; gap: 8px; align-items: center; }
+    .origin-row input {
+      flex: 1; padding: 8px 10px; font-family: var(--font-mono); font-size: 13px;
+      background: var(--bg-primary); color: var(--text-primary);
+      border: 1px solid var(--border); border-radius: var(--radius-sm);
+    }
+    .origin-row input:focus { outline: none; border-color: var(--accent); }
+    .origin-row input.rejected { border-color: var(--error); }
+    .rm {
+      display: grid; place-items: center; width: 30px; height: 30px; flex: none;
+      background: none; border: 1px solid var(--border); border-radius: var(--radius-sm);
+      color: var(--text-muted); cursor: pointer;
+    }
+    .rm:hover { color: var(--error); border-color: var(--error); }
+    .actions { display: flex; gap: 8px; align-items: center; margin-top: 12px; }
+    .danger-note {
+      display: flex; gap: 8px; padding: 10px 12px; margin: 0 0 12px;
+      border: 1px solid var(--warning); border-radius: var(--radius-sm);
+      background: color-mix(in srgb, var(--warning) 8%, transparent);
+      font-size: 13px; line-height: 1.5; color: var(--text-primary);
+    }
+    .danger-note ph-icon { flex: none; color: var(--warning); margin-top: 2px; }
+    .hint { font-size: 12px; color: var(--text-muted); line-height: 1.5; }
+    .problem { font-size: 13px; color: var(--error); margin: 8px 0 0; }
+    .problem code { font-family: var(--font-mono); }
+    .saved { font-size: 13px; color: var(--success); margin: 0; }
+    .empty { font-size: 13px; color: var(--text-muted); margin: 0; }
+  `],
+  template: `
+    <div class="embed-page">
+      <app-settings-card
+        icon="corners-out"
+        [heading]="'embedding.origins.title' | transloco"
+        [purpose]="'embedding.origins.subtitle' | transloco">
+
+        <p class="danger-note">
+          <ph-icon name="warning" [size]="16"/>
+          <span>{{ 'embedding.origins.warning' | transloco }}</span>
+        </p>
+
+        @if (origins().length === 0) {
+          <p class="empty">{{ 'embedding.origins.none' | transloco }}</p>
+        }
+
+        <div class="origins">
+          @for (o of origins(); track $index) {
+            <div class="origin-row">
+              <input
+                type="text" spellcheck="false" autocomplete="off"
+                placeholder="https://portal.example.com"
+                [class.rejected]="rejected().includes(o)"
+                [ngModel]="o" (ngModelChange)="setOrigin($index, $event)"
+                [attr.aria-label]="'embedding.origins.entryLabel' | transloco" />
+              <button type="button" class="rm" (click)="removeOrigin($index)"
+                [attr.aria-label]="'common.remove' | transloco">
+                <ph-icon name="x" [size]="12"/>
+              </button>
+            </div>
+          }
+        </div>
+
+        <div class="actions">
+          <button type="button" class="btn" (click)="addOrigin()">
+            {{ 'embedding.origins.add' | transloco }}
+          </button>
+          <button type="button" class="btn btn-primary" [disabled]="saving()" (click)="save()">
+            {{ (saving() ? 'common.saving' : 'common.save') | transloco }}
+          </button>
+          @if (savedAt()) {
+            <p class="saved">{{ 'embedding.origins.saved' | transloco }}</p>
+          }
+        </div>
+
+        @if (problem()) {
+          <p class="problem">{{ problem() }}</p>
+        }
+
+        <p class="hint">{{ 'embedding.origins.hint' | transloco }}</p>
+      </app-settings-card>
+    </div>
+  `,
+})
+export class EmbeddingComponent {
+  private http = inject(HttpClient);
+
+  origins = signal<string[]>([]);
+  /** Entries the SERVER refused, so the row that is wrong is the row that is marked. */
+  rejected = signal<string[]>([]);
+  problem = signal<string | null>(null);
+  saving = signal(false);
+  savedAt = signal(false);
+
+  constructor() { this.load(); }
+
+  load(): void {
+    this.http.get<{ allowedOrigins: string[]; invalid: string[] }>('/api/admin/embed-config').subscribe({
+      next: r => {
+        this.origins.set([...(r.allowedOrigins ?? [])]);
+        /*
+         * A stored entry the validator drops is shown as rejected on arrival, not only after a save. An operator
+         * whose portal will not frame is looking at this page to find out why, and an invalid line in config.json
+         * that rendered identically to a valid one would be the whole answer, hidden.
+         */
+        this.rejected.set([...(r.invalid ?? [])]);
+      },
+      error: () => this.problem.set('Could not load the embed configuration.'),
+    });
+  }
+
+  addOrigin(): void {
+    this.origins.update(list => [...list, '']);
+  }
+
+  setOrigin(i: number, value: string): void {
+    /*
+     * The PREVIOUS value is what leaves the rejected list — read before the update, because after it the old text
+     * is gone. My first version filtered the NEW value instead, which removes nothing and leaves the old entry
+     * sitting in `rejected` forever. It looked right on screen (the row compares against its current text, which no
+     * longer matches) and was wrong in the state, so a row could come back red on an edit that had cleared it.
+     */
+    const previous = this.origins()[i];
+    this.origins.update(list => list.map((o, n) => (n === i ? value : o)));
+    if (previous !== undefined) this.rejected.update(list => list.filter(o => o !== previous));
+    this.savedAt.set(false);
+  }
+
+  removeOrigin(i: number): void {
+    this.origins.update(list => list.filter((_, n) => n !== i));
+    this.savedAt.set(false);
+  }
+
+  save(): void {
+    this.saving.set(true);
+    this.problem.set(null);
+    this.savedAt.set(false);
+    // Blank rows are dropped rather than sent: an empty input is somebody who clicked Add and changed their mind,
+    // not an origin they want refused.
+    const allowedOrigins = this.origins().map(o => o.trim()).filter(Boolean);
+    this.http.patch<{ allowedOrigins: string[] }>('/api/admin/embed-config', { allowedOrigins }).subscribe({
+      next: r => {
+        this.origins.set([...r.allowedOrigins]);
+        this.rejected.set([]);
+        this.saving.set(false);
+        this.savedAt.set(true);
+      },
+      error: err => {
+        this.saving.set(false);
+        const invalid: string[] = err?.error?.invalid ?? [];
+        this.rejected.set(invalid);
+        this.problem.set(err?.error?.error ?? 'The change was refused.');
+      },
+    });
+  }
+}

--- a/client/src/app/pages/shell/shell.component.ts
+++ b/client/src/app/pages/shell/shell.component.ts
@@ -305,6 +305,9 @@ import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
         <a class="nav-link" routerLink="/settings/media-processing" routerLinkActive="active">
           <span class="nav-icon"><ph-icon name="brain" [size]="16"/></span>{{ 'nav.models' | transloco }}
         </a>
+        <a class="nav-link" routerLink="/settings/embedding" routerLinkActive="active">
+          <span class="nav-icon"><ph-icon name="corners-out" [size]="16"/></span>{{ 'nav.embedding' | transloco }}
+        </a>
         <a class="nav-link" routerLink="/settings/help" routerLinkActive="active">
           <span class="nav-icon"><ph-icon name="question" [size]="16"/></span>{{ 'nav.help' | transloco }}
         </a>

--- a/client/src/app/shared/help-anchors.ts
+++ b/client/src/app/shared/help-anchors.ts
@@ -29,6 +29,7 @@ export const HELP_ANCHORS: { prefix: string; target: HelpTarget }[] = [
   { prefix: '/settings/data', target: { doc: 'userguide', anchor: 'settings--data' } },
   { prefix: '/settings/audit-log', target: { doc: 'userguide', anchor: 'settings--audit-log' } },
   { prefix: '/settings/webhooks', target: { doc: 'userguide', anchor: 'settings--webhooks' } },
+  { prefix: '/settings/embedding', target: { doc: 'userguide', anchor: 'settings--embedding' } },
   // MFA has no page of its own — `<app-mfa/>` is embedded in Preferences, so that is the page whose Help
   // control should open the MFA section. The entry used to read `/settings/mfa`, which nothing routes to.
   { prefix: '/settings/preferences', target: { doc: 'userguide', anchor: 'multi-factor-authentication-mfa' } },

--- a/docs/integration-guide/15-about-and-embedding.md
+++ b/docs/integration-guide/15-about-and-embedding.md
@@ -188,7 +188,26 @@ texture over text costs legibility and every layer is another composite.
 
 ### Enabling cross-origin embedding (opt-in)
 
-By default Ythril may only be framed and themed by its own origin. To embed it in a portal on a **different** origin, list that origin in `config.json`:
+By default Ythril may only be framed and themed by its own origin. There are two ways to list a **different** origin, and they enforce the same rule.
+
+#### From the admin UI — Settings → Embedding
+
+An instance admin can manage the list at **Settings → Embedding** without shell access. This is the route to point an operator at when the brain is theirs and the portal is yours: added 3.2.0, after breituai-platform reported that talking somebody through editing JSON on their own server means, in practice, that it does not happen.
+
+| | admin UI | `config.json` |
+|---|---|---|
+| who can | a token with `instanceAdmin`, plus MFA | anyone with shell access to the host |
+| an invalid entry | **refused, and named back to you** | dropped, with a warning in the log |
+| takes effect | next request | next request |
+| API | `GET`/`PATCH /api/admin/embed-config` | — |
+
+The difference in the middle row is the important one. A form has somebody waiting on an answer, so an origin it cannot accept comes back as a `400` naming it; a config file has nobody to tell, so a bad entry is skipped rather than failing the whole boot. Both call the same validator, so what is *accepted* never differs.
+
+`GET /api/admin/embed-config` also reports `invalid` — the stored entries the validator drops. If a portal will not frame and the list looks right, that field is where the answer is.
+
+#### From `config.json`
+
+Equivalent, and still the right choice for a provisioned or infra-managed deployment:
 
 ```json
 {
@@ -211,6 +230,10 @@ A listed origin is granted **both** rights together, because they are the same t
 - an invalid entry is dropped with a warning rather than coerced
 
 The resolved allowlist is logged at startup, and is served to the SPA on `/api/theme` as `allowedOrigins` so the client knows which senders to trust.
+
+**`GET /api/theme` is public, and that is contract rather than an accident.** It is how an embedder can ask *may I frame this instance* before trying — a refused cross-origin frame is undetectable from the embedding side, because the browser reports nothing, so without something the brain volunteers about itself the only safe default is a new tab for everybody. Depend on it; a change to its shape would go through a deprecation with a version's notice.
+
+**No restart is required, by either route.** `config.json` is watched and a foreign edit goes through the full reload path; the CSP `frame-ancestors` directive is rebuilt on every response; `/api/theme` resolves the list per request. An edit is live within about two seconds, and a UI save is live on the next request.
 
 ### Security
 

--- a/docs/userguide/04-settings.md
+++ b/docs/userguide/04-settings.md
@@ -480,3 +480,53 @@ These settings live in `config.json` under `mediaEmbedding.documentProcessing`:
 **Default behaviour (no configuration needed):** every uploaded PDF is OCR'd with full layout detection, embedded images are extracted and independently captioned, and tables are converted to structured HTML. For text-heavy documents without scanned content or images, `"fast"` is significantly quicker.
 
 ---
+
+## Settings — Embedding
+
+**Who may show Ythril inside their own page.** By default, nobody: Ythril can only be framed by itself, and a
+portal that tries gets nothing. Adding an origin here is how you say yes.
+
+The case this is for: somebody runs a portal and wants your brain to appear inside it as a panel rather than
+opening in a new browser tab. They cannot grant that themselves — only the brain's operator can, and until 3.2.0
+that meant editing `config.json` on the server.
+
+### Adding an origin
+
+Enter one exact origin per row — scheme, host and port, nothing else:
+
+```text
+https://portal.example.com
+https://intranet.example.com:8443
+```
+
+Then **Save**. The change is active on the next request; nothing needs restarting.
+
+What is refused, and why the form tells you rather than tidying up:
+
+| Entry | Result |
+|---|---|
+| `https://portal.example.com` | accepted |
+| `https://portal.example.com/app` | refused — an origin has no path |
+| `http://portal.example.com` | refused — `https` is required (except on `localhost`) |
+| `*` or `https://*.example.com` | refused — there is no "allow everything" mode, by design |
+
+A refused row is marked and named back to you. An entry that was silently dropped would look like a save that
+worked, and you would go looking at the portal for a fault that was here.
+
+If the list looks right and a portal still opens in a tab, the row to check is any one marked red on load: an
+invalid entry written directly into `config.json` is skipped by the server and shown as refused here.
+
+### What you are agreeing to
+
+**A listed origin gets two permissions together, and they cannot be separated:**
+
+1. it may display Ythril inside a frame on its own page; and
+2. it may restyle Ythril at runtime — colours, surfaces, the whole palette.
+
+They share one list deliberately: an origin you trust to render Ythril inside its own chrome is exactly the origin
+you trust to change how it looks. Both are also ways to impersonate this interface — a frame can be positioned
+under something else, and a restyle can make a real page look like a different one. So the practical rule is the
+same as for any credential: list only origins you operate, or trust to the degree you would trust yourself.
+
+Removing an origin takes effect immediately too. There is no per-user version of this list and no API that lets a
+non-admin token extend it; changing it requires an instance admin and a second factor.

--- a/server/src/api/embed-config.ts
+++ b/server/src/api/embed-config.ts
@@ -1,0 +1,117 @@
+/**
+ * The embed-origin allowlist, over the admin API — so granting a portal permission to frame this instance does not
+ * require shell access to the server.
+ *
+ * ## Why this route exists
+ *
+ * `embed.allowedOrigins` has worked since the embedding feature shipped, and it lived only in `config.json`. Asked
+ * for by breituai-platform 2026-08-19T1046Z, whose case is the one the file-only shape does not serve:
+ *
+ *   > someone runs a brain, someone else wants to use it inside a portal, and the person who must act has to be
+ *   > talked through editing a JSON file on a server.
+ *
+ * In practice that does not happen and the brain stays in a browser tab. Their portal already reads the resolved
+ * list from the public `GET /api/theme` to decide whether to frame a brain at all, which is the half that works
+ * today; what was missing is a way for the brain's operator to say yes.
+ *
+ * ## One validator, two dispositions — and that is deliberate
+ *
+ * `isValidEmbedOrigin` is the single rule, shared with the config-file path. A second copy in this route, or in the
+ * client, would be the defect `CLAUDE.md` names as this repo's most frequent — and here the weaker copy would be
+ * deciding who may frame and restyle the admin UI.
+ *
+ * What differs is what happens to a bad entry, and it differs because the situations differ:
+ *
+ * | path | bad entry | why |
+ * |---|---|---|
+ * | `config.json` | dropped, with a warning | nobody is waiting on an answer; refusing would fail the whole boot |
+ * | this route | **400, naming it** | somebody typed it and is watching. Dropping it silently would report success |
+ *
+ * Silently accepting-and-dropping is the shape that produced the unscoped-token defect: a caller told 201 while the
+ * field they sent went nowhere. A form must never do that.
+ *
+ * ## What this route does NOT do, at their request as much as ours
+ *
+ * No wildcard mode. No per-user list. And no way for a non-admin token to extend it — their words, which are better
+ * than ours: *an origin allowlist that any authenticated caller could extend is not an allowlist.* Hence
+ * `requireAdminMfa` on the write, the same bar as the media/model configuration, because listing an origin grants
+ * framing AND restyling together and both are spoofing primitives.
+ *
+ * ## No restart, and no reload call here either
+ *
+ * `saveConfig` updates the in-memory config, the CSP `frame-ancestors` header is rebuilt by
+ * `frameAncestorsDirective()` on every response, and `GET /api/theme` resolves the list per request. So the change
+ * is live on the next request with nothing to restart and nothing to invalidate.
+ */
+
+import { Router } from 'express';
+import { z } from 'zod';
+import { requireAdmin, requireAdminMfa } from '../auth/middleware.js';
+import { getConfig, saveConfig } from '../config/loader.js';
+import { getAllowedEmbedOrigins, isValidEmbedOrigin } from '../config/embed.js';
+
+export const embedConfigRouter = Router();
+
+/**
+ * `.strict()` for the same reason every credential body has it: an unknown key here is a caller who thinks they
+ * are setting something. `POST {allowedOrigin: 'https://x'}` — singular — would otherwise answer 200 having
+ * changed nothing.
+ */
+const EmbedConfigBody = z.object({
+  allowedOrigins: z.array(z.string()).max(64),
+}).strict();
+
+/**
+ * Both lists, because they answer different questions.
+ *
+ * `allowedOrigins` is what is stored — what the operator typed. `resolved` is what the CSP header and `/api/theme`
+ * actually serve. They differ when `config.json` holds an entry the validator drops, and an operator looking at a
+ * portal that will not frame needs to see exactly that difference rather than one list that might be either.
+ */
+embedConfigRouter.get('/', requireAdmin, (_req, res) => {
+  const stored = getConfig().embed?.allowedOrigins ?? [];
+  const configured = Array.isArray(stored) ? stored : [];
+  const resolved = getAllowedEmbedOrigins();
+  res.json({
+    allowedOrigins: configured,
+    resolved,
+    invalid: configured.filter(entry => !isValidEmbedOrigin(entry)),
+  });
+});
+
+embedConfigRouter.patch('/', requireAdminMfa, (req, res) => {
+  const parsed = EmbedConfigBody.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({
+      error: 'Body must be {"allowedOrigins": ["https://portal.example.com"]} and nothing else.',
+      detail: parsed.error.issues.map(i => `${i.path.join('.') || '(root)'}: ${i.message}`),
+    });
+    return;
+  }
+
+  // Refused, not dropped. See the table in the header: the caller is watching, so silence would be a lie.
+  const invalid = parsed.data.allowedOrigins.filter(entry => !isValidEmbedOrigin(entry));
+  if (invalid.length > 0) {
+    res.status(400).json({
+      error: 'Every entry must be an exact, scheme-qualified origin with no path — https only, except on '
+        + 'localhost. Wildcards are never accepted; there is no "allow everything" mode.',
+      invalid,
+    });
+    return;
+  }
+
+  /*
+   * Normalised through `new URL().origin` and de-duplicated, so what is stored is what the CSP header and the
+   * postMessage check compare against. Without this, `https://portal.example.com/` would be stored with its
+   * trailing slash, served normalised, and an operator comparing the two would see a mismatch that is not one.
+   */
+  const origins = [...new Set(parsed.data.allowedOrigins.map(entry => new URL(entry.trim()).origin))];
+
+  const config = getConfig();
+  config.embed = { ...config.embed, allowedOrigins: origins };
+  saveConfig(config);
+
+  // The audit middleware records `config.embed.update`; the response carries the stored list so a UI does not have
+  // to re-read to know what it now says.
+  res.json({ allowedOrigins: origins, resolved: getAllowedEmbedOrigins() });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -36,6 +36,7 @@ import { schemaLibraryRouter } from './api/schema-library.js';
 import { localAgentRouter } from './api/local-agent.js';
 import { dataRouter } from './api/data.js';
 import { mediaConfigRouter } from './api/media-config.js';
+import { embedConfigRouter } from './api/embed-config.js';
 import { modelVerifyRouter } from './api/model-verify.js';
 import { pipelineStatusRouter } from './api/pipeline-status.js';
 import { spaceActivityRouter } from './api/space-activity.js';
@@ -321,6 +322,9 @@ export function createApp() {
   // one should not have to know they live in different files.
   app.use('/api/admin/media-config', modelVerifyRouter);
   app.use('/api/admin/pipeline-status', pipelineStatusRouter);
+  // Who may frame and restyle this instance. Admin-only by the same reasoning as the media config: the write is
+  // security-relevant, and the public `GET /api/theme` is what an embedder reads to find out the answer.
+  app.use('/api/admin/embed-config', embedConfigRouter);
   // Cross-space usage comparison. One request for the whole table — per-space calls from the Spaces page
   // would be a front-end N+1, sixty-five requests to render sixty-five rows.
   app.use('/api/admin/space-activity', spaceActivityRouter);

--- a/server/src/audit/middleware.ts
+++ b/server/src/audit/middleware.ts
@@ -223,6 +223,10 @@ const ROUTE_RULES: RouteRule[] = [
   // target it exercises the acknowledged-egress path. Which admin triggered that, and when, is worth
   // having.
   { method: 'POST',   pattern: /^\/api\/admin\/media-config\/verify$/,              operation: 'config.media.verify' },
+  // Who may frame and restyle this instance. Worth auditing more than most config: an added origin gains a
+  // clickjacking primitive and a UI-spoofing one together, and the change is invisible from inside the product —
+  // nothing in the admin UI looks different afterwards, so the log is the only place it leaves a trace.
+  { method: 'PATCH',  pattern: /^\/api\/admin\/embed-config$/,                     operation: 'config.embed.update' },
   { method: 'POST',   pattern: /^\/api\/admin\/local-agent\/bootstrap$/,           operation: 'local_agent.bootstrap' },
   { method: 'POST',   pattern: /^\/api\/admin\/local-agent\/enable-networks\/execute$/, operation: 'local_agent.enable_networks' },
 

--- a/testing/standalone/embed-origins-are-editable.test.js
+++ b/testing/standalone/embed-origins-are-editable.test.js
@@ -1,0 +1,207 @@
+/**
+ * The embed-origin allowlist is reachable from the admin UI, and the UI cannot be looser than the file.
+ *
+ * ## What was asked for, and what the risk in answering it is
+ *
+ * `embed.allowedOrigins` worked and lived only in `config.json`, so granting a portal permission to frame a brain
+ * meant shell access. breituai-platform asked for it in the admin UI on 2026-08-19T1046Z; the reason it is worth
+ * doing is theirs: *someone runs a brain, someone else wants to use it inside a portal, and the person who must act
+ * has to be talked through editing a JSON file on a server.*
+ *
+ * The risk in answering it is that a NEW write path to a security-relevant list is a second chance to get the rule
+ * wrong. What this list grants is framing plus runtime restyling, together, which is a clickjacking primitive and a
+ * UI-spoofing primitive — so the failure mode is not "the form is awkward", it is an origin nobody vetted being
+ * allowed to impersonate the admin interface.
+ *
+ * So this gate holds the three properties that make the new path no weaker than the old one:
+ *
+ *  1. **ONE validator.** The route calls `isValidEmbedOrigin`, the same function the config-file path uses. A
+ *     second copy — in the route or in the client — is the defect `CLAUDE.md` names as this repo's most frequent,
+ *     and here the weaker copy would be deciding who may frame the admin UI.
+ *  2. **A bad entry is REFUSED, not dropped.** The file path drops with a warning because nobody is waiting; a form
+ *     must answer. Accepting-and-silently-dropping is the exact shape of the unscoped-token defect, where a caller
+ *     was told 201 while the field they sent went nowhere.
+ *  3. **The write is admin-and-MFA gated.** Their own line: *an origin allowlist that any authenticated caller
+ *     could extend is not an allowlist.*
+ *
+ * ## Why source-level
+ *
+ * Driving the route needs a server, a config file and a TOTP secret, which the Docker suites have and this does
+ * not. What is cheap and precise here is that the wiring cannot rot: the validator is shared, the refusal exists,
+ * the middleware is the MFA one, the change is audited, and the client does not re-implement the rule.
+ *
+ * Run: node --test testing/standalone/embed-origins-are-editable.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripComments } from './_strip-comments.mjs';
+import { balancedFrom } from './_structural-window.mjs';
+
+const ROUTE = 'server/src/api/embed-config.ts';
+const route = stripComments(readFileSync(ROUTE, 'utf8'));
+const app = stripComments(readFileSync('server/src/app.ts', 'utf8'));
+const audit = stripComments(readFileSync('server/src/audit/middleware.ts', 'utf8'));
+const page = stripComments(readFileSync('client/src/app/pages/settings/embedding.component.ts', 'utf8'));
+
+describe('the rule is shared, not copied', () => {
+  it('the route validates with the SAME function the config file path uses', () => {
+    assert.match(route, /import \{[^}]*isValidEmbedOrigin[^}]*\} from '\.\.\/config\/embed\.js'/,
+      'the route must call the shared validator — a local copy would be free to disagree with the file path, and '
+      + 'the looser of the two would decide who may frame the admin UI');
+  });
+
+  it('and does not re-implement any part of it', () => {
+    /*
+     * The four rules `isValidEmbedOrigin` enforces. Any of them appearing HERE means a second opinion exists, which
+     * is how the two paths start diverging — not on the day the copy is written, on the day one of them is fixed.
+     */
+    for (const [pattern, what] of [
+      [/includes\('\*'\)/, 'the wildcard rejection'],
+      [/protocol === 'https:'/, 'the scheme check'],
+      [/hostname === 'localhost'/, 'the localhost exception'],
+      [/url\.username \|\| url\.password/, 'the credentials check'],
+    ]) {
+      assert.doesNotMatch(route, pattern, `${what} is re-implemented in the route instead of being called`);
+    }
+  });
+
+  it('the CLIENT does not validate either — it shows what the server refused', () => {
+    /*
+     * A form that pre-validates locally is the same defect one layer out, and it fails in a nastier way: the
+     * operator is told their origin is invalid by code that may be a version behind the server's.
+     *
+     * Scoped to things that BRANCH on the value, not to the word `https`. The first version of this assertion
+     * matched the placeholder `https://portal.example.com` and reported the page as validating — an example is not
+     * a rule, and a gate that cannot tell them apart is the over-broad-selector mistake this suite has made before.
+     */
+    for (const pattern of [/new URL\(/, /startsWith\('http/, /includes\('\*'\)/, /\/\^https/]) {
+      assert.doesNotMatch(page, pattern,
+        'the page must not decide what a valid origin is — it sends the list and renders the refusal');
+    }
+    assert.match(page, /rejected/, 'it must be able to MARK a refused entry, which is the half it does own');
+  });
+});
+
+describe('a bad entry is refused rather than absorbed', () => {
+  const patch = balancedFrom(route, route.indexOf('embedConfigRouter.patch('), 'the PATCH handler');
+
+  it('invalid entries produce a 400 that NAMES them', () => {
+    assert.match(patch, /filter\(entry => !isValidEmbedOrigin\(entry\)\)/,
+      'the handler must collect the invalid entries');
+    assert.match(patch, /status\(400\)/, 'and refuse');
+    assert.match(patch, /invalid,?\s*\}\)/,
+      'and send them back — "something you typed was wrong" without saying which is barely better than silence');
+  });
+
+  it('nothing filters invalid entries out and carries on', () => {
+    /*
+     * The shape this must never take: `origins.filter(isValidEmbedOrigin)` followed by a save. It would answer 200
+     * having stored less than was sent, and the operator would go looking at their portal for a fault that is here.
+     */
+    assert.doesNotMatch(patch, /filter\(\s*isValidEmbedOrigin\s*\)/,
+      'a silent drop on the write path reports success for a change that did not fully happen');
+  });
+
+  it('the body is strict, so a misspelled field cannot answer 200', () => {
+    // `{allowedOrigin: 'https://x'}` — singular — would otherwise be accepted, store an empty list, and read as
+    // success. The same trap the token bodies had.
+    assert.match(route, /\}\)\.strict\(\)/, 'the request body schema must reject unknown keys');
+  });
+});
+
+describe('the write is gated like the other security-relevant config', () => {
+  it('PATCH requires admin AND MFA', () => {
+    assert.match(route, /embedConfigRouter\.patch\('\/', requireAdminMfa/,
+      'the same bar as the media/model configuration — this list grants framing and restyling together');
+  });
+
+  it('GET requires admin', () => {
+    // The RESOLVED list is public on `/api/theme` by design, because an embedder must be able to ask before trying.
+    // What is admin-only is the configured list plus which entries were rejected, which is operator diagnostics.
+    assert.match(route, /embedConfigRouter\.get\('\/', requireAdmin/);
+  });
+
+  it('the route is mounted under /api/admin, where the auth prefix rules apply', () => {
+    assert.match(app, /app\.use\('\/api\/admin\/embed-config', embedConfigRouter\)/);
+  });
+
+  it('the change is audited', () => {
+    // Nothing in the product looks different after an origin is added, so the log is the only place it leaves a
+    // trace. `audit-route-coverage.test.js` would fail on a missing rule; this names the operation deliberately.
+    assert.match(audit, /pattern: \/\^\\\/api\\\/admin\\\/embed-config\$\/,\s*operation: 'config\.embed\.update'/,
+      'a PATCH that changes who may frame this instance must be attributable to an admin');
+  });
+});
+
+describe('what the operator is told, since the UI is now the surface', () => {
+  it('the page carries the framing-AND-restyling warning', () => {
+    // The guide says it; the guide is not what somebody is reading while they paste an origin into a text box.
+    assert.match(page, /embedding\.origins\.warning/, 'the warning must be rendered on the page');
+  });
+
+  it('every key it renders exists in all three locales', () => {
+    /*
+     * The failure this catches is invisible in development: a key present in `en` and missing in `de` renders its
+     * raw id to a German-speaking operator, and nothing in the build objects. Checked here rather than trusted to
+     * a reviewer, because adding a key to one file and not three is a single-character-of-attention mistake.
+     */
+    const used = [...page.matchAll(/'((?:embedding|nav|common)\.[a-zA-Z.]+)'/g)].map(m => m[1]);
+    assert.ok(used.length >= 8, `expected the page's translation keys, found ${used.length}`);
+    for (const locale of ['en', 'de', 'pl']) {
+      const dict = JSON.parse(readFileSync(`client/public/assets/i18n/${locale}.json`, 'utf8'));
+      const missing = [...new Set(used)].filter(k => !(k in dict));
+      assert.deepEqual(missing, [], `${locale}.json is missing: ${missing.join(', ')}`);
+    }
+  });
+
+  it('the page is reachable — a route AND a nav entry', () => {
+    // A route with no nav entry is a page only somebody who reads the source can find, which would answer the ask
+    // in the letter and not at all in practice.
+    const routes = readFileSync('client/src/app/app.routes.ts', 'utf8');
+    assert.match(routes, /path: 'embedding'/, 'the route must exist');
+    const shell = readFileSync('client/src/app/pages/shell/shell.component.ts', 'utf8');
+    assert.match(shell, /routerLink="\/settings\/embedding"/, 'and the sidebar must link to it');
+  });
+});
+
+describe('no restart is implied anywhere, because none is needed', () => {
+  it('the resolved list is read per request on both surfaces', () => {
+    /*
+     * The claim made to breituai-platform in answer to their sub-question, pinned so it cannot quietly stop being
+     * true. If either of these captured the value once at startup, an operator would save a change in the UI, see
+     * nothing happen, and be told by the docs that no restart was needed.
+     */
+    const appSrc = stripComments(readFileSync('server/src/app.ts', 'utf8'));
+    assert.match(appSrc, /frame-ancestors \$\{frameAncestorsDirective\(\)\}/,
+      'the CSP header must call the directive per response, not hold a string built at boot');
+    const theme = stripComments(readFileSync('server/src/api/theme.ts', 'utf8'));
+    assert.match(theme, /allowedOrigins: getAllowedEmbedOrigins\(\)/,
+      'the public endpoint must resolve the list per request');
+  });
+
+  it('the save updates the in-memory config, not only the file', () => {
+    // `saveConfig` assigns `_config` before writing. Writing the file alone would leave the running process serving
+    // the old header until the watcher noticed, which is a two-second lie rather than an eternal one — but the UI
+    // says "active immediately" and that has to be true.
+    /*
+     * Asserted on the PATCH handler, bounded by the paren that closes it. My first version windowed
+     * `bodyOf(route, 'embedConfigRouter')` — which is a top-level `const` whose body is ONE LINE, so the window
+     * held the router construction and nothing else. A `|| route` fallback beside it never fired, because the
+     * one-line window is truthy. Exactly the failure the structural-window work is about: a bound that returns too
+     * little and an assertion that still looks like it is checking something.
+     */
+    assert.match(balancedFrom(route, route.indexOf('embedConfigRouter.patch('), 'the PATCH handler'),
+      /saveConfig\(config\)/, 'the handler must persist through saveConfig');
+  });
+
+  it('the page says it is immediate, and does not tell anyone to restart', () => {
+    const en = JSON.parse(readFileSync('client/public/assets/i18n/en.json', 'utf8'));
+    assert.match(en['embedding.origins.saved'], /no restart/i,
+      'the operator should be told, because the file-only shape trained everyone to expect one');
+    for (const key of Object.keys(en).filter(k => k.startsWith('embedding.'))) {
+      assert.doesNotMatch(en[key], /\brestart (the )?(server|instance|container)\b/i,
+        `${key} tells the operator to restart, which is not required`);
+    }
+  });
+});


### PR DESCRIPTION
feat(embed): granting a portal permission to frame this brain no longer needs shell access

`embed.allowedOrigins` has worked since embedding shipped and lived only in `config.json`.
Asked for in the admin UI by breituai-platform 2026-08-19T1046Z, answered yes the same day,
and this is it: Settings -> Embedding.

WHY IT WAS WORTH DOING, IN THEIR WORDS

  someone runs a brain, someone else wants to use it inside a portal, and the person who
  must act has to be talked through editing a JSON file on a server

Which in practice means it does not happen, and the brain stays in a browser tab. Their
portal already reads the resolved list from the public `GET /api/theme` to decide whether
to frame a brain at all — that half worked. What was missing was a way for the brain's
operator to say yes.

ONE VALIDATOR, TWO DISPOSITIONS — AND THE DIFFERENCE IS THE POINT

`isValidEmbedOrigin` is the single rule, shared with the config-file path. A copy in the
route, or in the client, would be the defect CLAUDE.md names as this repo's most frequent,
and here the weaker copy would be deciding who may frame and restyle the admin UI. The gate
asserts each of its four rules is absent from both the route and the page.

What differs is what happens to a bad entry:

  config.json   dropped, with a warning     nobody is waiting; refusing would fail the boot
  this route    400, naming it              somebody typed it and is watching

Silently accepting-and-dropping is the shape of the unscoped-token defect: a caller told
201 while the field they sent went nowhere. A form must never do that, so the gate also
refuses the `filter(isValidEmbedOrigin)` shape on the write path.

`GET` reports `invalid` as well — the STORED entries the validator drops. That is the
answer when a portal will not frame and the list looks right, and the page marks those rows
red on load rather than only after a save.

NO RESTART, WHICH THEY HAD ASSUMED THERE WAS

Established while answering them and now pinned, because the UI says "active immediately"
and that has to stay true: `config.json` is watched on a 2s poll and a foreign edit goes
through the full reload path; the CSP `frame-ancestors` directive is rebuilt per response;
`/api/theme` resolves the list per request. The gate holds the last two, and refuses any
`embedding.*` string that tells an operator to restart.

THE WARNING IS ON THE PAGE, NOT ONLY IN THE GUIDE

Listing an origin grants framing AND runtime restyling together — a clickjacking primitive
and a UI-spoofing one — and they share one list deliberately: an origin you trust to render
Ythril inside its chrome is exactly the origin you trust to restyle it. Somebody pasting an
origin into a text box has to be told that at the moment they do it, so it is a callout on
the page in all three locales.

`requireAdminMfa` on the write, the same bar as the media/model config. Their line, which is
better than ours: an origin allowlist that any authenticated caller could extend is not an
allowlist. No wildcard mode, no per-user list, no remote write.

A BUG THE SPEC CAUGHT IN MY OWN CODE

`setOrigin` filtered the NEW value out of the rejected list instead of the old one, so
editing a red row left its stale entry behind forever. It LOOKED right on screen, because a
row compares against its current text and no longer matched — wrong in the state and
invisible in the pixels, which is why the state is what the spec asserts on.

THE FIVE PLACES

REST route, the userguide (Settings -> Embedding), the integration guide (with a table
comparing the two routes), the in-product Help anchor — which the anchor gate caught me
missing — and rights. **No MCP tool, and no `REST_ONLY_CAPABILITIES` row:** instance-admin
configuration is not on the MCP surface at all, the same as `media-config`, and a row there
would promise a gap in a surface this capability does not belong to. Rights likewise:
`ROUTE_RIGHTS` governs per-SPACE routes, and instance-level ones are governed by the admin
flag and `instanceAdmin` — which is what `requireAdmin`/`requireAdminMfa` enforce here.
