### PR TITLE
chore(testing): two gates were vacuous, and the capped-gap population is 66 rather than 30

### DIFF
--- a/testing/standalone/_structural-window.mjs
+++ b/testing/standalone/_structural-window.mjs
@@ -173,9 +173,17 @@ export function blockAfter(src, at, label = 'blockAfter') {
   return balancedFrom(src, brace, label);
 }
 
-/** From `at` to the `;` that ends the statement it begins, inclusive. */
+/**
+ * From `at` to the `;` that ends the statement it sits in, inclusive.
+ *
+ * `depth <= 0`, not `=== 0`, and that is what makes it usable from the MIDDLE of an expression. The walk starts at
+ * the anchor, so depth is relative to it and goes NEGATIVE as brackets opened before the anchor close:
+ * `endsAt` inside `{ endsAt: z.string() }` reaches its `;` at relative depth -2. Requiring exactly 0 refused every
+ * anchor that was not already at the start of a statement, which is most of them — it reported "no statement
+ * terminator" on a file full of them.
+ */
 export function statementFrom(src, at, label = 'statementFrom') {
-  const end = scanCode(src, at, (c, i, depth) => (depth === 0 && c === ';' ? i : undefined));
+  const end = scanCode(src, at, (c, i, depth) => (depth <= 0 && c === ';' ? i : undefined));
   assert.ok(end > at, `${label}: no statement terminator after index ${at} — re-anchor this gate`);
   return src.slice(at, end + 1);
 }
@@ -205,12 +213,36 @@ export function statementUpTo(src, at, label = 'statementUpTo') {
    * as unguarded. Only a boundary at the anchor's own nesting level ends its statement.
    */
   const { marks, depthAt } = boundariesBefore(src, at, label);
+  /*
+   * AT OR SHALLOWER than the anchor, not exactly equal. An anchor inside parentheses sits DEEPER than the statement
+   * that contains it — `endsAt` in `if (rec.endsAt < rec.startsAt)` is one level in from the `if` — so an exact-depth
+   * rule found no boundary at all and fell back to the top of the file, returning the first statement in the source
+   * instead of the one the anchor is in. That is a window that is too BIG, which fails loudly, but it made
+   * `statementAround` return the wrong statement entirely.
+   */
   const boundary = marks.filter(m =>
-    (m.c === ';' && m.depth === depthAt)
-    || (m.c === '{' && m.depth === depthAt - 1)    // the brace that opened the block we are in
-    || (m.c === '}' && m.depth === depthAt),       // a sibling block that closed before us
+    (m.c === ';' && m.depth <= depthAt)
+    || (m.c === '{' && m.depth <= depthAt - 1)     // the brace that opened the block we are in
+    || (m.c === '}' && m.depth <= depthAt),        // a sibling block that closed before us
   ).pop();
   return src.slice(boundary ? boundary.i + 1 : 0, at);
+}
+
+/**
+ * The WHOLE statement containing `at` — both halves, and safe when `at` is inside a string.
+ *
+ * Prefer this to `statementUpTo(...) + statementFrom(...)`. Those two compose incorrectly when the anchor sits
+ * inside a string literal, which is common the moment a gate matches an identifier that also appears as a quoted
+ * field name: `'endsAt'` in a list of field names. `statementFrom` starts walking AT the anchor, so it reads the
+ * string's own closing quote as an OPENING one, desynchronises quote parity, and reports "no statement terminator"
+ * on ordinary code.
+ *
+ * `statementUpTo` cannot make that mistake — it walks from the start of the file, so it knows what is a string. So
+ * the statement's START is resolved first, and the forward walk begins from there, where the text is real code.
+ */
+export function statementAround(src, at, label = 'statementAround') {
+  const start = at - statementUpTo(src, at, label).length;
+  return statementFrom(src, start, label);
 }
 
 /**

--- a/testing/standalone/chrono-status-descriptions-match-the-derivation.test.js
+++ b/testing/standalone/chrono-status-descriptions-match-the-derivation.test.js
@@ -32,6 +32,7 @@ import { describe, it, before } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { stripComments } from './_strip-comments.mjs';
+import { statementAround } from './_structural-window.mjs';
 
 let deriveChronoStatus, ALL_TOOLS;
 before(async () => {
@@ -197,7 +198,26 @@ describe('no tool repeats the claim that was false', () => {
     const routes = stripComments(readFileSync('server/src/api/brain/chrono.ts', 'utf8'));
     const validation = stripComments(readFileSync('server/src/spaces/schema-validation.ts', 'utf8'));
     for (const [name, src] of [['the REST route', routes], ['schema validation', validation]]) {
-      assert.doesNotMatch(src, /endsAt[\s\S]{0,60}?[<>]=?[\s\S]{0,20}?startsAt/,
+      /*
+       * Per STATEMENT, with no cap at all.
+       *
+       * A comparison and both its operands live in one statement, so the statement is the bound. The `{0,60}` /
+       * `{0,20}` gaps this replaces were trying to say "close together" as a proxy for exactly that, and a
+       * formatted multi-line condition already exceeded them — so the absence they asserted would have been
+       * satisfied by a comparison written across three lines.
+       *
+       * Getting here found two real bugs in the helper, both of which only a caller could have surfaced. The
+       * enclosing BLOCK was tried first and over-reported — a whole route handler contains both names and some
+       * unrelated `<`. Narrowing to the statement then failed, because `statementFrom` demanded a terminator at
+       * relative depth exactly 0 and so refused every anchor mid-expression. And once that was fixed it failed
+       * again, on `'endsAt'` as a quoted FIELD NAME in a list: a walk that starts inside a string reads the string's
+       * own closing quote as an opening one. `statementAround` resolves the statement's start from the top of the
+       * file, where quote parity is known.
+       */
+      const compared = [...src.matchAll(/\bendsAt\b/g)]
+        .map(m => statementAround(src, m.index, name))
+        .filter(stmt => /\bstartsAt\b/.test(stmt) && /[<>]=?/.test(stmt));
+      assert.deepEqual(compared, [],
         `${name} now compares the two — the descriptions may say it is refused, and should`);
     }
   });

--- a/testing/standalone/duplicate-pair-signals.test.js
+++ b/testing/standalone/duplicate-pair-signals.test.js
@@ -30,6 +30,7 @@
 import { describe, it, before } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
+import { blockAfter, balancedFrom, statementFrom } from './_structural-window.mjs';
 
 let mod;
 before(async () => { mod = await import('../../server/dist/api/duplicates.js'); });
@@ -51,8 +52,26 @@ describe('the pair key joins the two candidate collections', () => {
     // 500 pairs × a round trip each would make this endpoint quietly slow, and the contradiction rows are
     // keyed by exactly this key — so an $in over the page is the whole cost.
     assert.match(src, /_id: \{ \$in: keys \}/, 'the join must be batched');
-    assert.equal(/for \(const p of pairs\)[\s\S]{0,200}await col\(/.test(src), false,
-      'no awaited query inside a per-pair loop');
+    /*
+     * EVERY such loop, and each bounded by its own body — which is not always a block.
+     *
+     * `indexOf` found the FIRST one, and that one is braceless: `for (const p of pairs) out.set(pairKey(p), {...})`.
+     * So `blockAfter` bounded the OBJECT LITERAL in its argument, checked that for `await col(`, found none, and
+     * passed — while the braced loop further down went unexamined. A vacuous check that reads as a real one.
+     */
+    const loops = [...src.matchAll(/for \(const p of pairs\)/g)];
+    assert.ok(loops.length > 0, 'no per-pair loop found — re-anchor this gate');
+    for (const m of loops) {
+      const header = balancedFrom(src, m.index, 'the loop header');
+      const afterHeader = m.index + src.slice(m.index).indexOf(header) + header.length;
+      // The next non-space character, found rather than sliced — `slice(afterHeader, afterHeader + 8)` is a magic
+      // window, and the ratchet in this same suite caught it the moment it was written.
+      const braced = src[afterHeader + src.slice(afterHeader).search(/\S/)] === '{';
+      const body = braced
+        ? blockAfter(src, afterHeader, 'the per-pair loop body')
+        : statementFrom(src, afterHeader, 'the per-pair loop body');
+      assert.doesNotMatch(body, /await col\(/, 'no awaited query inside a per-pair loop');
+    }
   });
 });
 

--- a/testing/standalone/gates-bound-their-subject-structurally.test.js
+++ b/testing/standalone/gates-bound-their-subject-structurally.test.js
@@ -160,6 +160,72 @@ const GRANDFATHERED = new Map([
  * CSS behind a declaration; `config-key-docs-coverage` reads a doc comment above a key; `index-ready-poll` reads
  * what precedes a call. Those are three different structural bounds, not one conversion applied nine times.
  */
+/**
+ * A CAPPED GAP inside a regex: `/marker[\s\S]{0,400}?other/`. Files still allowed to carry one, with how many.
+ *
+ * **66 occurrences across 36 files, and the tracker recorded 30.** Measured here rather than trusted, and the number
+ * is in the gate so nobody has to re-measure it — a population counted once in a markdown file is a population that
+ * drifts.
+ *
+ * ## Why this is a THIRD list rather than a ban
+ *
+ * The syntax wears two meanings and only one is a defect:
+ *
+ *   - a WINDOW between two markers — the cap is a guess at how much of a subject fits, and it can only ever make
+ *     the check see less. This is the defect.
+ *   - an ADJACENCY claim — "these two words in one sentence", `[^.\n]{0,40}`; "the guard within three lines". The
+ *     number IS the rule, and converting it would replace a correct assertion with a vaguer one.
+ *
+ * Banning both without reading each is the blind sweep this whole gate exists to prevent. So the population is
+ * frozen, and the SIX whose assertion was NEGATIVE are converted first — that is the polarity where a short window
+ * finds nothing, the absence holds, and the gate passes on the thing it was written to catch.
+ *
+ * Two of those six turned out not to be cap problems at all. One bounded the wrong loop, because `indexOf` found a
+ * braceless one and the window landed on an object literal in its argument. The other matched ZERO occurrences in
+ * any version — the three stages it names are built in a `.map`, so their key is a template and never the quoted
+ * literal the regex looked for. Both had been reading as passing gates.
+ *
+ * **This list may only shrink.**
+ */
+const GRANDFATHERED_GAP = new Map([
+  ['testing/red-team-tests/ssrf-ipv6.test.js', 1],
+  ['testing/standalone/backups-are-not-world-readable.test.js', 1],
+  ['testing/standalone/brain-if-match.test.js', 2],
+  ['testing/standalone/brain-read-bodies-are-strict.test.js', 2],
+  ['testing/standalone/caller-supplied-ids-are-uuids.test.js', 1],
+  ['testing/standalone/chrono-retention.test.js', 1],
+  ['testing/standalone/chrono-status-descriptions-match-the-derivation.test.js', 9],
+  ['testing/standalone/collectors-are-timed.test.js', 1],
+  ['testing/standalone/contradiction-scanner.test.js', 1],
+  ['testing/standalone/document-description.test.js', 3],
+  ['testing/standalone/file-mutation-tools-state-their-cascade.test.js', 2],
+  ['testing/standalone/graph-spill-is-not-content.test.js', 1],
+  ['testing/standalone/infra-managed-locks-every-field.test.js', 3],
+  ['testing/standalone/mcp-tool-rights.test.js', 2],
+  ['testing/standalone/merge-relinks-every-entity-reference.test.js', 2],
+  ['testing/standalone/meta-precondition.test.js', 1],
+  ['testing/standalone/model-verify.test.js', 1],
+  ['testing/standalone/no-boot-migration-on-synced-data.test.js', 1],
+  ['testing/standalone/no-copyleft-in-the-shipped-tree.test.js', 2],
+  ['testing/standalone/no-polling-a-deleted-space.test.js', 2],
+  ['testing/standalone/notice-coverage.test.js', 1],
+  ['testing/standalone/oidc-carries-a-rights-matrix.test.js', 1],
+  ['testing/standalone/overview-pending-is-cleared.test.js', 1],
+  ['testing/standalone/recall-params-reach-the-ui.test.js', 2],
+  ['testing/standalone/reembed-backfill.test.js', 1],
+  ['testing/standalone/retention-reaches-every-collection.test.js', 3],
+  ['testing/standalone/rights-are-explained.test.js', 3],
+  ['testing/standalone/route-guard-coverage.test.js', 1],
+  ['testing/standalone/schema-derived-type-controls.test.js', 4],
+  ['testing/standalone/search-tool-schemas-document-their-response.test.js', 3],
+  ['testing/standalone/single-flight.test.js', 1],
+  ['testing/standalone/space-admin-reaches-its-own-space-settings.test.js', 1],
+  ['testing/standalone/space-op-recovery-guard.test.js', 1],
+  ['testing/standalone/stt-multipart-and-partial.test.js', 2],
+  ['testing/standalone/sync-waits-retrigger-and-diagnose.test.js', 1],
+  ['testing/standalone/vlm-endpoint-egress.test.js', 1],
+]);
+
 const GRANDFATHERED_BACK = new Map([
   /*
    * EMPTY. All nine are converted, and the list stays here rather than being deleted because an empty ratchet is the
@@ -191,8 +257,12 @@ const SELF = 'gates-bound-their-subject-structurally.test.js';
  */
 const FIXTURES = 'structural-window-helper.test.js';
 
+/** A capped gap inside a regex — `{0,400}` — whichever of the two things it means. */
+const CAPPED_GAP = /\{0,\d+\}/g;
+
 const found = new Map();
 const foundBack = new Map();
+const foundGap = new Map();
 for (const root of ROOTS) {
   for (const file of sources(root)) {
     // Split on the platform separator and rejoin with `/`, so the keys read the same on Windows and in CI. A
@@ -204,6 +274,15 @@ for (const root of ROOTS) {
     if (n > 0) found.set(key, n);
     const back = [...code.matchAll(MAGIC_WINDOW_BACK)].length;
     if (back > 0) foundBack.set(key, back);
+    /*
+     * Counted on the RAW source, not the comment-stripped copy. Every other count here is on `code`, and for this
+     * one that would be wrong in the expensive direction: a `{0,N}` written inside a comment — which is how this
+     * suite documents the lesson, and there are several — would be invisible, so a file could carry a real one and
+     * a comment about it and the numbers would not add up. Counting raw keeps the frozen number checkable by hand
+     * with a grep, which is what somebody converting one of these will actually do.
+     */
+    const gaps = [...readFileSync(file, 'utf8').matchAll(CAPPED_GAP)].length;
+    if (gaps > 0) foundGap.set(key, gaps);
   }
 }
 
@@ -290,6 +369,29 @@ describe('no NEW magic window', () => {
       'a gate reads a fixed number of characters BEHIND its anchor. That is the same defect as a forward window\n'
       + 'and a worse one: it starts inside its subject silently, and it is usually paired with `doesNotMatch`, so\n'
       + 'an absence gets asserted over less text than intended and passes. Bound it with `_structural-window.mjs`.\n'
+      + problems.join('\n'));
+  });
+
+  it('no NEW capped gap inside a regex, and that list only shrinks too', () => {
+    /*
+     * Frozen rather than banned, because the syntax means two different things and only one is a defect — see the
+     * note on `GRANDFATHERED_GAP`. What this refuses is a NEW one appearing anywhere, which is the part that does
+     * not need each site read first.
+     */
+    const problems = [];
+    for (const [file, n] of foundGap) {
+      const allowed = GRANDFATHERED_GAP.get(file) ?? 0;
+      if (n > allowed) problems.push(`${file}: ${n} capped gap(s), allowed ${allowed}`);
+    }
+    for (const [file, allowed] of GRANDFATHERED_GAP) {
+      const actual = foundGap.get(file) ?? 0;
+      if (actual < allowed) problems.push(`${file}: allowed ${allowed} gaps, now has ${actual} — lower it`);
+    }
+    assert.deepEqual(problems, [],
+      'a capped gap inside a regex — `/marker[\\s\\S]{0,400}?other/`. If the number is a GUESS at how much of a\n'
+      + 'subject fits, bound it with `_structural-window.mjs` instead; the cap can only make the check see less.\n'
+      + 'If the number IS the rule — two words in one sentence, a guard within three lines — say so in a comment\n'
+      + 'beside it and raise this file\'s entry deliberately.\n'
       + problems.join('\n'));
   });
 

--- a/testing/standalone/instance-admin-agrees-with-the-legacy-flag.test.js
+++ b/testing/standalone/instance-admin-agrees-with-the-legacy-flag.test.js
@@ -31,6 +31,7 @@ import { describe, it, before } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { stripComments } from './_strip-comments.mjs';
+import { bodyOf } from './_structural-window.mjs';
 
 let migrateToken;
 before(async () => {
@@ -110,7 +111,11 @@ describe('the guard has moved onto the matrix, and this evidence is why it could
    */
   it('enforceAdmin no longer reads the legacy boolean directly', () => {
     const mw = stripComments(readFileSync('server/src/auth/middleware.ts', 'utf8'));
-    assert.doesNotMatch(mw, /function enforceAdmin\([\s\S]{0,200}?if \(!record\.admin\)/,
+    /*
+     * The whole function, to the next top-level declaration. An ABSENCE assertion behind a 200-character cap passes
+     * the moment the function grows past it — so the check would have quietly stopped covering the thing it names.
+     */
+    assert.doesNotMatch(bodyOf(mw, 'enforceAdmin'), /if \(!record\.admin\)/,
       'the switch has happened; the agreement above is what made it safe');
   });
 

--- a/testing/standalone/optional-index-cannot-fail-a-space.test.js
+++ b/testing/standalone/optional-index-cannot-fail-a-space.test.js
@@ -37,6 +37,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { stripComments } from './_strip-comments.mjs';
+import { bodyOf } from './_structural-window.mjs';
 
 const { deriveLiveIndexState, isDrifted } = await import('../../server/dist/api/pipeline-status.js');
 
@@ -44,25 +45,16 @@ const FILE = 'server/src/spaces/vector-index.ts';
 const src = stripComments(readFileSync(FILE, 'utf8'));
 
 /**
- * The body of one exported function, by LINES rather than by a character count.
+ * The body of one exported function in THIS file's source.
  *
- * A fixed `slice(at, at + N)` window spans different lines on CRLF than on LF, so a gate that passed here
- * could look at less than it meant to in CI. Bounded by the next top-level `export ` instead, which is
- * structural and cannot drift with line endings.
+ * A one-argument wrapper so the calls below stay short. The loop that used to be here was one of three
+ * independent hand-rolls of the same bound, written within hours of each other — which is what
+ * `_structural-window.mjs` was extracted for, and this was the last of the three still standing.
  */
-function bodyOf(name) {
-  const lines = src.split(/\r?\n/);
-  const start = lines.findIndex(l => l.includes(`export async function ${name}(`));
-  assert.ok(start > -1, `${name} is gone from ${FILE} — re-anchor this gate`);
-  let end = lines.length;
-  for (let i = start + 1; i < lines.length; i++) {
-    if (/^export (async function|function|const) /.test(lines[i])) { end = i; break; }
-  }
-  return lines.slice(start, end).join('\n');
-}
+const bodyIn = (name) => bodyOf(src, name, `${name} in ${FILE}`);
 
 describe('the face gallery is polled but gets no vote on the space status', () => {
-  const body = bodyOf('waitForSpaceIndexesReady');
+  const body = bodyIn('waitForSpaceIndexesReady');
 
   it('the verdict is computed over the REQUIRED indexes alone', () => {
     // The regression is one `push` away. Pushing the face poll into the array that `every(Boolean)` runs over
@@ -109,7 +101,7 @@ describe('the face gallery is polled but gets no vote on the space status', () =
 });
 
 describe('an index that does not exist is a terminal state, not a slow one', () => {
-  const body = bodyOf('pollVectorIndexReady');
+  const body = bodyIn('pollVectorIndexReady');
 
   it('absence ends the poll instead of running out the window', () => {
     assert.match(body, /if \(absentFor >= ABSENT_IS_TERMINAL_AFTER\)/,
@@ -217,7 +209,9 @@ describe('the admin health panel does not call a healthy space missing', () => {
     const panel = stripComments(readFileSync('server/src/api/pipeline-status.ts', 'utf8'));
     assert.match(panel, /indexName: `\$\{space\.id\}_files_faceEmbedding`, optional: true/,
       'the face index must be marked optional at the point it is added to the expected set');
-    assert.doesNotMatch(panel, /deriveLiveIndexState[\s\S]{0,400}faceEmbedding/,
+    // The verdict function's own body. Bounded by a count, this absence check would pass on any version of the
+    // function longer than 400 characters — including one that had just gained the hardcoded name it forbids.
+    assert.doesNotMatch(bodyOf(panel, 'deriveLiveIndexState'), /faceEmbedding/,
       'the verdict function must not know any index BY NAME — it reads the flag, so a second optional index '
       + 'needs no change here');
   });

--- a/testing/standalone/structural-window-helper.test.js
+++ b/testing/standalone/structural-window-helper.test.js
@@ -35,6 +35,7 @@ import {
   yamlItemAt,
   bodyOf,
   statementUpTo,
+  statementAround,
   enclosingBlockAround,
   enclosingBlocksMatching,
   lineBefore,
@@ -108,6 +109,25 @@ describe('statementFrom — the bound is the terminator', () => {
     assert.ok(statementFrom(src, 0).includes('here'));
   });
 
+  it('works from the MIDDLE of an expression, where depth goes negative', () => {
+    /*
+     * The case that made this unusable. The walk starts at the anchor, so brackets opened BEFORE it close into
+     * negative depth: `endsAt` inside `{ endsAt: z.string() }` reaches its `;` at relative depth -2. Requiring
+     * exactly 0 reported "no statement terminator" on ordinary code, and a gate converted to use it failed.
+     */
+    const src = 'const S = z.object({ endsAt: z.string().optional() });\nconst after = 1;';
+    const got = statementFrom(src, src.indexOf('endsAt'));
+    assert.ok(got.endsWith(';'));
+    assert.ok(!got.includes('const after'), 'it ran past the end of the statement');
+  });
+
+  it('and from inside a nested block', () => {
+    const src = 'fn(() => {\n  if (a.endsAt < a.startsAt) throw new Error("no");\n});\n';
+    const got = statementFrom(src, src.indexOf('endsAt'));
+    assert.ok(got.includes('startsAt'), 'the rest of the comparison is outside the window');
+    assert.ok(got.endsWith(';'));
+  });
+
   it('a missing terminator is an error, not a short window', () => {
     assert.throws(() => statementFrom('const x = 1', 0), /no statement terminator/);
   });
@@ -156,6 +176,32 @@ describe('statementUpTo — the bound behind an anchor is where its statement st
     const base = 'const v = someVeryLongCondition\n  ? a()\n  : b();';
     const grown = base.replace('someVeryLongCondition', 'someVeryLongCondition /* ' + 'x'.repeat(800) + ' */');
     assert.ok(statementUpTo(grown, grown.lastIndexOf('b()')).includes('someVeryLongCondition'));
+  });
+});
+
+describe('statementAround — safe when the anchor is inside a string', () => {
+  it('THE case that broke the composed version: a quoted FIELD NAME', () => {
+    /*
+     * `statementUpTo(at) + statementFrom(at)` looks equivalent and is not. `statementFrom` starts walking AT the
+     * anchor, so when the anchor is inside `'endsAt'` it reads that string's own closing quote as an OPENING one,
+     * desynchronises quote parity for the rest of the file, and reports "no statement terminator" on ordinary code.
+     *
+     * This is not a contrived input: any gate matching an identifier that also appears as a quoted field name hits
+     * it, and one did — the chrono source lists `'startsAt', 'endsAt'` in an array of updatable fields.
+     */
+    const src = "const FIELDS = [\n  'title', 'startsAt', 'endsAt', 'status',\n];\nconst after = 1;";
+    const got = statementAround(src, src.indexOf("endsAt"));
+    assert.ok(got.includes('FIELDS'), 'it did not reach the start of the statement');
+    assert.ok(got.trimEnd().endsWith(';'), 'it did not reach the end of the statement');
+    assert.ok(!got.includes('const after'), 'it ran past the statement');
+  });
+
+  it('returns the whole statement from an anchor in the middle of real code', () => {
+    const src = 'const a = 1;\nif (rec.endsAt < rec.startsAt) throw new Error("out of order");\nnext();';
+    const got = statementAround(src, src.indexOf('endsAt'));
+    assert.ok(got.includes('startsAt'));
+    assert.ok(!got.includes('const a'), 'it ran back past the statement');
+    assert.ok(!got.includes('next()'), 'it ran forward past the statement');
   });
 });
 

--- a/testing/standalone/update-validation.test.js
+++ b/testing/standalone/update-validation.test.js
@@ -29,6 +29,7 @@
 import { describe, it, before } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
+import { blockAfter } from './_structural-window.mjs';
 
 let classifyUpdateViolations;
 let describeUpdateViolations;
@@ -239,8 +240,17 @@ describe('every update path runs the gate', () => {
   it('no update path still gates validation behind deleteFields alone', () => {
     // The exact shape of the original hole: `if (dfPaths) { ...validate... }`. Validation must run
     // unconditionally and merely *apply* the deletions when they are present.
-    const offenders = PATHS.filter(p => /if \(dfPaths\) \{[\s\S]{0,600}?validate(Memory|Entity|Edge|Chrono)\(/
-      .test(strip(readFileSync(p, 'utf8'))));
+    /*
+     * The `if (dfPaths)` BLOCK, bounded by its closing brace. At 600 characters this reported no offenders for any
+     * branch longer than that — and the branch is where the validation call would sit, so the longer the hole, the
+     * more certainly this passed over it.
+     */
+    const offenders = PATHS.filter(p => {
+      const src = strip(readFileSync(p, 'utf8'));
+      const at = src.indexOf('if (dfPaths) {');
+      if (at === -1) return false;
+      return /validate(Memory|Entity|Edge|Chrono)\(/.test(blockAfter(src, at, `the dfPaths branch in ${p}`));
+    });
     assert.deepEqual(offenders, [],
       'validation must not be conditional on deleteFields — that was the original gap');
   });

--- a/testing/standalone/vlm-endpoint-egress.test.js
+++ b/testing/standalone/vlm-endpoint-egress.test.js
@@ -34,7 +34,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
-import { bodyOf, statementUpTo } from './_structural-window.mjs';
+import { bodyOf, statementUpTo, enclosingBlockAround } from './_structural-window.mjs';
 
 const ENDPOINT_SRC = 'server/src/files/converters/vlm-endpoint.ts';
 const CLIENT_SRC = 'server/src/files/converters/vlm-client.ts';
@@ -156,7 +156,25 @@ describe('the status board and the extractor cannot disagree', () => {
 
   it('document stages no longer hardcode external: false', () => {
     // The exact defect: three stages asserting `false` on a URL the line above them classifies.
-    assert.doesNotMatch(status, /key: 'doc-(vlm|repair|verify)'[\s\S]{0,200}external: false/);
+    /*
+     * The stage's own object literal, bounded by the brace that closes it.
+     *
+     * TWO things were wrong here, and the second is worse. The 200-character gap is an ABSENCE assertion, so a stage
+     * that grew a field would have pushed `external: false` out of range and passed on the defect it names.
+     *
+     * And the pattern matched NOTHING — zero occurrences, in this version and in the one before it. The three stages
+     * are built in a `.map`, so the key is a TEMPLATE (`` key: `doc-${slot}` ``) and never the quoted literal the
+     * regex looked for. The check has been vacuous since it was written, which is the failure that reads exactly
+     * like a passing gate. Hence the floor assertion below: matching nothing must be an error, never a silence.
+     */
+    const stages = [...status.matchAll(/key: `doc-\$\{slot\}`|key: 'doc-(?:vlm|repair|verify)'/g)];
+    assert.ok(stages.length > 0,
+      'no document stage found in pipeline-status.ts — this check would pass by examining nothing');
+    const hardcoded = stages
+      .map(m => enclosingBlockAround(status, m.index, 'a document stage'))
+      .filter(stage => /external: false/.test(stage));
+    assert.deepEqual(hardcoded, [],
+      'a document stage asserts external: false on a URL the resolver classifies — the original defect');
   });
 
   it('they read the shared resolver instead', () => {


### PR DESCRIPTION
chore(testing): two gates were vacuous, and the capped-gap population is 66 rather than 30

X-25c, the last part of X-25: a capped gap inside a regex — `/marker[\s\S]{0,400}?other/`.
The population is frozen, and the six whose assertion was NEGATIVE are converted, because
that is the polarity where a short window finds nothing, the absence holds, and the gate
passes on exactly what it was written to catch.

THE COUNT WAS WRONG, AND NOT BY A LITTLE

66 occurrences across 36 files. The tracker said 30. It is now measured by the gate rather
than recorded in markdown, because a population counted once in a tracker is a population
that drifts — and this one had.

TWO OF THE SIX WERE NOT CAP PROBLEMS AT ALL

This is the argument for reading each site instead of sweeping them, and it is stronger than
I expected going in:

**`vlm-endpoint-egress` matched ZERO occurrences, in every version it has ever had.** The
check reads "no document stage hardcodes `external: false`" and looked for `key: 'doc-vlm'`.
The three stages are built in a `.map`, so the key is a template — `` key: `doc-${slot}` `` —
and the quoted literal appears nowhere. It has been asserting the absence of a pattern that
cannot occur since the day it was written, on the egress path that sends page images off the
instance. Now anchored on the real construction, with a floor assertion that matching nothing
is an error rather than a silence.

**`duplicate-pair-signals` bounded the wrong loop.** `indexOf` found the first
`for (const p of pairs)`, and that one is braceless, so the window landed on an object
literal in its argument — while the braced loop below it went unexamined. Every such loop is
checked now, and a braceless one is bounded by its statement rather than by a block that is
not there.

Both read as passing gates. Expect more of the same in the remaining 60: a cap is often the
second thing wrong with a check, not the first.

THE OTHER FOUR

`instance-admin` (does `enforceAdmin` still read the legacy boolean), `optional-index` (does
the verdict function know an index by name), `update-validation` (is validation gated behind
`deleteFields`), and `chrono-status` (does anything compare `endsAt` with `startsAt`). Each
now bounded by its subject — a function body, a branch, a statement — with no cap.

THREE BUGS IN THE HELPER, ALL FOUND BY CALLERS RATHER THAN BY READING IT

The chrono one took three attempts and each failure was a real defect:

1. The enclosing BLOCK over-reported — a whole route handler contains both names and some
   unrelated `<`.
2. Narrowing to the statement failed: `statementFrom` demanded a terminator at relative
   depth exactly 0, so it refused every anchor in the middle of an expression, which is most
   of them. `endsAt` inside `{ endsAt: z.string() }` reaches its `;` at depth -2.
3. Fixed, it failed again on `'endsAt'` as a quoted FIELD NAME in a list of updatable
   fields. A walk that starts inside a string reads that string's own closing quote as an
   opening one and desynchronises quote parity for the rest of the file.

`statementAround` resolves the statement's start from the top of the file, where quote parity
is known, and then walks forward from real code. `statementUpTo`'s depth rule also had to
become "at or shallower than the anchor" — an exact-depth match found no boundary for an
anchor inside parentheses and fell back to the top of the file, returning the first statement
in the source instead of the one the anchor is in.

Each is a spec case now, on the input that broke it.

WHAT THE RATCHET DOES WITH THE REST

Frozen, not banned, because the syntax wears two meanings: a WINDOW between markers, where
the number is a guess and can only make the check see less; and an ADJACENCY claim — two
words in one sentence, a guard within three lines — where the number IS the rule. Banning
both without reading each is the blind sweep this gate exists to prevent.

Counted on the RAW source rather than the comment-stripped copy, deliberately: this suite
documents the lesson in comments containing the very syntax, so stripping would hide them and
the frozen number would stop matching a hand-run grep. The person converting one of these
will reach for grep.

The gate also caught a magic window I introduced while fixing `duplicate-pair-signals` — a
`slice(afterHeader, afterHeader + 8)` to peek for a brace — within a minute of writing it.

No CHANGELOG entry: no product behaviour changes, and `testing/` is exempt from the entry
gate for that reason.
