### PR TITLE
chore(sync): a push cycle now says what it looked for and what it decided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -361,6 +361,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **A sync push cycle now says what it looked for and what it decided, at debug level.** Two lines: per collection,
+  the cursor it queried from and how many documents it found — empty passes included; and per cycle, the watermark
+  before and after beside the counts pushed. Both are `log.debug`, so they cost nothing unless `DEBUG` is set.
+  Added for X-20, a propagation stall whose only recorded symptom is that the sender's cycles ran every 3 s in 19 ms
+  each — the signature of a cycle finding NOTHING rather than of a slow sender. Nothing in the log could separate
+  "found nothing because there is nothing" from "found nothing because the watermark is already past it", and those
+  are a healthy cycle and a permanent data loss. `DEBUG` is enabled for the two test instances the pub/sub topology
+  test uses, because a failure that only happens in CI cannot be diagnosed by instrumentation that is off there.
 - **Gates may no longer bound their subject with a magic number.** `src.slice(at, at + 3000)` decides in advance
   how much of its subject a gate can see; grow the subject and the gate either fails on correct code or passes
   while checking less than it meant to. A character count also spans different LINES on CRLF than on LF, so a

--- a/server/src/sync/engine.ts
+++ b/server/src/sync/engine.ts
@@ -1028,6 +1028,19 @@ async function pushToPeer(
         .sort({ seq: 1 })
         .limit(PUSH_BATCH_SIZE)
         .toArray() as T[];
+      /*
+       * X-20 instrumentation. The stall this exists to name has one recorded symptom and it is this loop:
+       * `A's cycles ran every 3 s in 19 ms each` — the signature of a cycle that FOUND NOTHING, not of a slow
+       * sender. Nothing in the log could tell "found nothing because there is nothing" from "found nothing
+       * because the cursor is already past it", and those are a healthy cycle and a permanent data loss.
+       *
+       * So the cursor and the count are logged on every pass, empty ones included. Gated on `DEBUG`, so it is
+       * free unless somebody is looking — and it is the one line that would have made six failed reproduction
+       * attempts conclusive instead of inconclusive.
+       */
+      log.debug(`Push ${payloadKey} to ${member.label ?? member.instanceId} space '${spaceId}': `
+        + `${batch.length} doc(s) with seq > ${seqCursor}`
+        + (batch.length ? ` (through ${(batch[batch.length - 1] as MemoryDoc).seq})` : ''));
       if (batch.length === 0) break;
       const resp = await peerSafeFetch(batchEndpoint, {
         ...batchOpts(), method: 'POST',
@@ -1074,6 +1087,17 @@ async function pushToPeer(
     transfers: { memories: memP, entities: entP, edges: edgeP, chrono: chronoP, tombstones },
     warn: log.warn,
   });
+
+  /*
+   * The other half of the X-20 instrumentation: what the cycle DECIDED, beside what it found.
+   *
+   * A watermark that moves while every transfer reported zero documents is the shape that would explain the
+   * stall — the cursor advancing past a record nothing sent, after which every later cycle correctly finds
+   * nothing and the record is never offered again. That combination is invisible without both numbers in one
+   * line, which is why they are logged together rather than at four separate call sites.
+   */
+  log.debug(`Push cycle to ${member.label ?? member.instanceId} space '${spaceId}': watermark ${lastSeqPushed} -> `
+    + `${maxSeqPushed}, pushed ${pushedMemories}m/${pushedEntities}e/${pushedEdges}g/${pushedChrono}c`);
 
   // Persist the push high-water mark so next sync only sends new/changed docs
   if (maxSeqPushed > lastSeqPushed) {

--- a/testing/docker-compose.test.yml
+++ b/testing/docker-compose.test.yml
@@ -48,6 +48,18 @@ services:
       SKIP_AUTH_RATE_LIMIT: "true"
       SKIP_GLOBAL_RATE_LIMIT: "true"
       SKIP_SYNC_RATE_LIMIT: "true"
+      # DEBUG on for A and B only — the two instances the pub/sub topology test uses.
+      #
+      # X-20 is a CI-ONLY failure: `Subscriber-local content survives publisher tombstone` times out on its
+      # 25 s wait, passes on a re-run of the same commit, and the container logs say nothing about why. The
+      # sync engine's push loop logs its cursor and batch count at debug, so instrumentation that is not
+      # enabled here cannot answer the one question the failure raises — did the cycle find nothing because
+      # there was nothing, or because the watermark was already past it.
+      #
+      # A and B rather than all four, deliberately: the lines are per collection per member per cycle on a 3 s
+      # timer, so switching on the whole stack would add thousands of lines to every CI run to answer a
+      # question about two of them.
+      DEBUG: "1"
       # Enable DB migration on instance A so db-migration.test.js can exercise it.
       # Instances B and C intentionally omit this flag — used by red-team tests to
       # verify the feature is disabled by default.
@@ -116,6 +128,18 @@ services:
       SKIP_AUTH_RATE_LIMIT: "true"
       SKIP_GLOBAL_RATE_LIMIT: "true"
       SKIP_SYNC_RATE_LIMIT: "true"
+      # DEBUG on for A and B only — the two instances the pub/sub topology test uses.
+      #
+      # X-20 is a CI-ONLY failure: `Subscriber-local content survives publisher tombstone` times out on its
+      # 25 s wait, passes on a re-run of the same commit, and the container logs say nothing about why. The
+      # sync engine's push loop logs its cursor and batch count at debug, so instrumentation that is not
+      # enabled here cannot answer the one question the failure raises — did the cycle find nothing because
+      # there was nothing, or because the watermark was already past it.
+      #
+      # A and B rather than all four, deliberately: the lines are per collection per member per cycle on a 3 s
+      # timer, so switching on the whole stack would add thousands of lines to every CI run to answer a
+      # question about two of them.
+      DEBUG: "1"
     depends_on:
       ythril-mongo-b:
         condition: service_healthy


### PR DESCRIPTION
chore(sync): a push cycle now says what it looked for and what it decided

X-20 instrumentation. Not a fix — the cause is not named yet, and this is what would
name it.

WHAT THE FAILURE LOOKS LIKE, AND WHY NO LOG COULD EXPLAIN IT

`Subscriber-local content survives publisher tombstone` times out on its 25 s wait in CI,
passes on a re-run of the same commit, and has never reproduced on an unconstrained local
stack. The one recorded symptom, from the failing run's own container log: A completed
sync cycles every 3 s in 19 ms each.

That is the signature of a cycle that FOUND NOTHING — not of a sender running out of time.
And nothing in the log could separate the two readings of "found nothing":

  there is nothing to send            a healthy cycle
  the watermark is already past it    a record that will never be offered again

Those are opposite conclusions and they produce identical output. Six reproduction attempts
were inconclusive partly for that reason: even the runs that were slow could not be read.

THE TWO LINES

Per collection, on every pass including the empty ones: the cursor it queried from and how
many documents came back. Per cycle: the watermark before and after, beside the counts
pushed.

Together rather than at four separate call sites, because the shape that would explain the
stall is only visible in the combination — a watermark that MOVES while every transfer
reported zero documents. Either number alone is unremarkable.

Both are `log.debug`, which is gated on `DEBUG`, so this is free unless somebody is looking.

WHY DEBUG IS ON FOR TWO TEST INSTANCES

Because a failure that only happens in CI cannot be diagnosed by instrumentation that is
switched off there. A and B only — the two the pub/sub topology test uses — since the lines
are per collection per member per cycle on a 3 s timer, and enabling the whole stack would
add thousands of lines to every run to answer a question about two of them.

WHAT I READ AND DID NOT FIND, SO NOBODY REPEATS IT

The push loop pages by `seq > cursor` and only advances `localMaxSeq` to seqs of documents
it actually sent, so it cannot skip a record by arithmetic. `resolveWatermark` already caps
the shared watermark at the lowest `deliveredThrough` of any truncated transfer, and both
call sites pass all five transfers. The mechanism is sound as written, which is why the next
step is a measurement rather than another reading.
