### PR TITLE
feat(auth): a request quota an admin sets per token, under a ceiling infra sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A request quota an instance admin can set per TOKEN, under a ceiling infra sets instance-wide.** Owner
+  request, 2026-08-20. `rateLimitPerMinute` on a token, settable at create and via `PATCH /api/tokens/:id`;
+  `YTHRIL_RATE_LIMIT_PER_MINUTE` for the instance. Resolution is `token > instance > 300/minute`, the same
+  `record > … > default` order `ttlDays` and `suppressEmbeddings` use, so **an instance that configures
+  neither behaves exactly as it did before** and absence on a token means INHERIT rather than unlimited.
+  The env value is a **ceiling, not just a default**: a per-token value above it is refused with a `403`
+  naming the ceiling, never accepted and quietly reduced — a ceiling an admin can exceed is decorative, and
+  storing a smaller number than was asked for is the accepted-but-discarded defect this codebase keeps
+  finding. `GET /api/tokens` and the MCP `list_tokens` tool both report `rateLimitPerMinute` (what was set)
+  beside `rateLimitEffective` (what is enforced), derived in `listTokens` so the two doors cannot disagree.
+  **Enforced by a SECOND limiter, after authentication.** The existing one runs before auth deliberately —
+  it is the only throttle in front of admin TOTP, so it must throttle requests carrying no valid credential
+  and therefore cannot know which token a request holds without a bcrypt compare per request. It is
+  unchanged and remains the outer bound. The new one is applied inside `attachToken`, the one function every
+  auth entry point calls, and that function now consumes `next` so a new auth path cannot attach a token
+  without metering it.
+
 ## [3.2.0] — 2026-08-20
 
 ### Breaking

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1951,5 +1951,11 @@
   "embedding.origins.add": "Herkunft hinzufügen",
   "embedding.origins.entryLabel": "Erlaubte Herkunft",
   "embedding.origins.saved": "Gespeichert — sofort aktiv, kein Neustart nötig.",
-  "embedding.origins.hint": "Eine exakte Herkunft pro Zeile: nur Schema, Host und Port, ohne Pfad. https ist erforderlich, außer auf localhost. Platzhalter werden nie akzeptiert. Eine Änderung greift ab der nächsten Anfrage."
+  "embedding.origins.hint": "Eine exakte Herkunft pro Zeile: nur Schema, Host und Port, ohne Pfad. https ist erforderlich, außer auf localhost. Platzhalter werden nie akzeptiert. Eine Änderung greift ab der nächsten Anfrage.",
+  "tokens.create.rateLimit": "Anfragen pro Minute",
+  "tokens.create.rateLimitInherit": "Standard der Instanz",
+  "tokens.create.rateLimitHint": "Leer lassen, um den Standard der Instanz zu verwenden. Für einen Client mit Massenverarbeitung einen niedrigeren Wert setzen, damit er nicht alles andere verdrängt.",
+  "tokens.table.quota": "Kontingent",
+  "tokens.table.perMin": "/min",
+  "tokens.table.quotaInherited": "(geerbt)"
 }

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1951,5 +1951,11 @@
   "embedding.origins.add": "Add an origin",
   "embedding.origins.entryLabel": "Allowed origin",
   "embedding.origins.saved": "Saved — active immediately, no restart.",
-  "embedding.origins.hint": "One exact origin per line: scheme, host and port only, with no path. https is required except on localhost. Wildcards are never accepted. A change takes effect on the next request."
+  "embedding.origins.hint": "One exact origin per line: scheme, host and port only, with no path. https is required except on localhost. Wildcards are never accepted. A change takes effect on the next request.",
+  "tokens.create.rateLimit": "Requests per minute",
+  "tokens.create.rateLimitInherit": "Instance default",
+  "tokens.create.rateLimitHint": "Leave blank to use the instance default. Set a lower number for a client doing bulk work, so it cannot crowd out everything else.",
+  "tokens.table.quota": "Quota",
+  "tokens.table.perMin": "/min",
+  "tokens.table.quotaInherited": "(inherited)"
 }

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1951,5 +1951,11 @@
   "embedding.origins.add": "Dodaj źródło",
   "embedding.origins.entryLabel": "Dozwolone źródło",
   "embedding.origins.saved": "Zapisano — działa od razu, bez restartu.",
-  "embedding.origins.hint": "Jedno dokładne źródło w wierszu: tylko schemat, host i port, bez ścieżki. https jest wymagane z wyjątkiem localhost. Symbole wieloznaczne nigdy nie są akceptowane. Zmiana działa od następnego żądania."
+  "embedding.origins.hint": "Jedno dokładne źródło w wierszu: tylko schemat, host i port, bez ścieżki. https jest wymagane z wyjątkiem localhost. Symbole wieloznaczne nigdy nie są akceptowane. Zmiana działa od następnego żądania.",
+  "tokens.create.rateLimit": "Żądania na minutę",
+  "tokens.create.rateLimitInherit": "Domyślna wartość instancji",
+  "tokens.create.rateLimitHint": "Pozostaw puste, aby użyć domyślnej wartości instancji. Dla klienta wykonującego pracę masową ustaw niższą wartość, aby nie wypierał pozostałych.",
+  "tokens.table.quota": "Limit",
+  "tokens.table.perMin": "/min",
+  "tokens.table.quotaInherited": "(odziedziczony)"
 }

--- a/client/src/app/core/api.types.ts
+++ b/client/src/app/core/api.types.ts
@@ -224,6 +224,19 @@ export interface TokenRecord {
    */
   mfa?: 'inherit' | 'exempt' | 'required';
   /**
+   * This token's own request quota per minute, as SET by an admin. Absent on most tokens, and absent means
+   * inherit the instance value — never unlimited.
+   */
+  rateLimitPerMinute?: number;
+  /**
+   * The quota actually ENFORCED, resolved by the server from token, then instance env, then the default.
+   *
+   * Read this one to show an operator what applies. Showing only the field above would make "inherits 300"
+   * and "inherits 50 because infra capped it" look identical — both blank — which is the absent-versus-
+   * not-checked ambiguity this product keeps having to fix.
+   */
+  rateLimitEffective?: number;
+  /**
    * The per-space rights matrix, when the server has one for this token.
    *
    * Optional because OIDC-derived records never pass through the config backfill that derives it. A missing

--- a/client/src/app/core/auth-api.service.ts
+++ b/client/src/app/core/auth-api.service.ts
@@ -47,7 +47,7 @@ export class AuthApi {
     return this.http.get<{ tokens: TokenRecord[] }>('/api/tokens');
   }
 
-  createToken(body: { name: string; expiresAt?: string; spaces?: string[]; admin?: boolean; readOnly?: boolean; schemaLibrary?: boolean; mfa?: 'exempt' | 'required' }): Observable<{ token: TokenRecord; plaintext: string }> {
+  createToken(body: { name: string; expiresAt?: string; spaces?: string[]; admin?: boolean; readOnly?: boolean; schemaLibrary?: boolean; mfa?: 'exempt' | 'required'; rateLimitPerMinute?: number }): Observable<{ token: TokenRecord; plaintext: string }> {
     return this.http.post<{ token: TokenRecord; plaintext: string }>('/api/tokens', body);
   }
 

--- a/client/src/app/pages/settings/token-create-dialog.component.ts
+++ b/client/src/app/pages/settings/token-create-dialog.component.ts
@@ -86,6 +86,12 @@ import type { Space, TokenRecord } from '../../core/api.types';
                 <label>{{ 'tokens.create.expires' | transloco }}</label>
                 <input type="date" class="styled-input" [(ngModel)]="newExpiry" name="expiry" />
               </div>
+              <div class="field" style="margin-bottom:0;">
+                <label>{{ 'tokens.create.rateLimit' | transloco }}</label>
+                <input type="number" class="styled-input" [(ngModel)]="newRateLimit" name="rateLimit"
+                  min="1" step="1" [placeholder]="'tokens.create.rateLimitInherit' | transloco" />
+                <div class="hint">{{ 'tokens.create.rateLimitHint' | transloco }}</div>
+              </div>
             </div>
 
             <!-- The per-space matrix, and it is the whole permission model now.
@@ -174,6 +180,12 @@ export class TokenCreateDialogComponent {
   draftRights = signal<TokenRights>({ instanceAdmin: false, createSpaces: false, floor: null, perSpace: {} });
   newName = '';
   newExpiry = '';
+  /*
+   * Empty means INHERIT the instance value, which is what most tokens should carry — so the field is left
+   * blank by default and an empty string is never sent as a number. Sending a resolved default instead would
+   * freeze today's instance value onto every token minted through this dialog.
+   */
+  newRateLimit: number | null = null;
 
   /**
    * The two instance-level flags, settable at MINT time — which they were not.
@@ -197,11 +209,14 @@ export class TokenCreateDialogComponent {
     // ONE description of access, always the matrix. The legacy `spaces`/`admin`/`readOnly` trio is mutually
     // exclusive with `rights` on the server, so a form offering both could compose a body the API refuses —
     // and the operator would read that 400 as a bug rather than as a choice they had made.
-    const body: { name: string; expiresAt?: string; rights: TokenRights } = {
+    const body: { name: string; expiresAt?: string; rights: TokenRights; rateLimitPerMinute?: number } = {
       name: this.newName.trim(),
       rights: this.draftRights(),
     };
     if (this.newExpiry) body.expiresAt = new Date(this.newExpiry).toISOString();
+    // Only when actually given. A blank field means inherit, and `0` is not a legal quota — the server
+    // refuses it — so a falsy check is the right test rather than a null check.
+    if (this.newRateLimit) body.rateLimitPerMinute = Number(this.newRateLimit);
 
     this.authApi.createToken(body).subscribe({
       next: ({ token, plaintext }) => {
@@ -210,6 +225,7 @@ export class TokenCreateDialogComponent {
         this.created.emit({ token, plaintext });
         this.newName = '';
         this.newExpiry = '';
+        this.newRateLimit = null;
       },
       error: (err) => {
         this.creating.set(false);

--- a/client/src/app/pages/settings/token-quota-cell.component.ts
+++ b/client/src/app/pages/settings/token-quota-cell.component.ts
@@ -1,0 +1,58 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { TranslocoModule } from '@jsverse/transloco';
+
+/**
+ * One token's request quota, as a table cell.
+ *
+ * ## Why this is its own component
+ *
+ * `no-new-god-files.test.js` refused it inside `tokens.component.ts`, which is already among the largest files
+ * and frozen at its size. Its reasoning is the right one here: *"the failure mode of a god-file is not its size
+ * on any given day — it is that every change lands in the same place because that is where the code already
+ * is."* The quota cell is also the third thing in that table with a real display RULE rather than a value, so it
+ * benefits from being somewhere it can be read on its own.
+ *
+ * ## The rule, which is the whole reason this is not a `{{ }}`
+ *
+ * Two numbers arrive and they answer different questions:
+ *
+ *   `perToken`   what an admin SET on this token. Absent on most tokens.
+ *   `effective`  what is actually enforced, resolved by the server from token, then instance, then default.
+ *
+ * **Showing only the first would make "inherits 300" and "inherits 50 because infra capped it" identical** —
+ * both blank — which is the absent-versus-not-checked ambiguity this product keeps having to fix. So the
+ * effective number is always shown, and an explicitly-set one is badged, because "somebody chose this" and
+ * "this is what the instance gives you" are different facts and an operator acts on them differently.
+ *
+ * NOTE: no backticks anywhere below. A backtick inside an inline template terminates the string and Angular
+ * reports `NG1001: Decorator argument must be literal`, pointing at the decorator rather than at the line.
+ */
+@Component({
+  selector: 'app-token-quota-cell',
+  standalone: true,
+  imports: [TranslocoModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  styles: [`
+    .inherited { color: var(--text-muted); }
+    .note { font-style: italic; }
+  `],
+  template: `
+    @if (perToken()) {
+      <span class="badge badge-gray">{{ perToken() }}{{ 'tokens.table.perMin' | transloco }}</span>
+    } @else if (effective()) {
+      <span class="inherited">{{ effective() }}{{ 'tokens.table.perMin' | transloco }}
+        <span class="note">{{ 'tokens.table.quotaInherited' | transloco }}</span></span>
+    } @else {
+      <!-- Neither number known: an OIDC-derived record carries no stored quota, and an older server does not
+           send the derived one. A dash is honest; inventing 300 here would be this component asserting a
+           default the server may not be using. -->
+      <span class="inherited">&mdash;</span>
+    }
+  `,
+})
+export class TokenQuotaCellComponent {
+  /** What an admin set on this token. Absent means inherit — never unlimited. */
+  perToken = input<number | undefined>(undefined);
+  /** What the server says is actually enforced. */
+  effective = input<number | undefined>(undefined);
+}

--- a/client/src/app/pages/settings/tokens.component.ts
+++ b/client/src/app/pages/settings/tokens.component.ts
@@ -18,6 +18,7 @@ import { RightsGlyphComponent, type TokenRights } from './rights-glyph.component
 import { TokenCreateDialogComponent } from './token-create-dialog.component';
 import { TokenRightsDialogComponent } from './token-rights-dialog.component';
 import { OwnTokenRightsComponent } from './own-token-rights.component';
+import { TokenQuotaCellComponent } from './token-quota-cell.component';
 import { ErrorStateComponent } from '../../shared/error-state.component';
 import { httpErrorReason } from '../../core/http-error';
 import { TOKENS_PAGE_STYLES } from './tokens.styles';
@@ -28,7 +29,7 @@ import { TOKENS_PAGE_STYLES } from './tokens.styles';
   imports: [CommonModule, FormsModule, TranslocoPipe, PhIconComponent, ModalDirective,
             SummaryStripComponent, StatusPillComponent, HscrollTopDirective,
             ErrorStateComponent, RightsGlyphComponent, TokenCreateDialogComponent,
-            TokenRightsDialogComponent, OwnTokenRightsComponent],
+            TokenRightsDialogComponent, OwnTokenRightsComponent, TokenQuotaCellComponent],
   styles: [TOKENS_PAGE_STYLES],
   template: `
     <!-- New token success banner -->
@@ -114,7 +115,7 @@ import { TOKENS_PAGE_STYLES } from './tokens.styles';
           <table>
             <thead>
               <tr>
-                <th>{{ 'tokens.table.label' | transloco }}</th><th>{{ 'tokens.table.permission' | transloco }}</th><th>{{ 'tokens.table.created' | transloco }}</th><th>{{ 'tokens.table.lastUsed' | transloco }}</th><th>{{ 'tokens.table.expires' | transloco }}</th><th>{{ 'tokens.table.spaces' | transloco }}</th><th></th>
+                <th>{{ 'tokens.table.label' | transloco }}</th><th>{{ 'tokens.table.permission' | transloco }}</th><th>{{ 'tokens.table.created' | transloco }}</th><th>{{ 'tokens.table.lastUsed' | transloco }}</th><th>{{ 'tokens.table.expires' | transloco }}</th><th>{{ 'tokens.table.spaces' | transloco }}</th><th>{{ 'tokens.table.quota' | transloco }}</th><th></th>
               </tr>
             </thead>
             <tbody>
@@ -179,6 +180,9 @@ import { TOKENS_PAGE_STYLES } from './tokens.styles';
                     } @else {
                       <span class="badge badge-gray">{{ t.spaces.join(', ') }}</span>
                     }
+                  </td>
+                  <td>
+                    <app-token-quota-cell [perToken]="t.rateLimitPerMinute" [effective]="t.rateLimitEffective" />
                   </td>
                   <td style="white-space:nowrap; display:flex; gap:6px; align-items:center;">
                     <button class="icon-btn" [attr.title]="'tokens.action.rotateTitle' | transloco" [attr.aria-label]="'tokens.action.rotateAriaLabel' | transloco" (click)="regenerate(t)"><ph-icon name="arrows-clockwise" [size]="14"/></button>

--- a/docs/integration-guide/03-auth-and-limits.md
+++ b/docs/integration-guide/03-auth-and-limits.md
@@ -134,7 +134,8 @@ to correct. The information is identical; only the envelope differs.
 | Scope | Limit | Keyed by | Applies To |
 |---|---|---|---|
 | Auth | 10 / min | source IP | Token creation, setup, invite/apply |
-| Global | 300 / min | client | All authenticated endpoints |
+| Global | 300 / min | client | All authenticated endpoints — the pre-auth backstop |
+| Per token | 300 / min by default, **settable** | token id | All authenticated endpoints, once the token is resolved |
 | Sync | 2 000 / min | client (peer) | Sync API endpoints |
 | Notify | 60 / min | client | `GET /api/notify`, `POST /api/notify`, `POST /api/notify/trigger` |
 | Bulk wipe | 5 / min | client | `DELETE /api/brain/spaces/:spaceId/{memories,entities,edges,chrono}` |
@@ -150,6 +151,32 @@ appears in a key, a log line, or a header.
 Requests with **no** credential (login, setup, an anonymous probe) key on the source IP — that is the only
 identity they have — and IPv6 addresses are normalised to their `/64` so a client cannot rotate through
 addresses it already owns.
+
+### The per-token quota is settable, and there are two tiers
+
+Added in 3.3.0. The number a token gets is resolved in this order:
+
+1. the token's own `rateLimitPerMinute`, set by an instance admin;
+2. `YTHRIL_RATE_LIMIT_PER_MINUTE`, set by whoever runs the instance;
+3. **300 / min**, which is what the global limiter has always allowed.
+
+So an instance that configures neither tier behaves exactly as it did before.
+
+**Absent on a token means INHERIT, not unlimited.** Most tokens carry no value at all, and that is the
+default state rather than an escape from the limit.
+
+`GET /api/tokens` and the MCP `list_tokens` tool both return two fields, and you almost always want the
+second: `rateLimitPerMinute` is what somebody SET, and `rateLimitEffective` is the number actually
+enforced. Read the effective one to answer *why is this client getting 429*.
+
+**`YTHRIL_RATE_LIMIT_PER_MINUTE` is a ceiling, not just a default.** When it is set, a per-token value above
+it is refused with a **403** naming the ceiling — never accepted and quietly reduced. If you automate token
+creation, that 403 means infra owns the number and your request asked for more than it allows.
+
+**Two limiters, not one.** The global limiter still runs BEFORE authentication and is unchanged: it has to
+throttle requests carrying no valid credential, so it keys on a hash of what you presented and cannot know
+which token that is. The per-token quota is enforced after the token is resolved. In practice you may see a
+429 from either, and the message says which.
 
 The **flood backstop** is a per-IP ceiling in front of every route, set far above any legitimate single
 client. It exists because per-client keying alone would let a flood of random bearer strings mint an

--- a/docs/userguide/04-settings.md
+++ b/docs/userguide/04-settings.md
@@ -230,6 +230,36 @@ If MFA is on, a space administrator is prompted for a code like everybody else.
 **The second factor is not a token setting.** MFA is instance-wide and lives in **Settings → Preferences**;
 there is nothing about it in the token dialogs, and there is no per-token exemption to grant here.
 
+### How many requests a token may make
+
+**Each token has its own request budget, per minute.** Left alone, every token gets the instance's number — so
+you do not have to think about this at all unless one client is drowning out the others.
+
+Set a lower one on a token when it is doing bulk work you do not want competing with people using the product:
+a nightly importer, an agent that crawls, anything that would happily send a thousand requests a second if you
+let it.
+
+#### What you will see on the token list
+
+Two numbers, and the second is the one that answers questions:
+
+| column | means |
+|---|---|
+| the value you set | blank on most tokens, and blank means *use the instance's number* — not *unlimited* |
+| the effective limit | what is actually enforced right now |
+
+When a client goes over, its requests get **429 Too Many Requests** and a `Retry-After` telling it how long to
+wait. Other tokens are unaffected — the budget is per token, which is the entire point.
+
+#### If the box refuses your number
+
+Whoever runs this instance can set a ceiling that admins cannot exceed. If they have, and you ask for more, the
+save is refused and the message tells you the ceiling and who owns it. Nothing is saved in that case — you will
+not find a smaller number quietly stored in place of what you typed.
+
+That ceiling is set outside the product, in the instance's environment. If you need it raised, that is a
+conversation with whoever operates the server rather than something this page can change.
+
 ### Rotating a token
 
 Click the ↺ icon on any token row. A new secret is generated; the old one stops working immediately. The new value is shown once.

--- a/server/src/api/tokens.ts
+++ b/server/src/api/tokens.ts
@@ -2,7 +2,8 @@
 import type { Request, Response } from 'express';
 import { requireAuth, requireAdminOrSpaceAdmin, requireAdminOrSpaceAdminMfa, isInstanceAdmin } from '../auth/middleware.js';
 import { authRateLimit, globalRateLimit } from '../rate-limit/middleware.js';
-import { createToken, listTokens, revokeToken, regenerateToken, renameToken, setTokenRights, setTokenMfa } from '../auth/tokens.js';
+import { rateLimitRefusal } from '../rate-limit/per-token.js';
+import { createToken, listTokens, revokeToken, regenerateToken, renameToken, setTokenRights, setTokenMfa, setTokenRateLimit } from '../auth/tokens.js';
 import { isMfaEnabled, verifyMfaCode } from '../auth/totp.js';
 import { z } from 'zod';
 import { SPACE_AREAS, RUNGS, RUNG_IMPLICATIONS, DERIVED_RUNGS } from '../config/rights-shape.js';
@@ -108,7 +109,12 @@ tokensRouter.get('/rights-catalog', globalRateLimit, requireAuth, (_req, res) =>
  * the strictness. Neither is sufficient alone, which is exactly how the first attempt at this fix broke: it
  * added `.strict()` and turned the round-trip into a 400.
  */
-const SERVER_OWNED_TOKEN_FIELDS = ['id', 'hash', 'prefix'] as const;
+// `rateLimitEffective` is DERIVED for the response (see `listTokens`) and is not a field anybody may set.
+// It joins the strip list for exactly the reason the list exists: a client that reads a token back and posts
+// it is round-tripping, and being told "unknown key" for a field we ourselves emitted is a worse answer than
+// ignoring it. Without this the new field would 400 every round-trip — the defect this list was created for,
+// reintroduced by the next response field somebody adds.
+const SERVER_OWNED_TOKEN_FIELDS = ['id', 'hash', 'prefix', 'rateLimitEffective'] as const;
 
 function stripServerOwnedToken(body: unknown): unknown {
   if (body == null || typeof body !== 'object' || Array.isArray(body)) return body;
@@ -145,6 +151,15 @@ const CreateTokenBody = z.object({
    * See `TokenRecord.mfa` for why it is three states.
    */
   mfa: z.enum(['inherit', 'exempt', 'required']).optional(),
+  /**
+   * This token's own request quota, per minute. Absent = inherit the instance value.
+   *
+   * Deliberately NOT bounded here. The bounds and the instance ceiling live in
+   * `rate-limit/per-token.ts` because the MCP tool enforces the same rule, and a `z.number().max(…)` in this
+   * schema would be a second copy of a number infra owns — the one that goes stale when the env changes.
+   * See `rateLimitRefusal`.
+   */
+  rateLimitPerMinute: z.number().int().optional(),
   /**
    * The per-space rights matrix for the new token.
    *
@@ -217,7 +232,7 @@ tokensRouter.post('/', authRateLimit, requireAdminOrSpaceAdminMfa, async (req, r
     res.status(400).json({ error: parsed.error.message });
     return;
   }
-  const { name, expiresAt, spaces, admin, readOnly, peerInstanceId, schemaLibrary, mfa, rights } = parsed.data;
+  const { name, expiresAt, spaces, admin, readOnly, peerInstanceId, schemaLibrary, mfa, rights, rateLimitPerMinute } = parsed.data;
 
   // One description of access per request. A body carrying both `rights` and a legacy field describes the
   // same thing twice, and whichever lost would do so silently — which is the failure this whole area keeps
@@ -246,6 +261,19 @@ tokensRouter.post('/', authRateLimit, requireAdminOrSpaceAdminMfa, async (req, r
     }
   }
   if (!exemptionNeedsLiveCode(req, res, mfa)) return;
+  /*
+   * The quota, checked with the SHARED refusal — the MCP tool calls the same function.
+   *
+   * `403` rather than `400` when it is the instance ceiling that refuses, matching what a pinned media-config
+   * field answers: the request is well-formed and the caller is not allowed to ask for that number. A malformed
+   * value is still a `400`. Never accepted-and-clamped: storing a smaller number than was asked for and
+   * answering 201 is the defect this file's `.strict()` comment is about, one field over.
+   */
+  const quotaRefusal = rateLimitRefusal(rateLimitPerMinute);
+  if (quotaRefusal) {
+    res.status(quotaRefusal.includes('instance ceiling') ? 403 : 400).json({ error: quotaRefusal });
+    return;
+  }
   if (admin && readOnly) {
     res.status(400).json({ error: 'A token cannot be both admin and readOnly' });
     return;
@@ -281,7 +309,7 @@ tokensRouter.post('/', authRateLimit, requireAdminOrSpaceAdminMfa, async (req, r
   // schemaLibrary tokens are always read-only and have no space access
   const effectiveReadOnly = schemaLibrary ? true : (readOnly ?? false);
   const effectiveSpaces = schemaLibrary ? [] : spaces;
-  const { record, plaintext } = await createToken({ name, expiresAt: expiresAt ?? null, spaces: effectiveSpaces, admin, readOnly: effectiveReadOnly, peerInstanceId, schemaLibrary, mfa, rights: rights as never });
+  const { record, plaintext } = await createToken({ name, expiresAt: expiresAt ?? null, spaces: effectiveSpaces, admin, readOnly: effectiveReadOnly, peerInstanceId, schemaLibrary, mfa, rights: rights as never, rateLimitPerMinute });
   // Return plaintext only on creation — never retrievable again
   const { hash: _h, ...safeRecord } = record;
   res.status(201).json({ token: withReadOnlyAlias(safeRecord), plaintext });
@@ -371,6 +399,15 @@ const RenameTokenBody = z.object({
    * is shorter still than minting.
    */
   mfa: z.enum(['inherit', 'exempt', 'required']).optional(),
+  /**
+   * This token's own request quota, per minute. Absent = inherit the instance value.
+   *
+   * Deliberately NOT bounded here. The bounds and the instance ceiling live in
+   * `rate-limit/per-token.ts` because the MCP tool enforces the same rule, and a `z.number().max(…)` in this
+   * schema would be a second copy of a number infra owns — the one that goes stale when the env changes.
+   * See `rateLimitRefusal`.
+   */
+  rateLimitPerMinute: z.number().int().optional(),
   // ── The rest of the record, accepted ONLY unchanged ──────────────────────────────────────────────
   //
   // These are declared so that echoing back a token you just read does not 400 on the first field the
@@ -388,7 +425,7 @@ tokensRouter.patch('/:id', requireAdminOrSpaceAdminMfa, (req, res) => {
     return;
   }
   const id = req.params['id'] as string;
-  const { name, rights, mfa } = parsed.data;
+  const { name, rights, mfa, rateLimitPerMinute } = parsed.data;
   const previous = listTokens().find(t => t.id === id);
   if (!previous) {
     res.status(404).json({ error: 'Token not found' });
@@ -499,6 +536,21 @@ tokensRouter.patch('/:id', requireAdminOrSpaceAdminMfa, (req, res) => {
   if (mfa !== undefined && !setTokenMfa(id, mfa)) {
     res.status(404).json({ error: 'Token not found' });
     return;
+  }
+  /*
+   * Same shared refusal as the create path, and the same status split: `403` when the instance ceiling is
+   * what refuses, `400` when the value itself is malformed. One function, two surfaces, one answer.
+   */
+  if (rateLimitPerMinute !== undefined) {
+    const refusal = rateLimitRefusal(rateLimitPerMinute);
+    if (refusal) {
+      res.status(refusal.includes('instance ceiling') ? 403 : 400).json({ error: refusal });
+      return;
+    }
+    if (!setTokenRateLimit(id, rateLimitPerMinute)) {
+      res.status(404).json({ error: 'Token not found' });
+      return;
+    }
   }
 
   const updated = listTokens().find(t => t.id === id);

--- a/server/src/auth/middleware.ts
+++ b/server/src/auth/middleware.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from 'express';
 import { log } from '../util/log.js';
+import { tokenRateLimit } from '../rate-limit/middleware.js';
 import { findMatchingToken, touchToken } from './tokens.js';
 import { consumeSseTicket } from './sse-ticket.js';
 import { isMfaEnabled, verifyMfaCode } from './totp.js';
@@ -179,15 +180,37 @@ function extractBearer(req: Request): string | null {
 // helpers hold each in one place so a change — a new metric, an audit hook, an
 // OIDC tweak — is made once instead of mirrored by hand across ~6 functions.
 
-/** Attach the resolved record to the request and refresh a PAT's lastUsed. */
+/**
+ * Attach the resolved record, refresh a PAT's `lastUsed`, and METER the request against the token's quota.
+ *
+ * ## Why the metering lives here, and why this function consumes `next`
+ *
+ * There are NINE auth entry points — `requireAuth`, `requireMcpAuth`, `requireSpaceAuth`, the admin variants,
+ * the MFA one — and each resolves a record and attaches it separately. Applying the per-token limiter at any
+ * one of them would leave the other eight uncounted, and a quota with a hole in it is not a quota. Applying it
+ * at all nine works until somebody adds a tenth.
+ *
+ * So the function that ATTACHES a token is the function that METERS it, and it takes `next` rather than letting
+ * the caller call it. A new auth path cannot attach a token without metering, because attaching is how a
+ * request proceeds: there is no `next()` left for a caller to reach on its own.
+ *
+ * It also cannot be applied any earlier than this. The limit is a property of the token, so until the record is
+ * resolved there is nothing to read it from — which is exactly why the pre-auth `globalRateLimit` keys on a
+ * hash of the credential and identifies nothing.
+ *
+ * `tokenRateLimit` calls `next()` on a pass and answers 429 on a hit.
+ */
 function attachToken(
   req: Request,
+  res: Response,
+  next: NextFunction,
   record: Omit<TokenRecord, 'hash'> | OidcTokenRecord,
   bearer: string,
 ): void {
   req.authToken = record;
   // Update lastUsed asynchronously for PAT tokens — do not block the request.
   if (isPat(bearer) && 'id' in record) touchToken(record.id);
+  tokenRateLimit(req, res, next);
 }
 
 /**
@@ -502,8 +525,7 @@ async function performAuth(
   }
 
   authAttemptsTotal.inc({ result: 'success' });
-  attachToken(req, record, bearer);
-  next();
+  attachToken(req, res, next, record, bearer);
 }
 
 /**
@@ -536,8 +558,7 @@ export async function acceptSchemaLibraryToken(
   }
 
   authAttemptsTotal.inc({ result: 'success' });
-  attachToken(req, record, bearer);
-  next();
+  attachToken(req, res, next, record, bearer);
 }
 
 /**
@@ -568,9 +589,8 @@ export function requireSpaceAuthScoped(paramName: string) {
     if (!enforceAreaRung(res, record, req, spaceTargets(spaceId, record))) return;
 
     authAttemptsTotal.inc({ result: 'success' });
-    attachToken(req, record, bearer);
     req.resolvedSpaceId = spaceId;
-    next();
+    attachToken(req, res, next, record, bearer);
   };
 }
 
@@ -605,8 +625,7 @@ export function requireAdminMfaScoped(paramName: string) {
     if (!enforceSpaceScope(res, record, spaceId)) return;
   if (!enforceAreaRung(res, record, req, spaceTargets(spaceId, record))) return;
 
-    attachToken(req, record, bearer);
-    next();
+    attachToken(req, res, next, record, bearer);
   };
 }
 
@@ -657,8 +676,7 @@ export function requireAdminOrSpaceAdminMfaScoped(paramName: string) {
     if (!enforceSpaceScope(res, record, spaceId)) return;
     if (!enforceAreaRung(res, record, req, spaceTargets(spaceId, record))) return;
 
-    attachToken(req, record, bearer);
-    next();
+    attachToken(req, res, next, record, bearer);
   };
 }
 
@@ -676,8 +694,7 @@ export async function requireAdmin(req: Request, res: Response, next: NextFuncti
 
   if (!enforceAdmin(res, record)) return;
 
-  attachToken(req, record, bearer);
-  next();
+  attachToken(req, res, next, record, bearer);
 }
 
 /**
@@ -694,8 +711,7 @@ export async function requireAdminOrSpaceAdmin(req: Request, res: Response, next
 
   if (!enforceAdminOrSpaceAdmin(res, record)) return;
 
-  attachToken(req, record, bearer);
-  next();
+  attachToken(req, res, next, record, bearer);
 }
 
 /** As `requireAdminMfa`, and a matrix space administrator also passes. See `requireAdminOrSpaceAdmin`. */
@@ -709,8 +725,7 @@ export async function requireAdminOrSpaceAdminMfa(req: Request, res: Response, n
   // make "space admin" a way around the instance-wide second factor.
   if (!enforceMfa(req, res, bearer, record)) return;
 
-  attachToken(req, record, bearer);
-  next();
+  attachToken(req, res, next, record, bearer);
 }
 
 /**
@@ -735,6 +750,5 @@ export async function requireAdminMfa(req: Request, res: Response, next: NextFun
   if (!enforceAdmin(res, record)) return;
   if (!enforceMfa(req, res, bearer, record)) return;
 
-  attachToken(req, record, bearer);
-  next();
+  attachToken(req, res, next, record, bearer);
 }

--- a/server/src/auth/tokens.ts
+++ b/server/src/auth/tokens.ts
@@ -5,6 +5,7 @@ import { getConfig, saveConfig, mutateConfig, getSecrets, saveSecrets } from '..
 import { log } from '../util/log.js';
 import type { TokenRecord } from '../config/types.js';
 import { migrateToken } from './rights-migration.js';
+import { resolveLimitFor } from '../rate-limit/per-token.js';
 
 const BCRYPT_ROUNDS = 12;
 const BASE62 = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
@@ -191,6 +192,14 @@ export async function createToken(opts: {
    * knowing about it. Absent means the load-time backfill will derive one from the legacy fields.
    */
   rights?: TokenRecord['rights'];
+  /**
+   * This token's own request quota per minute. Absent = inherit the instance value.
+   *
+   * Validated by the CALLER against `rateLimitRefusal`, which owns the bounds and the instance ceiling.
+   * Not re-checked here for the same reason `rights` is not re-capped here: the check needs the env and the
+   * caller's context, and a second copy of a rule infra owns is how the two answers drift.
+   */
+  rateLimitPerMinute?: number;
 }): Promise<{ record: TokenRecord; plaintext: string }> {
   const plaintext = generateToken();
   const hash = await hashToken(plaintext);
@@ -207,6 +216,9 @@ export async function createToken(opts: {
     // Stored only when it says something. `inherit` IS the absent state, so writing it would put a field on
     // every future token that means exactly what its absence already means.
     ...(opts.mfa && opts.mfa !== 'inherit' ? { mfa: opts.mfa } : {}),
+    // Stored only when set, for the same reason: absence MEANS inherit-the-instance-value, so writing the
+    // resolved number would freeze today's instance default onto the token and stop it following a change.
+    ...(opts.rateLimitPerMinute !== undefined ? { rateLimitPerMinute: opts.rateLimitPerMinute } : {}),
     // ALWAYS stored. Owner ruling 2026-08-13: *"translate old tokens into matrix rights and overwrite on
     // update. only matrix from now on."*
     //
@@ -307,8 +319,22 @@ export async function createOAuthToken(opts: {
 }
 
 /** List all token records (hashes excluded) */
-export function listTokens(): Omit<TokenRecord, 'hash'>[] {
-  return getConfig().tokens.map(({ hash: _h, ...rest }) => rest);
+export function listTokens(): (Omit<TokenRecord, 'hash'> & { rateLimitEffective: number })[] {
+  return getConfig().tokens.map(({ hash: _h, ...rest }) => ({
+    ...rest,
+    /*
+     * The limit that ACTUALLY applies, derived here rather than at either door.
+     *
+     * `rateLimitPerMinute` absent means "inherit the instance value", and from a list that is indistinguishable
+     * from "inherits 300" versus "inherits 50 because infra set a ceiling" — the absent-versus-not-checked
+     * ambiguity this codebase keeps having to fix. So the resolved number rides along beside the stored one.
+     *
+     * In `listTokens` and not in the REST response shaper, because the MCP `list_tokens` tool calls this
+     * function directly. Deriving it at one door would give the two doors different answers to the same
+     * question, which is the parity defect `CLAUDE.md` calls the most expensive lesson in this codebase.
+     */
+    rateLimitEffective: resolveLimitFor(rest),
+  }));
 }
 
 
@@ -355,6 +381,26 @@ export function setTokenMfa(id: string, mfa: 'inherit' | 'exempt' | 'required'):
   if (idx < 0) return false;
   if (mfa === 'inherit') delete config.tokens[idx]!.mfa;
   else config.tokens[idx]!.mfa = mfa;
+  saveConfig(config);
+  return true;
+}
+
+/**
+ * Set (or clear) one token's request quota.
+ *
+ * `null` CLEARS it, and that is the only way back to inheriting the instance value — the same shape
+ * `setTokenMfa` uses for `inherit`. Writing the resolved number instead would freeze today's instance default
+ * onto the token and stop it following a later change, which is a quota nobody set and nobody can see they set.
+ *
+ * The value is validated by the CALLER against `rateLimitRefusal`, which owns the bounds and the instance
+ * ceiling. Re-checking here would be a second copy of a rule infra owns.
+ */
+export function setTokenRateLimit(id: string, perMinute: number | null): boolean {
+  const config = getConfig();
+  const idx = config.tokens.findIndex(t => t.id === id);
+  if (idx < 0) return false;
+  if (perMinute === null) delete config.tokens[idx]!.rateLimitPerMinute;
+  else config.tokens[idx]!.rateLimitPerMinute = perMinute;
   saveConfig(config);
   return true;
 }

--- a/server/src/config/env-num.ts
+++ b/server/src/config/env-num.ts
@@ -61,6 +61,11 @@ export const NUMERIC_SETTINGS: readonly NumericSetting[] = [
   { name: 'INDEX_READY_TIMEOUT_MS', min: 0, max: 3_600_000, what: 'how long boot waits for vector indexes' },
   { name: 'MCP_OAUTH_TOKEN_TTL_DAYS', min: 0, max: 3_650, what: 'the lifetime of a connector token (0 = never expires)' },
   { name: 'YTHRIL_CONNECTOR_PORT', min: 1, max: 65535, what: "the local agent connector's listen port" },
+  // Infra's instance-wide request quota, and the CEILING a per-token value may not exceed. Registered here
+  // rather than read with a bare `??` for the reason this whole file exists: a typo in a rate limit would
+  // otherwise become NaN, and `max: NaN` in express-rate-limit rejects every request — an instance that
+  // refuses all traffic because somebody wrote `3OO`.
+  { name: 'YTHRIL_RATE_LIMIT_PER_MINUTE', min: 1, max: 1_000_000, what: 'the instance-wide request quota per token, per minute' },
   // Both bound the same scan, and the ceilings are the point rather than the defaults. The scan runs on a
   // write path: 30 minutes of window or 5,000 documents would make a duplicate check cost seconds, which
   // is a slower way to fail than not checking at all.

--- a/server/src/config/types.ts
+++ b/server/src/config/types.ts
@@ -60,6 +60,23 @@ export interface TokenRecord {
    */
   mfa?: 'inherit' | 'exempt' | 'required';
   /**
+   * This token's own request quota, in requests per minute. Absent = inherit the instance value.
+   *
+   * Owner request, 2026-08-20. Resolution is `record > instance > default`, the same order `ttlDays` and
+   * `suppressEmbeddings` use: this field, then `YTHRIL_RATE_LIMIT_PER_MINUTE`, then the 300/minute the global
+   * limiter has always allowed — so an instance that configures nothing behaves exactly as it does today.
+   *
+   * **Set by an instance admin; bounded by infra.** When `YTHRIL_RATE_LIMIT_PER_MINUTE` is set it is a CEILING
+   * and not merely a default: a write above it is refused naming the ceiling, because a ceiling an admin can
+   * exceed is decorative. See `rate-limit/per-token.ts` for the resolution and the refusal, which the REST
+   * route and the MCP tool share rather than each implementing.
+   *
+   * Enforced AFTER authentication, by a second limiter. The existing pre-auth limiter cannot be made
+   * token-aware: it must throttle requests carrying no valid credential, so identifying which token a request
+   * holds would mean a bcrypt compare against every stored token, per request.
+   */
+  rateLimitPerMinute?: number;
+  /**
    * The per-space rights matrix, derived from `admin`/`readOnly`/`spaces` by `migrateToken()` at load.
    *
    * **Not authoritative yet.** Enforcement still reads the legacy fields; this is written and compared

--- a/server/src/mcp/tools/spaces.ts
+++ b/server/src/mcp/tools/spaces.ts
@@ -724,9 +724,14 @@ export const list_tokensTool: ToolHandler = {
     + 'An expired token is still LISTED. Expiry is enforced when the token is used, not by removing the row, '
     + 'so seeing it here does not mean it works — check `expiresAt` before concluding anything about who has '
     + 'access.\n\n'
+    + 'THE QUOTA IS TWO FIELDS AND YOU WANT THE SECOND ONE. `rateLimitPerMinute` is what an admin SET on '
+    + 'this token, and it is absent on most of them — absent means "inherit the instance value", which is '
+    + 'not the same as unlimited. `rateLimitEffective` is the number actually enforced, resolved from the '
+    + 'token, then YTHRIL_RATE_LIMIT_PER_MINUTE, then the 300/minute default. Read the effective one to '
+    + 'answer "why is this client getting 429"; read the stored one to answer "did somebody set this".\n\n'
     + 'RESPONSE: one row per token with its id, name, prefix, expiry, whether it carries a rights matrix or '
-    + 'legacy scope, and the matrix itself. Use it to answer "which tokens reach this space, and at what '
-    + 'level" — the question the rights editor answers one token at a time.',
+    + 'legacy scope, the matrix itself, and both quota fields. Use it to answer "which tokens reach this '
+    + 'space, and at what level" — the question the rights editor answers one token at a time.',
   admin: true,
   inputSchema: () => ({
     type: 'object',

--- a/server/src/rate-limit/middleware.ts
+++ b/server/src/rate-limit/middleware.ts
@@ -2,6 +2,7 @@ import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import { createHash } from 'node:crypto';
 import type { Request } from 'express';
 import { log } from '../util/log.js';
+import { resolveLimitFor, WINDOW_MS } from './per-token.js';
 
 /**
  * Bucket requests by CLIENT, not by source IP.
@@ -163,5 +164,53 @@ export const bulkWipeRateLimit = rateLimit({
     log.warn(`bulkWipeRateLimit hit: ${req.ip} on ${req.method} ${req.path}`);
     res.status(options.statusCode).json(options.message);
   },
+  skip: () => skipRateLimit('SKIP_GLOBAL_RATE_LIMIT'),
+});
+
+/**
+ * The PER-TOKEN quota, enforced after authentication.
+ *
+ * ## Why it is separate from `globalRateLimit`
+ *
+ * That one runs before auth, deliberately — it is the only throttle in front of admin TOTP verification, so it
+ * must throttle requests carrying no valid credential at all. It therefore cannot know WHICH token a request
+ * holds: answering that means a bcrypt compare against every stored token, per request. So it keys on a hash of
+ * the credential, which buckets correctly and identifies nothing.
+ *
+ * This one runs where the record is already resolved and free. `globalRateLimit` is unchanged and remains the
+ * outer bound for the anonymous surface.
+ *
+ * ## Keyed on the token ID, not on the credential hash
+ *
+ * A rotated token is a new credential and the same grant. Keying on the hash would hand a fresh bucket to every
+ * rotation, which turns a quota into an inconvenience.
+ *
+ * ## Why `max` is a function
+ *
+ * Because the answer is per request: `express-rate-limit` calls it with the request, and
+ * `resolveLimitFor` reads the resolved record. A constant here is what this change exists to remove.
+ */
+export const tokenRateLimit = rateLimit({
+  windowMs: WINDOW_MS,
+  max: (req: Request) => resolveLimitFor(req.authToken as { rateLimitPerMinute?: number } | undefined),
+  standardHeaders: 'draft-7',
+  legacyHeaders: false,
+  keyGenerator: (req: Request) => {
+    const token = req.authToken as { id?: string } | undefined;
+    // An OIDC-derived identity has no stored token id; fall back to the shared client key so it is still
+    // bucketed rather than exempt. Exempting anything from a quota is how a quota stops being one.
+    return token?.id ? `t:${token.id}` : clientRateLimitKey(req);
+  },
+  message: { error: 'Rate limit exceeded for this token, please slow down.' },
+  handler: (req, res, _next, options) => {
+    const token = req.authToken as { id?: string; name?: string } | undefined;
+    // The token is named because the operator's next question is always WHICH one, and a quota they set
+    // themselves is the one thing they can act on.
+    log.warn(`tokenRateLimit hit: token '${token?.name ?? 'unknown'}' (${token?.id ?? 'no id'}) `
+      + `on ${req.method} ${req.path} — limit ${resolveLimitFor(token as { rateLimitPerMinute?: number })}/min`);
+    res.status(options.statusCode).json(options.message);
+  },
+  // The same kill-switch the global limiter honours, and for the same reason: parallel test suites on one host
+  // would otherwise exhaust a shared window. Non-production only, enforced in `skipRateLimit`.
   skip: () => skipRateLimit('SKIP_GLOBAL_RATE_LIMIT'),
 });

--- a/server/src/rate-limit/per-token.ts
+++ b/server/src/rate-limit/per-token.ts
@@ -1,0 +1,100 @@
+/**
+ * A rate limit an admin can set per TOKEN, under a ceiling infra can set instance-wide.
+ *
+ * Owner request, 2026-08-20: *"ratelimit should be settable on token by instance admin"* and *"and instancewide
+ * by infra"*. Two tiers, and the pure resolution lives here so it can be tested without an HTTP server.
+ *
+ * ## The bucket was already per token — only the ceiling was a constant
+ *
+ * `clientRateLimitKey` has always keyed the global limiter on a hash of the credential, so requests were already
+ * counted per token. `max: 300` was simply hardcoded. This is not a new counting mechanism; it is the number
+ * becoming resolvable.
+ *
+ * ## Why a SECOND limiter rather than making the existing one token-aware
+ *
+ * The global limiter runs BEFORE authentication, deliberately — it is the only throttle in front of admin TOTP
+ * verification, so it has to throttle requests carrying no valid credential at all. That means it cannot know
+ * which token a request holds: answering that needs a bcrypt compare against every stored token, per request.
+ *
+ * So the per-token quota is enforced after auth, where the record is already resolved and free. The pre-auth
+ * limiter is untouched and remains the outer backstop for the anonymous surface.
+ *
+ * ## Resolution, in the order this codebase already resolves tiers
+ *
+ * `record > instance > default`, the same shape as `ttlDays` and `suppressEmbeddings`:
+ *
+ *   1. the token's own `rateLimitPerMinute`, set by an instance admin;
+ *   2. `YTHRIL_RATE_LIMIT_PER_MINUTE`, set by infra;
+ *   3. `DEFAULT_PER_MINUTE`, which is the number the global limiter has always used — so an instance that sets
+ *      nothing behaves exactly as it does today.
+ *
+ * ## The infra value is a CEILING, not just a default
+ *
+ * If it were only a default, an admin could set a per-token value above it and infra's control would be
+ * decorative. So a write above the ceiling is **refused, naming the ceiling** — never accepted and clamped.
+ * Storing a smaller number than the caller asked for, and answering 200, is the defect this repo keeps finding:
+ * the caller is told it worked and the thing they asked for did not happen.
+ */
+
+import { envIntOpt } from '../config/env-num.js';
+import type { TokenRecord } from '../config/types.js';
+
+/**
+ * What the global limiter has always allowed, and therefore what an instance that configures nothing gets.
+ *
+ * Kept equal to `globalRateLimit`'s `max` on purpose: the per-token limiter is a second gate on the same
+ * traffic, so a lower default here would silently tighten every existing deployment.
+ */
+export const DEFAULT_PER_MINUTE = 300;
+
+/** The window both limiters count over. One minute, stated once so the two cannot drift. */
+export const WINDOW_MS = 60_000;
+
+/** Infra's instance-wide value, or `undefined` when infra has not set one. */
+export function instanceCeiling(): number | undefined {
+  return envIntOpt('YTHRIL_RATE_LIMIT_PER_MINUTE');
+}
+
+/**
+ * The limit that applies to one resolved token.
+ *
+ * Takes the record rather than a request so it is pure. An OIDC-derived token carries no `rateLimitPerMinute`
+ * field at all — it is built per request from a claim mapping — so it resolves to the instance value, which is
+ * the correct answer rather than a special case.
+ */
+export function resolveLimitFor(token: { rateLimitPerMinute?: number } | undefined): number {
+  const own = token?.rateLimitPerMinute;
+  if (typeof own === 'number' && Number.isFinite(own) && own > 0) return own;
+  return instanceCeiling() ?? DEFAULT_PER_MINUTE;
+}
+
+/** The bounds a per-token value must satisfy regardless of the ceiling. */
+export const MIN_PER_MINUTE = 1;
+export const MAX_PER_MINUTE = 1_000_000;
+
+/**
+ * Why a requested per-token limit is unacceptable, or `null` when it is fine.
+ *
+ * One function so the REST route and the MCP tool cannot disagree — `CLAUDE.md`'s most expensive lesson is one
+ * rule with two implementations, and here the weaker one would be handing out quota nobody granted. The message
+ * is returned rather than thrown so each surface can attach it to its own status code.
+ */
+export function rateLimitRefusal(requested: unknown): string | null {
+  if (requested === undefined || requested === null) return null;   // absent = inherit, which is the default
+  if (typeof requested !== 'number' || !Number.isInteger(requested)) {
+    return 'rateLimitPerMinute must be a whole number of requests per minute.';
+  }
+  if (requested < MIN_PER_MINUTE || requested > MAX_PER_MINUTE) {
+    return `rateLimitPerMinute must be between ${MIN_PER_MINUTE} and ${MAX_PER_MINUTE}.`;
+  }
+  const ceiling = instanceCeiling();
+  if (ceiling !== undefined && requested > ceiling) {
+    return `rateLimitPerMinute ${requested} exceeds the instance ceiling of ${ceiling} set by `
+      + 'YTHRIL_RATE_LIMIT_PER_MINUTE. Infra owns that number; lower the per-token value or have infra raise '
+      + 'the ceiling. The request was refused rather than silently reduced.';
+  }
+  return null;
+}
+
+/** The subset of a token this module needs, so callers do not have to hand over a whole record. */
+export type RateLimited = Pick<TokenRecord, 'rateLimitPerMinute'>;

--- a/testing/standalone/per-token-rate-limit.test.js
+++ b/testing/standalone/per-token-rate-limit.test.js
@@ -1,0 +1,244 @@
+/**
+ * A rate limit an admin sets per token, under a ceiling infra sets instance-wide.
+ *
+ * Owner request 2026-08-20, in two parts: *"ratelimit should be settable on token by instance admin"* and *"and
+ * instancewide by infra"*.
+ *
+ * ## What is worth testing, and what is a Docker suite's job
+ *
+ * Not "does a 429 arrive after N requests" — that needs a running instance and belongs in the integration
+ * suite. What is cheap and exact here is the part that decides WHICH number applies, and the part that decides
+ * whether a write is allowed to set it. Both are pure, and both have a wrong answer that is silent:
+ *
+ *  - a resolution that reads the wrong tier gives a token a quota nobody granted;
+ *  - a refusal that clamps instead of refusing tells an admin their number was accepted when a smaller one was
+ *    stored, which is the defect `api/tokens.ts` already carries a long comment about one field over.
+ *
+ * ## And the structural half, which is the part that rots
+ *
+ * The quota is metered in `attachToken`, the one function every auth entry point calls. That is deliberate:
+ * there are nine such entry points and wiring the limiter at any subset leaves the rest uncounted. So this file
+ * asserts that arrangement directly — a tenth auth path added without metering is exactly the regression that
+ * would produce a quota with a hole in it and no failing test.
+ *
+ * Run: node --test testing/standalone/per-token-rate-limit.test.js
+ * (requires a prior `npm run build:server`)
+ */
+import { describe, it, before, beforeEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { stripComments } from './_strip-comments.mjs';
+import { bodyOf, balancedFrom } from './_structural-window.mjs';
+
+let resolveLimitFor, rateLimitRefusal, instanceCeiling, DEFAULT_PER_MINUTE, MAX_PER_MINUTE;
+
+const ENV = 'YTHRIL_RATE_LIMIT_PER_MINUTE';
+const original = process.env[ENV];
+
+before(async () => {
+  ({ resolveLimitFor, rateLimitRefusal, instanceCeiling, DEFAULT_PER_MINUTE, MAX_PER_MINUTE } =
+    await import('../../server/dist/rate-limit/per-token.js'));
+});
+
+beforeEach(() => { delete process.env[ENV]; });
+after(() => { if (original === undefined) delete process.env[ENV]; else process.env[ENV] = original; });
+
+describe('which number applies', () => {
+  it('nothing configured anywhere: the number the global limiter has always used', () => {
+    // The point of this default. A deployment that sets neither tier must behave exactly as it does today —
+    // a lower number here would silently tighten every existing instance on upgrade.
+    assert.equal(resolveLimitFor(undefined), 300);
+    assert.equal(resolveLimitFor({}), 300);
+    assert.equal(DEFAULT_PER_MINUTE, 300);
+  });
+
+  it('infra sets it: every token inherits that', () => {
+    process.env[ENV] = '50';
+    assert.equal(instanceCeiling(), 50);
+    assert.equal(resolveLimitFor({}), 50);
+  });
+
+  it('the token wins over infra — that is what "settable per token" means', () => {
+    process.env[ENV] = '50';
+    assert.equal(resolveLimitFor({ rateLimitPerMinute: 20 }), 20);
+  });
+
+  it('absence on the token means INHERIT, not unlimited', () => {
+    /*
+     * The distinction the whole design rests on. If absence meant unlimited, every token minted before this
+     * feature would become unthrottled on upgrade — a change nobody asked for, applied to every existing
+     * deployment, and invisible until something floods.
+     */
+    process.env[ENV] = '50';
+    for (const shape of [{}, { rateLimitPerMinute: undefined }, undefined]) {
+      assert.equal(resolveLimitFor(shape), 50, `${JSON.stringify(shape)} must inherit, not escape`);
+    }
+  });
+
+  it('a stored value that is not a usable number falls back rather than throwing', () => {
+    // A hand-edited config is a real input. `max: NaN` in express-rate-limit rejects EVERY request, so the
+    // failure mode of trusting it is an instance that serves nothing.
+    process.env[ENV] = '50';
+    for (const bad of [0, -1, NaN, Infinity, 'many', null]) {
+      assert.equal(resolveLimitFor({ rateLimitPerMinute: bad }), 50, `${String(bad)} must not be honoured`);
+    }
+  });
+
+  it('an unusable ENV value falls back to the default rather than to NaN', () => {
+    // `envIntOpt` returns undefined for anything it cannot parse, and the boot check reports it separately.
+    process.env[ENV] = 'three hundred';
+    assert.equal(instanceCeiling(), undefined);
+    assert.equal(resolveLimitFor({}), 300);
+  });
+});
+
+describe('what an admin may set', () => {
+  it('absent is always fine — it is the default state', () => {
+    assert.equal(rateLimitRefusal(undefined), null);
+    assert.equal(rateLimitRefusal(null), null);
+  });
+
+  it('a sane number with no ceiling set is accepted', () => {
+    assert.equal(rateLimitRefusal(1), null);
+    assert.equal(rateLimitRefusal(10_000), null);
+  });
+
+  it('a non-integer or out-of-range value is refused, and says which', () => {
+    for (const bad of [1.5, '100', {}, true]) {
+      assert.match(String(rateLimitRefusal(bad)), /whole number/, `${JSON.stringify(bad)} was accepted`);
+    }
+    assert.match(String(rateLimitRefusal(0)), /between/);
+    assert.match(String(rateLimitRefusal(MAX_PER_MINUTE + 1)), /between/);
+  });
+
+  it('THE POINT: above the infra ceiling is REFUSED, not clamped', () => {
+    /*
+     * If the infra value were only a default, an admin could set a per-token value above it and infra's
+     * control would be decorative. And it must REFUSE rather than store a smaller number: accepting 500,
+     * storing 50 and answering 201 tells the admin their quota is 500 when it is not — the same defect the
+     * `.strict()` comment in `api/tokens.ts` exists for, one field over.
+     */
+    process.env[ENV] = '50';
+    const refusal = rateLimitRefusal(500);
+    assert.ok(refusal, 'a value above the ceiling must be refused');
+    assert.match(refusal, /exceeds the instance ceiling of 50/, 'the refusal must NAME the ceiling');
+    assert.match(refusal, new RegExp(ENV), 'and name the env var, so the reader knows who owns it');
+    assert.match(refusal, /refused rather than silently reduced/, 'and say it was not clamped');
+  });
+
+  it('at the ceiling exactly is fine — the bound is inclusive', () => {
+    process.env[ENV] = '50';
+    assert.equal(rateLimitRefusal(50), null);
+  });
+
+  it('and with no ceiling set, a large value is not refused for that reason', () => {
+    // Infra not having an opinion is not the same as infra saying no.
+    assert.equal(rateLimitRefusal(100_000), null);
+  });
+});
+
+describe('the metering cannot be forgotten on a new auth path', () => {
+  const mw = stripComments(readFileSync('server/src/auth/middleware.ts', 'utf8'));
+
+  it('attachToken is what meters, so attaching without metering is not expressible', () => {
+    /*
+     * There are nine auth entry points. Wiring the limiter at a subset of them leaves the rest uncounted, and
+     * a quota with a hole in it is not a quota — so the function that ATTACHES a token is the function that
+     * METERS it, and it consumes `next` so a caller has no `next()` left to reach around it.
+     */
+    const fn = bodyOf(mw, 'attachToken');
+    assert.match(fn, /tokenRateLimit\(req, res, next\)/,
+      'attachToken must meter — otherwise each auth path has to remember, and the tenth will not');
+    assert.match(fn, /next: NextFunction/, 'and it must take next, so proceeding REQUIRES going through it');
+  });
+
+  it('no auth path calls next() beside an attach — that would bypass the meter', () => {
+    /*
+     * The regression this forbids: someone restores the old two-line shape, `attachToken(...)` followed by
+     * `next()`. The token is attached, the request proceeds, and it is counted against nothing.
+     */
+    /*
+     * Counted, not windowed. My first version excluded the DECLARATION — whose parameter list is typed rather
+     * than a call's bare arguments — with `slice(Math.max(0, i - 12), i)`, which is a backwards magic window
+     * and is refused by `gates-bound-their-subject-structurally.test.js`. Two counts say the same thing with no
+     * bound at all: every occurrence except the declaration must hand over `res` and `next`.
+     */
+    const total = [...mw.matchAll(/attachToken\(/g)].length;
+    const metered = [...mw.matchAll(/attachToken\(req, res, next,/g)].length;
+    assert.ok(total >= 9, `expected the declaration plus the auth paths, found ${total} occurrences`);
+    assert.equal(metered, total - 1,
+      `${total - 1 - metered} attachToken call(s) do not hand over res and next, so those requests are attached `
+      + 'to a token and counted against nothing');
+    assert.doesNotMatch(mw, /attachToken\([^)]*\);\s*next\(\);/,
+      'an auth path attaches a token and then calls next() itself, so that request is never metered');
+  });
+
+  it('it keys on the token ID, not the credential hash', () => {
+    const rl = stripComments(readFileSync('server/src/rate-limit/middleware.ts', 'utf8'));
+    const limiter = balancedFrom(rl, rl.indexOf('export const tokenRateLimit'), 'tokenRateLimit');
+    assert.match(limiter, /t:\$\{token\.id\}/,
+      'a rotated token is a new credential and the same grant — keying on the hash would hand every rotation '
+      + 'a fresh bucket, which turns a quota into an inconvenience');
+  });
+
+  it('the pre-auth limiter is untouched and still keyed the old way', () => {
+    // It has to be: it throttles requests carrying no valid credential, which is the only thing standing in
+    // front of admin TOTP. This change must not have made it token-aware.
+    const rl = stripComments(readFileSync('server/src/rate-limit/middleware.ts', 'utf8'));
+    const global = balancedFrom(rl, rl.indexOf('export const globalRateLimit'), 'globalRateLimit');
+    assert.match(global, /keyGenerator: clientRateLimitKey/, 'the pre-auth limiter must still key on the client');
+    assert.doesNotMatch(global, /authToken/, 'it runs before auth — it cannot read a resolved token');
+  });
+});
+
+describe('one rule, both write paths, and the read surface agrees', () => {
+  const routes = stripComments(readFileSync('server/src/api/tokens.ts', 'utf8'));
+
+  it('create and PATCH both use the SHARED refusal', () => {
+    // Two copies of "what is an acceptable quota" is the defect CLAUDE.md names most expensive, and here the
+    // weaker copy would be handing out quota nobody granted.
+    assert.equal([...routes.matchAll(/rateLimitRefusal\(/g)].length, 2,
+      'both write paths must consult the shared refusal — no more, no fewer');
+    assert.doesNotMatch(routes, /instanceCeiling\(\)/,
+      'the route must not read the ceiling itself; that is a second copy of a rule infra owns');
+  });
+
+  it('the body schema does not restate the bounds', () => {
+    // A `z.number().max(…)` here would be a second copy of a number infra owns — and the one that goes stale
+    // the moment the env changes, since a schema is built at import.
+    assert.doesNotMatch(routes, /rateLimitPerMinute: z\.number\(\)\.int\(\)\.(min|max)\(/,
+      'the bounds belong to rate-limit/per-token.ts, not to the request schema');
+  });
+
+  it('the effective limit is derived where BOTH doors read it', () => {
+    /*
+     * `listTokens` is what the REST list and the MCP `list_tokens` tool both call. Deriving the effective
+     * number at one door would give the two doors different answers to the same question.
+     */
+    const tokens = stripComments(readFileSync('server/src/auth/tokens.ts', 'utf8'));
+    assert.match(bodyOf(tokens, 'listTokens'), /rateLimitEffective: resolveLimitFor\(/,
+      'the resolved limit must ride along from listTokens, so both surfaces answer alike');
+  });
+
+  it('the MCP tool description explains which of the two fields to read', () => {
+    // A schema description is authoritative reference — `help()` says so — and "absent means inherit" is
+    // exactly the kind of thing a caller gets wrong by guessing.
+    const mcp = readFileSync('server/src/mcp/tools/spaces.ts', 'utf8');
+    assert.match(mcp, /rateLimitEffective/, 'the tool must name the derived field');
+    assert.match(mcp, /absent means "inherit the instance value"/,
+      'and say what absence means, because absent-versus-unlimited is the reading that goes wrong');
+  });
+
+  it('the env var is registered so a typo stops the boot', () => {
+    // `max: NaN` in express-rate-limit rejects every request. An instance that serves nothing because somebody
+    // wrote `3OO` must fail loudly at startup, not silently at the first request.
+    const env = readFileSync('server/src/config/env-num.ts', 'utf8');
+    assert.match(env, new RegExp(`name: '${ENV}'`), 'the quota env var must be in NUMERIC_SETTINGS');
+  });
+
+  it('a cleared quota is expressible — null means inherit again', () => {
+    const tokens = stripComments(readFileSync('server/src/auth/tokens.ts', 'utf8'));
+    assert.match(bodyOf(tokens, 'setTokenRateLimit'), /if \(perMinute === null\) delete/,
+      'there must be a way back to inheriting, or a quota set once can never be unset');
+  });
+});

--- a/testing/standalone/token-read-shape-round-trips.test.js
+++ b/testing/standalone/token-read-shape-round-trips.test.js
@@ -60,7 +60,11 @@ describe('every field the list route emits is answerable by the edit route', () 
     // meant changing a scheduler's second factor required revoking the token and minting a replacement —
     // rotating a secret to change a flag. Granting an exemption still costs a live TOTP code on the request,
     // pinned by `mfa-is-editable-and-still-guarded.test.js`.
-    const accountedFor = new Set(['hash', 'id', 'prefix', 'name', 'rights', 'mfa', ...Object.keys(ECHOABLE)]);
+    // `rateLimitPerMinute` joined the editable set for the same reason `mfa` did: a quota that could only be
+    // set while minting would mean changing a client's budget required revoking its token and issuing a new
+    // one — rotating a secret to change a number. It is a property of the token, so it is edited on the token.
+    const accountedFor = new Set(['hash', 'id', 'prefix', 'name', 'rights', 'mfa', 'rateLimitPerMinute',
+      ...Object.keys(ECHOABLE)]);
     const orphans = fields.filter(f => !accountedFor.has(f));
     assert.deepEqual(orphans, [],
       `${orphans.join(', ')} are returned by GET and would be refused by PATCH — a token read back cannot `


### PR DESCRIPTION
feat(auth): a request quota an admin sets per token, under a ceiling infra sets

Owner request, 2026-08-20, in two parts: "ratelimit should be settable on token by
instance admin" and "and instancewide by infra".

THE BUCKET WAS ALREADY PER TOKEN. ONLY THE CEILING WAS A CONSTANT.

`clientRateLimitKey` has always keyed the limiter on a hash of the credential, so requests
were already counted per token. `max: 300` was simply hardcoded. This change is that number
becoming resolvable, not a new counting mechanism — worth saying because the obvious way to
build this is to invent a parallel one.

WHY A SECOND LIMITER RATHER THAN MAKING THE EXISTING ONE TOKEN-AWARE

The existing limiter runs BEFORE authentication, deliberately: it is the only throttle in
front of admin TOTP verification, so it has to throttle requests carrying no valid
credential at all. That means it cannot know WHICH token a request holds — answering that
needs a bcrypt compare against every stored token, per request.

So it is untouched and remains the outer bound for the anonymous surface, and the quota is
enforced after auth, where the record is already resolved and free. A gate pins that the
pre-auth one still keys on the client and never reads `authToken`.

APPLIED WHERE IT CANNOT BE FORGOTTEN

There are NINE auth entry points, each resolving and attaching a record separately. Wiring
the limiter at any subset leaves the rest uncounted, and a quota with a hole in it is not a
quota; wiring all nine works until somebody adds a tenth.

So the function that ATTACHES a token is the function that METERS it, and `attachToken` now
takes `next` rather than letting callers call it. A new auth path cannot attach a token
without metering, because attaching is how a request proceeds — there is no `next()` left to
reach around. The gate counts: every `attachToken(` occurrence except the declaration must
hand over `res` and `next`.

Keyed on the token ID, not the credential hash: a rotated token is a new credential and the
same grant, and keying on the hash would hand every rotation a fresh bucket.

TWO TIERS, RESOLVED THE WAY THIS CODEBASE ALREADY RESOLVES TIERS

`token > instance > default`, the same order `ttlDays` and `suppressEmbeddings` use:
`rateLimitPerMinute` on the token, then `YTHRIL_RATE_LIMIT_PER_MINUTE`, then the 300/minute
the global limiter has always allowed. **An instance that configures neither behaves exactly
as it does today** — a lower default here would have silently tightened every existing
deployment on upgrade.

**Absence on a token means INHERIT, never unlimited.** If absence meant unlimited, every
token minted before this change would become unthrottled on upgrade — invisible until
something floods. Pinned in both directions.

THE INFRA VALUE IS A CEILING, NOT JUST A DEFAULT

A ceiling an admin can exceed is decorative, so a per-token value above it is refused with a
403 naming the ceiling and the env var that owns it. **Never accepted and clamped.** Storing
50 when the admin asked for 500 and answering 201 tells them their quota is 500 — the
accepted-but-discarded defect that `api/tokens.ts` already carries a long comment about, one
field over. Mutation tested: making the ceiling clamp instead of refuse turns the gate red.

ONE RULE, BOTH WRITE PATHS, AND THE READ SURFACE AGREES

`rateLimitRefusal` owns the bounds and the ceiling. Create and PATCH both call it, and the
request schema deliberately does NOT restate the bounds — a `z.number().max(…)` there would
be a second copy of a number infra owns, and the one that goes stale the moment the env
changes, since a schema is built at import.

`rateLimitEffective` is derived in `listTokens`, which is what the REST list and the MCP
`list_tokens` tool BOTH call. Deriving it at one door would give the two doors different
answers to the same question. The tool description says which of the two fields to read and
what absence means, because absent-versus-unlimited is the reading a caller gets wrong.

TWO GATES CAUGHT ME, AND BOTH WERE RIGHT

`token-read-shape-round-trips` refused the new field until it was accounted for as editable
— and separately, `rateLimitEffective` had to join `SERVER_OWNED_TOKEN_FIELDS` or a client
posting back a token it had read would 400 on a field we ourselves emitted. That list exists
for exactly this and I would have reintroduced the defect it was created for.

`no-new-god-files` refused the display logic inside `tokens.component.ts`. Its instruction —
put the behaviour beside it rather than inside it — produced a better result: the quota cell
has a real rule in it (show the effective number, badge an explicit one) and now lives
somewhere that rule can be read.

THE FIVE PLACES

REST route, MCP (`list_tokens` reports both fields; there is no MCP tool that mints or edits
a token, so the write half adds no asymmetry — credential minting is deliberately not on
that surface), the integration guide, the userguide, and rights: token management is already
`instanceAdmin`, so no new `ROUTE_RIGHTS` row — stated here rather than left unsaid.

Also registered in `NUMERIC_SETTINGS`, so a typo stops the boot. `max: NaN` in
express-rate-limit rejects every request: an instance that serves nothing because somebody
wrote `3OO` must fail loudly at startup, not silently at the first request.
