### PR TITLE
fix(testing): a cleanup that swallowed its own failure cost 60 runs of a measurement

### DIFF
--- a/testing/integration/db-migration.test.js
+++ b/testing/integration/db-migration.test.js
@@ -49,9 +49,52 @@ async function adminDel(path_) {
   return del(BASE, adminToken, path_);
 }
 
-/** Ensure maintenance mode is off — used in cleanup hooks */
+/**
+ * Ensure maintenance mode is off — and PROVE it, because this is global state.
+ *
+ * ## What the swallowed version cost
+ *
+ * This was `await adminPost(...).catch(() => {})`. The catch is the defect: maintenance mode makes the instance
+ * answer **503 to everything**, so a cleanup that fails and says nothing does not lose one test — it poisons
+ * every suite that runs after it in the same job. Measured 2026-08-20 while instrumenting X-20: one failed
+ * cleanup under CPU contention, and then 60 consecutive `pubsub-topology` runs failed at `Create space on A`
+ * with `503 System is in maintenance mode`. Sixty runs of a measurement, against a stack that could not answer.
+ *
+ * A swallow is right where the cost of being wrong is a missing log line. It is wrong here, where the cost is
+ * every later suite reporting a catastrophic regression that is really a cleanup that did not run.
+ *
+ * ## So: retry, verify, and throw
+ *
+ * Retried because the failure mode observed was a request that did not get through under load, which is exactly
+ * what a retry fixes. Verified with a GET rather than trusting the POST's own status, because "I asked" and "it
+ * is off" are different claims and only the second one matters to the next suite. And it THROWS if it cannot,
+ * so the suite that broke the instance is the suite that reports it.
+ */
 async function ensureMaintenanceOff() {
-  await adminPost('/api/admin/data/maintenance', { active: false }).catch(() => {});
+  let last = '';
+  for (let attempt = 1; attempt <= 4; attempt++) {
+    try {
+      /*
+       * The STATUS is checked, not just the absence of a throw. `reqJson` resolves for every response — it
+       * returns `{status, body}` and never rejects on a 4xx/5xx — so a `try/catch` around it catches a dropped
+       * connection and nothing else. A version that only caught exceptions would treat a 503 as success, which
+       * is the same silence this function is being fixed for, one layer in.
+       */
+      const set = await adminPost('/api/admin/data/maintenance', { active: false });
+      const check = await adminGet('/api/admin/data/maintenance');
+      if (check.status === 200 && check.body?.active === false) return;
+      last = `POST ${set.status}, GET ${check.status} active=${JSON.stringify(check.body?.active)}`;
+    } catch (err) {
+      last = err instanceof Error ? err.message : String(err);
+    }
+    // The instance may be saturated rather than broken; give it a moment before asking again.
+    await new Promise(r => setTimeout(r, 250 * attempt));
+  }
+  throw new Error(
+    `Could not turn maintenance mode off after 4 attempts (${last}). Refusing to exit quietly: this instance `
+    + 'answers 503 to everything while maintenance is on, so leaving it set makes every later suite in this job '
+    + 'fail for a reason that has nothing to do with what it tests.',
+  );
 }
 
 // ── Data Config ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
fix(testing): a cleanup that swallowed its own failure cost 60 runs of a measurement

`ensureMaintenanceOff` in `db-migration.test.js` was:

    await adminPost('/api/admin/data/maintenance', { active: false }).catch(() => {});

THE MEASURED COST, WHICH IS WHY THIS IS NOT A TIDY-UP

Found while instrumenting X-20. Under CPU contention that request did not get through, the
suite exited reporting success, and the next thing that ran was 60 iterations of
`pubsub-topology` — every one of which failed at `Create space on A` with

    503 {"error":"System is in maintenance mode. Please try again later.","maintenance":true}

Sixty runs of a measurement against a stack that could not answer, and the harness reported
all sixty as findings. Maintenance mode makes the instance answer 503 to EVERYTHING, so a
failed restore does not lose one test — it poisons every suite that runs after it in the
same job, and CI runs integration before sync.

A swallow is right where the cost of being wrong is a missing log line. It is wrong where
the cost is every later suite reporting a catastrophic regression that is really a cleanup
that did not run.

WHAT IT DOES NOW

Retries — the observed failure was a request that did not get through under load, which is
what a retry is for. Verifies with a GET rather than trusting the POST, because "I asked"
and "it is off" are different claims and only the second matters to the next suite. And
THROWS, so the suite that broke the instance is the suite that reports it.

A SECOND SWALLOW ONE LAYER IN, WHICH THE FIRST DRAFT OF THIS FIX HAD

`reqJson` resolves for every response — it returns `{status, body}` and never rejects on a
4xx/5xx. So a `try/catch` around it catches a dropped connection and nothing else, and my
first version would have treated a 503 as a successful restore: the same silence, moved
inside the fix. The status is checked explicitly.

THE OTHER SEVEN, AND WHY THEY ARE A SEPARATE ROW

Swept rather than assumed. `testing/` holds 338 swallowed cleanups and the overwhelming
majority are "delete the record I just made", where swallowing is correct and converting
them would be noise. Seven restore INSTANCE-WIDE config and swallow it: six in
`media-config.test.js`, one restoring the whole backup config in `db-backup-offsite.test.js`.

They are the same shape with a much smaller blast radius — a leftover media-config value
affects only the tests that read it, where maintenance mode affects everything. Filed as
X-26 with the plan: one `restoreOrFail(label, apply, verify)` helper, then a ratchet
refusing a swallowed `.catch(() => {})` on an `/api/admin/` write with those seven
grandfathered in a list that only shrinks. The ratchet is what stops an eighth, and the
eighth is how this one was found.

No CHANGELOG entry: `testing/` only, no product behaviour change.
