### PR TITLE
release: 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.0] — 2026-08-20
+
 ### Breaking
 
 - **The three per-stage scores are the ORDERING, and they were hidden behind a flag whose purpose is removing
@@ -894,7 +896,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Eleven mutations across the three rules, eleven caught. A twelfth was dropped as an equivalent
   mutant with the reason recorded rather than chased: on CRLF text `split('
-')` and `split(/?
+')` and `split(/
+?
 /)` yield arrays
   of the same length, and the call reads `.length`.
 

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/client",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ythril",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ythril",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "workspaces": [
         "server",
@@ -18,7 +18,7 @@
     },
     "client": {
       "name": "@ythril/client",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@angular/animations": "^21.0.0",
@@ -21022,7 +21022,7 @@
     },
     "server": {
       "name": "@ythril/server",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "PolyForm-Small-Business-1.0.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ythril",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "private": true,
   "type": "module",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ythril/server",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "license": "PolyForm-Small-Business-1.0.0",
   "type": "module",
   "scripts": {

--- a/testing/standalone/one-switch-three-tiers-is-documented.test.js
+++ b/testing/standalone/one-switch-three-tiers-is-documented.test.js
@@ -204,12 +204,29 @@ describe('both doors name the one tier name', () => {
     // CHANGELOG that had become MORE correct. The rule is that an upgrader searching the old spelling finds
     // it in the current notes; which heading it sits under is the release process's business, not this
     // gate's.
+    /*
+     * THE WHOLE CURRENT-MAJOR CHANGELOG, and that is the second correction this assertion has needed for the
+     * same underlying reason: a window measured in RELEASES decays every time one is cut.
+     *
+     * Version one pinned `[Unreleased]` alone, and cutting 3.1.0 — which moved the entry into a dated heading,
+     * exactly as a release is supposed to — turned it red against a CHANGELOG that had become more correct.
+     * Version two widened to "[Unreleased] plus the newest released section", which survived one release and
+     * broke on the next: cutting 3.2.0 pushed 3.1.0 into second place and the entry out of the window.
+     *
+     * A window of N sections is just a magic number wearing release clothes. The actual rule is the one the
+     * comment above always stated — **an upgrader searching the old spelling finds it in the current notes** —
+     * and `CHANGELOG.md` IS the current major series by construction: its own header says earlier majors are
+     * archived under `changelog/`.
+     *
+     * So this holds while the old spelling is still ACCEPTED, which is the whole point of documenting it. When
+     * 4.0 removes the field and this file is archived, the gate goes red and asks to be revisited — which is
+     * correct, because that is the release where an upgrader stops needing to find it and starts needing to be
+     * told it is gone.
+     */
     const ch = readFileSync('CHANGELOG.md', 'utf8');
-    const m = /^## \[Unreleased\]$([\s\S]*?)^## \[[^\]]+\][^\n]*$([\s\S]*?)^## \[/m.exec(ch);
-    assert.ok(m, 'expected [Unreleased] then at least two released sections — this gate measures nothing now');
-    const unreleased = m[1] + m[2];
-    assert.match(unreleased, /excludeFromVectorSearch/,
-      'the [Unreleased] section must name the OLD spelling — that is the word an upgrader searches for');
-    assert.match(unreleased, /suppressEmbeddings/, 'and the new one');
+    assert.match(ch, /^## \[Unreleased\]$/m, 'the changelog has no [Unreleased] heading — this gate measures nothing');
+    assert.match(ch, /excludeFromVectorSearch/,
+      'the current-major changelog must name the OLD spelling — that is the word an upgrader searches for');
+    assert.match(ch, /suppressEmbeddings/, 'and the new one');
   });
 });


### PR DESCRIPTION
release: 3.2.0

Version bumped across the root and both workspaces, and the CHANGELOG's `[Unreleased]`
section dated.

THE LOCKFILE, WHICH IS WHERE THIS GOES WRONG

`package-lock.json` contains **twenty** occurrences of `"3.1.0"` and only four are ours —
the root and the three workspace entries. The other sixteen are third-party dependencies
that happen to sit at that version, and a global find-and-replace rewrites them all while
`npm ci` never notices.

So the bump is `npm version 3.2.0 --workspaces --include-workspace-root
--no-git-tag-version`, and the diff is exactly four lines. Verified rather than assumed.

WHY 3.2.0 AND NOT 4.0

The section carries six `### Breaking` entries. 3.1.0 also shipped a `### Breaking` section,
so a minor is the established convention here and changing it silently at a release is not
a decision to make in passing.

A GATE THAT DECAYS ON EVERY RELEASE, FIXED RATHER THAN NUDGED

`one-switch-three-tiers-is-documented` requires the `excludeFromVectorSearch` ->
`suppressEmbeddings` rename to be findable, because a renamed request field that appears
nowhere is a caller debugging a 200 that did nothing.

It windowed `[Unreleased]` plus the newest released section. That survived one release and
broke on this one: cutting 3.2.0 pushed 3.1.0 — where the entry lives — into second place
and out of the window. Its first version had already broken the same way, on 3.1.0, and been
widened by one section.

A window measured in RELEASES is a magic number wearing release clothes. The rule its own
comment always stated is *an upgrader searching the old spelling finds it in the current
notes*, and `CHANGELOG.md` IS the current major by construction — its header says earlier
majors are archived under `changelog/`. So it now asserts on the file.

That holds while the old spelling is still accepted, which is the entire reason to document
it. When 4.0 removes the field and this file is archived, the gate goes red and asks to be
revisited — correctly, because that is the release where an upgrader stops needing to find
the rename and starts needing to be told the field is gone.

Release gate green: docs match code, the CHANGELOG carries 3.2.0, NOTICE complete.
