### PR TITLE
chore(sync): the receiving half now says what it did with each batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -361,6 +361,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **A sync batch-upsert now says what it did with each collection, at debug level.** The receiving half. `200` on a
+  batch means it was ACCEPTED, not that a record was stored, and this handler has four ways to accept one and keep
+  nothing: an existing tombstone at or above the record's seq, an already-current record, a fork chain at its cap,
+  and the same per collection. Every one was already counted and none was logged, so the decision was computed and
+  thrown away with the response. Now logged with the seq range, because a count cannot say which record it refers to
+  and the question is always about one id at one seq. Reproduced under CPU contention on 2026-08-20 — the sender
+  pushes a memory at seq 2, gets a `200`, advances its watermark, and the peer never serves that id, so the record
+  is marked sent and is never offered again. The sender's half was already answered by the push logging below: it is
+  not stalling.
 - **A sync push cycle now says what it looked for and what it decided, at debug level.** Two lines: per collection,
   the cursor it queried from and how many documents it found — empty passes included; and per cycle, the watermark
   before and after beside the counts pushed. Both are `log.debug`, so they cost nothing unless `DEBUG` is set.

--- a/server/src/api/sync/docs.ts
+++ b/server/src/api/sync/docs.ts
@@ -686,6 +686,31 @@ syncDocsRouter.post('/batch-upsert', syncRateLimit, requireAuth, denyReadOnly, a
       }
     }
 
+    /*
+     * X-20 instrumentation, the RECEIVER half — and it is the half that matters now.
+     *
+     * The sender's side is answered: with `DEBUG` on, its log shows it pushing the record and advancing its
+     * watermark, so it is not stalling. Reproduced under CPU contention 2026-08-20 (2 runs in 10): A pushes the
+     * memory at seq 2, gets a 200, moves its watermark to 2 — and B never serves that id, so the record is
+     * marked sent and will never be offered again.
+     *
+     * **A 200 says the batch was accepted, not that a record was stored**, and this handler has four ways to
+     * accept one and keep nothing: an existing tombstone at or above its seq (`tombstoned`), an already-current
+     * record (`skipped`), a fork chain at its cap (`forkDepthRefused`), and the same for the other three
+     * collections. Every one of those is COUNTED here and none of them was logged, so the decision existed and
+     * was thrown away with the response.
+     *
+     * The seq range is included because the counters alone cannot say WHICH records a number refers to, and the
+     * question is always about one specific id at one specific seq.
+     */
+    const range = (docs: { seq?: number }[]): string =>
+      docs.length === 0 ? '-' : `${Math.min(...docs.map(d => d.seq ?? 0))}..${Math.max(...docs.map(d => d.seq ?? 0))}`;
+    log.debug(`Batch-upsert accepted for space '${spaceId}': `
+      + `memories ${JSON.stringify(memStats)} seq ${range(memories)}; `
+      + `entities ${JSON.stringify(entStats)} seq ${range(entities)}; `
+      + `edges ${JSON.stringify(edgeStats)} seq ${range(edges)}; `
+      + `chrono ${JSON.stringify(chronoStats)} seq ${range(chrono)}`);
+
     res.status(200).json({ status: 'ok', memories: memStats, entities: entStats, edges: edgeStats, chrono: chronoStats });
 
     // Bump the local seq counter so future local writes always get a seq higher


### PR DESCRIPTION
chore(sync): the receiving half now says what it did with each batch

The other side of #997, and the side the question has moved to.

X-20 IS REPRODUCED, RELIABLY, FOR THE FIRST TIME

Nine containers pinned to four SHARED CPUs with no per-container cap — contention, not
throttling. 7 failures in 26 runs, every one the full 25 s timeout rather than a slow pass.

That distinction is the whole reason six earlier attempts found nothing, and it is a
mechanism difference rather than a dose: `--cpus 0.4` per container LIMITS throughput while
GUARANTEEING that share, and on a 16-CPU host nine containers asking for 0.4 never compete.
112 runs that way produced nothing. A runner gives nine containers four vCPU and no cap, so
one busy mongod starves its neighbour in bursts.

WHAT THE SENDER'S LOG ALREADY ANSWERED

    Push memories to Instance B space '…915728': 1 doc(s) with seq > 1 (through 2)
    Push cycle   to Instance B space '…915728': watermark 1 -> 2, pushed 1m/0e/0g/0c
    Push memories to Instance B space '…915728': 0 doc(s) with seq > 2      <- forever after

A pushed the record, got a 200, advanced its watermark, and then correctly found nothing
more. **The sender is not stalling** — which was the open question and is now closed. The
test's own diagnostic agrees: *the SENDER HOLDS c452e1c3 at seq 2; pushed=2 — a watermark is
at or past that seq, so it was marked sent and never will be again.*

So the record was accepted by B and is not retrievable from B.

WHY THE RECEIVER NEEDED THE SAME TREATMENT

**A 200 says the batch was accepted, not that a record was stored.** `batch-upsert` has four
ways to accept one and keep nothing:

  tombstoned          an existing tombstone at or above the record's seq — silently dropped
  skipped             already current
  forkDepthRefused    fork chain at its cap
  …and the same three per collection

Every one of those was already COUNTED and none was logged. The decision existed and went
out with the response. Now it is one debug line per batch with all four counters and the seq
range — the range because a count cannot say which record it refers to, and the question is
always about one id at one seq.

`log.debug`, so it is free unless `DEBUG` is set, which it is for test instances A and B.

WHAT THIS IS NOT

Not a fix. I do not yet know which of the four paths fires, and guessing would be the thing
this instrumentation exists to replace. The next run reads it.

One observation worth recording ahead of that: the failures CLUSTER — runs 3-4, 14-15,
24-25-26 — so once it starts it persists for a run or two and then recovers. That is the
shape of leftover state between runs rather than an independent per-run dice roll.
