### PR TITLE
fix(testing): the other seven admin-state cleanups now prove their restore took

### DIFF
--- a/testing/integration/db-backup-offsite.test.js
+++ b/testing/integration/db-backup-offsite.test.js
@@ -17,7 +17,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'url';
-import { INSTANCES, reqJson, post, put } from '../sync/helpers.js';
+import { INSTANCES, reqJson, post, put, get, restoreOrFail } from '../sync/helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TOKEN_FILE_A = path.join(__dirname, '..', 'sync', 'configs', 'a', 'token.txt');
@@ -189,9 +189,22 @@ describe('PUT /api/admin/data/backup-config', () => {
   };
 
   after(async () => {
-    // Best-effort restore — if the PUT fails here the test stack will be
-    // re-built before the next run anyway.
-    await put(BASE_A, tokenA, '/api/admin/data/backup-config', ORIGINAL_CONFIG).catch(() => {});
+    /*
+     * NOT best-effort. The old comment read "if the PUT fails here the test stack will be re-built before the
+     * next run anyway" — and that is not true within a single CI job, where every suite runs against the same
+     * stack. A backup config left pointing somewhere else is inherited by whatever runs next.
+     *
+     * The verify re-reads the schedule, which is the field this suite changes.
+     */
+    await restoreOrFail('backup-config',
+      () => put(BASE_A, tokenA, '/api/admin/data/backup-config', ORIGINAL_CONFIG),
+      async () => {
+        // `{config: {...}}`, not the config at the top level — every assertion in this file reads
+        // `r.body.config.schedule`, and a verify against the wrong shape would never pass and would throw on
+        // every run. Checked against the tests above rather than assumed.
+        const now = await get(BASE_A, tokenA, '/api/admin/data/backup-config');
+        return now.status === 200 && now.body?.config?.schedule === ORIGINAL_CONFIG?.schedule;
+      });
   });
 
   it('returns 403 FEATURE_DISABLED on instance B (flag absent)', async () => {

--- a/testing/integration/media-config.test.js
+++ b/testing/integration/media-config.test.js
@@ -18,7 +18,7 @@ import assert from 'node:assert/strict';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { INSTANCES, get, patch, post } from '../sync/helpers.js';
+import { INSTANCES, get, patch, post, restoreOrFail } from '../sync/helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONFIGS = path.join(__dirname, '..', 'sync', 'configs');
@@ -56,8 +56,9 @@ describe('Media config hot-reload (A6)', () => {
   after(async () => {
     // Restore whatever the model was so we don't leak state into other suites.
     if (originalModel) {
-      await patch(INSTANCES.a, tokenA, '/api/admin/media-config',
-        { vision: { model: originalModel } }).catch(() => {});
+      await restoreOrFail('vision.model',
+        () => patch(INSTANCES.a, tokenA, '/api/admin/media-config', { vision: { model: originalModel } }),
+        async () => (await get(INSTANCES.a, tokenA, '/api/admin/media-config')).body?.vision?.model === originalModel);
     }
   });
 
@@ -97,8 +98,10 @@ describe('Media config — documentProcessing (F11)', () => {
   });
   after(async () => {
     // Restore to OCR so the (inert in this PR) mode doesn't leak into other suites.
-    await patch(INSTANCES.a, tokenA, '/api/admin/media-config',
-      { documentProcessing: originalDp ?? { mode: 'ocr' } }).catch(() => {});
+    const want = originalDp ?? { mode: 'ocr' };
+    await restoreOrFail('documentProcessing',
+      () => patch(INSTANCES.a, tokenA, '/api/admin/media-config', { documentProcessing: want }),
+      async () => (await get(INSTANCES.a, tokenA, '/api/admin/media-config')).body?.documentProcessing?.mode === want.mode);
   });
 
   it('accepts and round-trips a documentProcessing.mode change', async () => {
@@ -150,7 +153,12 @@ describe('Media config — text embedding', () => {
   before(async () => { tokenA = fs.readFileSync(path.join(CONFIGS, 'a', 'token.txt'), 'utf8').trim(); });
   after(async () => {
     // Restore to the bundled local model so no external/broken endpoint leaks into other suites.
-    await patch(INSTANCES.a, tokenA, '/api/admin/media-config', { embedding: { provider: 'local', baseUrl: null } }).catch(() => {});
+    await restoreOrFail('embedding.provider/baseUrl',
+      () => patch(INSTANCES.a, tokenA, '/api/admin/media-config', { embedding: { provider: 'local', baseUrl: null } }),
+      async () => {
+        const emb = (await get(INSTANCES.a, tokenA, '/api/admin/media-config')).body?.embedding;
+        return emb?.provider === 'local' && !emb?.baseUrl;
+      });
   });
 
   it('GET surfaces the embedding block', async () => {
@@ -178,7 +186,10 @@ describe('Media config — text embedding', () => {
     const reread = await get(INSTANCES.a, tokenA, '/api/admin/media-config');
     const key = reread.body?.embedding?.apiKey;
     assert.ok(!key || !key.includes('sk-emb-secret'), `key must be masked, got: ${key}`);
-    await patch(INSTANCES.a, tokenA, '/api/admin/media-config', { embedding: { provider: 'local', apiKey: null } }).catch(() => {});
+    // A cleared key comes back `undefined` and a set one as a bullet string, so falsiness IS the check.
+    await restoreOrFail('embedding.apiKey (cleared)',
+      () => patch(INSTANCES.a, tokenA, '/api/admin/media-config', { embedding: { provider: 'local', apiKey: null } }),
+      async () => !(await get(INSTANCES.a, tokenA, '/api/admin/media-config')).body?.embedding?.apiKey);
   });
 });
 
@@ -190,11 +201,15 @@ describe('Media config — external assist model (F11-b)', () => {
   });
   after(async () => {
     // Lower the rung so no external routing leaks into other suites. (`uses` is retired — the extraction
-    // rung IS the switch now, so dropping below `repair` is what disables the egress path. Note we do not
-    // try to blank `baseUrl`: the schema requires a valid URL, so an empty string would 400 and the
-    // `.catch()` would swallow it, leaving the cleanup silently undone.)
-    await patch(INSTANCES.a, tokenA, '/api/admin/media-config',
-      { documentProcessing: { mode: 'ocr' } }).catch(() => {});
+    // rung IS the switch now, so dropping below `repair` is what disables the egress path. We do not try to
+    // blank `baseUrl`: the schema requires a valid URL, so an empty string would 400.)
+    //
+    // This is the site whose own comment named the defect — "the `.catch()` would swallow it, leaving the
+    // cleanup silently undone" — and worked around it by not attempting the harder restore. It no longer
+    // swallows, so the workaround is a choice about what to restore rather than a hedge against silence.
+    await restoreOrFail('documentProcessing.mode (egress rung)',
+      () => patch(INSTANCES.a, tokenA, '/api/admin/media-config', { documentProcessing: { mode: 'ocr' } }),
+      async () => (await get(INSTANCES.a, tokenA, '/api/admin/media-config')).body?.documentProcessing?.mode === 'ocr');
   });
 
   it('making an endpoint REACHABLE without acknowledgment is rejected (egress gate)', async () => {
@@ -241,7 +256,10 @@ describe('Media config — external assist model (F11-b)', () => {
     const key = reread.body?.documentProcessing?.assistModel?.apiKey;
     assert.ok(key && !key.includes('sk-secret-xyz'), `key must be masked, got: ${key}`);
     // Clear the stored key.
-    await patch(INSTANCES.a, tokenA, '/api/admin/media-config',
-      { documentProcessing: { assistModel: { apiKey: null } } }).catch(() => {});
+    await restoreOrFail('documentProcessing.assistModel.apiKey (cleared)',
+      () => patch(INSTANCES.a, tokenA, '/api/admin/media-config',
+        { documentProcessing: { assistModel: { apiKey: null } } }),
+      async () => !(await get(INSTANCES.a, tokenA, '/api/admin/media-config'))
+        .body?.documentProcessing?.assistModel?.apiKey);
   });
 });

--- a/testing/integration/vlm-extraction.test.js
+++ b/testing/integration/vlm-extraction.test.js
@@ -11,7 +11,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'url';
-import { INSTANCES, get, patch } from '../sync/helpers.js';
+import { INSTANCES, get, patch, restoreOrFail } from '../sync/helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TOKEN_FILE_A = path.join(__dirname, '..', 'sync', 'configs', 'a', 'token.txt');
@@ -36,8 +36,13 @@ describe('VLM extraction mode wiring (F11)', () => {
   });
   after(async () => {
     // Restore OCR mode so this doesn't leak into other suites.
-    await patch(INSTANCES.a, tokenA, '/api/admin/media-config',
-      { documentProcessing: originalDp ?? { mode: 'ocr' } }).catch(() => {});
+    //
+    // Found by the ratchet and not by a grep: the path and the `.catch` are on different LINES here, so a
+    // line-based sweep for the shape missed it while a statement-bounded one did not.
+    const want = originalDp ?? { mode: 'ocr' };
+    await restoreOrFail('documentProcessing (vlm-extraction)',
+      () => patch(INSTANCES.a, tokenA, '/api/admin/media-config', { documentProcessing: want }),
+      async () => (await get(INSTANCES.a, tokenA, '/api/admin/media-config')).body?.documentProcessing?.mode === want.mode);
   });
 
   it('a PDF uploaded under mode:vlm is still accepted (202) and degrades to the async path', async () => {

--- a/testing/standalone/admin-state-cleanups-must-verify.test.js
+++ b/testing/standalone/admin-state-cleanups-must-verify.test.js
@@ -1,0 +1,222 @@
+/**
+ * A cleanup that restores INSTANCE-WIDE state may not swallow its own failure.
+ *
+ * ## The measured cost
+ *
+ * `ensureMaintenanceOff` in `db-migration.test.js` was `await adminPost(...).catch(() => {})`. Under CPU
+ * contention that request did not get through, the suite exited reporting success, and the 60
+ * `pubsub-topology` runs that followed all died at `Create space on A` with
+ * `503 System is in maintenance mode`. Sixty runs of a measurement against a stack that could not answer.
+ *
+ * A suite does not get its own instance. Every suite in a CI job runs against the same stack, so a restore that
+ * silently does not happen is not a lost test — it is a later suite failing for a reason that has nothing to do
+ * with what it tests, and looking like a catastrophic regression while it does.
+ *
+ * ## What is banned, and what is deliberately NOT
+ *
+ * `testing/` holds well over three hundred swallowed cleanups and the overwhelming majority are *delete the
+ * record I just made*. Swallowing is CORRECT there: a leftover record costs nothing and the next run uses fresh
+ * ids. Converting them would be noise, and noise in a gate is how a gate stops being read.
+ *
+ * What this refuses is a swallowed write to an `/api/admin/` path — instance-wide configuration — where the
+ * blast radius is the whole job. `restoreOrFail` in `testing/sync/helpers.js` is the replacement: it applies,
+ * re-reads, retries, and throws with a label naming what could not be restored.
+ *
+ * ## Why a ratchet rather than an absolute
+ *
+ * Because it is one now, and the eighth is how the first was found. If a future admin cleanup genuinely must
+ * tolerate failure, it goes in the list with the reason beside it — which is a decision somebody made rather
+ * than a `.catch(() => {})` nobody noticed.
+ *
+ * Run: node --test testing/standalone/admin-state-cleanups-must-verify.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { statementAround } from './_structural-window.mjs';
+import { stripComments } from './_strip-comments.mjs';
+import { restoreOrFail } from '../sync/helpers.js';
+
+/**
+ * Files still allowed a swallowed `/api/admin/` write in a cleanup, with how many. **May only shrink.**
+ *
+ * EMPTY. All seven are converted — six in `media-config.test.js` (vision model, documentProcessing twice,
+ * embedding provider/baseUrl, embedding apiKey, assist apiKey) and the backup config in
+ * `db-backup-offsite.test.js`, whose own comment had argued it was safe because "the test stack will be re-built
+ * before the next run anyway" — true between runs and false within one job, which is where it matters.
+ */
+const GRANDFATHERED = new Map([
+  /*
+   * `config-loader.test.js` — `POST /api/admin/reload-config`, and this one is CORRECT as written.
+   *
+   * The cleanup writes the original config to disk unconditionally FIRST, then asks the instance to reload it.
+   * The reload is best-effort on purpose, and the comment beside it says why: the suite deliberately tests
+   * configs with the tokens array stripped, so the reload can legitimately answer 401 with auth broken by what
+   * the test just did. Throwing there would fail a suite for a state it created on purpose — and the durable
+   * half of the restore, the file on disk, has already happened and survives to the next container start.
+   *
+   * Kept as a row rather than excluded by a pattern, because "a reload is exempt" as a RULE would also exempt
+   * the next one that is not.
+   */
+  ['testing/standalone/config-loader.test.js', 1],
+]);
+
+/** Every tracked test file, so a new one cannot arrive unscanned. */
+function testFiles() {
+  return execFileSync('git', ['ls-files', 'testing'], { encoding: 'utf8' })
+    .split('\n')
+    .map(f => f.trim())
+    .filter(f => /\.(test|spec)\.(js|mjs|ts)$/.test(f));
+}
+
+/**
+ * Swallowed calls whose STATEMENT touches an `/api/admin/` path.
+ *
+ * Bounded by the statement rather than by a character window, so a call spread over four lines — which is what
+ * these look like after a prettier pass — is still seen whole. The path and the `.catch` are frequently on
+ * different lines, and that is exactly the case a proximity window gets wrong.
+ */
+function swallowedAdminWrites(raw) {
+  /*
+   * COMMENTS STRIPPED FIRST. This suite documents its own lessons by quoting the banned shape, and the
+   * `db-migration.test.js` fix quotes `adminPost(...).catch(() => {})` in the doc comment explaining why it was
+   * wrong. Scanning raw source reported that explanation as the defect.
+   */
+  const src = stripComments(raw);
+  const out = [];
+  for (const m of src.matchAll(/\.catch\(\(\)\s*=>\s*\{\s*\}\)/g)) {
+    /*
+     * An anchor inside a STRING is not code and cannot be a swallowed call.
+     *
+     * `statementAround` refuses an unreachable index rather than guessing, which is right for a gate pointed at
+     * one subject and wrong for a sweep over a whole tree: `red-team-tests/file-hardening.test.js` contains the
+     * shape inside a string literal, and one such literal aborted the entire scan. Skipping is safe here for a
+     * reason worth stating — the strings this can match are test fixtures and assertion text, never a call.
+     */
+    let stmt;
+    try {
+      stmt = statementAround(src, m.index, 'a swallowed call');
+    } catch {
+      continue;
+    }
+    if (!/['"`]\/api\/admin\//.test(stmt)) continue;
+    /*
+     * A MUTATION OF A CONFIGURATION VALUE — and `del` is deliberately not one of them.
+     *
+     * `DELETE /api/admin/webhooks/{id}` is a RECORD delete that happens to sit under an admin path: the test
+     * created a webhook and is removing it, so a leftover costs nothing and the next run makes its own. The
+     * blast radius this gate is about comes from a VALUE left changed — a model, a mode, a schedule, a flag —
+     * which only a patch/put/post can do. Including `del` made the gate report two correct cleanups, and a gate
+     * that reports correct code is a gate people learn to override.
+     *
+     * A read is excluded for the same reason: a failed read gives the caller undefined and the assertion says so.
+     */
+    if (!/\b(patch|put|post|adminPost|adminPut|adminPatch)\s*\(/.test(stmt)) continue;
+    out.push(stmt.replace(/\s+/g, ' ').slice(0, 120));
+  }
+  return out;
+}
+
+describe('the scan works before anything is concluded from it', () => {
+  it('walks a real tree', () => {
+    const files = testFiles();
+    assert.ok(files.length >= 80, `only enumerated ${files.length} test files — the walk is broken`);
+  });
+
+  it('recognises the shape it is about, and leaves a READ alone', () => {
+    // Proven against literals, so a pattern that silently stopped matching cannot pass as "none left".
+    const bad = "await patch(A, tok, '/api/admin/media-config', { vision: {} }).catch(() => {});";
+    assert.equal(swallowedAdminWrites(bad).length, 1, 'the banned shape is no longer recognised');
+
+    for (const ok of [
+      // A record delete: swallowing is right, and there are hundreds of these.
+      "await del(A, tok, `/api/brain/spaces/general/memories/${id}`).catch(() => {});",
+      // An admin READ: a failure gives undefined and the assertion says so.
+      "const r = await get(A, tok, '/api/admin/media-config').catch(() => {});",
+      // The replacement.
+      "await restoreOrFail('vision.model', () => patch(A, tok, '/api/admin/media-config', {}), verify);",
+    ]) {
+      assert.deepEqual(swallowedAdminWrites(ok), [], `false positive on: ${ok}`);
+    }
+  });
+});
+
+describe('no swallowed admin-state cleanup', () => {
+  it('every file carrying one is grandfathered, and none has more than its entry', () => {
+    const problems = [];
+    for (const file of testFiles()) {
+      const key = file.replaceAll('\\', '/');
+      // This file quotes the banned shape as a fixture; scanning it would force that proof to be deleted.
+      if (key.endsWith('admin-state-cleanups-must-verify.test.js')) continue;
+      const found = swallowedAdminWrites(readFileSync(file, 'utf8'));
+      const allowed = GRANDFATHERED.get(key) ?? 0;
+      if (found.length > allowed) {
+        problems.push(`${key}: ${found.length} swallowed admin write(s), allowed ${allowed}\n    ${found.join('\n    ')}`);
+      }
+    }
+    assert.deepEqual(problems, [],
+      'a cleanup writes instance-wide configuration and discards its own failure. Every suite in a CI job shares\n'
+      + 'one stack, so a restore that silently does not happen makes a LATER suite fail for a reason unrelated to\n'
+      + 'what it tests. Use `restoreOrFail(label, apply, verify)` from `testing/sync/helpers.js` — it applies,\n'
+      + 're-reads, retries and throws naming what it could not restore.\n'
+      + problems.join('\n'));
+  });
+
+  it('the list only shrinks', () => {
+    const stale = [];
+    for (const [file, allowed] of GRANDFATHERED) {
+      const actual = swallowedAdminWrites(readFileSync(file, 'utf8')).length;
+      if (actual < allowed) stale.push(`${file}: allowed ${allowed}, now has ${actual} — lower or remove it`);
+    }
+    assert.deepEqual(stale, [], 'the grandfathered list is above reality:\n' + stale.join('\n'));
+  });
+});
+
+describe('the replacement is EXERCISED, not read', () => {
+  /*
+   * Behaviour, not source text. The first version of this asserted that the string `throw new Error(...Could not
+   * restore...` was present — and mutation testing put `if (false)` in front of that throw, which left the text
+   * exactly where it was and the gate green. A source-reading assertion about control flow cannot see a guard;
+   * a call can.
+   */
+
+  it('REJECTS when the value does not come back, naming what it was', async () => {
+    let applied = 0;
+    await assert.rejects(
+      () => restoreOrFail('the thing', async () => { applied++; }, async () => false, { attempts: 2, delayMs: 1 }),
+      /Could not restore the thing/,
+      'a restore that never takes must fail the suite that broke it',
+    );
+    assert.equal(applied, 2, 'it must have tried every attempt before giving up');
+  });
+
+  it('RESOLVES as soon as the verify passes, and stops trying', async () => {
+    let applied = 0;
+    await restoreOrFail('the thing', async () => { applied++; }, async () => applied >= 2,
+      { attempts: 5, delayMs: 1 });
+    assert.equal(applied, 2, 'it must stop at the first successful verify, not run every attempt');
+  });
+
+  it('a THROWING apply is retried rather than escaping', async () => {
+    // The observed failure was a request that did not get through, which is what a retry is for.
+    let applied = 0;
+    await restoreOrFail('the thing',
+      async () => { applied++; if (applied < 3) throw new Error('connection reset'); },
+      async () => applied >= 3, { attempts: 5, delayMs: 1 });
+    assert.equal(applied, 3);
+  });
+
+  it('a 200 that changed nothing is a FAILURE, which is the whole point', async () => {
+    /*
+     * `reqJson` resolves for every response — it returns `{status, body}` and never rejects on a 4xx/5xx — so
+     * "the apply did not throw" is not "the value is back". The first draft of the maintenance fix relied on a
+     * try/catch alone and would have read a 503 as a successful restore: the same silence, one layer in.
+     */
+    await assert.rejects(
+      () => restoreOrFail('a value the server ignored', async () => { /* answered 200 */ }, async () => false,
+        { attempts: 1, delayMs: 1 }),
+      /Could not restore a value the server ignored/,
+    );
+  });
+});

--- a/testing/sync/helpers.js
+++ b/testing/sync/helpers.js
@@ -404,3 +404,51 @@ export async function listMemories(baseUrl, token) {
   }
   return { status: 200, body: { memories: all } };
 }
+
+/**
+ * Restore instance-wide state in a cleanup hook, and PROVE it took.
+ *
+ * ## The failure this exists to stop
+ *
+ * A cleanup written `await patch(...).catch(() => {})` reports success whatever happens. For a cleanup that
+ * deletes a record it created, that is right: a leftover record costs nothing and the next run uses fresh ids.
+ * For a cleanup that restores INSTANCE-WIDE state it is wrong, because the cost is not this test — it is every
+ * suite that runs after it in the same job, failing for a reason that has nothing to do with what it tests.
+ *
+ * Measured 2026-08-20 (X-26): `ensureMaintenanceOff` swallowed its own failure under CPU contention, and the 60
+ * `pubsub-topology` runs that followed all died at `Create space on A` with `503 System is in maintenance mode`.
+ * Sixty runs of a measurement against a stack that could not answer.
+ *
+ * ## Why VERIFY and not just check the status
+ *
+ * "I asked" and "it is set" are different claims, and only the second one matters to the next suite. A `200` on
+ * the write can still leave the value unchanged — a field the server ignores, a pin that refuses silently, a
+ * merge that dropped the key. So the caller supplies a predicate over the re-read value.
+ *
+ * Note that `reqJson` RESOLVES for every response: it returns `{status, body}` and never rejects on a 4xx/5xx.
+ * So a `try/catch` alone catches a dropped connection and nothing else, which is why the verify step is the
+ * thing that decides rather than the absence of a throw.
+ *
+ * @param label   what is being restored, quoted in the failure — the next reader needs to know WHICH cleanup
+ * @param apply   performs the restore; its return value is ignored
+ * @param verify  re-reads and returns true when the value is actually back
+ */
+export async function restoreOrFail(label, apply, verify, { attempts = 4, delayMs = 250 } = {}) {
+  let last = 'never ran';
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      await apply();
+      if (await verify()) return;
+      last = `verify still false after attempt ${attempt}`;
+    } catch (err) {
+      last = err instanceof Error ? err.message : String(err);
+    }
+    // Saturated rather than broken is the observed failure, and a wait is what fixes that.
+    await new Promise(r => setTimeout(r, delayMs * attempt));
+  }
+  throw new Error(
+    `Could not restore ${label} after ${attempts} attempts (${last}). Refusing to exit quietly: this is `
+    + 'instance-wide state, so leaving it changed makes later suites in this job fail for a reason that has '
+    + 'nothing to do with what they test.',
+  );
+}


### PR DESCRIPTION
fix(testing): the other seven admin-state cleanups now prove their restore took

X-26, closing the population the maintenance-mode fix (#999) came out of.

WHAT WAS WRONG WITH ALL EIGHT

A cleanup written `await patch('/api/admin/...', …).catch(() => {})` reports success
whatever happens. A suite does not get its own instance — every suite in a CI job runs
against the same stack — so a restore that silently does not happen is not a lost test. It
is a LATER suite failing for a reason unrelated to what it tests, and looking like a
catastrophic regression while it does.

The eighth cost sixty runs of a measurement against a stack answering 503 to everything.

ONE SHARED HELPER, BECAUSE THE RULE IS ONE RULE

`restoreOrFail(label, apply, verify)` in `testing/sync/helpers.js`: apply, re-read, retry,
and throw naming what could not be restored. Seven call sites — six in `media-config`
(vision model, documentProcessing twice, embedding provider/baseUrl, embedding apiKey,
assist apiKey) and the backup config in `db-backup-offsite`.

VERIFY, not "the write did not throw". `reqJson` resolves for every response — it returns
`{status, body}` and never rejects on a 4xx/5xx — so a try/catch alone catches a dropped
connection and nothing else. A 200 can also leave a value unchanged: a field the server
ignores, a pin that refuses, a merge that dropped the key. So each site supplies a predicate
over the RE-READ value.

TWO SITES ARGUED THEY WERE SAFE, AND BOTH ARGUMENTS WERE WRONG

`db-backup-offsite` said *"if the PUT fails here the test stack will be re-built before the
next run anyway"* — true between runs, false within one job, which is where it matters.

`media-config`'s egress-rung cleanup had already NAMED this defect: *"the `.catch()` would
swallow it, leaving the cleanup silently undone"* — and worked around it by not attempting
the harder restore. Somebody saw it and hedged rather than fixing it.

THE RATCHET FOUND FOUR MORE THAN MY GREP DID

`admin-state-cleanups-must-verify.test.js` bounds each candidate by its STATEMENT rather
than by a line, and that difference found `vlm-extraction.test.js` — where the path and the
`.catch` sit on different lines, so a line-based sweep missed it. Exactly the argument the
structural-window work has been making all session.

It also reported three that were CORRECT, and narrowing those is the more interesting half:

  webhooks (x2)     `DELETE /api/admin/webhooks/{id}` is a RECORD delete under an admin
                    path. A leftover costs nothing. `del` is now excluded — the blast radius
                    comes from a VALUE left changed, which only a patch/put/post can do.
  db-migration      the match was inside my own doc COMMENT quoting the banned shape.
                    Comments stripped first, as every source-reading gate here must.
  config-loader     `POST /api/admin/reload-config`, and it is right as written: the config
                    is written to disk unconditionally FIRST, and the reload is best-effort
                    because the suite deliberately tests configs with the tokens stripped,
                    so a 401 is a state it created on purpose. Grandfathered with the
                    reason, because "a reload is exempt" as a RULE would exempt the next one
                    that is not.

A gate that reports correct code is a gate people learn to override, so those three mattered
as much as the one real find.

THE GATE'S OWN FIRST VERSION HAD THE DEFECT IT GATES

It asserted that the string `throw new Error(...Could not restore...)` was PRESENT. Mutation
testing put `if (false)` in front of that throw: the text stayed exactly where it was and the
gate stayed green. A source read cannot see control flow. `restoreOrFail` is now EXERCISED —
four calls asserting it rejects when the verify never passes, stops at the first success,
retries a throwing apply, and treats a 200-that-changed-nothing as failure.

Five mutants, all killed. One of them took three attempts to aim: `helpers.js` has four
`throw new Error(` and the first is `waitFor`'s, so replacing the first occurrence guarded
the wrong function and read as a surviving mutant.

No CHANGELOG entry: `testing/` only, no product behaviour change.
