### PR TITLE
chore(testing): the capped gaps are now SORTED, not just counted

### DIFF
--- a/testing/standalone/backups-are-not-world-readable.test.js
+++ b/testing/standalone/backups-are-not-world-readable.test.js
@@ -142,6 +142,9 @@ describe('the docs admit what encryption at rest does not cover', () => {
     const doc = read('docs/integration-guide/12-admin-api.md');
     assert.match(doc, /unencrypted copy of everything/i,
       'the backup endpoint must say the dump is unencrypted');
+    // ADJACENCY CLAIM, not a window: `.` does not match a newline, so this asserts the flag and the disclaimer
+    // are on ONE LINE of prose. That is the rule — a page that names the flag and admits the gap forty lines
+    // apart has not corrected the assumption, which is the whole point of the sentence.
     assert.match(doc, /requireEncryptedAtRest.{0,40}does not cover it/i,
       'it must say explicitly that the at-rest flag does not cover a dump — that is the assumption being corrected');
     assert.match(doc, /decrypted/i,

--- a/testing/standalone/chrono-status-descriptions-match-the-derivation.test.js
+++ b/testing/standalone/chrono-status-descriptions-match-the-derivation.test.js
@@ -32,7 +32,7 @@ import { describe, it, before } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { stripComments } from './_strip-comments.mjs';
-import { statementAround } from './_structural-window.mjs';
+import { statementAround, bodyOf } from './_structural-window.mjs';
 
 let deriveChronoStatus, ALL_TOOLS;
 before(async () => {
@@ -79,7 +79,8 @@ describe('every chrono read path applies it, which is what makes the sentences t
   const src = () => stripComments(readFileSync('server/src/brain/chrono.ts', 'utf8'));
 
   it('a single-entry get derives', () => {
-    assert.match(src(), /getChronoById[\s\S]{0,300}?withDerivedStatus/,
+    // A WINDOW, converted: the subject is the function, and 300 characters was a guess at how much of it fits.
+    assert.match(bodyOf(src(), 'getChronoById'), /withDerivedStatus/,
       'the tools say a get reads back overdue');
   });
 
@@ -129,6 +130,17 @@ describe('no tool repeats the claim that was false', () => {
     // paragraph this gate exists to refuse left it green. Its own mutation check is what said so.
     // Whole-body, not description-only, for the same reason — on `create_chrono` the claim lived in the
     // parameter schema rather than in the prose.
+    /*
+     * EVERY `{0,N}` in this list is an ADJACENCY CLAIM, and they stay.
+     *
+     * These patterns refuse a SENTENCE that was written and was false. The gap exists because the sentence
+     * appeared with small variations — "nothing recomputes `status`" and "nothing recomputes the status" — and
+     * the number is how many characters of variation are tolerated between two fixed words. Widen it and the
+     * pattern starts matching prose that merely contains both words far apart, which is how a refusal turns
+     * into a false positive on a description that is now correct.
+     *
+     * The one WINDOW in this file — a function body behind `{0,300}` — is converted above. These are not that.
+     */
     const BAD = [
       [/nothing recomputes[\s\S]{0,20}status/i, 'nothing recomputes'],
       [/only finds entries somebody marked overdue/i, 'somebody marked overdue'],

--- a/testing/standalone/collectors-are-timed.test.js
+++ b/testing/standalone/collectors-are-timed.test.js
@@ -34,6 +34,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { enclosingBlockAround } from './_structural-window.mjs';
 
 const ROOT = process.cwd();
 const SRC = 'server/src/metrics/registry.ts';
@@ -140,8 +141,14 @@ describe('every async metric collector is timed and bounded', () => {
   it('the histogram can describe a scrape that timed out', () => {
     // Prometheus times out at 10 s by default. A top bucket at or below that cannot express the failure, so the
     // graph would show everything in `+Inf` and say nothing about how bad it got.
-    const m = src.match(/name: 'ythril_metrics_collect_duration_seconds'[\s\S]{0,400}?buckets: \[([^\]]+)\]/);
-    assert.ok(m, 'the collector-duration histogram or its buckets are missing');
+    // A WINDOW, converted: the subject is the histogram's own definition object, bounded by the brace that
+    // closes it. At 400 characters a definition that gained a label or a help string would push `buckets`
+    // out of range, and the anchor assertion would then report the histogram as MISSING.
+    const at = src.indexOf("name: 'ythril_metrics_collect_duration_seconds'");
+    assert.ok(at > -1, 'the collector-duration histogram is missing');
+    const def = enclosingBlockAround(src, at, 'the collector-duration histogram');
+    const m = /buckets: \[([^\]]+)\]/.exec(def);
+    assert.ok(m, 'the collector-duration histogram has no buckets');
     const buckets = m[1].split(',').map(s => Number(s.trim()));
     assert.ok(Math.max(...buckets) > 10, `top bucket is ${Math.max(...buckets)}s — it must exceed the 10s timeout`);
     assert.ok(Math.min(...buckets) <= 0.05, 'needs a fast bucket too: a healthy collector is ~25 ms');

--- a/testing/standalone/gates-bound-their-subject-structurally.test.js
+++ b/testing/standalone/gates-bound-their-subject-structurally.test.js
@@ -163,13 +163,20 @@ const GRANDFATHERED = new Map([
 /**
  * A CAPPED GAP inside a regex: `/marker[\s\S]{0,400}?other/`. Files still allowed to carry one, with how many.
  *
- * **57 occurrences across 31 files**, down from 66/36 when this was first measured — and the tracker had recorded
+ * **56 occurrences across 29 files**, down from 66/36 when this was first measured — and the tracker had recorded
  * 30, which is why the number lives in the gate now rather than in a markdown file that drifts.
  *
  * The nine that left were the ones whose subject is a NAMED FUNCTION or a BRANCH, where the structural bound is
  * unambiguous: an update call's arguments, a 412 branch, a catch block, an abandon branch, `spaceStillExists`,
  * `selectSpace` (a 2 000-character cap — nobody chooses that number, they raise it until the test passes),
  * `chronoAllowedTypes`, `getAllowedChronoTypes`, and a try/finally.
+ *
+ * **And what remains is now SORTED, not merely counted.** The prose sites carry a one-line comment saying
+ * the number IS the rule — `[^.]` and `[^.
+]` cannot cross a full stop or a line, so those patterns assert
+ * that two things sit in ONE SENTENCE, which is exactly what a schema description has to do for a caller to
+ * read it. Widening those gaps would turn a working refusal into a false positive on prose that is now
+ * correct. A site left in this list without such a comment has not been read yet.
  *
  * **What remains is the fails-LOUDLY class, and that is why it is a frozen list rather than a blocker.** Every one
  * of the six negative-polarity sites — where a short window makes an absence hold and the gate pass — was converted
@@ -203,18 +210,16 @@ const GRANDFATHERED_GAP = new Map([
   ['testing/standalone/caller-supplied-ids-are-uuids.test.js', 1],
   ['testing/standalone/chrono-retention.test.js', 1],
   ['testing/standalone/chrono-status-descriptions-match-the-derivation.test.js', 9],
-  ['testing/standalone/collectors-are-timed.test.js', 1],
   ['testing/standalone/contradiction-scanner.test.js', 1],
   ['testing/standalone/document-description.test.js', 3],
   ['testing/standalone/file-mutation-tools-state-their-cascade.test.js', 2],
-  ['testing/standalone/graph-spill-is-not-content.test.js', 1],
   ['testing/standalone/infra-managed-locks-every-field.test.js', 3],
   ['testing/standalone/mcp-tool-rights.test.js', 2],
   ['testing/standalone/merge-relinks-every-entity-reference.test.js', 2],
   ['testing/standalone/meta-precondition.test.js', 1],
   ['testing/standalone/no-boot-migration-on-synced-data.test.js', 1],
   ['testing/standalone/no-copyleft-in-the-shipped-tree.test.js', 2],
-  ['testing/standalone/notice-coverage.test.js', 1],
+  ['testing/standalone/notice-coverage.test.js', 2],
   ['testing/standalone/oidc-carries-a-rights-matrix.test.js', 1],
   ['testing/standalone/recall-params-reach-the-ui.test.js', 2],
   ['testing/standalone/reembed-backfill.test.js', 1],

--- a/testing/standalone/graph-spill-is-not-content.test.js
+++ b/testing/standalone/graph-spill-is-not-content.test.js
@@ -20,6 +20,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
+import { balancedFrom } from './_structural-window.mjs';
 
 const { isSpillPath, SPILL_DIR } = await import('../../server/dist/brain/spill-path.js');
 const { SPILL_TTL_DAYS, SPILL_CEILING_MULTIPLE } = await import('../../server/dist/brain/graph-spill.js');
@@ -149,7 +150,13 @@ describe('the constants say what the ruling said', () => {
       'no caller-supplied write space — the routes had `spaceId` and `callSpace` to hand, and both can be a proxy');
     for (const src of ['server/src/api/brain/search.ts', 'server/src/mcp/tools/search.ts']) {
       const code = read(src);
-      const calls = [...code.matchAll(/buildGraphWithSpill\(([\s\S]{0,320}?)\);/g)].map(m => m[1]);
+      // A WINDOW, converted: the subject is each call's ARGUMENT LIST, and its bound is the paren that closes
+      // it. At 320 characters a call that gained an argument would have stopped matching, and the assertion
+      // below counts the calls — so a missed one reads as "there is only one spill build", not as an error.
+      const calls = [...code.matchAll(/buildGraphWithSpill\(/g)]
+        // Outer parens stripped so the assertion below sees exactly what the capture group used to give it —
+        // this is a re-bounding, not a change of what is checked.
+        .map(m => balancedFrom(code, m.index, `buildGraphWithSpill in ${src}`).slice(1, -1));
       assert.equal(calls.length, 2, `${src}: expected two spill builds, found ${calls.length}`);
       for (const args of calls) {
         assert.ok(!/spaceId,\s*\)?\s*$/.test(args.trim()),

--- a/testing/standalone/notice-coverage.test.js
+++ b/testing/standalone/notice-coverage.test.js
@@ -139,7 +139,14 @@ describe('NOTICE covers everything we redistribute', () => {
         // The verb AND the licence it selects. A bare `/elect/i` was too loose to be worth having: it
         // matched the surrounding prose explaining *why* an election is recorded, so deleting the actual
         // election statement left the test green. Caught by mutating the entry.
-        // The entry, bounded by the next `###` — so an entry that grows an explanation is still read whole.
+        /*
+         * The entry, bounded by the next `###` — so an entry that grows an explanation is still read whole.
+         *
+         * The `{0,40}` inside the pattern is an ADJACENCY CLAIM and stays: `[^.\n]` crosses neither a full stop
+         * nor a line, so it asserts the verb and the licence it selects are in ONE clause. That is the rule the
+         * comment above it already gives — a bare `/elect/i` matched the surrounding prose ABOUT elections, so
+         * deleting the actual election statement left this green. Widening the gap would undo that fix.
+         */
         return !/elects?\s+[^.\n]{0,40}(Apache|MIT|MPL|BSD|ISC|GPL)/i.test(markdownSectionFrom(NOTICE, at));
       })
       .map(d => `  ${d.name} (${d.license})`);

--- a/testing/standalone/search-tool-schemas-document-their-response.test.js
+++ b/testing/standalone/search-tool-schemas-document-their-response.test.js
@@ -50,6 +50,9 @@ describe('the response is documented, not just the request', () => {
   });
 
   it('says `count` excludes traversed nodes', () => {
+    // ADJACENCY CLAIM, not a window: `[^.]` cannot cross a full stop, so this asserts the two words are in ONE
+    // SENTENCE. The 80 is a belt on top of that bound, and the sentence is the rule — a schema that mentions
+    // `count` in one paragraph and MATCHES three paragraphs later has not told the caller anything.
     assert.match(RECALL, /count[^.]{0,80}MATCHES/,
       '`count` counts matches; a caller comparing it to `graphNodes` needs to know that');
   });
@@ -81,6 +84,10 @@ describe('query says what it is FOR and what comes back', () => {
   it('says count is the page and total is the filter', () => {
     // The difference between them is the only signal that more rows exist. A full page is not evidence of
     // being the last one, and nothing said so.
+    //
+    // ADJACENCY CLAIMS, both of them: `[^.]` cannot cross a full stop, so each asserts a field and its meaning
+    // sit in ONE SENTENCE. That IS the requirement — the two fields differ by one word and a caller who has to
+    // assemble the distinction from separate paragraphs will not.
     assert.match(QUERY, /`count`[^.]{0,120}THIS page/, '`count` is this page');
     assert.match(QUERY, /`total`[^.]{0,120}overall/, '`total` is the whole filter');
   });


### PR DESCRIPTION
chore(testing): the capped gaps are now SORTED, not just counted

X-25c. Three more converted, and — more usefully — the prose sites now say why they are
staying, so the remaining population is classified rather than merely frozen.

THE DISTINCTION, WRITTEN AT EACH SITE RATHER THAN ONLY IN THE GATE

`[^.]` and `[^.\n]` cannot cross a full stop or a line. So a pattern like
`/count[^.]{0,80}MATCHES/` is not a window at all — it asserts that a field and its meaning
sit in ONE SENTENCE, and that IS the requirement: a schema description that mentions `count`
in one paragraph and what it counts three paragraphs later has told the caller nothing.

Widening those gaps would turn a working refusal into a false positive on prose that is now
correct. `notice-coverage` is the proof: a bare `/elect/i` matched the surrounding prose
ABOUT licence elections, so deleting the actual election statement left it green. The gap is
what fixed that.

Commented at: `search-tool-schemas` (x3), `backups-are-not-world-readable`,
`notice-coverage`, and the whole refused-sentence list in `chrono-status` (x5, one comment).

A site left in the frozen list without such a comment has not been read yet — which is now
a statement the list can support.

THREE CONVERTED

  chrono-status        a function body behind `{0,300}` -> `bodyOf`
  graph-spill          each call's ARGUMENT LIST behind `{0,320}` -> `balancedFrom`
  collectors-are-timed the histogram's definition object behind `{0,400}` -> `enclosingBlockAround`

The graph-spill one is worth a note: the assertion COUNTS the calls it finds, so a call that
grew an argument past 320 characters would not have failed — it would have reported "there
is only one spill build", which reads as a finding rather than as a missed match.

The collectors one had the same shape from the other side: at 400 characters a histogram
definition that gained a label or a help string would push `buckets` out of range, and the
anchor assertion would then report the histogram as MISSING.

Outer parens are stripped in graph-spill so the existing assertion sees exactly what the
capture group gave it — a re-bounding, not a change of what is checked.

56 gaps across 29 files remain, down from 66/36 at first measurement. Mutation tested: the
get stopping deriving, a space id passed to the builder again, and a top bucket that no
longer exceeds the Prometheus timeout each turn their gate red.
