### PR TITLE
chore(testing): nine more capped gaps converted, and a fourth hand-rolled bodyOf removed

### DIFF
--- a/testing/standalone/brain-if-match.test.js
+++ b/testing/standalone/brain-if-match.test.js
@@ -29,6 +29,7 @@ import { describe, it, before } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { balancedFrom, blockAfter } from './_structural-window.mjs';
 
 const ROOT = process.cwd();
 const src = (p) => readFileSync(join(ROOT, p), 'utf8');
@@ -189,7 +190,11 @@ describe('all four record types, or none', () => {
   it('every PATCH route hands the seq to its update function', () => {
     for (const r of RECORDS) {
       const code = withoutComments(src(r.route));
-      assert.match(code, new RegExp(`${r.update}\\([\\s\\S]{0,400}?ifMatch\\.seq`),
+      // The update CALL, bounded by the paren that closes it — the seq is one of its arguments, so the
+      // argument list is the subject and 400 characters was a guess at how long one gets.
+      const at = code.indexOf(`${r.update}(`);
+      assert.ok(at > -1, `${r.name}: ${r.update} is not called at all — re-anchor this gate`);
+      assert.match(balancedFrom(code, at, `${r.update} call`), /ifMatch\.seq/,
         `${r.name}: the parsed precondition never reaches ${r.update}, so it is parsed and then dropped`);
     }
   });
@@ -197,7 +202,10 @@ describe('all four record types, or none', () => {
   it('every PATCH route answers 412, and only when a precondition was given', () => {
     for (const r of RECORDS) {
       const code = withoutComments(src(r.route));
-      assert.match(code, /if \(ifMatch\.seq !== undefined[\s\S]{0,120}?res\.status\(412\)/,
+      // The branch, bounded by the brace that closes it.
+      const at = code.indexOf('if (ifMatch.seq !== undefined');
+      assert.ok(at > -1, `${r.name}: the precondition branch is gone — re-anchor this gate`);
+      assert.match(blockAfter(code, at, 'the 412 branch'), /res\.status\(412\)/,
         `${r.name}: a refused write does not produce a 412`);
     }
   });

--- a/testing/standalone/gates-bound-their-subject-structurally.test.js
+++ b/testing/standalone/gates-bound-their-subject-structurally.test.js
@@ -163,9 +163,18 @@ const GRANDFATHERED = new Map([
 /**
  * A CAPPED GAP inside a regex: `/marker[\s\S]{0,400}?other/`. Files still allowed to carry one, with how many.
  *
- * **66 occurrences across 36 files, and the tracker recorded 30.** Measured here rather than trusted, and the number
- * is in the gate so nobody has to re-measure it — a population counted once in a markdown file is a population that
- * drifts.
+ * **57 occurrences across 31 files**, down from 66/36 when this was first measured — and the tracker had recorded
+ * 30, which is why the number lives in the gate now rather than in a markdown file that drifts.
+ *
+ * The nine that left were the ones whose subject is a NAMED FUNCTION or a BRANCH, where the structural bound is
+ * unambiguous: an update call's arguments, a 412 branch, a catch block, an abandon branch, `spaceStillExists`,
+ * `selectSpace` (a 2 000-character cap — nobody chooses that number, they raise it until the test passes),
+ * `chronoAllowedTypes`, `getAllowedChronoTypes`, and a try/finally.
+ *
+ * **What remains is the fails-LOUDLY class, and that is why it is a frozen list rather than a blocker.** Every one
+ * of the six negative-polarity sites — where a short window makes an absence hold and the gate pass — was converted
+ * first. For a POSITIVE assertion a cap that falls short breaks the match and turns the gate red on correct code:
+ * a nuisance that announces itself, not a hole.
  *
  * ## Why this is a THIRD list rather than a ban
  *
@@ -190,7 +199,6 @@ const GRANDFATHERED = new Map([
 const GRANDFATHERED_GAP = new Map([
   ['testing/red-team-tests/ssrf-ipv6.test.js', 1],
   ['testing/standalone/backups-are-not-world-readable.test.js', 1],
-  ['testing/standalone/brain-if-match.test.js', 2],
   ['testing/standalone/brain-read-bodies-are-strict.test.js', 2],
   ['testing/standalone/caller-supplied-ids-are-uuids.test.js', 1],
   ['testing/standalone/chrono-retention.test.js', 1],
@@ -204,23 +212,19 @@ const GRANDFATHERED_GAP = new Map([
   ['testing/standalone/mcp-tool-rights.test.js', 2],
   ['testing/standalone/merge-relinks-every-entity-reference.test.js', 2],
   ['testing/standalone/meta-precondition.test.js', 1],
-  ['testing/standalone/model-verify.test.js', 1],
   ['testing/standalone/no-boot-migration-on-synced-data.test.js', 1],
   ['testing/standalone/no-copyleft-in-the-shipped-tree.test.js', 2],
-  ['testing/standalone/no-polling-a-deleted-space.test.js', 2],
   ['testing/standalone/notice-coverage.test.js', 1],
   ['testing/standalone/oidc-carries-a-rights-matrix.test.js', 1],
-  ['testing/standalone/overview-pending-is-cleared.test.js', 1],
   ['testing/standalone/recall-params-reach-the-ui.test.js', 2],
   ['testing/standalone/reembed-backfill.test.js', 1],
   ['testing/standalone/retention-reaches-every-collection.test.js', 3],
   ['testing/standalone/rights-are-explained.test.js', 3],
   ['testing/standalone/route-guard-coverage.test.js', 1],
-  ['testing/standalone/schema-derived-type-controls.test.js', 4],
+  ['testing/standalone/schema-derived-type-controls.test.js', 2],
   ['testing/standalone/search-tool-schemas-document-their-response.test.js', 3],
   ['testing/standalone/single-flight.test.js', 1],
   ['testing/standalone/space-admin-reaches-its-own-space-settings.test.js', 1],
-  ['testing/standalone/space-op-recovery-guard.test.js', 1],
   ['testing/standalone/stt-multipart-and-partial.test.js', 2],
   ['testing/standalone/sync-waits-retrigger-and-diagnose.test.js', 1],
   ['testing/standalone/vlm-endpoint-egress.test.js', 1],

--- a/testing/standalone/model-verify.test.js
+++ b/testing/standalone/model-verify.test.js
@@ -26,6 +26,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
+import { blockAfter } from './_structural-window.mjs';
 
 const SRC = readFileSync('server/src/api/model-verify.ts', 'utf8');
 const AUDIT = readFileSync('server/src/audit/middleware.ts', 'utf8');
@@ -112,7 +113,11 @@ describe('outcomes are honest about what was established', () => {
 
   it('a thrown error becomes a failed outcome, not a 500', () => {
     // The whole point is to report on a broken endpoint; crashing on one would be perverse.
-    assert.match(SRC, /catch \(err\)[\s\S]{0,220}return done\('failed'/);
+    // The catch BLOCK, bounded by its own brace. A cap here says "within 220 characters of the catch", which
+    // is a guess about formatting rather than a claim about the handler.
+    const at = SRC.indexOf('catch (err)');
+    assert.ok(at > -1, 'the catch is gone — re-anchor this gate');
+    assert.match(blockAfter(SRC, at, 'the verify catch'), /return done\('failed'/);
   });
 });
 

--- a/testing/standalone/no-polling-a-deleted-space.test.js
+++ b/testing/standalone/no-polling-a-deleted-space.test.js
@@ -30,21 +30,17 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { stripComments } from './_strip-comments.mjs';
+import { blockAfter, bodyOf } from './_structural-window.mjs';
 
 const vector = stripComments(readFileSync('server/src/spaces/vector-index.ts', 'utf8'));
 const lifecycle = stripComments(readFileSync('server/src/spaces/lifecycle.ts', 'utf8'));
 
-/** One exported function's body, bounded structurally — never by a character count. */
-function bodyOf(src, name) {
-  const lines = src.split(/\r?\n/);
-  const start = lines.findIndex(l => l.includes(`export async function ${name}(`));
-  assert.ok(start > -1, `${name} is gone — re-anchor this gate`);
-  let end = lines.length;
-  for (let i = start + 1; i < lines.length; i++) {
-    if (/^export (async function|function|const) /.test(lines[i])) { end = i; break; }
-  }
-  return lines.slice(start, end).join('\n');
-}
+/*
+ * The local `bodyOf` that used to live here was the FOURTH independent hand-roll of the same bound, and it was
+ * narrower than it looked: it matched `export async function ${name}(` only, so it could not have found
+ * `spaceStillExists`, which is a plain non-exported function. The shared helper matches any top-level
+ * declaration, which is why the assertion below could move onto it at all.
+ */
 
 describe('the poll abandons a space that no longer exists', () => {
   const body = bodyOf(vector, 'pollVectorIndexReady');
@@ -66,7 +62,9 @@ describe('the poll abandons a space that no longer exists', () => {
   });
 
   it('abandons rather than continues — a `continue` would spin at full speed', () => {
-    assert.match(body, /if \(!spaceStillExists\(spaceId\)\) \{[\s\S]{0,220}?return false;/,
+    const at = body.indexOf('if (!spaceStillExists(spaceId))');
+    assert.ok(at > -1, 'the existence check is gone — re-anchor this gate');
+    assert.match(blockAfter(body, at, 'the abandon branch'), /return false;/,
       'the check must return, not continue');
   });
 
@@ -76,7 +74,7 @@ describe('the poll abandons a space that no longer exists', () => {
      * returning `false` would make every such poll conclude its space was deleted — the fix causing the outage
      * it was written to prevent, and quietly, since the log line is `debug`.
      */
-    assert.match(vector, /function spaceStillExists\(spaceId: string\): boolean \{[\s\S]{0,200}?catch \{ return true; \}/,
+    assert.match(bodyOf(vector, 'spaceStillExists'), /catch \{ return true; \}/,
       'an unreadable config must read as "the space still exists"');
   });
 });

--- a/testing/standalone/overview-pending-is-cleared.test.js
+++ b/testing/standalone/overview-pending-is-cleared.test.js
@@ -21,6 +21,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { blockAfter } from './_structural-window.mjs';
 
 const ROOT = process.cwd();
 const BRAIN = 'client/src/app/pages/brain/brain.component.ts';
@@ -116,7 +117,11 @@ describe('an Overview skeleton can always be dismissed', () => {
     // (G-2). The guarantee is unchanged and so is its shape — raised beside the blanks, in one place — so this
     // anchors on that method, and separately requires the space switch to still call it. Splitting the two is
     // what keeps "blanked on a switch" true rather than merely "blanked somewhere".
-    assert.match(src, /selectSpace\(id: string\): void \{[\s\S]{0,2000}?this\.ov\.blankForSpaceSwitch\(\)/,
+    // The METHOD, bounded by the brace that closes it. 2 000 characters was the largest cap in the suite and
+    // the clearest sign of a guess: nobody chooses that number, they raise it until the test passes.
+    const sel = src.indexOf('selectSpace(id: string): void {');
+    assert.ok(sel > -1, 'selectSpace is gone — re-anchor this gate');
+    assert.match(blockAfter(src, sel, 'selectSpace'), /this\.ov\.blankForSpaceSwitch\(\)/,
       'a space switch must still blank the panels, or the skeletons never go up in the first place');
     const at = src.indexOf('  blankForSpaceSwitch(): void {');
     assert.ok(at > 0, 'blankForSpaceSwitch method not found');

--- a/testing/standalone/schema-derived-type-controls.test.js
+++ b/testing/standalone/schema-derived-type-controls.test.js
@@ -49,6 +49,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
+import { blockAfter, bodyOf } from './_structural-window.mjs';
 
 const BRAIN_DIR = 'client/src/app/pages/brain';
 
@@ -134,9 +135,10 @@ describe('a brain type control offers server-accepted values, not a hardcoded li
 
   it('the client mirror REPLACES the built-ins on a declared schema — it does not union with them', () => {
     const src = stripComments(readFileSync(`${BRAIN_DIR}/brain-store.service.ts`, 'utf8'));
-    const fn = /chronoAllowedTypes\(\)\s*:\s*string\[\]\s*\{([\s\S]{0,600}?)\n  \}/.exec(src);
-    assert.ok(fn, 'chronoAllowedTypes() not found in brain-store.service.ts');
-    const body = fn[1];
+    const at = src.indexOf('chronoAllowedTypes()');
+    assert.ok(at > -1, 'chronoAllowedTypes() not found in brain-store.service.ts');
+    // The method body, bounded by its own closing brace rather than by 600 characters of it.
+    const body = blockAfter(src, at, 'chronoAllowedTypes');
 
     assert.match(body, /typeSchemas\?\.chrono/, 'the mirror must read the space\'s declared chrono types');
 
@@ -161,10 +163,10 @@ describe('a brain type control offers server-accepted values, not a hardcoded li
 
   it('the server rule this mirrors is still exclusive — if it changes, come back here', () => {
     const src = stripComments(readFileSync('server/src/spaces/schema-validation.ts', 'utf8'));
-    const fn = /export function getAllowedChronoTypes\([\s\S]{0,400}?\n\}/.exec(src);
-    assert.ok(fn, 'getAllowedChronoTypes not found — the client mirror has lost its subject');
+    // The whole function, to the next top-level declaration.
+    const fnBody = bodyOf(src, 'getAllowedChronoTypes', 'the client mirror has lost its subject');
     // Two returns, one per branch, and the declared branch returns ONLY the declared keys.
-    assert.match(fn[0], /return new Set\(Object\.keys\(customTypes\)\)/,
+    assert.match(fnBody, /return new Set\(Object\.keys\(customTypes\)\)/,
       'the declared branch no longer returns exactly the declared keys — re-check chronoAllowedTypes()');
   });
 });

--- a/testing/standalone/space-op-recovery-guard.test.js
+++ b/testing/standalone/space-op-recovery-guard.test.js
@@ -30,6 +30,7 @@
 import { describe, it, before } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
+import { enclosingBlockFrom } from './_structural-window.mjs';
 
 let beginSpaceOp, endSpaceOp, spaceOpInFlight;
 const strip = s => s
@@ -85,7 +86,19 @@ describe('both space operations claim the guard, and recovery reads it', () => {
 
   it('removeSpace does too — it writes the same kind of marker', () => {
     const src = strip(readFileSync('server/src/spaces/lifecycle.ts', 'utf8'));
-    assert.match(src, /beginSpaceOp\(\);[\s\S]{0,200}?finally\s*\{\s*endSpaceOp\(\);/);
+    /*
+     * The rest of the FUNCTION the marker is opened in, bounded by the brace that closes it.
+     *
+     * `blockAfter` on the `try` was the obvious choice and is wrong: a `finally` is a SIBLING of the try block,
+     * not inside it, so bounding at the try's own brace excludes the very thing being looked for. The enclosing
+     * function is the smallest bound that contains both halves, and it still refuses an `endSpaceOp()` that
+     * belongs to some other function further down the file — which is what the 200-character cap could not.
+     */
+    const at = src.indexOf('beginSpaceOp();');
+    assert.ok(at > -1, 'beginSpaceOp is no longer called here — re-anchor this gate');
+    const rest = enclosingBlockFrom(src, at, 'the removeSpace body');
+    assert.match(rest, /finally\s*\{[\s\S]*?endSpaceOp\(\);/,
+      'the marker must be cleared in a finally of the function it was opened in');
   });
 
   it('reconcilePendingSpaceOp checks it BEFORE doing any work', () => {


### PR DESCRIPTION
chore(testing): nine more capped gaps converted, and a fourth hand-rolled bodyOf removed

X-25c, taking the half where the structural bound is unambiguous.

WHICH NINE, AND WHY THESE

Every site whose subject is a named FUNCTION or a BRANCH. There is no judgement call in
those: the update call's argument list, the 412 branch, the verify catch block, the abandon
branch, `spaceStillExists`, `selectSpace`, `chronoAllowedTypes`, `getAllowedChronoTypes`,
and a try/finally.

`selectSpace` carried a **2 000-character** cap, the largest in the suite. Nobody chooses
that number; it gets raised until the test passes.

57 gaps across 31 files remain, down from 66 across 36. The count lives in the gate rather
than in a tracker — this item claimed 30 when the real number was 66.

THE REMAINING 57 ALL FAIL LOUDLY, WHICH IS WHY THEY ARE FROZEN AND NOT A BLOCKER

The six NEGATIVE-polarity sites went first, because that is the polarity where a short
window makes an absence hold and the gate pass on the very defect it names. Two of those
six turned out to be vacuous rather than capped.

What is left is positive assertions. There a cap that falls short breaks the match and turns
the gate RED on correct code — a nuisance that announces itself. Worth fixing, not worth
holding a release for.

A FOURTH INDEPENDENT `bodyOf`

`no-polling-a-deleted-space.test.js` had its own, and it was narrower than it looked: it
matched `export async function ${name}(` only, so it could not have found `spaceStillExists`
at all — a plain non-exported function. The shared helper matches any top-level declaration,
which is the only reason the assertion could move onto it.

That is four hand-rolls of one bound found and removed since the helper was extracted.

TWO CONVERSIONS THAT WERE WRONG THE OBVIOUS WAY

`space-op-recovery-guard` asserts that `beginSpaceOp()` is released in a `finally`.
`blockAfter` on the `try` is the obvious bound and excludes the answer: a `finally` is a
SIBLING of the try block, not inside it. The enclosing FUNCTION is the smallest bound that
holds both halves, and it still refuses an `endSpaceOp()` belonging to some other function
further down the file — which the 200-character cap could not.

`schema-derived-type-controls` had a capture-group window whose captured text was used as the
body; switching to `blockAfter` meant the assertion had to move off `fn[1]`, which is the
kind of edit that silently asserts on the wrong string if you do not read the whole test.

MUTATION TESTED

Six mutants, one per converted gate, each breaking the property the gate is about — the
write filter renamed, `done('failed')` turned into `done('ok')`, the cannot-tell catch
flipped to `false`, the space-switch blank removed, the exclusive type rule turned into a
union, and `endSpaceOp()` dropped from the finally. All six turn their gate red.
