### PR TITLE
fix(sync): a wiped database left three of the four watermarks describing reused seqs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -433,7 +433,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **An infrastructure env pin was a UI hint rather than a guarantee, for five of the six field families it
+- **After a wiped database, three of the four sync watermarks kept describing sequence numbers about to be
+  reused.** `resetStaleWatermarksIfNeeded` exists for a state operators do reach — `docker compose down -v` wipes
+  the MongoDB volume while `config.json` survives on a host bind-mount, so the sequence counter restarts at 1 while
+  the config still records positions from the previous run. It cleared `lastSeqReceived` and left the rest, and each
+  one fails differently: a stale **`lastSeqPushed`** means we push `seq > 47` and **never send our own new 1..47**;
+  a stale `lastSeqServed` or `lastFileTombstoneAckedAt` means we believe a peer applied deletions it has not and
+  prune the tombstones, so a deleted record comes back from that peer. The push case is the same defect as the one
+  the function was written for, pointing the other way, and it is the harder one to notice: the sender's cycles
+  complete normally, because `seq > 47` genuinely matches nothing. All four are now cleared from one declared list,
+  the reset walks that list rather than naming fields, and the warning enumerates which maps it reset instead of
+  claiming one field was the whole job.
   covers.** `PATCH /api/admin/media-config` refuses a write to a pinned field with `403` — but the guard only
   understood nested pins for `faceRecognition`, so a patch overwriting any other pinned `block.field` path
   answered **200** and was written to `config.json`:

--- a/server/src/util/seq.ts
+++ b/server/src/util/seq.ts
@@ -117,41 +117,78 @@ export async function bumpSeq(spaceId: string, minSeq: number): Promise<void> {
 }
 
 /**
+ * Every watermark that becomes a LIE when the seq counters are wiped.
+ *
+ * All four are `spaceId -> position` maps on a network member, and all four are meaningless once the counter
+ * they were measured against restarts at zero. Listing them here rather than at the reset below is what makes
+ * "did we cover all of them" a readable question — the reset used to clear exactly one, and the other three
+ * were not excluded for a reason, they were not thought of.
+ */
+const STALE_ON_COUNTER_WIPE = ['lastSeqReceived', 'lastSeqPushed', 'lastSeqServed',
+  'lastFileTombstoneAckedAt'] as const;
+
+/**
  * Detects the bind-mount / volume mismatch that occurs when `docker compose
  * down -v` wipes MongoDB but leaves config.json intact on the host bind-mount.
  *
- * Symptom: ythril_counters is empty (seq counter was in the wiped volume) yet
- * one or more network members carry a non-zero lastSeqReceived watermark from
- * the previous run.  Without this fix those networks would pull with a high
- * sinceSeq and silently miss every document whose seq falls below the stale
- * watermark.
+ * Symptom: `ythril_counters` is empty — the counter lived in the wiped volume — yet one or more network
+ * members still carry watermarks from the previous run. Local seqs now restart at 1 while the watermarks
+ * describe a history of numbers that will be reused for entirely different records.
  *
- * Safe to call at every startup: it is a no-op when ythril_counters is
- * non-empty (normal restart) or when all watermarks are already zero.
+ * ## It used to clear ONE of the four, and the other three fail in different directions
+ *
+ * | watermark | what it means | stale-high costs |
+ * |---|---|---|
+ * | `lastSeqReceived` | our position in the peer's data | we pull `sinceSeq=47` and silently miss its 1..47 |
+ * | `lastSeqPushed` | our position in what we have sent | we push `seq > 47` and NEVER send our own new 1..47 |
+ * | `lastSeqServed` | the peer's position in ours | we believe it has applied deletions it has not, and prune |
+ * | `lastFileTombstoneAckedAt` | file deletions a peer has taken | same, for files: prune, and the file returns |
+ *
+ * Only the first was reset, and the second is the same defect pointing the other way — a silent, permanent
+ * failure to deliver our own records, with the sender's cycles completing normally because `seq > 47`
+ * genuinely matches nothing. That is indistinguishable from a healthy idle cycle without the debug line the
+ * push loop now emits.
+ *
+ * The third and fourth fail toward PRUNING, which `sync/served-watermark.ts` names as the dangerous direction:
+ * a tombstone dropped too early lets a deleted record come back from a peer that never saw the deletion.
+ * Clearing them fails toward keeping, which is that module's stated rule.
+ *
+ * Safe to call at every startup: a no-op when `ythril_counters` is non-empty (a normal restart) or when no
+ * watermark is set.
  */
 export async function resetStaleWatermarksIfNeeded(): Promise<void> {
   const count = await col<SpaceCounterDoc>('ythril_counters').estimatedDocumentCount();
   if (count > 0) return; // MongoDB intact — nothing to do
 
   const cfg = getConfig();
-  let changed = false;
-  for (const net of cfg.networks) {
-    for (const member of net.members) {
-      if (member.lastSeqReceived && Object.keys(member.lastSeqReceived).length > 0) {
-        member.lastSeqReceived = {};
-        changed = true;
+  const cleared: string[] = [];
+
+  /** Clear every stale map on one member, reporting which were actually set. */
+  const clear = (member: Record<string, unknown> | undefined, where: string): void => {
+    if (!member) return;
+    for (const field of STALE_ON_COUNTER_WIPE) {
+      const value = member[field];
+      if (value && typeof value === 'object' && Object.keys(value).length > 0) {
+        member[field] = {};
+        cleared.push(`${where}.${field}`);
       }
     }
-    // Also clear any pendingMember watermarks inside vote rounds
+  };
+
+  for (const net of cfg.networks) {
+    for (const member of net.members) clear(member as unknown as Record<string, unknown>, member.instanceId);
+    // A vote round in flight carries its own copy of the joining member, with its own watermarks.
     for (const round of net.pendingRounds) {
-      if (round.pendingMember?.lastSeqReceived && Object.keys(round.pendingMember.lastSeqReceived).length > 0) {
-        round.pendingMember.lastSeqReceived = {};
-        changed = true;
-      }
+      clear(round.pendingMember as unknown as Record<string, unknown> | undefined, 'pendingMember');
     }
   }
-  if (changed) {
+
+  if (cleared.length > 0) {
     saveConfig(cfg);
-    log.warn('Seq counters absent but watermarks were non-zero — reset all lastSeqReceived to 0 (bind-mount/volume mismatch recovery)');
+    log.warn(
+      `Seq counters absent but ${cleared.length} watermark map(s) were set — reset (bind-mount/volume mismatch `
+      + `recovery). Local seqs restart at 1, so a retained watermark would describe numbers about to be reused: `
+      + `${cleared.join(', ')}`,
+    );
   }
 }

--- a/testing/standalone/counter-wipe-clears-every-watermark.test.js
+++ b/testing/standalone/counter-wipe-clears-every-watermark.test.js
@@ -1,0 +1,118 @@
+/**
+ * When the seq counters are wiped, EVERY watermark measured against them is cleared — not one of the four.
+ *
+ * ## The defect
+ *
+ * `resetStaleWatermarksIfNeeded` exists for a real and reachable state: `docker compose down -v` wipes the
+ * MongoDB volume while `config.json` survives on a host bind-mount. The counter restarts at 1; the watermarks in
+ * the config still describe a history of numbers that are about to be handed to entirely different records.
+ *
+ * It cleared `lastSeqReceived` and left the other three, and they fail in different directions:
+ *
+ * | watermark | stale-high costs |
+ * |---|---|
+ * | `lastSeqReceived` | we pull `sinceSeq=47` and silently miss the peer's 1..47 — the one it was written for |
+ * | `lastSeqPushed` | we push `seq > 47` and NEVER send our own new 1..47 |
+ * | `lastSeqServed` | we believe a peer applied deletions it has not, and prune the tombstones |
+ * | `lastFileTombstoneAckedAt` | the same for files: prune, and a deleted file comes back from the peer |
+ *
+ * The second is the same defect pointing the other way, and it is the worse one to diagnose: the sender's cycles
+ * complete normally, because `seq > 47` genuinely matches nothing. A healthy idle cycle and a permanent failure
+ * to deliver look identical from outside — which is the shape X-20 has been chasing.
+ *
+ * ## Why this is asserted as ALL-OR-NONE
+ *
+ * `two-surfaces-one-rule-weaker-version` is the lesson: a gate that checks "the reset handles
+ * `lastSeqReceived`" passes on exactly the code that had the bug. So this derives the field list from the member
+ * TYPE — every `spaceId -> position` map on a network member — and requires the reset to cover all of them. A
+ * fifth watermark added tomorrow fails this test until somebody decides whether it is stale on a wipe.
+ *
+ * Run: node --test testing/standalone/counter-wipe-clears-every-watermark.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripComments } from './_strip-comments.mjs';
+import { bodyOf, balancedFrom } from './_structural-window.mjs';
+
+const seqSrc = stripComments(readFileSync('server/src/util/seq.ts', 'utf8'));
+const typesSrc = stripComments(readFileSync('server/src/config/types-networks.ts', 'utf8'));
+
+/**
+ * Every per-space position map declared on `NetworkMember`, read from the type.
+ *
+ * Derived rather than listed, because a hand-written list is the thing that produced the bug: the reset's author
+ * knew about one field and there was nothing to tell them about the others.
+ */
+function memberWatermarkFields() {
+  const iface = balancedFrom(typesSrc, typesSrc.indexOf('interface NetworkMember'), 'NetworkMember');
+  // `lastX?: Record<string, number>` / `Record<string, string>` — a position per space, whatever it counts.
+  return [...iface.matchAll(/(\w+)\?:\s*Record<string,\s*(?:number|string)>/g)].map(m => m[1]);
+}
+
+describe('the field list this reset is built from', () => {
+  it('finds the per-space position maps on NetworkMember', () => {
+    // A scan that found none would make every assertion below vacuous — the failure this whole suite keeps
+    // rediscovering.
+    const fields = memberWatermarkFields();
+    assert.ok(fields.length >= 4,
+      `expected at least four per-space watermark maps on NetworkMember, found ${fields.length}: ${fields}`);
+    for (const expected of ['lastSeqReceived', 'lastSeqPushed', 'lastSeqServed']) {
+      assert.ok(fields.includes(expected), `${expected} is no longer a Record on NetworkMember — re-anchor this`);
+    }
+  });
+});
+
+describe('the wipe recovery covers every one of them', () => {
+  it('names all of them, and names them in ONE place', () => {
+    /*
+     * ALL-OR-NONE, which is the only assertion that would have failed on the buggy version. "It handles
+     * lastSeqReceived" was true the whole time the other three were being ignored.
+     */
+    const list = balancedFrom(seqSrc, seqSrc.indexOf('STALE_ON_COUNTER_WIPE'), 'the stale-watermark list');
+    const missing = memberWatermarkFields().filter(f => !list.includes(`'${f}'`));
+    assert.deepEqual(missing, [],
+      'these per-space watermarks are measured against the seq counter and are NOT cleared when it is wiped. '
+      + 'Each one that survives describes numbers about to be reused by different records. If one genuinely '
+      + 'should survive a wipe, exclude it deliberately with the reason beside it.');
+  });
+
+  it('the reset iterates the list rather than repeating field names', () => {
+    // Four hand-written clears is how the fifth gets forgotten. The loop is what makes the list authoritative.
+    const body = bodyOf(seqSrc, 'resetStaleWatermarksIfNeeded');
+    assert.match(body, /for \(const field of STALE_ON_COUNTER_WIPE\)/,
+      'the reset must walk the declared list');
+    for (const f of memberWatermarkFields()) {
+      assert.doesNotMatch(body, new RegExp(`member\\.${f}\\s*=`),
+        `${f} is cleared by name inside the reset — that is a second copy of the list`);
+    }
+  });
+
+  it('a vote round in flight is covered too', () => {
+    // `pendingMember` is a whole member with its own watermarks, and it was the one place the original DID
+    // remember a second site — for one field.
+    const body = bodyOf(seqSrc, 'resetStaleWatermarksIfNeeded');
+    assert.match(body, /pendingMember/,
+      'a pending member carries its own watermarks and is stale for the same reason');
+  });
+
+  it('it still only fires when the counters are actually gone', () => {
+    // The guard is what makes this safe at every startup. Without it, a normal restart would wipe every
+    // watermark and re-push the entire history to every peer on every boot.
+    const body = bodyOf(seqSrc, 'resetStaleWatermarksIfNeeded');
+    assert.match(body, /estimatedDocumentCount\(\)/, 'it must check whether the counters exist');
+    assert.match(body, /if \(count > 0\) return;/, 'and do nothing when they do');
+  });
+
+  it('and says WHICH watermarks it cleared', () => {
+    /*
+     * The original logged "reset all lastSeqReceived to 0" — which was accurate about what it did and wrong
+     * about what was needed, and an operator reading it had no way to know three other maps were untouched. A
+     * recovery that silently does part of its job is the hardest kind to notice.
+     */
+    const body = bodyOf(seqSrc, 'resetStaleWatermarksIfNeeded');
+    assert.match(body, /cleared\.join\(/, 'the warning must enumerate what it reset, not describe it in prose');
+    assert.doesNotMatch(body, /reset all lastSeqReceived/,
+      'the old message named one field as though it were the whole job');
+  });
+});


### PR DESCRIPTION
fix(sync): a wiped database left three of the four watermarks describing reused seqs

Found while instrumenting X-20, and it is a defect on its own terms whether or not it is
X-20's cause.

THE STATE THIS IS FOR IS REACHABLE, NOT THEORETICAL

`docker compose down -v` wipes the MongoDB volume while `config.json` survives on a host
bind-mount. The sequence counter lived in the volume, so it restarts at 1 — and the config
still records how far each peer got, in numbers that are about to be handed to entirely
different records.

`resetStaleWatermarksIfNeeded` was written for exactly this. It cleared ONE of the four
maps.

WHAT EACH OF THE OTHER THREE COSTS

  lastSeqReceived   we pull `sinceSeq=47` and silently miss the peer's 1..47   (was fixed)
  lastSeqPushed     we push `seq > 47` and NEVER send our own new 1..47        (was not)
  lastSeqServed     we think a peer applied deletions it has not, and prune    (was not)
  lastFileTombstoneAckedAt   the same for files: prune, and the file comes back (was not)

The second is the same defect as the one the function was written for, pointing the other
way. It is the harder one to notice: the sender's cycles complete normally, because
`seq > 47` genuinely matches nothing. A healthy idle cycle and a permanent failure to
deliver are indistinguishable from outside — which is the shape X-20 has been chasing, and
why the push loop now logs its cursor.

The third and fourth fail toward PRUNING, which `sync/served-watermark.ts` names as the
dangerous direction in as many words: keeping a tombstone too long costs a few hundred
bytes, dropping one early resurrects a deleted record. Clearing them fails toward keeping,
which is that module's own stated rule.

WHY THE FIX IS A LIST AND A LOOP

Four hand-written clears is how the fifth gets forgotten — and the original is the proof,
because the other three were not excluded for a reason, they were not thought of. One
declared list, one loop over it, and the warning enumerates which maps were actually reset
instead of naming a single field as though it were the whole job.

THE GATE ASSERTS ALL-OR-NONE, DERIVED FROM THE TYPE

A gate reading "the reset handles `lastSeqReceived`" passes on precisely the code that had
the bug. So the field list comes from `NetworkMember` itself — every `spaceId -> position`
map declared on it — and the reset must cover all of them. A fifth watermark added tomorrow
fails the test until somebody decides whether it is stale on a wipe.

Mutation tested against the pre-fix shape, which is the direction that usually goes
unchecked: restoring the one-field list, dropping the push watermark, replacing the loop
with a hand-written clear, removing the counters-exist guard, and reverting the log message
all turn it red.

The guard itself is unchanged and still the thing that makes this safe at every startup:
without `if (count > 0) return`, a normal restart would wipe every watermark and re-push
the whole history to every peer on every boot.
