### PR TITLE
fix(auth): a deliberately exempt route was logged as an oversight on every request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A route deliberately outside the rights grid stopped being logged as an oversight — and the log can now
+  actually become clean.** Reported by breituai-platform, 2026-08-20, read off a live pod's stdout: two routes
+  warned on **every request** that they had *"no inventory entry — reach enforced, area not. Add it to
+  ROUTE_RIGHTS; misses become refusals once the log is clean."* Both are on `NOT_AREA_SCOPED`, the list that
+  records — with a written reason each — that a route is not a view of a space's DATA. Renaming a space is
+  space-admin; reading which tokens reach it is a read of AUTH state; per-space usage counters are instance
+  observability keyed by space. The list was read by the build-time gate and by nothing at runtime, so
+  `enforceAreaRung` could not tell a decision from an oversight and reported the decision as one. Two
+  consequences, the second worse than the first: the advice was **wrong** for those routes, since following it
+  would have area-scoped a route the design says is not area-scoped; and *"once the log is clean"* named a
+  state four routes guaranteed could never be reached, so the promised flip from allow to refuse could never
+  fire — and had anyone forced it, four routes that worked yesterday would answer `403`. This repo's signature
+  defect exactly: one rule, two implementations, the weaker one winning in silence. `requiredRung` is now
+  `rungFor` and answers with three kinds — `requires`, `not-area-scoped`, `unclassified` — so the two cannot be
+  conflated at any call site, and the warning names both lists instead of only one.
+- **A stale exemption for a route that does not exist.** `/api/spaces/:id/token-access` sat in
+  `NOT_AREA_SCOPED` with a two-line reason; the server serves no such route, only the brain one, which has its
+  own entry. Invisible because the coverage gate's staleness check read `ROUTE_RIGHTS` alone — an exemption
+  could name anything at all. It now checks both lists through one shared existence helper. A stale exemption
+  is the more dangerous of the two: a stale classification guards nothing, while a stale exemption is a
+  **standing licence** — the day a route with that path is added it arrives pre-excused from the rights matrix
+  and no gate objects, because the excuse was written before the route existed.
+
+### Added
+
+- **`notAreaScoped` on `GET /api/tokens/rights-catalog`, and in the Space admin panel.** The same defect one
+  layer up: a route absent from `routes` was indistinguishable to a caller from one nobody had classified, so
+  *"the matrix does not govern renaming a space"* was a fact only the server's source held, and a grid of four
+  areas read as complete while three space-scoped routes sat outside all of them. Now published with the
+  server's own reason per route, on the same argument the endpoint already makes for `routes` and
+  `derivedRungs` — the list the server decides from is the only description of a right that cannot be wrong.
+  No `method`, unlike `routes`: an exemption is a claim about what the route IS, so it covers every verb on
+  that path, and `/api/spaces/:id/rename` is registered as `PATCH` where a method-keyed exemption written for
+  `POST` would have silently missed it. It does not mean unauthenticated or ungoverned — reach is still
+  enforced and each route keeps its own admin guard; it says only which mechanism decides.
+
 ### Added
 
 - **A request quota an instance admin can set per TOKEN, under a ceiling infra sets instance-wide.** Owner

--- a/client/public/assets/i18n/de.json
+++ b/client/public/assets/i18n/de.json
@@ -1889,6 +1889,7 @@
   "tokens.rights.spaceAdmin.off": "Kein Administrator dieses Space (leert alle vier Bereiche)",
   "tokens.rights.spaceAdmin.grants": "Erlaubt zusätzlich:",
   "tokens.rights.spaceAdmin.excludes": "Erlaubt nie:",
+  "tokens.rights.notAreaScoped": "Space-bezogene Routen, die kein Bereich steuert, und warum:",
   "tokens.own.title": "Ihre Berechtigungen",
   "tokens.own.readOnly": "Was das Token darf, mit dem Sie angemeldet sind. Nur Anzeige — Änderungen erfordern eine Administratorin oder einen Administrator.",
   "tokens.own.legacy": "Dieses Token stammt aus der Zeit vor dem Rechtemodell und hat kein Raster. Es funktioniert unverändert; die Administration kann es umstellen.",

--- a/client/public/assets/i18n/en.json
+++ b/client/public/assets/i18n/en.json
@@ -1889,6 +1889,7 @@
   "tokens.rights.spaceAdmin.off": "Not an administrator of this space (clears all four areas)",
   "tokens.rights.spaceAdmin.grants": "Also grants:",
   "tokens.rights.spaceAdmin.excludes": "Never grants:",
+  "tokens.rights.notAreaScoped": "Space-scoped routes that no area governs, and why:",
   "tokens.own.title": "Your access",
   "tokens.own.readOnly": "What the token you are signed in with may do. Read-only — changing it needs an administrator.",
   "tokens.own.legacy": "This token predates the rights model and carries no grid. It works exactly as before; an administrator can convert it.",

--- a/client/public/assets/i18n/pl.json
+++ b/client/public/assets/i18n/pl.json
@@ -1889,6 +1889,7 @@
   "tokens.rights.spaceAdmin.off": "Nie administrator tej przestrzeni (czyści wszystkie cztery obszary)",
   "tokens.rights.spaceAdmin.grants": "Daje również:",
   "tokens.rights.spaceAdmin.excludes": "Nigdy nie daje:",
+  "tokens.rights.notAreaScoped": "Trasy w obrębie przestrzeni, których nie kontroluje żaden obszar, i dlaczego:",
   "tokens.own.title": "Twoje uprawnienia",
   "tokens.own.readOnly": "Co może token, którym jesteś zalogowany. Tylko do wglądu — zmiana wymaga administratora.",
   "tokens.own.legacy": "Ten token powstał przed modelem uprawnień i nie ma siatki. Działa tak jak dotąd; administrator może go przenieść.",

--- a/client/src/app/pages/settings/rights-catalog.service.ts
+++ b/client/src/app/pages/settings/rights-catalog.service.ts
@@ -42,6 +42,23 @@ export interface CatalogDerivedRung {
   excludes: string;
 }
 
+/**
+ * A space-scoped route governed by NO area, with the server's reason.
+ *
+ * The gap this closes in the grid: four areas are shown, and a route absent from `routes` was
+ * indistinguishable from one nobody had classified. Renaming a space, reading which tokens reach it, and
+ * reading its usage counters are all deliberately outside the four DATA areas — a decision recorded in the
+ * server's `NOT_AREA_SCOPED` with a reason each, and until now readable nowhere else.
+ *
+ * No `method`: an exemption is a claim about what the route IS, so it covers every verb on that path. That
+ * asymmetry with `CatalogRoute` is deliberate and matches what the server enforces.
+ */
+export interface CatalogNotAreaScoped {
+  route: string;
+  /** The server's own words. Not reformatted here, for the same reason `grants` is not. */
+  why: string;
+}
+
 export interface RightsCatalog {
   areas: readonly string[];
   rungs: readonly Rung[];
@@ -50,6 +67,8 @@ export interface RightsCatalog {
   /** Absent on an older server too, and read the same way: no derived rungs, not an error. */
   derivedRungs?: readonly CatalogDerivedRung[];
   routes: readonly CatalogRoute[];
+  /** Absent on an older server: the grid then shows no exemption list, which is how it looked before. */
+  notAreaScoped?: readonly CatalogNotAreaScoped[];
 }
 
 /**
@@ -127,6 +146,17 @@ export class RightsCatalogService {
    */
   derived(id: string): CatalogDerivedRung | null {
     return this.catalog()?.derivedRungs?.find(d => d.id === id) ?? null;
+  }
+
+  /**
+   * The space-scoped routes no area governs, or an empty list on a server that does not publish them.
+   *
+   * Empty and absent are the same answer here on purpose: both mean "nothing to show", and an older server is
+   * not an error condition. The alternative — distinguishing them in the UI — would put a version check in a
+   * template for no reader's benefit.
+   */
+  notAreaScoped(): readonly CatalogNotAreaScoped[] {
+    return this.catalog()?.notAreaScoped ?? [];
   }
 
   routesFor(area: string, rung: Rung): CatalogRoute[] {

--- a/client/src/app/pages/settings/rights-matrix.component.ts
+++ b/client/src/app/pages/settings/rights-matrix.component.ts
@@ -153,6 +153,18 @@ const EMPTY = (): WireRungs => ({ knowledge: 'none', files: 'none', schema: 'non
               <li>{{ 'tokens.rights.spaceAdmin.excludes' | transloco }} {{ d.excludes }}</li>
             </ul>
           }
+          <!-- The routes NO area governs, from the server's own exemption list. This belongs in the Space
+               Admin panel because it answers the question the panel raises: if the four areas do not cover
+               renaming a space, what does. Before this the answer existed only in server source, so a grid
+               of four areas read as complete while three space-scoped routes sat outside all of them. -->
+          @if (catalog.notAreaScoped().length) {
+            <p class="muted">{{ 'tokens.rights.notAreaScoped' | transloco }}</p>
+            <ul class="rungs">
+              @for (n of catalog.notAreaScoped(); track n.route) {
+                <li><code>{{ n.route }}</code> — {{ n.why }}</li>
+              }
+            </ul>
+          }
         } @else {
         <h4>{{ 'tokens.rights.area.' + a | transloco }}</h4>
         <p>{{ 'tokens.rights.area.' + a + '.desc' | transloco }}</p>

--- a/docs/integration-guide/07-tokens-api.md
+++ b/docs/integration-guide/07-tokens-api.md
@@ -63,6 +63,10 @@ Authorization: Bearer <token>
   "routes": [
     { "area": "knowledge", "method": "POST", "route": "/api/brain/spaces/:spaceId/recall", "needs": "read" },
     { "area": "files", "method": "DELETE", "route": "/api/files/:spaceId", "needs": "write" }
+  ],
+  "notAreaScoped": [
+    { "route": "/api/spaces/:id/rename",
+      "why": "Renaming a space is Space-admin, which is a column in the approved design but not one of the four DATA areas this inventory covers." }
   ]
 }
 ```
@@ -126,6 +130,27 @@ applying this table on read; do not persist the result, or a rung that exists on
 
 The same resolution governs both doors. A capability refused over REST is refused over MCP for the identical
 reason, because `effectiveRung` is the single place either surface asks what a token holds.
+
+#### `notAreaScoped` — the space-scoped routes NO area governs
+
+Some space-scoped routes are deliberately outside the four data areas, and each carries the reason. Renaming a
+space is Space-admin. Reading which tokens reach a space is a read of **auth** state, not of the space's
+contents. Per-space usage counters are instance observability that happens to be keyed by space.
+
+**Why this is published rather than left implicit.** A route absent from `routes` used to be indistinguishable
+from one nobody had classified — so "the matrix does not govern renaming" was a fact only the server's source
+held, and a grid of four areas read as complete while three routes sat outside all of them. Same argument as
+`routes` itself: the list the server decides from is the only description of a right that cannot be wrong.
+
+**No `method`, unlike `routes`.** An exemption is a claim about what the route *is*, so it covers every verb on
+that path. `routes` keys on method + path because `GET` and `DELETE` genuinely need different rungs; an
+exemption does not have that shape.
+
+**What it does not mean.** Not "unauthenticated", and not "ungoverned". Reach is still enforced — a token that
+cannot touch the space cannot call these either — and each route keeps its own guard, which for all of them
+today is admin or space-admin. What the field says is only that *the four-area grid* is not the thing deciding.
+
+Absent on a server that predates the field. Read that as an empty list, never as an error.
 
 ---
 

--- a/docs/userguide/04-settings.md
+++ b/docs/userguide/04-settings.md
@@ -230,6 +230,19 @@ If MFA is on, a space administrator is prompted for a code like everybody else.
 **The second factor is not a token setting.** MFA is instance-wide and lives in **Settings → Preferences**;
 there is nothing about it in the token dialogs, and there is no per-token exemption to grant here.
 
+#### A few actions belong to no area, and the panel now says which
+
+Open the **?** beside `Space admin` and, under what it grants, there is a short list of routes the four-area
+grid does **not** decide — renaming a space, reading which tokens reach it, and its usage counters — each with
+the reason. They are read from the server, so the list cannot fall out of step with what is enforced.
+
+**Why it is worth a line.** A grid of four areas looks complete, and nothing used to say that three
+space-scoped actions sat outside all four. If you were checking whether a token can rename a space, no cell in
+the matrix answered and none said it would not.
+
+It does **not** mean those actions are unguarded. A token that cannot reach the space cannot call them at all,
+and each one still needs admin or space-admin. What the list says is only which mechanism decides.
+
 ### How many requests a token may make
 
 **Each token has its own request budget, per minute.** Left alone, every token gets the instance's number — so

--- a/server/src/api/tokens.ts
+++ b/server/src/api/tokens.ts
@@ -7,7 +7,7 @@ import { createToken, listTokens, revokeToken, regenerateToken, renameToken, set
 import { isMfaEnabled, verifyMfaCode } from '../auth/totp.js';
 import { z } from 'zod';
 import { SPACE_AREAS, RUNGS, RUNG_IMPLICATIONS, DERIVED_RUNGS } from '../config/rights-shape.js';
-import { ROUTE_RIGHTS } from '../auth/space-rights.js';
+import { ROUTE_RIGHTS, NOT_AREA_SCOPED } from '../auth/space-rights.js';
 import { refusalsOutsideEditorScope, editorScopeFor } from '../auth/editor-scope.js';
 import { capRights, describeExcess } from '../auth/mint-cap.js';
 import { refuseSelfFloorRaise } from '../auth/floor-guard.js';
@@ -93,6 +93,12 @@ tokensRouter.get('/rights-catalog', globalRateLimit, requireAuth, (_req, res) =>
     // cannot be wrong, because `requires` is computed from `SPACE_AREAS` rather than restated.
     derivedRungs: DERIVED_RUNGS,
     routes: ROUTE_RIGHTS.map(r => ({ area: r.area, method: r.method, route: r.route, needs: r.needs })),
+    // Space-scoped routes governed by NO area, each with the reason. Same argument as `routes` and
+    // `derivedRungs`: a route absent from `routes` was indistinguishable to a caller from one we forgot to
+    // classify, so "the matrix does not govern renaming a space" was a fact only the server source held. Four
+    // rows, and they are the difference between a complete grid and a grid with an unexplained gap. No method:
+    // an exemption is a claim about the route rather than about one verb of it — see NOT_AREA_SCOPED.
+    notAreaScoped: NOT_AREA_SCOPED.map(r => ({ route: r.route, why: r.why })),
   });
 });
 

--- a/server/src/auth/middleware.ts
+++ b/server/src/auth/middleware.ts
@@ -11,7 +11,7 @@ import type { OidcTokenRecord } from './oidc.js';
 import { resolveMemberSpaces } from '../spaces/proxy.js';
 import { reachesSpace } from './space-reach.js';
 import { legacySpacesOf } from './legacy-spaces.js';
-import { requiredRung, satisfies } from './required-rung.js';
+import { rungFor, satisfies } from './required-rung.js';
 import { effectiveRung } from './mint-cap.js';
 import { authAttemptsTotal } from '../metrics/registry.js';
 import { logAuthFailure } from '../audit/middleware.js';
@@ -411,12 +411,18 @@ function enforceAreaRung(
   if (!rights) return true;                    // OIDC records: reach already answered for them
 
   const routePath = `${req.baseUrl ?? ''}${(req.route as { path?: string } | undefined)?.path ?? ''}`;
-  const need = requiredRung(req.method, routePath);
-  if (!need) {
+  const verdict = rungFor(req.method, routePath);
+  // A route on NOT_AREA_SCOPED is DECIDED, not missed, so it says nothing. Warning on it told an operator to
+  // add it to ROUTE_RIGHTS — which would undo the recorded decision — and made "once the log is clean" a state
+  // four routes guaranteed could never be reached. See the note on NOT_AREA_SCOPED for the whole account.
+  if (verdict.kind === 'not-area-scoped') return true;
+  if (verdict.kind === 'unclassified') {
     log.warn(`Space rights: no inventory entry for '${req.method} ${routePath}' — reach enforced, area not. `
-      + 'Add it to ROUTE_RIGHTS; misses become refusals once the log is clean.');
+      + 'Add it to ROUTE_RIGHTS with its area and lowest rung, or to NOT_AREA_SCOPED with the reason it is not '
+      + 'a view of the space\'s data; misses become refusals once the log is clean.');
     return true;
   }
+  const need = verdict;
   if (need.scope !== 'path') return true;      // iterating routes gate their LOOP, not the call
 
   for (const sid of targets) {

--- a/server/src/auth/required-rung.ts
+++ b/server/src/auth/required-rung.ts
@@ -7,19 +7,42 @@
  * Scattering the requirement across the handlers would put it back where the gate cannot see it, and the
  * gate is the only reason an unclassified route fails the build rather than quietly ungoverned.
  *
+ * ## THREE answers, not two, and conflating two of them was a real defect
+ *
+ * A route can be in one of three states, and the previous shape of this function could express only two:
+ *
+ *  - **`requires`** — classified in `ROUTE_RIGHTS`. Enforce it.
+ *  - **`not-area-scoped`** — on the `NOT_AREA_SCOPED` list, with a written reason. Somebody DECIDED this
+ *    route is not a view of the space's data. There is nothing to enforce and nothing to report.
+ *  - **`unclassified`** — nobody decided. That is the state this whole feature exists to make impossible.
+ *
+ * Returning `null` for the last two made them one event. `enforceAreaRung` then logged every request to a
+ * deliberately-exempt route as an oversight, advising the operator to add it to `ROUTE_RIGHTS` — advice that
+ * would have undone the recorded decision. Worse, the message's own plan (*"misses become refusals once the
+ * log is clean"*) could never fire, because four routes were guaranteed to keep warning forever. Reported
+ * from a live pod's stdout by breituai-platform, 2026-08-20; see the long note on `NOT_AREA_SCOPED`.
+ *
  * ## Matching, and the one thing that must never happen
  *
  * Express gives the registered pattern (`/spaces/:spaceId/entities/:id`), not the concrete URL, so matching
- * is on the pattern and is exact. **A miss returns `null`, and a `null` must be treated by the caller as
- * REFUSE, never as allow.** That is the whole safety property: an unclassified route is one nobody decided
- * about, and defaulting it to permissive reproduces the situation this feature exists to end — access that
- * works because nothing said otherwise.
+ * is on the pattern and is exact. **`unclassified` must be treated by the caller as REFUSE, never as allow.**
+ * That is the whole safety property: an unclassified route is one nobody decided about, and defaulting it to
+ * permissive reproduces the situation this feature exists to end — access that works because nothing said
+ * otherwise. `not-area-scoped` is the opposite: an explicit allow, and safe precisely because it is written
+ * down with a reason a reader can disagree with.
  *
- * The build-time gate makes a miss unreachable in practice. This function assumes it will happen anyway,
- * because "unreachable in practice" is how the last three silent failures in this codebase described
+ * The build-time gate makes `unclassified` unreachable in practice. This function assumes it will happen
+ * anyway, because "unreachable in practice" is how the last three silent failures in this codebase described
  * themselves.
+ *
+ * ## Method on one list, path on the other
+ *
+ * `ROUTE_RIGHTS` keys on method + path: `GET` and `DELETE` on one path need different rungs. `NOT_AREA_SCOPED`
+ * keys on path alone, because an exemption is a claim about what the route IS rather than about one verb of
+ * it. That asymmetry is deliberate and matches what the gate has always done; `every-space-route-has-an-area`
+ * asserts the two readers agree instead of assuming it.
  */
-import { ROUTE_RIGHTS, type SpaceArea } from './space-rights.js';
+import { ROUTE_RIGHTS, NOT_AREA_SCOPED_PATHS, type SpaceArea } from './space-rights.js';
 import type { Rung } from '../config/rights-shape.js';
 
 export interface RungRequirement {
@@ -28,9 +51,20 @@ export interface RungRequirement {
   scope: 'path' | 'iterates';
 }
 
+/** The three states a route can be in. Discriminated so a caller cannot read one as another. */
+export type RungVerdict =
+  | ({ kind: 'requires' } & RungRequirement)
+  | { kind: 'not-area-scoped' }
+  | { kind: 'unclassified' };
+
 /** Normalise a mount + route pair into the key the inventory stores. */
 function key(method: string, routePath: string): string {
   return `${method.toUpperCase()} ${routePath.replace(/\/+$/, '') || '/'}`;
+}
+
+/** Trailing slashes normalised the same way, so the two lists cannot disagree on `/x` versus `/x/`. */
+function path(routePath: string): string {
+  return routePath.replace(/\/+$/, '') || '/';
 }
 
 const BY_KEY: ReadonlyMap<string, RungRequirement> = new Map(
@@ -38,12 +72,17 @@ const BY_KEY: ReadonlyMap<string, RungRequirement> = new Map(
 );
 
 /**
- * The requirement for a route, or `null` when the inventory does not classify it.
+ * Which of the three states this route is in.
  *
- * `null` is not "no requirement". See the note above: the caller must refuse.
+ * `ROUTE_RIGHTS` is consulted FIRST. If a path ever appears on both lists the classification wins, which is
+ * the safe direction — but a gate refuses that overlap outright, because a route that is both governed and
+ * exempt is a contradiction somebody needs to resolve rather than a precedence rule to rely on.
  */
-export function requiredRung(method: string, fullPath: string): RungRequirement | null {
-  return BY_KEY.get(key(method, fullPath)) ?? null;
+export function rungFor(method: string, fullPath: string): RungVerdict {
+  const found = BY_KEY.get(key(method, fullPath));
+  if (found) return { kind: 'requires', ...found };
+  if (NOT_AREA_SCOPED_PATHS.has(path(fullPath))) return { kind: 'not-area-scoped' };
+  return { kind: 'unclassified' };
 }
 
 /** Does a held rung satisfy a required one? Rungs contain the ones below them. */

--- a/server/src/auth/space-rights.ts
+++ b/server/src/auth/space-rights.ts
@@ -279,16 +279,47 @@ export const TOOL_RIGHTS: readonly ToolRight[] = [
   { tool: 'update_space', area: 'schema', needs: 'write' },
 ];
 
+/**
+ * Routes deliberately outside the four DATA areas — and the runtime reads THIS list, not just the gate.
+ *
+ * ## Why that sentence is the whole point
+ *
+ * For five releases this list was read by exactly one thing: the build-time gate. `enforceAreaRung` knew only
+ * `ROUTE_RIGHTS`, so a route on this list and a route nobody had classified were the SAME event at runtime —
+ * both logged
+ *
+ *     Space rights: no inventory entry for 'GET /api/brain/spaces/:spaceId/activity'
+ *       — reach enforced, area not. Add it to ROUTE_RIGHTS; misses become refusals once the log is clean.
+ *
+ * on every single request. breituai-platform read that off their pod's stdout on 2026-08-20 and reported it,
+ * correctly, as two routes in the rights subsystem that are reach-enforced but not area-enforced.
+ *
+ * Two things were wrong, and the second is worse than the first:
+ *
+ * 1. **The advice was wrong for these routes.** Following it — adding them to `ROUTE_RIGHTS` — would area-scope
+ *    a route the design says is not area-scoped, which is the opposite of the decision recorded in each `why`.
+ * 2. **"Once the log is clean" was UNREACHABLE.** The plan the message states is to flip a miss from allow to
+ *    refuse when nothing warns any more. These four could never stop warning, so the log could never be clean,
+ *    so the flip could never happen — and if somebody had made it happen anyway, four routes that worked
+ *    yesterday would answer 403. A deferred safety improvement that its own log message makes unreachable is
+ *    indistinguishable from one nobody got round to.
+ *
+ * This repo's signature defect, exactly: one rule, two implementations, and the weaker one wins silently. The
+ * fix is that both readers now resolve through `rungFor` in `required-rung.ts`, so an exemption is a THIRD
+ * answer rather than an absence dressed as one.
+ *
+ * ## The list carries no METHOD, and that is deliberate
+ *
+ * `ROUTE_RIGHTS` keys on method + path because `GET` and `DELETE` on one path need different rungs. An
+ * exemption is a statement about the ROUTE — "this is not a view of the space's data" — which is true of every
+ * verb on it. `every-space-route-has-an-area.test.js` has always matched exemptions path-only; the runtime now
+ * matches the same way, and a gate below asserts the two agree rather than trusting that they do.
+ */
 export const NOT_AREA_SCOPED: readonly { route: string; why: string }[] = [
   {
     route: '/api/spaces/:id/rename',
     why: 'Renaming a space is Space-admin, which is a column in the approved design but not one of the four '
        + 'DATA areas this inventory covers. It moves with the Space-admin work, not with these.',
-  },
-  {
-    route: '/api/spaces/:id/token-access',
-    why: 'Lists which tokens reach this space. Governed by the Space-admin column for the same reason, and '
-       + 'it is a read of AUTH state rather than of the space\'s contents.',
   },
   {
     route: '/api/brain/spaces/:spaceId/token-access',
@@ -301,3 +332,11 @@ export const NOT_AREA_SCOPED: readonly { route: string; why: string }[] = [
        + 'that happens to be keyed by space, not a view of the space\'s data.',
   },
 ];
+
+/**
+ * The exemption list as a path lookup, so the runtime asks the same question the gate asks.
+ *
+ * Derived rather than written out beside it: a second literal list is the copy that drifts, and this whole file
+ * exists because one list had two readers who disagreed.
+ */
+export const NOT_AREA_SCOPED_PATHS: ReadonlySet<string> = new Set(NOT_AREA_SCOPED.map(r => r.route));

--- a/testing/standalone/area-rung-is-staged.test.js
+++ b/testing/standalone/area-rung-is-staged.test.js
@@ -27,6 +27,8 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { blockAfter } from './_structural-window.mjs';
+
 const ROOT = process.cwd();
 const SRC = 'server/src/auth/middleware.ts';
 const code = readFileSync(join(ROOT, SRC), 'utf8')
@@ -48,9 +50,47 @@ describe('the area check', () => {
 
   it('an unresolved route falls through to reach, and says so', () => {
     const b = body('enforceAreaRung');
-    assert.match(b, /if \(!need\)/, 'a miss is not handled at all');
+    assert.match(b, /verdict\.kind === 'unclassified'/, 'a miss is not handled at all');
     assert.match(b, /log\.warn/, 'a miss is silent, so nothing would ever reveal the gap');
     assert.match(b, /return true;/, 'a miss must fall through to reach, not refuse');
+  });
+
+  it('a DELIBERATELY exempt route is silent — it is decided, not missed', () => {
+    /*
+     * The defect breituai-platform read off a live pod on 2026-08-20. `NOT_AREA_SCOPED` records, with a
+     * written reason each, that four routes are not views of a space's DATA. The runtime knew only
+     * `ROUTE_RIGHTS`, so every request to one of them logged
+     *
+     *     no inventory entry for 'GET /api/brain/spaces/:spaceId/activity' — reach enforced, area not.
+     *     Add it to ROUTE_RIGHTS; misses become refusals once the log is clean.
+     *
+     * Two things wrong with that, and the second is the serious one. The advice would have UNDONE the
+     * recorded decision. And "once the log is clean" was a state four routes guaranteed could never be
+     * reached, so the refusal flip the message promises could never happen — a deferred safety improvement
+     * that its own log message makes unreachable is indistinguishable from one nobody got round to.
+     */
+    const b = body('enforceAreaRung');
+    const exempt = b.indexOf("verdict.kind === 'not-area-scoped'");
+    const unclassified = b.indexOf("verdict.kind === 'unclassified'");
+    assert.ok(exempt > -1, 'the exempt case is not handled, so an exemption reads as an oversight again');
+    assert.ok(unclassified > exempt,
+      'the exempt check must come FIRST; after the warning it cannot prevent it');
+
+    // AN ORDERING CLAIM, not a window: the exempt branch has to return before ANY log call in this function,
+    // which is what makes it silent. Comparing indices says exactly that and nothing about how much text
+    // sits between them.
+    assert.ok(b.indexOf('log.warn') > exempt, 'the warning is reachable from the exempt path');
+
+    // And the warning belongs to the unclassified branch specifically, bounded by that branch's own brace —
+    // not to the function at large. `blockAfter` because a cap here could not tell "inside the branch" from
+    // "a few lines after it", and those are the two opposite behaviours.
+    assert.match(blockAfter(b, unclassified, 'the unclassified branch'), /log\.warn/,
+      'the warning must live inside the unclassified branch, or it fires for decided routes too');
+
+    // The advice in the message names BOTH lists now. Naming only ROUTE_RIGHTS is what sent an operator at
+    // the wrong fix for two of the four.
+    assert.match(b, /NOT_AREA_SCOPED/,
+      'the warning must offer the exemption list as well, or the only advice on offer is the wrong one');
   });
 
   it('iterating routes are NOT gated on the call', () => {

--- a/testing/standalone/every-space-route-has-an-area.test.js
+++ b/testing/standalone/every-space-route-has-an-area.test.js
@@ -88,6 +88,31 @@ function exemptRoutes() {
   return new Set([...block.matchAll(/route:\s*'([^']+)'/g)].map(m => m[1]));
 }
 
+/**
+ * Does this route exist on the real surface? Takes `METHOD path` or a bare path.
+ *
+ * Extracted because the two staleness checks below need the identical question, and this repo's most-produced
+ * defect is one rule with two implementations where the weaker one wins. The spaces router needs the special
+ * case: it is not wholly space-scoped, so it is not in SPACE_ROUTERS and its entries are checked against the
+ * file directly.
+ */
+function routeExists(methodAndPath) {
+  const space = methodAndPath.indexOf(' ');
+  const bare = space === -1 ? methodAndPath : methodAndPath.slice(space + 1);
+  if (bare.startsWith('/api/spaces/')) {
+    const code = withoutComments(read('server/src/api/spaces.ts'))
+      + withoutComments(read('server/src/api/spaces-activity.ts'))
+      + withoutComments(read('server/src/api/spaces-reembed.ts'));
+    const path = bare.replace('/api/spaces', '') || '/';
+    return code.includes(`'${path}'`);
+  }
+  const found = discoveredRoutes();
+  // A bare path matches any verb registered on it, which is what a method-less exemption means.
+  return space === -1
+    ? [...found].some(r => r.slice(r.indexOf(' ') + 1) === bare)
+    : found.has(methodAndPath);
+}
+
 describe('every space-scoped route is classified', () => {
   it('discovers a real route surface', () => {
     // A gate that enumerates nothing passes vacuously, and would keep passing if a router moved.
@@ -123,18 +148,29 @@ describe('every space-scoped route is classified', () => {
   it('the inventory claims no route that does not exist', () => {
     // The other direction, and the one that rots quietly: a classified route that was deleted or renamed
     // leaves a rule guarding nothing, and the count still looks healthy.
-    const found = discoveredRoutes();
-    const stale = [...classifiedRoutes()].filter(r => {
-      // The spaces router is not in SPACE_ROUTERS — it is not wholly space-scoped — so its entries are
-      // checked against the file directly rather than against the discovered set.
-      if (r.includes('/api/spaces/:id')) {
-        const code = withoutComments(read('server/src/api/spaces.ts'));
-        const path = r.slice(r.indexOf(' ') + 1).replace('/api/spaces', '') || '/';
-        return !code.includes(`'${path}'`);
-      }
-      return !found.has(r);
-    }).sort();
+    const stale = [...classifiedRoutes()].filter(r => !routeExists(r)).sort();
     assert.deepEqual(stale, [], `the inventory classifies routes that no longer exist:\n  ${stale.join('\n  ')}`);
+  });
+
+  it('and the EXEMPTION list claims none either', () => {
+    /*
+     * The same rot, on the list nobody was checking. `/api/spaces/:id/token-access` sat in NOT_AREA_SCOPED
+     * with a two-line reason for a route that does not exist anywhere in the server — the only token-access
+     * route is the brain one, which has its own entry. Found by reading the list while fixing the runtime,
+     * not by any gate: the staleness check above iterated `classifiedRoutes()` alone, so an exemption could
+     * name anything at all.
+     *
+     * Worth its own test rather than a wider one, because a stale exemption is the more dangerous of the two.
+     * A stale CLASSIFICATION guards nothing and enforces nothing. A stale EXEMPTION is a standing licence:
+     * the day a route with that path is added, it arrives pre-excused from the rights matrix and no gate
+     * objects, because the excuse was written before the route existed.
+     *
+     * Exemptions carry no method, so existence is checked path-only — `routeExists` takes either shape.
+     */
+    const stale = [...exemptRoutes()].filter(r => !routeExists(r)).sort();
+    assert.deepEqual(stale, [], 'NOT_AREA_SCOPED exempts routes that do not exist. Delete the entry — an '
+      + 'exemption for a path nothing serves is a standing licence for whatever is added there next:\n  '
+      + stale.join('\n  '));
   });
 
   it('every data-quality route scopes by iterating, not by path', () => {

--- a/testing/standalone/required-rung-lookup.test.js
+++ b/testing/standalone/required-rung-lookup.test.js
@@ -3,13 +3,25 @@
  *
  * ## The property that carries the whole feature
  *
- * `requiredRung()` returns `null` for a route the inventory does not classify. That `null` must be treated
- * as a refusal, never as "no requirement". An unclassified route is one nobody decided about, and defaulting
- * it to permissive reproduces exactly the situation this feature exists to end: access that works because
- * nothing said otherwise.
+ * `rungFor()` answers with one of THREE kinds, and the reason it is three rather than two is a defect that
+ * shipped for five releases.
  *
- * The build-time gate makes a miss unreachable in practice. This file assumes it happens anyway, because
- * "unreachable in practice" is how the last three silent failures in this codebase described themselves.
+ *   requires          classified in ROUTE_RIGHTS. Enforce it.
+ *   not-area-scoped   on NOT_AREA_SCOPED, with a written reason. An explicit allow.
+ *   unclassified      nobody decided. **The caller must treat this as REFUSE, never as "no requirement".**
+ *
+ * An unclassified route is one nobody decided about, and defaulting it to permissive reproduces exactly the
+ * situation this feature exists to end: access that works because nothing said otherwise.
+ *
+ * The old shape returned `null` for the last TWO, so a deliberate exemption and an oversight were the same
+ * event. `enforceAreaRung` logged every request to an exempt route as a miss, advising the operator to add it
+ * to `ROUTE_RIGHTS` -- which would have undone the decision the exemption records -- and the message's own
+ * plan ("misses become refusals once the log is clean") could never fire, because four routes were guaranteed
+ * to warn forever. breituai-platform read those two log lines off a live pod on 2026-08-20 and reported them.
+ *
+ * The build-time gate makes `unclassified` unreachable in practice. This file assumes it happens anyway,
+ * because "unreachable in practice" is how the last three silent failures in this codebase described
+ * themselves.
  *
  * Run: node --test testing/standalone/required-rung-lookup.test.js
  * (requires a prior `npm run build` in server/)
@@ -17,36 +29,61 @@
 import { describe, it, before } from 'node:test';
 import assert from 'node:assert/strict';
 
-let requiredRung, satisfies, ROUTE_RIGHTS;
+let rungFor, satisfies, ROUTE_RIGHTS, NOT_AREA_SCOPED;
 before(async () => {
-  ({ requiredRung, satisfies } = await import('../../server/dist/auth/required-rung.js'));
-  ({ ROUTE_RIGHTS } = await import('../../server/dist/auth/space-rights.js'));
+  ({ rungFor, satisfies } = await import('../../server/dist/auth/required-rung.js'));
+  ({ ROUTE_RIGHTS, NOT_AREA_SCOPED } = await import('../../server/dist/auth/space-rights.js'));
 });
 
 describe('the lookup', () => {
   it('answers for a classified route', () => {
-    const r = requiredRung('POST', '/api/brain/spaces/:spaceId/recall');
-    assert.deepEqual(r, { area: 'knowledge', needs: 'read', scope: 'path' });
+    const r = rungFor('POST', '/api/brain/spaces/:spaceId/recall');
+    assert.deepEqual(r, { kind: 'requires', area: 'knowledge', needs: 'read', scope: 'path' });
   });
 
   it('distinguishes methods on the same path', () => {
     // GET and DELETE on a collection are not the same permission, and a path-only lookup would say they are.
-    assert.equal(requiredRung('GET', '/api/brain/spaces/:spaceId/memories').needs, 'read');
-    assert.equal(requiredRung('POST', '/api/brain/spaces/:spaceId/memories').needs, 'write');
-    assert.equal(requiredRung('DELETE', '/api/brain/spaces/:spaceId/memories').needs, 'admin');
+    assert.equal(rungFor('GET', '/api/brain/spaces/:spaceId/memories').needs, 'read');
+    assert.equal(rungFor('POST', '/api/brain/spaces/:spaceId/memories').needs, 'write');
+    assert.equal(rungFor('DELETE', '/api/brain/spaces/:spaceId/memories').needs, 'admin');
   });
 
-  it('returns null for an unclassified route, NOT a permissive default', () => {
-    assert.equal(requiredRung('GET', '/api/brain/spaces/:spaceId/invented'), null);
-    assert.equal(requiredRung('PUT', '/api/brain/spaces/:spaceId/recall'), null,
+  it('says UNCLASSIFIED for a route nobody decided about, NOT a permissive default', () => {
+    assert.deepEqual(rungFor('GET', '/api/brain/spaces/:spaceId/invented'), { kind: 'unclassified' });
+    assert.deepEqual(rungFor('PUT', '/api/brain/spaces/:spaceId/recall'), { kind: 'unclassified' },
       'a method the inventory does not list must miss, not inherit the path');
+  });
+
+  it('says NOT-AREA-SCOPED for an exempt route, which is a different answer from unclassified', () => {
+    // The distinction the old two-state shape could not make. Both were `null`, so the runtime reported a
+    // written-down decision as an oversight on every request.
+    for (const { route } of NOT_AREA_SCOPED) {
+      assert.deepEqual(rungFor('GET', route), { kind: 'not-area-scoped' },
+        `${route} is exempt and must resolve as such, not as unclassified`);
+    }
+  });
+
+  it('an exemption covers every verb on its path, deliberately', () => {
+    // ROUTE_RIGHTS keys on method + path because GET and DELETE need different rungs. An exemption is a claim
+    // about what the route IS, so it is path-only -- and `/api/spaces/:id/rename` is registered as PATCH,
+    // which a method-keyed exemption written for POST would have silently missed.
+    assert.deepEqual(rungFor('PATCH', '/api/spaces/:id/rename'), { kind: 'not-area-scoped' });
+    assert.deepEqual(rungFor('DELETE', '/api/spaces/:id/rename'), { kind: 'not-area-scoped' });
+  });
+
+  it('no path is on both lists', () => {
+    // A route that is both governed and exempt is a contradiction, not a precedence question. `rungFor` would
+    // answer `requires` (the safe direction), but relying on that hides the disagreement.
+    const both = ROUTE_RIGHTS.map(r => r.route).filter(r => NOT_AREA_SCOPED.some(e => e.route === r));
+    assert.deepEqual([...new Set(both)], [],
+      'these paths are classified into an area AND exempt from areas -- resolve which one is true');
   });
 
   it('carries the scope shape through, because Data quality needs it', () => {
     // Those routes take no space and iterate the token's reachable ones. A caller that ignores `scope` would
     // gate the call instead of the loop, leaving that column decorative.
-    assert.equal(requiredRung('GET', '/api/duplicates').scope, 'iterates');
-    assert.equal(requiredRung('POST', '/api/brain/spaces/:spaceId/recall').scope, 'path');
+    assert.equal(rungFor('GET', '/api/duplicates').scope, 'iterates');
+    assert.equal(rungFor('POST', '/api/brain/spaces/:spaceId/recall').scope, 'path');
   });
 
   it('every inventory entry is findable — the map has no dropped rows', () => {
@@ -54,8 +91,8 @@ describe('the lookup', () => {
     // which would leave one route unclassified while the inventory looks complete.
     let found = 0;
     for (const r of ROUTE_RIGHTS) {
-      const got = requiredRung(r.method, r.route);
-      assert.ok(got, `${r.method} ${r.route} is in the inventory but not findable`);
+      const got = rungFor(r.method, r.route);
+      assert.equal(got.kind, 'requires', `${r.method} ${r.route} is in the inventory but not findable`);
       assert.equal(got.needs, r.needs);
       found++;
     }
@@ -63,8 +100,10 @@ describe('the lookup', () => {
   });
 
   it('a trailing slash does not change the answer', () => {
-    assert.deepEqual(requiredRung('POST', '/api/brain/spaces/:spaceId/recall/'),
-      requiredRung('POST', '/api/brain/spaces/:spaceId/recall'));
+    assert.deepEqual(rungFor('POST', '/api/brain/spaces/:spaceId/recall/'),
+      rungFor('POST', '/api/brain/spaces/:spaceId/recall'));
+    // The exemption path is normalised the same way, or the two lists disagree on `/x` versus `/x/`.
+    assert.deepEqual(rungFor('PATCH', '/api/spaces/:id/rename/'), { kind: 'not-area-scoped' });
   });
 });
 


### PR DESCRIPTION
Reported by breituai-platform, 2026-08-20, read verbatim off a live pod's stdout during
the 3.2.0 canary:

    Space rights: no inventory entry for 'GET /api/brain/spaces/:spaceId/token-access'
      — reach enforced, area not. Add it to ROUTE_RIGHTS; misses become refusals once
        the log is clean.
    Space rights: no inventory entry for 'GET /api/brain/spaces/:spaceId/activity'
      — reach enforced, area not. Add it to ROUTE_RIGHTS; misses become refusals once
        the log is clean.

Both are on `NOT_AREA_SCOPED` — the list that records, with a written reason each, that a
route is not a view of a space's DATA. Renaming a space is space-admin. Reading which tokens
reach it is a read of AUTH state. Per-space usage counters are instance observability that
happens to be keyed by space.

That list was read by the build-time gate and by NOTHING at runtime. So `enforceAreaRung`
could not distinguish a decision from an oversight, and reported the decision as one.

TWO CONSEQUENCES, AND THE SECOND IS THE SERIOUS ONE.

The advice was WRONG for these routes. Following it — adding them to `ROUTE_RIGHTS` — would
area-scope a route the design says is not area-scoped, undoing the decision each `why`
records.

And "once the log is clean" named a state that could never be reached. The message states a
plan: a miss allows today and becomes a refusal when nothing warns any more. Four routes
were guaranteed to warn forever, so the log could never be clean, so the flip could never
happen. A deferred safety improvement that its own log message makes unreachable is
indistinguishable from one nobody got round to — and had somebody forced the flip anyway,
four routes that worked yesterday would answer 403. That is precisely what the reporters
flagged as the failure mode.

This repo's signature defect: one rule, two implementations, and the weaker one winning in
silence.

WHAT CHANGED

`requiredRung` becomes `rungFor` and answers with THREE kinds instead of two:

    requires          classified in ROUTE_RIGHTS. Enforce it.
    not-area-scoped   on NOT_AREA_SCOPED, with a reason. An explicit allow, silent.
    unclassified      nobody decided. Still allows + warns, deliberately (see below).

Discriminated, so no call site can read one as the other. `null` for both was the whole bug.
The warning now names BOTH lists, because naming only `ROUTE_RIGHTS` sent an operator at the
wrong fix for two of the four.

The staged allow-and-warn for `unclassified` is unchanged and stays: flipping it is a
separate decision, and now it is one that can actually be taken.

A STALE EXEMPTION, FOUND WHILE READING THE LIST

`/api/spaces/:id/token-access` sat in `NOT_AREA_SCOPED` with a two-line reason. The server
serves no such route — the only token-access route is the brain one, which has its own entry.
Invisible because the coverage gate's staleness check iterated `classifiedRoutes()` alone, so
an exemption could name anything at all. Both directions now go through one `routeExists`
helper rather than two copies of the same question.

A stale exemption is the more dangerous of the two. A stale classification guards nothing and
enforces nothing. A stale exemption is a STANDING LICENCE: the day a route with that path is
added, it arrives pre-excused from the rights matrix and no gate objects, because the excuse
was written before the route existed.

THE SAME DEFECT ONE LAYER UP — `notAreaScoped` IS NOW PUBLISHED

A route absent from the catalog's `routes` was indistinguishable to a caller from one nobody
had classified. So "the matrix does not govern renaming a space" was a fact only the server's
source held, and a grid of four areas read as complete while three space-scoped routes sat
outside all of them. `GET /api/tokens/rights-catalog` now carries `notAreaScoped` with the
server's own reason per route, on the argument that endpoint already makes for `routes` and
`derivedRungs`: the list the server decides from is the only description of a right that
cannot be wrong.

No `method`, unlike `routes` — an exemption is a claim about what the route IS, so it covers
every verb on that path. Worth stating because `/api/spaces/:id/rename` is registered as
PATCH, and a method-keyed exemption written for POST would have silently missed it.

It does not mean unauthenticated and it does not mean ungoverned: reach is still enforced and
each route keeps its own admin or space-admin guard. It says only which mechanism decides.

THE FIVE PLACES

REST route (the catalog gains a field), the client (`Space admin` panel renders the list,
three locales), `docs/integration-guide/07-tokens-api.md` (its own subsection, and what the
field does NOT mean), `docs/userguide/04-settings.md` (what an operator sees in the panel),
and token rights (`auth/space-rights.ts`, which is where the change lives). No MCP tool
mirrors `rights-catalog` — MCP gates through `effectiveRung`, not through this lookup, so it
never produced the false warning and has nothing to mirror.

MUTATION TESTED, each against the pre-fix shape

  exempt branch neutered in enforceAreaRung   -> area-rung-is-staged      1 fail
  rungFor answers unclassified for exemptions -> required-rung-lookup     3 fail
  the stale exemption put back                -> every-space-route-...    1 fail

The staged test's new case asserts by ORDER (the exempt branch returns before any log call)
and by a structural bound (`blockAfter` on the unclassified branch, so the warning must be
INSIDE it) — a character window there could not tell "in the branch" from "just after it",
which are the two opposite behaviours.