### PR TITLE
chore(testing): ten more capped gaps became structural bounds, and two changed the rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   auth entry point calls, and that function now consumes `next` so a new auth path cannot attach a token
   without metering it.
 
+### Changed
+
+- **Ten more guessed character windows in the gates became structural bounds, emptying five files.** Two of
+  them changed what "structural" has to mean rather than just moving a number. A `NOTICE` entry read with a
+  900-character window was **13 characters** from reading the *next* entry: `### jszip` sits at offset 18040
+  and the following entry's licence election at 18953, so at 913 the neighbour would have answered a check
+  whose whole stated purpose is refusing that. And the enclosing STATEMENT turned out to be the wrong bound
+  for a ternary — `pass === 'structured' ? judgePair(a, b, { structuredOnly: true }) : judgePair(a, b)` is
+  ONE statement holding both arms, so a statement-level bound stays green with the flag on the other branch,
+  which is the opposite behaviour and a paid model call per pair. The bound that holds is the argument list
+  of the call the branch makes. Structural is not automatically tighter than a character count; it is
+  tighter only when the structure chosen is the subject. Every conversion was mutation-tested against the
+  behaviour it claims. `GRANDFATHERED_GAP` falls to **46 across 24 files**, from 56/29.
+
 ## [3.2.0] — 2026-08-20
 
 ### Breaking

--- a/testing/standalone/contradiction-scanner.test.js
+++ b/testing/standalone/contradiction-scanner.test.js
@@ -22,6 +22,7 @@
 import { describe, it, before } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import { balancedFrom } from './_structural-window.mjs';
 
 let cursorKey, toJudgeable, DEFAULT_TYPES, unjudgedNeighbours;
 
@@ -152,7 +153,14 @@ describe('contradiction scanner — the free pass is actually free', () => {
   const code = src.replace(/\/\*[\s\S]*?\*\//g, '').split('\n').filter(l => !l.trim().startsWith('//')).join('\n');
 
   it('asks the judge for the deterministic pass only', () => {
-    assert.match(code, /pass === 'structured'[\s\S]{0,160}structuredOnly:\s*true/);
+    // A WINDOW, converted to the ARGUMENT LIST of the call the structured branch makes. Not the enclosing
+    // statement: the branch is a ternary, so the statement holds BOTH arms and the flag could sit on the NLI
+    // one and still satisfy it — which is the opposite behaviour, and the whole point of the test.
+    const at = code.indexOf("pass === 'structured'");
+    const call = code.indexOf('judgePair(', at);
+    assert.ok(at > -1 && call > at, 'the structured branch no longer calls judgePair — re-anchor this gate');
+    const args = balancedFrom(code, code.indexOf('(', call), 'the structured-pass judgePair call');
+    assert.match(args, /structuredOnly:\s*true/);
   });
 
   it('does not try to buy silence with an unreachable confidence floor', () => {

--- a/testing/standalone/file-mutation-tools-state-their-cascade.test.js
+++ b/testing/standalone/file-mutation-tools-state-their-cascade.test.js
@@ -30,6 +30,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
+import { blockAfter } from './_structural-window.mjs';
 import { stripComments } from './_strip-comments.mjs';
 
 const FILE_TOOLS = readFileSync('server/src/mcp/tools/file.ts', 'utf8');
@@ -141,7 +142,13 @@ describe('create_dir says when you do not need it', () => {
     // "an empty directory does not sync" true rather than plausible.
     const at = FILES.indexOf('export async function listFilesRecursive');
     const body = FILES.slice(at, FILES.indexOf('\nexport ', at + 10));
-    assert.match(body, /entry\.isDirectory\(\)[\s\S]{0,60}walk\(full\)/, 'it descends');
-    assert.match(body, /entry\.isFile\(\)[\s\S]{0,80}out\.push/, 'but only files are emitted');
+    // TWO WINDOWS, converted: each subject is a BRANCH of the same if/else, bounded by its own brace. The caps
+    // could not tell "the push is in the isFile arm" from "the push is 80 characters later" — and if it moved
+    // into the isDirectory arm the walk would emit directories, which is the exact claim above.
+    const dir = body.indexOf('entry.isDirectory()');
+    const file = body.indexOf('entry.isFile()');
+    assert.ok(dir > -1 && file > -1, 'the walk no longer branches on entry type — re-anchor this gate');
+    assert.match(blockAfter(body, dir, 'the isDirectory arm'), /walk\(full\)/, 'it descends');
+    assert.match(blockAfter(body, file, 'the isFile arm'), /out\.push/, 'but only files are emitted');
   });
 });

--- a/testing/standalone/gates-bound-their-subject-structurally.test.js
+++ b/testing/standalone/gates-bound-their-subject-structurally.test.js
@@ -163,13 +163,27 @@ const GRANDFATHERED = new Map([
 /**
  * A CAPPED GAP inside a regex: `/marker[\s\S]{0,400}?other/`. Files still allowed to carry one, with how many.
  *
- * **56 occurrences across 29 files**, down from 66/36 when this was first measured — and the tracker had recorded
+ * **46 occurrences across 24 files**, down from 66/36 when this was first measured — and the tracker had recorded
  * 30, which is why the number lives in the gate now rather than in a markdown file that drifts.
  *
  * The nine that left were the ones whose subject is a NAMED FUNCTION or a BRANCH, where the structural bound is
  * unambiguous: an update call's arguments, a 412 branch, a catch block, an abandon branch, `spaceStillExists`,
  * `selectSpace` (a 2 000-character cap — nobody chooses that number, they raise it until the test passes),
  * `chronoAllowedTypes`, `getAllowedChronoTypes`, and a try/finally.
+ *
+ * The ten after those emptied five files, and two of them are worth recording because they change what
+ * "structural" has to mean:
+ *
+ * - **A NOTICE entry read with a 900-character window was 13 characters from reading the WRONG entry.** `### jszip`
+ *   sits at offset 18040 and the next entry's election at 18953. The check asks whether *this* package's licence
+ *   arm is recorded; at 913 characters the neighbour's election would have answered for it, and the test that
+ *   would have gone green is the one whose stated purpose is refusing exactly that. Nothing maintains a
+ *   13-character margin, and nothing would have reported it.
+ * - **The enclosing STATEMENT is the wrong bound for a ternary.** `pass === 'structured' ? judgePair(a, b,
+ *   { structuredOnly: true }) : judgePair(a, b)` is one statement holding BOTH arms, so a statement-level bound is
+ *   satisfied by the flag sitting on the other branch — the opposite behaviour, and a paid model call. The bound
+ *   that holds is the ARGUMENT LIST of the call the branch makes. Structural is not automatically tighter than a
+ *   character count: it is tighter only when the structure chosen is the subject.
  *
  * **And what remains is now SORTED, not merely counted.** The prose sites carry a one-line comment saying
  * the number IS the rule — `[^.]` and `[^.
@@ -210,27 +224,22 @@ const GRANDFATHERED_GAP = new Map([
   ['testing/standalone/caller-supplied-ids-are-uuids.test.js', 1],
   ['testing/standalone/chrono-retention.test.js', 1],
   ['testing/standalone/chrono-status-descriptions-match-the-derivation.test.js', 9],
-  ['testing/standalone/contradiction-scanner.test.js', 1],
   ['testing/standalone/document-description.test.js', 3],
-  ['testing/standalone/file-mutation-tools-state-their-cascade.test.js', 2],
   ['testing/standalone/infra-managed-locks-every-field.test.js', 3],
   ['testing/standalone/mcp-tool-rights.test.js', 2],
   ['testing/standalone/merge-relinks-every-entity-reference.test.js', 2],
   ['testing/standalone/meta-precondition.test.js', 1],
   ['testing/standalone/no-boot-migration-on-synced-data.test.js', 1],
-  ['testing/standalone/no-copyleft-in-the-shipped-tree.test.js', 2],
   ['testing/standalone/notice-coverage.test.js', 2],
   ['testing/standalone/oidc-carries-a-rights-matrix.test.js', 1],
   ['testing/standalone/recall-params-reach-the-ui.test.js', 2],
   ['testing/standalone/reembed-backfill.test.js', 1],
-  ['testing/standalone/retention-reaches-every-collection.test.js', 3],
   ['testing/standalone/rights-are-explained.test.js', 3],
   ['testing/standalone/route-guard-coverage.test.js', 1],
   ['testing/standalone/schema-derived-type-controls.test.js', 2],
   ['testing/standalone/search-tool-schemas-document-their-response.test.js', 3],
   ['testing/standalone/single-flight.test.js', 1],
   ['testing/standalone/space-admin-reaches-its-own-space-settings.test.js', 1],
-  ['testing/standalone/stt-multipart-and-partial.test.js', 2],
   ['testing/standalone/sync-waits-retrigger-and-diagnose.test.js', 1],
   ['testing/standalone/vlm-endpoint-egress.test.js', 1],
 ]);

--- a/testing/standalone/no-copyleft-in-the-shipped-tree.test.js
+++ b/testing/standalone/no-copyleft-in-the-shipped-tree.test.js
@@ -37,6 +37,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
 import { join } from 'node:path';
+import { markdownSectionFrom } from './_structural-window.mjs';
 
 const ROOT = process.cwd();
 
@@ -119,10 +120,19 @@ describe('nothing copyleft is redistributed without a recorded election', () => 
 
     const unrecorded = [];
     for (const [name, v] of hits) {
-      const section = notice.match(new RegExp(`### ${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b[\\s\\S]{0,900}`));
-      if (!section) { unrecorded.push(`${name}@${v.version} (${v.license}) — no NOTICE entry`); continue; }
+      // A WINDOW, converted: the subject is the NOTICE entry, bounded by the next heading — so an entry that
+      // grows an explanation is still read whole, and an entry that grows past 900 characters no longer has
+      // its election cut off and fail for nothing.
+      //
+      // The other direction was 13 characters from being live. `### jszip` sits at offset 18040 and the NEXT
+      // entry's election (`Ythril elects Apache License 2.0`, dompurify's) at 18953 — 913 characters, so the
+      // 900 window stopped just short of letting a NEIGHBOUR'S election satisfy jszip's check. Nobody
+      // maintains a 13-character margin, and nothing would have reported it once a line was added.
+      const head = new RegExp(`^### ${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'm').exec(notice);
+      if (!head) { unrecorded.push(`${name}@${v.version} (${v.license}) — no NOTICE entry`); continue; }
+      const section = markdownSectionFrom(notice, head.index);
       // An entry that just names the dual grant is not an election. It has to say which arm Ythril takes.
-      if (!/elects/i.test(section[0])) {
+      if (!/elects/i.test(section)) {
         unrecorded.push(`${name}@${v.version} (${v.license}) — NOTICE entry does not record which arm is elected`);
       }
     }
@@ -138,9 +148,13 @@ describe('nothing copyleft is redistributed without a recorded election', () => 
     // Named explicitly so a NOTICE rewrite cannot quietly drop an election and leave the generic check satisfied
     // by some other package's wording.
     for (const [name, arm] of [['dompurify', /elects Apache License 2\.0/], ['jszip', /elects the MIT License/]]) {
-      const section = notice.match(new RegExp(`### ${name}[\\s\\S]{0,900}`));
-      assert.ok(section, `NOTICE has no entry for ${name}`);
-      assert.match(section[0], arm, `${name}'s election is not recorded as expected`);
+      // Bounded by the next heading, for the reason the comment above gives. A 900-character window contradicts
+      // its own stated purpose: it reads into the NEXT entry, which is precisely "satisfied by some other
+      // package's wording".
+      const head = new RegExp(`^### ${name}\\b`, 'm').exec(notice);
+      assert.ok(head, `NOTICE has no entry for ${name}`);
+      assert.match(markdownSectionFrom(notice, head.index), arm,
+        `${name}'s election is not recorded as expected`);
     }
   });
 

--- a/testing/standalone/retention-reaches-every-collection.test.js
+++ b/testing/standalone/retention-reaches-every-collection.test.js
@@ -27,6 +27,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { balancedFrom, blockAfter } from './_structural-window.mjs';
 
 const ROOT = process.cwd();
 
@@ -88,8 +89,12 @@ describe('the schema retention tier reaches every typed collection', () => {
       assert.ok(!/type:\s*doc\.type|type:\s*existing\.type/.test(c.args),
         `edges.ts:${c.line} resolves its retention type from \`type\`; the schema is keyed by \`label\``);
     }
+    // A WINDOW, converted: the subject is the TYPE_FIELD map itself, bounded by the brace that closes it. 200
+    // characters reached past the map into the functions below, where `'label'` appears for other reasons.
     const ttl = read('server/src/brain/ttl.ts');
-    assert.match(ttl, /TYPE_FIELD[\s\S]{0,200}edge:\s*'label'/,
+    const map = ttl.indexOf('TYPE_FIELD');
+    assert.ok(map > -1, 'TYPE_FIELD is gone — re-anchor this gate');
+    assert.match(balancedFrom(ttl, ttl.indexOf('{', map), 'the TYPE_FIELD map'), /edge:\s*'label'/,
       "ttl.ts must map edge -> 'label' in TYPE_FIELD");
   });
 
@@ -99,7 +104,12 @@ describe('the schema retention tier reaches every typed collection', () => {
     const src = read('server/src/brain/chrono-redaction.ts');
     assert.match(src, /TYPED_COLLECTIONS[^=]*=\s*\[\s*'entity',\s*'memory',\s*'edge',\s*'chrono'\s*\]/,
       'TYPED_COLLECTIONS must list all four typed collections');
-    assert.match(src, /for \(const collection of TYPED_COLLECTIONS\)[\s\S]{0,200}backfillTypedExpiry/,
+    // A WINDOW, converted: the subject is the loop BODY, bounded by the brace that closes it. A cap here also
+    // could not tell "the call is inside the loop" from "the call is 200 characters after it", which is the
+    // difference between per-collection and once.
+    const loop = src.indexOf('for (const collection of TYPED_COLLECTIONS)');
+    assert.ok(loop > -1, 'the sweep loop is gone — re-anchor this gate');
+    assert.match(blockAfter(src, loop, 'the retention sweep loop'), /backfillTypedExpiry/,
       'the sweep must call backfillTypedExpiry for each collection');
     // Files stay out: no type, so no schema window. Asserted so nobody "completes" the list.
     assert.ok(!/TYPED_COLLECTIONS[^=]*=[^\]]*'file/.test(src),
@@ -117,8 +127,13 @@ describe('the schema retention tier reaches every typed collection', () => {
   it('the documented worked example is the one that was broken', () => {
     // 04-brain-api.md promises the tier on `entity`, with `ticket` as its example. If that claim is ever
     // narrowed to chrono, this gate should be reconsidered rather than silently disagreeing with the docs.
+    // A WINDOW, converted: the subject is the `"entity"` object in the JSON example, bounded by its own brace.
+    // The example is prose-adjacent and gets reformatted; 120 characters is a claim about how somebody chose to
+    // wrap the snippet, not about whether `retention` is shown under `entity`.
     const doc = read('docs/integration-guide/04-brain-api.md');
-    assert.match(doc, /"entity":\s*\{[\s\S]{0,120}"retention"/,
+    const entity = doc.indexOf('"entity": {');
+    assert.ok(entity > -1, 'the guide no longer shows an "entity" schema object — re-anchor this gate');
+    assert.match(balancedFrom(doc, doc.indexOf('{', entity), 'the entity schema example'), /"retention"/,
       'the guide no longer shows an entity retention example — check whether the tier’s scope changed');
   });
 });

--- a/testing/standalone/stt-multipart-and-partial.test.js
+++ b/testing/standalone/stt-multipart-and-partial.test.js
@@ -34,6 +34,7 @@ import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import http from 'node:http';
+import { blockAfter } from './_structural-window.mjs';
 
 const { ssrfSafeFetch } = await import('../../server/dist/util/ssrf.js');
 
@@ -171,11 +172,19 @@ describe('a failed chunk is never reported as complete', () => {
   });
 
   it('the worker records partial when any chunk failed', () => {
-    assert.match(worker, /if \(a\.failed > 0\)[\s\S]{0,120}fileEmbeddingStatus = 'partial'/);
+    // A WINDOW, converted: the subject is the branch, bounded by its own brace. A cap cannot tell "the status
+    // is set INSIDE the branch" from "it is set 120 characters after it" — and those are opposite behaviours:
+    // one marks a file partial when a chunk failed, the other marks every file partial.
+    const at = worker.indexOf('if (a.failed > 0)');
+    assert.ok(at > -1, 'the audio-failure branch is gone — re-anchor this gate');
+    assert.match(blockAfter(worker, at, 'the audio partial branch'), /fileEmbeddingStatus = 'partial'/);
   });
 
   it('and does the same for video, whose audio can partly fail', () => {
-    assert.match(worker, /if \(v\.audioFailed > 0\)[\s\S]{0,120}fileEmbeddingStatus = 'partial'/);
+    // Same conversion as the audio branch above, for the same reason.
+    const at = worker.indexOf('if (v.audioFailed > 0)');
+    assert.ok(at > -1, 'the video-audio-failure branch is gone — re-anchor this gate');
+    assert.match(blockAfter(worker, at, 'the video partial branch'), /fileEmbeddingStatus = 'partial'/);
   });
 
   it('embedVideo propagates the audio outcome rather than returning void', () => {


### PR DESCRIPTION
Continues X-25c. Five files leave `GRANDFATHERED_GAP` entirely; the frozen count falls to
46 across 24 files, from 56/29.

Eight of the ten are the same conversion as the previous tranche — a branch bounded by its
own brace, a loop body, a map literal, a markdown section:

  retention-reaches-every-collection   the TYPED_COLLECTIONS loop body (blockAfter),
                                       the TYPE_FIELD map (balancedFrom),
                                       the guide's "entity" JSON example (balancedFrom)
  stt-multipart-and-partial            both `partial` branches in the media worker
  file-mutation-tools-state-cascade    both arms of the walk's isDirectory/isFile
  no-copyleft-in-the-shipped-tree      both NOTICE-entry reads (markdownSectionFrom)

The other two are worth the commit message.

**A NOTICE entry read with a 900-character window was 13 characters from reading the WRONG
entry.** `### jszip` sits at offset 18040 in NOTICE and the next entry's licence election
(dompurify's `Ythril elects Apache License 2.0`) at 18953 — 913 characters. The check asks
whether *this* package's arm is recorded, and at 913 a neighbour's election would have
answered for it. The test that would have gone green is the one whose stated purpose, in its
own comment, is refusing to be "satisfied by some other package's wording". Nobody maintains
a 13-character margin, and nothing would have reported it once a line was added.

**The enclosing STATEMENT is the wrong bound for a ternary, and this is the general lesson.**
The first version of the contradiction-scanner conversion used `statementAround`, which reads
correct: the flag must be part of the expression that tested the pass. But

    const verdict = pass === 'structured'
      ? await judgePair(a, b, { schemas: undefined, structuredOnly: true })
      : await judgePair(a, b);

is ONE statement holding BOTH arms, so moving `structuredOnly: true` onto the NLI branch
leaves a statement-level bound green — and that mutation is the opposite behaviour: the
structured pass would reach the endpoint, which is the operator-reported 2x this test exists
to prevent. The bound that holds is the ARGUMENT LIST of the call the branch makes
(`balancedFrom` on the first `judgePair(` after the anchor). Mutation-tested both ways.

So: structural is not automatically tighter than a character count. It is tighter only when
the structure chosen IS the subject. A statement, a block, a section — each is a claim about
what the assertion is about, and picking the wrong one is a wider window with better manners.
Recorded in the gate's own header so the next conversion does not repeat it.

Every conversion mutation-tested against the behaviour it claims, not against the pattern:
the loop call moved out of the loop, each `partial` assignment moved out of its branch, the
walk's arms swapped, `edge: 'label'` flipped to `'type'`, the guide's retention examples
replaced, jszip's election reworded. All eight killed. The restore in each case put the
original string back rather than reaching for git.