### PR TITLE
fix(spaces): the face gallery's readiness probe asked about the wrong field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   auth entry point calls, and that function now consumes `next` so a new auth path cannot attach a token
   without metering it.
 
+### Fixed
+
+- **The face gallery's readiness probe asked about the wrong field, so its answer carried no information.**
+  Reported indirectly by breituai-platform, 2026-08-20 — they quoted the log line as evidence that no face
+  index had ever been built on any of fourteen spaces, and stopped a configuration change on it:
+
+      Vector search index infrastructure_files_faceEmbedding: gave up after 600s
+        — probe did not serve: ... :: caused by :: embedding is not indexed as vector
+
+  `indexServes` hardcoded `path: 'embedding'` and took its width from `getEmbeddingConfig().dimensions`. Both
+  correct for the five text indexes; both wrong for the face gallery, which indexes `faceEmbedding` at 128. So
+  the probe queried a field that index does not index, with a vector of the wrong width, and MongoDB answered
+  exactly that string — every second, for the full 600 s window, on every space, whether or not the gallery
+  was READY and serving. **The probe could not succeed, so it was never evidence of anything.**
+  `pollVectorIndexReady` took no vector path, so the caller could not supply one — even though
+  `ensureVectorSearchIndex` two levels up had built the definition WITH the path and the width and simply did
+  not pass them on. The caller held the answer and the callee guessed.
+
+  Two costs. A READY gallery reported as failed makes the one diagnostic this feature has always read red —
+  the trap the same reporters named to us about space badges, that a red which is always red teaches an
+  operator to stop reading red. And each miss burns the whole window: fourteen spaces at 600 s each is the
+  boot-time starvation the `maxTimeMS` comment inside that very function warns about, arriving through the one
+  path the comment did not cover.
+
+  `pollVectorIndexReady` now takes a required `ProbeTarget` — the indexed path and the built width — with no
+  default, deliberately: a default would let the next non-`embedding` index silently inherit `embedding`/768
+  and fail to probe rather than fail to compile. The face caller resolves its width from the same two places
+  `initSpace` builds the index from, so the two cannot drift.
+
+  **Its own spec had passed for five releases.** `index-ready-poll.test.js` asserted the probe was a real
+  `$vectorSearch`, against the named index, cheap. All three were true of a probe that could never answer. It
+  now asserts the field and the width, per call site rather than in total, and refuses a caller that does not
+  name its target — five mutants killed against the pre-fix shape.
+
+
 ### Changed
 
 - **Ten more guessed character windows in the gates became structural bounds, emptying five files.** Two of
@@ -77,6 +112,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of the call the branch makes. Structural is not automatically tighter than a character count; it is
   tighter only when the structure chosen is the subject. Every conversion was mutation-tested against the
   behaviour it claims. `GRANDFATHERED_GAP` falls to **46 across 24 files**, from 56/29.
+
+- **`05c-face-recognition.md` no longer describes a migration path that was never built, and says what an
+  unset width IS.** An operator quoted two of its paragraphs back to us, could not reconcile them, and asked
+  rather than guessed — correctly, because neither covered the case they were in: gallery EMPTY, index never
+  built. One paragraph said there is no admin call to change the width; the next said *"to move a populated
+  gallery, re-embed its faces at the new width first"*, whose closing clause implies that having re-embedded
+  the width can then move. It cannot; there was never a call to set it. That sentence is gone and replaced by
+  what is true — re-create the space — and the create-only paragraph now opens by saying that every space has
+  a width from the moment it exists, defaults to 128, and does not derive it from the endpoint you configure.
+  Their own suggested wording, taken because it is better than what it replaces. The page also gains a section
+  on reading the gallery's readiness log, including that the line meant nothing before the probe fix above.
 
 ## [3.2.0] — 2026-08-20
 

--- a/docs/integration-guide/05c-face-recognition.md
+++ b/docs/integration-guide/05c-face-recognition.md
@@ -94,15 +94,39 @@ POST /api/spaces
 
 Also available as `faceDescriptorDims` on the `create_space` MCP tool. Use **128** for MobileFaceNet-class models (including the bundled one) and **512** for ArcFace / AdaFace / FaceNet / EdgeFace / buffalo_l.
 
-**It is create-only and permanent.** A populated gallery cannot be re-dimensioned: its stored vectors have not moved, so re-declaring the width would leave every existing descriptor unmatchable. There is no admin call to change it afterwards, and that is deliberate rather than missing — a space whose width is wrong is re-created, not migrated.
+**Every space has a width from the moment it exists, whether or not a face index was ever built.** An unset `faceDescriptorDims` is not "undecided" — it resolves to **128**, the built-in default, and nothing derives it from the endpoint you configure. So a space created without it, pointed at a 512-d recogniser, builds a 128-wide index and skips every descriptor it is handed. This sentence exists because the create-only rule below was read as leaving the empty case open, and it does not.
+
+**It is create-only.** There is no admin call to change it afterwards, on a populated gallery or an empty one. On a populated gallery that is deliberate: its stored vectors have not moved, so re-declaring the width would leave every existing descriptor unmatchable. On a space that has never held a face there is nothing to strand, and the restriction is broader than the safety guard needs to be — it is the API surface stopping you, not the guard. Reported by an operator on 2026-08-20 who read these two paragraphs and correctly concluded that neither covered them.
 
 **The supported order for bringing your own recogniser** is therefore: create the space with the right `faceDescriptorDims` **first**, then point `FACE_RECOGNITION_EXTERNAL_MODEL` at your endpoint. Doing it the other way round embeds at your width against a 128-wide gallery, and every descriptor is skipped.
 
 The matcher reads the width from **the space's own index**, not from an instance-wide constant, so a space is judged against the vectors it actually holds and a later change of default cannot invalidate an existing gallery.
 
-**This index is never re-dimensioned automatically, and that is deliberate.** Ythril rebuilds other vector indexes when their definition changes, because re-embedding the records makes the vectors catch up. Face vectors live on already-stored face-chunk records and nothing re-derives them, so a rebuild at a new width would leave the stored vectors indexed as if they were the new width — every similarity score wrong, with no error reported. If the configured width ever differs from an existing space's index, Ythril **refuses the change, keeps the existing width, and logs both numbers**. To move a populated gallery, re-embed its faces at the new width first. A filter-field change still applies, at the existing width.
+**This index is never re-dimensioned automatically, and that is deliberate.** Ythril rebuilds other vector indexes when their definition changes, because re-embedding the records makes the vectors catch up. Face vectors live on already-stored face-chunk records and nothing re-derives them, so a rebuild at a new width would leave the stored vectors indexed as if they were the new width — every similarity score wrong, with no error reported. If the configured width ever differs from an existing space's index, Ythril **refuses the change, keeps the existing width, and logs both numbers**. A filter-field change still applies, at the existing width.
+
+**There is no supported way to move a populated gallery to a new width.** An earlier version of this page said to re-embed its faces at the new width first, which described a path that was never built: having re-embedded, there is still no call that sets the new number. Re-create the space at the width you want. The refusal above protects a gallery that HAS vectors; it is not a step in a migration.
 
 When the face recognition feature is first enabled, any existing `initSpace` call will create the required index. If you add the feature after spaces already exist, re-run `initSpace` for each space or create the index manually via the Atlas UI / MongoDB admin API.
+
+#### Reading the gallery's readiness log
+
+At boot, each space's face index is polled and its outcome logged by name. The line to know:
+
+```text
+Vector search index photos_files_faceEmbedding: gave up after 600s — probe did not serve: ...
+```
+
+**This line used to mean nothing.** The readiness probe queried the field `embedding` at the text
+embedding width, against an index that indexes `faceEmbedding` at 128 — so it could never succeed, on any
+instance, and the message appeared for galleries that were READY and serving. An operator reported it, in good
+faith, as evidence that no face index had ever been built. It was not evidence of anything.
+
+It now asks about the field the index indexes, at the width it was built at, so the line means
+what it says: this space's gallery did not become queryable inside the window.
+
+**It never affects the space's `indexStatus`.** The face gallery is optional — recall, traversal and text
+search all work with it absent — so it is polled and logged but does not vote. A space with five ready text
+indexes and no gallery is `ready`, not `failed`.
 
 #### Configuration Reference
 

--- a/server/src/spaces/vector-index.ts
+++ b/server/src/spaces/vector-index.ts
@@ -253,7 +253,8 @@ export async function ensureVectorSearchIndex(
     try {
       await coll.updateSearchIndex(indexName, definition);
       if (waitForReady) {
-        const ready = await pollVectorIndexReady(spaceId, collectionSuffix, indexName);
+        const ready = await pollVectorIndexReady(spaceId, collectionSuffix, indexName,
+          { vectorPath, dims: numDimensions });
         if (!ready) log.warn(`Vector search index ${indexName} did not reach READY within 60s after update`);
       }
       return;
@@ -286,7 +287,8 @@ export async function ensureVectorSearchIndex(
 
   // Poll for READY status (unless the caller will confirm asynchronously — B1).
   if (waitForReady) {
-    const ready = await pollVectorIndexReady(spaceId, collectionSuffix, indexName);
+    const ready = await pollVectorIndexReady(spaceId, collectionSuffix, indexName,
+      { vectorPath, dims: numDimensions });
     if (!ready) log.warn(`Vector search index ${indexName} did not reach READY state within 60 seconds`);
   }
 }
@@ -361,17 +363,61 @@ export function probeQueryVector(dims: number): number[] {
 /** `numCandidates` for the probe. Must be >= `limit`; 1 sat on the boundary for no benefit. */
 export const PROBE_NUM_CANDIDATES = 10;
 
+/**
+ * What to ask an index about: the field it indexes, and the width it was built at.
+ *
+ * ## Why this is a parameter and not two constants
+ *
+ * The probe used to hardcode `path: 'embedding'` and take its width from `getEmbeddingConfig().dimensions`.
+ * Both are correct for the five text indexes and both are WRONG for the face gallery, which indexes
+ * `faceEmbedding` at 128. So the probe queried a field that index does not index, with a vector of the wrong
+ * width, and MongoDB answered — every second, for the full 600 s window, on every space:
+ *
+ *     Vector search index <space>_files_faceEmbedding: gave up after 600s
+ *       — probe did not serve: Executor error during aggregate command ...
+ *         :: caused by :: embedding is not indexed as vector
+ *
+ * **The probe could never succeed, so its answer carried no information at all.** breituai-platform read
+ * those lines off a live pod on 2026-08-20, concluded from them that no face index had ever been built, and
+ * stopped a configuration change on the strength of it. The index may well have been READY throughout; the
+ * only instrument that could have said was the broken one.
+ *
+ * Two costs. A READY gallery is reported as failed, so the one diagnostic this feature has always reads red —
+ * the trap the same reporters named to us about space badges: *"a red badge that is always red on a working
+ * system trains an operator to stop reading red badges."* And each miss burns the whole window: fourteen
+ * spaces at 600 s each is exactly the boot-time starvation the `maxTimeMS` comment in `indexServes` warns
+ * about, arriving through the one path that comment did not cover.
+ *
+ * `ensureVectorSearchIndex` knew both values — it built the definition with them — and simply did not pass
+ * them on. That is the shape worth naming: the caller had the answer and the callee guessed.
+ *
+ * Face is the only non-`embedding` path today, so this is one instance. The parameter is what stops the next
+ * one, and `probe-asks-the-indexed-field.test.js` refuses a caller that does not name its target.
+ */
+export interface ProbeTarget {
+  /** The `path` in the index definition — `embedding` for the five text indexes, `faceEmbedding` for faces. */
+  vectorPath: string;
+  /** `numDimensions` as the index was built. A probe vector of any other width is rejected outright. */
+  dims: number;
+}
+
 async function indexServes(
   coll: ReturnType<ReturnType<typeof getDb>['collection']>,
   indexName: string,
+  /**
+   * The path this index actually indexes, and the width it was built at.
+   *
+   * Both used to be assumed here — `path: 'embedding'` and the TEXT embedding width — and both are wrong for
+   * the one index whose path is not `embedding`. See the note above `ProbeTarget`.
+   */
+  target: ProbeTarget,
 ): Promise<ProbeOutcome> {
-  const dims = getEmbeddingConfig().dimensions ?? 768;
   try {
     await coll.aggregate([{
       $vectorSearch: {
         index: indexName,
-        path: 'embedding',
-        queryVector: probeQueryVector(dims),
+        path: target.vectorPath,
+        queryVector: probeQueryVector(target.dims),
         numCandidates: PROBE_NUM_CANDIDATES,
         limit: 1,
       },
@@ -416,6 +462,14 @@ export async function pollVectorIndexReady(
   spaceId: string,
   collectionSuffix: VectorIndexedCollection,
   indexName: string,
+  /**
+   * REQUIRED, and deliberately not defaulted to the text index's shape.
+   *
+   * A default here would be the bug again: the face caller would silently inherit `embedding`/768 and go on
+   * reporting a working index as failed. Making it required means a new index whose path nobody thought about
+   * fails to compile rather than fails to probe.
+   */
+  target: ProbeTarget,
   opts: { timeoutMs?: number } = {},
 ): Promise<boolean> {
   const coll = getDb().collection(`${spaceId}_${collectionSuffix}`);
@@ -530,7 +584,7 @@ export async function pollVectorIndexReady(
          * which matters at 65 indexes on one boot.
          */
         if (current.status === undefined && current.queryable === undefined) {
-          const probe = await indexServes(coll, indexName);
+          const probe = await indexServes(coll, indexName, target);
           if (probe.serves) {
             log.debug(`Vector search index ${indexName} serves queries (no lifecycle fields on this backend)`);
             return true;
@@ -634,14 +688,22 @@ export async function waitForSpaceIndexesReady(
   // at indexStatus='building' for five minutes when every index was in fact ready in seconds. That was
   // masked for as long as only `memories` was ever indexed — fixing that made the serial wait visible.
   const required = VECTOR_INDEXED_COLLECTIONS.map(suffix =>
-    pollVectorIndexReady(spaceId, suffix, `${spaceId}_${suffix}_embedding`, opts),
+    // The five text indexes: path `embedding`, at the configured embedding width.
+    pollVectorIndexReady(spaceId, suffix, `${spaceId}_${suffix}_embedding`,
+      { vectorPath: 'embedding', dims: getEmbeddingConfig().dimensions ?? 768 }, opts),
   );
   // Started alongside the required ones so it costs no extra wall-clock, and awaited separately so its answer
   // cannot reach the verdict. Kicked off before the await below for that reason — sequencing it after would
   // add its window to the total.
   const faceIndexName = `${spaceId}_files_faceEmbedding`;
+  // The path AND the width, from the same two places `initSpace` builds the index from. Passing neither is
+  // what made this poll uninformative for five releases: it probed `embedding` at the text width against an
+  // index that indexes `faceEmbedding` at 128, so it could only ever report failure. See `ProbeTarget`.
+  const faceDims = getConfig().spaces.find(sp => sp.id === spaceId)?.faceDescriptorDims
+    ?? FACE_DESCRIPTOR_DIMS;
   const face = getFaceRecognitionConfig().enabled
-    ? pollVectorIndexReady(spaceId, 'files', faceIndexName, opts)
+    ? pollVectorIndexReady(spaceId, 'files', faceIndexName,
+        { vectorPath: 'faceEmbedding', dims: faceDims }, opts)
     : null;
 
   const results = await Promise.all(required);

--- a/testing/standalone/dupe-check-sees-fresh-writes-db.test.js
+++ b/testing/standalone/dupe-check-sees-fresh-writes-db.test.js
@@ -105,7 +105,7 @@ describe('the duplicate check sees a record written a moment ago', { skip }, () 
 
     // And then check that it is actually usable, because `ensureVectorSearchIndex` reports failure by
     // logging and returning: a backend without search leaves this suite green-but-meaningless otherwise.
-    const ready = await vectorIndex.pollVectorIndexReady(SPACE, 'entities', `${SPACE}_entities_embedding`);
+    const ready = await vectorIndex.pollVectorIndexReady(SPACE, 'entities', `${SPACE}_entities_embedding`, { vectorPath: 'embedding', dims: 768 });
     assert.ok(ready,
       `no queryable vector index on ${SPACE}_entities — this suite compares the ANN index against `
       + 'committed documents, so without one it proves nothing either way. The test stack must be '

--- a/testing/standalone/index-ready-poll.test.js
+++ b/testing/standalone/index-ready-poll.test.js
@@ -30,7 +30,8 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
-import { enclosingBlockAround, bodyOfEndingWith, bodyOf } from './_structural-window.mjs';
+import { enclosingBlockAround, bodyOfEndingWith, bodyOf, statementAround, statementFrom }
+  from './_structural-window.mjs';
 
 const ROOT = 'server/src';
 
@@ -139,6 +140,12 @@ describe('search-index listing is never name-filtered', () => {
     assert.match(fn, /\$vectorSearch/, 'the probe must be a real vector query');
     assert.match(fn, /index: indexName/, 'against the index being polled, by name');
     assert.match(fn, /limit: 1/, 'and cheap — this is a liveness question, not a search');
+    // AND ABOUT THE RIGHT FIELD. This file passed for five releases with the three assertions above and
+    // without this one, which is the whole lesson: "a real vector query, cheap, against the named index"
+    // was true of a probe that could never succeed. A satisfied check is the strongest reason not to look
+    // further. See the block at the bottom of this file.
+    assert.match(fn, /path: target\.vectorPath/,
+      'the probe must ask about the field the index indexes, not about a literal');
   });
 
   it('the probe runs ONLY when both fields are absent', () => {
@@ -168,5 +175,98 @@ describe('search-index listing is never name-filtered', () => {
       'the success wording must be conditional on nothing having failed');
     assert.match(src, /did not reach ready for \$\{failed\.length\}/,
       'and the failure case must name how many, and which');
+  });
+});
+
+/**
+ * The probe asks about the field the index INDEXES, and at the width it was BUILT at.
+ *
+ * ## The defect, and how a passing spec hid it
+ *
+ * `indexServes` hardcoded `path: 'embedding'` and took its width from `getEmbeddingConfig().dimensions`.
+ * Correct for the five text indexes. Wrong for the face gallery, which indexes `faceEmbedding` at 128. So on
+ * every space, every second, for the full 600 s window:
+ *
+ *     Vector search index <space>_files_faceEmbedding: gave up after 600s
+ *       — probe did not serve: ... :: caused by :: embedding is not indexed as vector
+ *
+ * **The probe could not succeed, so its answer carried no information.** breituai-platform read those lines
+ * off a live pod on 2026-08-20, concluded no face index had ever been built, and stopped a configuration
+ * change on it. The index may have been READY the whole time.
+ *
+ * The test above asserted the probe was "a real vector query, against the named index, cheap". All three were
+ * true. None of them is the question. That is why this block asserts the FIELD and the WIDTH, and asserts them
+ * per call site rather than once: the bug was not in the probe's shape, it was in what two callers failed to
+ * tell it.
+ *
+ * `ensureVectorSearchIndex` had both values — it built the definition from them — and did not pass them on.
+ * Worth naming as a shape: the caller held the answer and the callee guessed.
+ */
+describe('the probe is told what to ask about, per call site', () => {
+  const src = readFileSync(`${ROOT}/spaces/vector-index.ts`, 'utf8')
+    .replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
+
+  it('nothing hardcodes a vector path in the probe path any more', () => {
+    // Comments stripped above, deliberately: the account of the defect quotes the old literal, and a naive
+    // search would find the explanation and report the fix as missing.
+    assert.doesNotMatch(src, /path: 'embedding'/,
+      "a literal path in this file is the defect returning — pass a ProbeTarget");
+    assert.doesNotMatch(bodyOf(src, 'indexServes'), /getEmbeddingConfig\(\)/,
+      'the probe must not reach for the TEXT embedding width; the face gallery is not that width');
+  });
+
+  it('the target is REQUIRED, not defaulted', () => {
+    // A default would be the bug again, silently: the face caller would inherit `embedding`/768 and go back to
+    // reporting a working index as failed. Required means a new index whose path nobody thought about fails to
+    // compile rather than fails to probe.
+    const sig = bodyOf(src, 'pollVectorIndexReady');
+    assert.match(sig, /target: ProbeTarget,/,
+      'pollVectorIndexReady must take a ProbeTarget with no default');
+    assert.doesNotMatch(sig, /target: ProbeTarget = /, 'a default here reintroduces the silent inheritance');
+  });
+
+  it('every call site names its target — none is left to guess', () => {
+    /*
+     * PER SITE, not two global counts. The first version of this counted `pollVectorIndexReady(` against
+     * `vectorPath:` and was wrong in both directions at once: the count of calls included the function's own
+     * DECLARATION, and the count of targets included the `ProbeTarget` interface field plus missed the two
+     * sites that pass the shorthand `{ vectorPath, dims: numDimensions }` — no colon, same argument.
+     *
+     * Two totals that happen to match prove nothing about which site matched which. Resolving each call's own
+     * statement asks the question directly, and the anti-vacuity floor below is what stops it passing on zero.
+     */
+    // A NEGATIVE LOOKBEHIND, not a backwards slice. The first version wrote
+    // `src.slice(Math.max(0, m.index - 20), m.index)` to skip the declaration — which is precisely the
+    // backwards magic window `gates-bound-their-subject-structurally` refuses, and it refused this file. A
+    // lookbehind asks the same question with no number in it.
+    const calls = [...src.matchAll(/(?<!function )pollVectorIndexReady\(/g)];
+    assert.ok(calls.length >= 4,
+      `expected the poll to be called from several places, found ${calls.length}`);
+    const guessing = calls
+      .filter(m => !/vectorPath/.test(statementFrom(src, m.index, 'a pollVectorIndexReady call')))
+      .map(m => `line ${src.slice(0, m.index).split('\n').length}`);
+    assert.deepEqual(guessing, [],
+      'these calls do not name the field to probe, so the probe guesses — and guessing wrong is the defect '
+      + `this gate exists for:\n  ${guessing.join('\n  ')}`);
+  });
+
+  it('the FACE caller names faceEmbedding, which is the whole point', () => {
+    const at = src.indexOf("pollVectorIndexReady(spaceId, 'files', faceIndexName");
+    assert.ok(at > -1, 'the face gallery poll is gone — re-anchor this gate');
+    // The statement the call sits in, bounded structurally: a character window could not tell "this call's
+    // argument" from "a faceEmbedding mentioned on the next line", and those differ by exactly the defect.
+    assert.match(statementAround(src, at, 'the face gallery poll'), /vectorPath: 'faceEmbedding'/,
+      'the face poll must probe faceEmbedding — probing `embedding` is what made it always fail');
+  });
+
+  it('and the face width comes from the same two places the INDEX is built from', () => {
+    // `initSpace` builds at `space.faceDescriptorDims ?? FACE_DESCRIPTOR_DIMS`. The probe must resolve the
+    // width identically or it asks about a real field with a wrong-width vector, which fails just as
+    // uninformatively. Two copies of one resolution is this repo's most-produced defect, so both are pinned.
+    const at = src.indexOf('faceDims');
+    assert.ok(at > -1, 'the face width is no longer resolved for the probe');
+    const resolution = statementAround(src, at, 'the face width resolution');
+    assert.match(resolution, /faceDescriptorDims/, "it must read the space's own width");
+    assert.match(resolution, /FACE_DESCRIPTOR_DIMS/, 'and fall back to the same constant initSpace does');
   });
 });

--- a/testing/standalone/startup-index-wait.test.js
+++ b/testing/standalone/startup-index-wait.test.js
@@ -27,7 +27,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
-import { bodyOf } from './_structural-window.mjs';
+import { balancedFrom, bodyOf } from './_structural-window.mjs';
 
 const LIFECYCLE = readFileSync('server/src/spaces/lifecycle.ts', 'utf8');
 const VECTOR = readFileSync('server/src/spaces/vector-index.ts', 'utf8');
@@ -108,12 +108,24 @@ describe('the readiness timeout is a parameter, and generous off the boot path',
   it('waitForSpaceIndexesReady and finalizeSpaceIndexReady thread it through', () => {
     // A timeout accepted at the top and dropped halfway down is the worst kind of knob: it looks
     // configurable and is not.
-    assert.match(VECTOR, /pollVectorIndexReady\(spaceId, suffix, `\$\{spaceId\}_\$\{suffix\}_embedding`, opts\)/);
-    // The face poll's index name moved into a named const, so the log line that reports it and the poll that
-    // waits for it cannot disagree about which index they mean. Asserted on the SUBJECT of this test — that
-    // `opts` reaches the call — rather than on the spelling of the second argument.
-    assert.match(VECTOR, /pollVectorIndexReady\(spaceId, 'files', faceIndexName, opts\)/,
-      'the face poll must still receive the timeout');
+    /*
+     * Asserted on `opts` being the LAST argument, not on the argument list's spelling.
+     *
+     * The previous version matched the whole call verbatim, and broke the day the poll gained a `ProbeTarget`
+     * argument in front of `opts` — a change that threads the timeout exactly as before. A test that fails on
+     * a new parameter is testing the signature, not the property; the property is "the timeout reaches the
+     * call", and `balancedFrom` on the call's own bracket asks that directly whatever else is in there.
+     */
+    for (const [label, anchor] of [
+      ['the text indexes', 'pollVectorIndexReady(spaceId, suffix,'],
+      ['the face gallery', "pollVectorIndexReady(spaceId, 'files', faceIndexName,"],
+    ]) {
+      const at = VECTOR.indexOf(anchor);
+      assert.ok(at > -1, `${label}: the poll call is gone — re-anchor this gate`);
+      const args = balancedFrom(VECTOR, VECTOR.indexOf('(', at + 'pollVectorIndexReady'.length - 1), label);
+      assert.match(args, /,\s*opts\s*\)$/,
+        `${label}: the timeout must be the last argument, or it is accepted at the top and dropped here`);
+    }
     assert.match(VECTOR, /const faceIndexName = `\$\{spaceId\}_files_faceEmbedding`/,
       'and it must still be the face gallery it polls');
     assert.match(VECTOR, /waitForSpaceIndexesReady\(spaceId, opts\)/);


### PR DESCRIPTION
Reported indirectly by breituai-platform during the 3.2.0 canary, 2026-08-20. They quoted
this off their pod as evidence that no face index had ever been built on any of fourteen
spaces, and stopped a configuration change on the strength of it:

    Vector search index infrastructure_files_faceEmbedding: gave up after 600s
      — probe did not serve: Executor error during aggregate command on namespace:
        ythril.infrastructure_files :: caused by :: embedding is not indexed as vector

It was not evidence of anything.

`indexServes` hardcoded two things:

    path: 'embedding'
    queryVector: probeQueryVector(getEmbeddingConfig().dimensions ?? 768)

Correct for the five text indexes. Wrong for the face gallery, which indexes `faceEmbedding`
at 128. So the probe queried a field that index does not index, with a vector of the wrong
width, and Mongo answered exactly that string — every second, for the full 600 s window, on
every space, whether or not the gallery was READY and serving. THE PROBE COULD NOT SUCCEED,
so its answer carried no information.

`pollVectorIndexReady` took no vector path, so no caller could supply one — even though
`ensureVectorSearchIndex` two levels up had built the index definition WITH the path and the
width, and simply did not pass them on. The caller held the answer and the callee guessed.

TWO COSTS, AND THE SECOND IS THEIRS

A READY gallery reported as failed makes the one diagnostic this feature has always read red.
That is the trap these same reporters named to us on 2026-08-17 about space badges: "a red
badge that is always red on a working system trains an operator to stop reading red badges."

And each miss burns the whole window. Fourteen spaces at 600 s each is precisely the boot-time
starvation the `maxTimeMS` comment INSIDE `indexServes` warns about — arriving through the one
path that comment did not cover.

THE FIX

`pollVectorIndexReady` takes a required `ProbeTarget` — the indexed path and the built width.
Required, with no default, deliberately: a default would let the next non-`embedding` index
silently inherit `embedding`/768 and fail to probe rather than fail to compile. The face caller
resolves its width from the same two places `initSpace` builds from
(`space.faceDescriptorDims ?? FACE_DESCRIPTOR_DIMS`) so the two cannot drift.

ITS OWN SPEC HAD PASSED FOR FIVE RELEASES, AND THAT IS THE LESSON

`index-ready-poll.test.js` asserted the probe was a real `$vectorSearch`, against the index by
name, and cheap. All three were true. None of them is the question. A satisfied check is the
strongest reason not to look further.

It now asserts the FIELD and the WIDTH, per call site rather than in total — the first draft
counted `pollVectorIndexReady(` against `vectorPath:` and was wrong in both directions at
once: the call count included the declaration, and the target count included the interface
field while missing the two sites that pass the `{ vectorPath, dims }` shorthand. Two totals
that happen to match prove nothing about which site matched which.

Five mutants, all killed: the literal path restored, the face poll pointed back at
`embedding`, the face width taken from the text config, the target given a default, and one
call site left to guess.

TWO OF MY OWN GATES CAUGHT ME ON THE WAY

`gates-bound-their-subject-structurally` refused this file, correctly: my first way of skipping
the function declaration was `src.slice(Math.max(0, m.index - 20), m.index)` — the backwards
magic window that ratchet exists to refuse. Replaced with a negative lookbehind, which asks the
same question with no number in it.

And `startup-index-wait` broke because it matched the poll call VERBATIM, so a new argument in
front of `opts` read as the timeout being dropped. It was testing the signature, not the
property. Rewritten to bound the call's own argument list and assert `opts` is last, which is
the property and survives the next parameter.

THE DOC HALF, AND A SECOND THING THE SAME REPORT FOUND

`05c-face-recognition.md` gains a section on reading that log line, including that it meant
nothing before this fix.

And two of its paragraphs were quoted back at us as irreconcilable, correctly. One said there
is no admin call to change the width; the next said "to move a populated gallery, re-embed its
faces at the new width first", whose closing clause implies that having re-embedded, the width
can then move. It cannot — there was never a call to set it. That sentence is replaced by what
is true (re-create the space), and the create-only paragraph now opens by saying every space
has a width from the moment it exists, defaults to 128, and does NOT derive it from the
endpoint you configure — which is the trap that would have cost them a silently empty gallery.
Their own suggested wording, taken because it is better than what it replaced.